### PR TITLE
fix(drawings): P0 remediation from drawings-production review

### DIFF
--- a/StingTools/Commands/Drawing/BatchProduceCommands.cs
+++ b/StingTools/Commands/Drawing/BatchProduceCommands.cs
@@ -344,20 +344,31 @@ namespace StingTools.Commands.Drawing
                 {
                     contextsToProduce = grids.Select(g =>
                     {
-                        var bb = new BoundingBoxXYZ();
                         try
                         {
                             var c = g.Curve as Line;
                             if (c == null) return null;
                             var origin = (c.GetEndPoint(0) + c.GetEndPoint(1)) * 0.5;
-                            double depthFt = sec.DepthMm / 304.8;
-                            var d = c.Direction;
-                            // perpendicular = (-d.Y, d.X)
-                            var perp = new XYZ(-d.Y, d.X, 0).Normalize();
                             var len = (c.GetEndPoint(1) - c.GetEndPoint(0)).GetLength();
-                            var widthFt = len * 0.5 + 5.0 / 0.3048;
-                            bb.Min = origin - perp * widthFt + new XYZ(0, 0, -3.0 / 0.3048);
-                            bb.Max = origin + perp * widthFt + new XYZ(0, 0, 30.0 / 0.3048);
+
+                            // P-5: one shared frame builder with the producer.
+                            // This used to offset Min/Max by a perpendicular
+                            // vector in MODEL space with an implicit identity
+                            // transform — so height landed on the wrong axis
+                            // (the producer put it on Y, this on Z), and for a
+                            // north-south grid the perpendicular's negative
+                            // components made Min > Max, which CreateSection
+                            // rejects outright. The section now cuts ALONG the
+                            // grid and looks perpendicular to it, which is what
+                            // "section along grid line" means.
+                            var bb = DrawingProducer.BuildSectionBox(
+                                origin:       origin,
+                                cutDirection: c.Direction,
+                                halfWidthFt:  len * 0.5 + 5.0 / 0.3048,
+                                bottomZ:      origin.Z - 3.0 / 0.3048,
+                                topZ:         origin.Z + 30.0 / 0.3048,
+                                depthFt:      sec.DepthMm / 304.8);
+
                             return new DrawingContext { CustomBounds = bb, Tag = "Grid-" + g.Name, PackageId = preset.PackageId };
                         }
                         catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return null; }

--- a/StingTools/Commands/Drawing/DrawingHealTitleBlocksCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingHealTitleBlocksCommand.cs
@@ -66,7 +66,8 @@ namespace StingTools.Commands.Drawing
                     MainContent =
                         "This rewrites every title-block parameter declared by each sheet's profile " +
                         "(titleBlockParams + per-symbol overlays). Scale / detail level / view template / " +
-                        "view-style pack / annotation are NOT touched. Locked sheets are skipped.",
+                        "view-style pack / annotation are NOT touched. Style-locked sheets are skipped, and " +
+                        "title blocks frozen with PRJ_TB_LOCK_BOOL are left untouched.",
                     CommonButtons = TaskDialogCommonButtons.Ok | TaskDialogCommonButtons.Cancel,
                     DefaultButton = TaskDialogResult.Ok,
                 };
@@ -75,6 +76,7 @@ namespace StingTools.Commands.Drawing
                 var auditRows = new List<HealRow>();
                 int totalParams = 0;
                 int healed = 0;
+                int lockedSkipped = 0;
                 using (TitleBlockParamApplier.Batch())
                 using (var tx = new Transaction(doc, "STING — Heal Title Blocks"))
                 {
@@ -91,6 +93,11 @@ namespace StingTools.Commands.Drawing
                             seq:        DrawingTokenContext.ExtractSeqFromSheetNumber(x.Sheet.SheetNumber));
                         var result = TitleBlockParamApplier.Apply(doc, x.Sheet, dt, tokens);
                         totalParams += result.ParamsWritten;
+                        // T-3: Apply now leaves PRJ_TB_LOCK_BOOL title blocks
+                        // alone. Count them so "healed N of M" doesn't quietly
+                        // read as a failure on a project that locks sheets on
+                        // purpose — a skipped lock is a success, not a miss.
+                        lockedSkipped += result.LockedSkipped;
                         if (result.ParamsWritten > 0) healed++;
                         if (result.ParamsWritten > 0 || result.Warnings.Count > 0)
                         {
@@ -114,6 +121,8 @@ namespace StingTools.Commands.Drawing
                 var sb = new StringBuilder();
                 sb.AppendLine($"Healed title blocks on {healed} of {sheets.Count} sheet(s).");
                 sb.AppendLine($"Total param writes: {totalParams}.");
+                if (lockedSkipped > 0)
+                    sb.AppendLine($"{lockedSkipped} title block(s) skipped — locked with {ParamRegistry.TB_LOCK}.");
                 int withWarn = auditRows.Count(a => a.Warnings != null && a.Warnings.Count > 0);
                 if (withWarn > 0) sb.AppendLine($"{withWarn} sheet(s) emitted warnings — see _BIM_COORD/titleblock_heal_audit.jsonl.");
                 TaskDialog.Show("STING — Heal Title Blocks", sb.ToString());

--- a/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
@@ -19,8 +19,7 @@
 //     TitleBlockRevisionSyncer.SyncAll writes the newest Revit Revision's
 //     number / date / description onto every stamped sheet (SHT_REV_TXT,
 //     SHT_REV_DATE_TXT) and its title-block instances
-//     (PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT /
-//     PRJ_TB_ISSUE_SUMMARY_TXT).
+//     (PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT).
 //
 //   Phase D — PDF export
 //     Every STING-stamped sheet is exported to PDF via doc.Export, ordered

--- a/StingTools/Commands/Drawing/TitleBlockRevisionSyncCommand.cs
+++ b/StingTools/Commands/Drawing/TitleBlockRevisionSyncCommand.cs
@@ -2,8 +2,7 @@
 // Wires TitleBlockRevisionSyncer.SyncAll() to a user-invocable command.
 // Writes the newest Revision's number / date / description onto every
 // sheet (SHT_REV_TXT, SHT_REV_DATE_TXT) and onto its title-block
-// instances (PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT /
-// PRJ_TB_ISSUE_SUMMARY_TXT).
+// instances (PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT).
 
 using System.Text;
 using Autodesk.Revit.Attributes;

--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -34,6 +34,8 @@ namespace StingTools.Core.Drawing
         public int DimsPlaced      { get; set; }
         public int DecorativePlaced { get; set; }
         public int SpotsPlaced     { get; set; }
+        /// <summary>Annotations not re-created because the view already had them (C-4).</summary>
+        public int Skipped         { get; set; }
         public List<string> Warnings { get; } = new List<string>();
     }
 
@@ -206,6 +208,14 @@ namespace StingTools.Core.Drawing
             else
                 return;
 
+            // C-4: one scan of this view's existing tags, shared by every
+            // category below. Lazy so a pack with no taggable category never
+            // pays for it. Without this the runner had no idempotency at all:
+            // AutoAnnotationRule.SkipIfTagged (default true) was read nowhere,
+            // so re-running SyncStyles, a drift heal, or DrawingTypePresentation
+            // .Apply doubled every tag on the view.
+            var taggedIndex = new Lazy<HashSet<ElementId>>(() => BuildTaggedElementIndex(doc, view, stats));
+
             var doneCats = new HashSet<long>(); // tag each category at most once
             foreach (var rule in effective)
             {
@@ -217,7 +227,7 @@ namespace StingTools.Core.Drawing
                     long cv = catId.Value;
                     if (!doneCats.Add(cv)) continue;
                     if (!Enum.IsDefined(typeof(BuiltInCategory), unchecked((int)cv))) continue; // skip custom categories
-                    TagCategory(doc, view, pack, (BuiltInCategory)cv, rule.Category, stats);
+                    TagCategory(doc, view, pack, (BuiltInCategory)cv, rule.Category, stats, rule, taggedIndex.Value);
                 }
                 catch (Exception ex) { stats.Warnings.Add($"Tag rule '{rule.Category}': {ex.Message}"); }
             }
@@ -264,8 +274,68 @@ namespace StingTools.Core.Drawing
         /// Drop a single overall dimension chain across all grids
         /// visible in the view. Each grid contributes one reference.
         /// </summary>
+        /// <summary>
+        /// C-4 idempotency for the two dimension chains.
+        ///
+        /// Strategy: detect an existing chain by what it REFERENCES rather than
+        /// by a stamped marker. A marker would need a new shared parameter bound
+        /// to Dimensions — provisioning across MR_PARAMETERS.txt, the .csv
+        /// mirror, PARAMETER_REGISTRY.json and a category binding — whereas
+        /// DimByRules places at most one grid chain and one level chain per
+        /// view, so a coarse "does this view already hold a dimension
+        /// referencing Grids / Levels?" question is exactly as precise as the
+        /// runner needs and requires nothing new.
+        ///
+        /// Residual limitation: Revit can report AreReferencesAvailable == false
+        /// (references lost, or the dimension is in a linked/【unloaded】 state).
+        /// Such a dimension is treated as "unknown" and skipped over rather than
+        /// counted as a match, so in the rare case where every dimension in the
+        /// view is unreadable AND a prior STING chain exists, a duplicate is
+        /// still possible. Failing that way round is deliberate: the alternative
+        /// silently refuses to dimension views that merely contain odd geometry.
+        /// </summary>
+        private static bool ViewHasDimensionReferencing(Document doc, View view, BuiltInCategory targetCat)
+        {
+            try
+            {
+                foreach (var el in new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(Dimension))
+                    .WhereElementIsNotElementType())
+                {
+                    if (!(el is Dimension dim)) continue;
+                    try
+                    {
+                        if (!dim.AreReferencesAvailable) continue;   // unknown — not a match
+                        var refs = dim.References;
+                        if (refs == null) continue;
+                        foreach (Reference r in refs)
+                        {
+                            var host = doc.GetElement(r);
+                            if (host?.Category == null) continue;
+                            if (host.Category.Id.Value == (long)targetCat) return true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"ViewHasDimensionReferencing: dimension {dim.Id} — {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ViewHasDimensionReferencing({view?.Name}): {ex.Message}");
+            }
+            return false;
+        }
+
         private static void DimGrids(Document doc, View view, AnnotationRulePack pack, AnnotationRunStats stats)
         {
+            if (ViewHasDimensionReferencing(doc, view, BuiltInCategory.OST_Grids))
+            {
+                stats.Skipped++;
+                return;
+            }
+
             var grids = new FilteredElementCollector(doc, view.Id)
                 .OfCategory(BuiltInCategory.OST_Grids)
                 .WhereElementIsNotElementType()
@@ -304,6 +374,12 @@ namespace StingTools.Core.Drawing
         /// </summary>
         private static void DimLevels(Document doc, View view, AnnotationRulePack pack, AnnotationRunStats stats)
         {
+            if (ViewHasDimensionReferencing(doc, view, BuiltInCategory.OST_Levels))
+            {
+                stats.Skipped++;
+                return;
+            }
+
             var levels = new FilteredElementCollector(doc, view.Id)
                 .OfCategory(BuiltInCategory.OST_Levels)
                 .WhereElementIsNotElementType()
@@ -340,8 +416,45 @@ namespace StingTools.Core.Drawing
         /// category. After placing each tag, applies CategoryDepths from
         /// the active ViewStylePack if declared.
         /// </summary>
+        /// <summary>
+        /// Element ids already carrying an IndependentTag in this view.
+        /// Built once per view and shared across every tag rule.
+        /// </summary>
+        private static HashSet<ElementId> BuildTaggedElementIndex(Document doc, View view, AnnotationRunStats stats)
+        {
+            var set = new HashSet<ElementId>();
+            try
+            {
+                foreach (var el in new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(IndependentTag))
+                    .WhereElementIsNotElementType())
+                {
+                    if (!(el is IndependentTag tag)) continue;
+                    try
+                    {
+                        foreach (var id in tag.GetTaggedLocalElementIds())
+                            if (id != null && id != ElementId.InvalidElementId) set.Add(id);
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"BuildTaggedElementIndex: tag {tag.Id} — {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail open with a warning: an empty index means "tag
+                // everything", i.e. the previous behaviour, rather than
+                // silently skipping work the user asked for.
+                stats.Warnings.Add($"Could not index existing tags in '{view.Name}' ({ex.Message}); " +
+                                   "duplicate tags are possible on this view.");
+            }
+            return set;
+        }
+
         private static void TagCategory(Document doc, View view, AnnotationRulePack pack,
-            BuiltInCategory bic, string catKey, AnnotationRunStats stats)
+            BuiltInCategory bic, string catKey, AnnotationRunStats stats,
+            AutoAnnotationRule rule = null, HashSet<ElementId> alreadyTagged = null)
         {
             var elements = new FilteredElementCollector(doc, view.Id)
                 .OfCategory(bic)
@@ -349,7 +462,7 @@ namespace StingTools.Core.Drawing
                 .ToElements();
             if (elements.Count == 0) return;
 
-            ElementId tagTypeId = ResolveTagTypeId(doc, view, pack, catKey, bic);
+            ElementId tagTypeId = ResolveTagTypeId(doc, view, pack, catKey, bic, stats);
             if (tagTypeId == ElementId.InvalidElementId)
             {
                 stats.Warnings.Add($"No tag family available for {catKey} — skipped.");
@@ -380,18 +493,50 @@ namespace StingTools.Core.Drawing
             }
             catch { /* resolver must never throw */ }
 
+            // C-4: honour the rule's skipIfTagged (POCO default true). Only the
+            // config dialog ever read this field before.
+            bool skipIfTagged = rule?.SkipIfTagged ?? true;
+
             foreach (var el in elements)
             {
                 try
                 {
+                    if (skipIfTagged && alreadyTagged != null && alreadyTagged.Contains(el.Id))
+                    {
+                        stats.Skipped++;
+                        continue;
+                    }
+
                     var pt = GetElementCentre(el);
+                    if (pt == null)
+                    {
+                        // A-9: GetElementCentre's comment promised an XYZ.Zero
+                        // sentinel "the caller can detect" but returned null,
+                        // and this call site passed it straight into
+                        // IndependentTag.Create — one exception per element on
+                        // floor / ceiling-heavy categories, flooding the
+                        // warning list and tagging nothing. It now falls back
+                        // to the bounding-box centre, so those categories tag
+                        // properly instead of being skipped; null here means
+                        // even that failed.
+                        stats.Skipped++;
+                        stats.Warnings.Add($"No taggable point for {catKey} element {el.Id} — skipped.");
+                        continue;
+                    }
+
                     // Revit 2025 removed IndependentTag.CanTagHost(doc, Reference) +
                     // renamed the Create parameters. The surrounding try/catch
                     // turns any "can't tag this host" failure into a Skipped
                     // count + warning row, replacing the dropped pre-check.
                     var tag = IndependentTag.Create(doc, tagTypeId, view.Id,
                         new Reference(el), false, TagOrientation.Horizontal, pt);
-                    if (tag != null) stats.TagsPlaced++;
+                    if (tag != null)
+                    {
+                        stats.TagsPlaced++;
+                        // Keep the index current so a later rule covering the
+                        // same element in this run doesn't tag it twice.
+                        alreadyTagged?.Add(el.Id);
+                    }
 
                     // Apply CategoryDepths from the active pack, if declared.
                     // FIX-6: write the tier flags CUMULATIVELY — a depth of N
@@ -450,17 +595,30 @@ namespace StingTools.Core.Drawing
                     var c = lc.Curve;
                     return (c.GetEndPoint(0) + c.GetEndPoint(1)) * 0.5;
                 }
-                // View-centre fallback removed: this overload doesn't have a `view`
-                // in scope. Origin XYZ.Zero is a sentinel the caller can detect.
+                // A-9: floors, ceilings, roofs and most system families have no
+                // LocationPoint and no LocationCurve, so both branches above
+                // miss and this used to return null — which the caller fed
+                // straight to IndependentTag.Create. The bounding-box centre is
+                // the natural point for those categories and makes them
+                // taggable rather than merely non-crashing. XYZ.Zero would have
+                // satisfied the old comment but piled every tag at the project
+                // origin, which is worse than skipping.
+                var bb = el.get_BoundingBox(null);
+                if (bb?.Min != null && bb.Max != null)
+                    return (bb.Min + bb.Max) * 0.5;
             }
-            catch { /* best effort */ }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"GetElementCentre({el?.Id}): {ex.Message}");
+            }
+            // Null means "no usable point" — the caller skips and reports.
             return null;
         }
 
         // ─── Resolution helpers ──────────────────────────────────────────
 
         private static ElementId ResolveTagTypeId(Document doc, View view, AnnotationRulePack pack,
-            string catKey, BuiltInCategory hostCategory)
+            string catKey, BuiltInCategory hostCategory, AnnotationRunStats stats = null)
         {
             ElementId result = ElementId.InvalidElementId;
 
@@ -468,11 +626,44 @@ namespace StingTools.Core.Drawing
             if (pack.TagFamilies != null && pack.TagFamilies.TryGetValue(catKey, out var famName)
                 && !string.IsNullOrWhiteSpace(famName))
             {
-                var byName = new FilteredElementCollector(doc)
+                var named = new FilteredElementCollector(doc)
                     .OfClass(typeof(FamilySymbol))
                     .Cast<FamilySymbol>()
-                    .FirstOrDefault(fs => string.Equals(fs.FamilyName, famName, StringComparison.OrdinalIgnoreCase));
-                if (byName != null) result = byName.Id;
+                    .Where(fs => string.Equals(fs.FamilyName, famName, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                // A-8: this matched by family name across EVERY category, so a
+                // model family sharing the name could win and then throw once
+                // per element inside IndependentTag.Create. Prefer a symbol in
+                // the expected tag category. The name-only match is kept as a
+                // second choice because TagCategoryFor falls through to the host
+                // category for anything not in its switch, so an exact category
+                // match is not always available — but a non-annotation match is
+                // reported, since that is the case that fails per element.
+                var wantCat = (long)TagCategoryFor(hostCategory);
+                var byCat = named.FirstOrDefault(fs => fs.Category != null && fs.Category.Id.Value == wantCat);
+                var chosen = byCat ?? named.FirstOrDefault();
+
+                if (chosen != null)
+                {
+                    if (byCat == null && chosen.Category?.CategoryType != CategoryType.Annotation)
+                        stats?.Warnings.Add(
+                            $"Tag family '{famName}' for {catKey} is not an annotation family " +
+                            $"(category '{chosen.Category?.Name ?? "none"}') — tagging will likely fail.");
+                    result = chosen.Id;
+                }
+                else
+                {
+                    // Previously silent: a rule naming a family that isn't
+                    // loaded fell straight through to "first loaded tag of the
+                    // category", so the drawing quietly used the wrong tag.
+                    // This is the mechanism that hides the known tagFamilies
+                    // debt (~87 key mismatches, 19 nonexistent STING_TAG_*
+                    // families) at runtime.
+                    stats?.Warnings.Add(
+                        $"Tag family '{famName}' declared for {catKey} is not loaded; " +
+                        "falling back to the first loaded tag of that category.");
+                }
             }
 
             // 2. First loaded tag of the host's tag category (project default)
@@ -591,6 +782,17 @@ namespace StingTools.Core.Drawing
             {
                 var sym = FindFamilySymbolByName(doc, familyName);
                 if (sym == null) { result.Warnings.Add($"Decorative family '{familyName}' not found — skipped."); return; }
+
+                // C-4: the decorative pass had no idempotency either, so every
+                // re-run stacked another north arrow / scale bar / key plan on
+                // the view. One instance of a given family per view is the
+                // whole intent, so an existing instance is the guard.
+                if (ViewHasInstanceOfFamily(doc, view, sym))
+                {
+                    result.Skipped++;
+                    return;
+                }
+
                 if (!sym.IsActive) { try { sym.Activate(); } catch { } }
                 var inset = (sizeMm ?? 0) / 304.8;
                 var pt = ResolvePositionPoint(outline, position, inset);
@@ -598,6 +800,35 @@ namespace StingTools.Core.Drawing
                 result.DecorativePlaced++;
             }
             catch (Exception ex) { result.Warnings.Add($"Decorative '{familyName}': {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// True when this view already owns an instance of the given family
+        /// symbol's family — the guard that keeps the decorative pass from
+        /// re-stacking a north arrow / scale bar / key plan on every run.
+        /// Matched on family rather than symbol so a type swap still counts.
+        /// </summary>
+        private static bool ViewHasInstanceOfFamily(Document doc, View view, FamilySymbol sym)
+        {
+            if (doc == null || view == null || sym == null) return false;
+            try
+            {
+                var famId = sym.Family?.Id;
+                if (famId == null) return false;
+                foreach (var el in new FilteredElementCollector(doc, view.Id)
+                    .OfClass(typeof(FamilyInstance))
+                    .WhereElementIsNotElementType())
+                {
+                    if (el is FamilyInstance fi && fi.Symbol?.Family?.Id == famId) return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail open: place it rather than silently omit a required
+                // north arrow because the scan failed.
+                StingLog.Warn($"ViewHasInstanceOfFamily('{sym.Name}'): {ex.Message}");
+            }
+            return false;
         }
 
         private static XYZ ResolvePositionPoint(BoundingBoxXYZ outline, string position, double inset)

--- a/StingTools/Core/Drawing/DrawingCropApplier.cs
+++ b/StingTools/Core/Drawing/DrawingCropApplier.cs
@@ -149,18 +149,80 @@ namespace StingTools.Core.Drawing
                 var union = GetOrComputeUnion(doc, view, warnings);
                 if (union == null) { warnings.Add("TightBbox: view is empty, no crop applied."); return; }
 
-                var marginFt = (marginMm / 304.8);
-                var withMargin = new BoundingBoxXYZ
-                {
-                    Min = union.Min - new XYZ(marginFt, marginFt, 0),
-                    Max = union.Max + new XYZ(marginFt, marginFt, 0),
-                };
+                var cropBox = ApplyUnionToCropFrame(view, union, marginMm, warnings);
+                if (cropBox == null) return;
 
                 view.CropBoxActive  = true;
                 view.CropBoxVisible = true;
-                view.CropBox        = withMargin;
+                view.CropBox        = cropBox;
             }
             catch (Exception ex) { warnings.Add($"TightBbox: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// E-2: convert a MODEL-space bounding box into the view's own crop
+        /// frame and apply the margin there.
+        ///
+        /// View.CropBox reads its Min/Max in the coordinate system carried by
+        /// the crop box's Transform, not in model space. Assigning a
+        /// model-space box with an identity transform only appears to work on
+        /// an unrotated plan, where the two frames coincide in XY; on a
+        /// section, an elevation or a rotated plan the crop lands somewhere
+        /// arbitrary. The built-in spool profiles use TightBbox on sections,
+        /// so this was the common case, not the exotic one.
+        ///
+        /// All eight corners are transformed, not just Min and Max: a rotation
+        /// mixes the axes, so the frame-space extents are only correct if every
+        /// corner is considered. The margin is then applied along the frame's
+        /// own X and Y, which is what "margin" means on the drawing.
+        /// </summary>
+        private static BoundingBoxXYZ ApplyUnionToCropFrame(
+            View view, BoundingBoxXYZ modelUnion, double marginMm, List<string> warnings)
+        {
+            try
+            {
+                var current = view.CropBox;
+                var frame = current?.Transform ?? Transform.Identity;
+                var inv = frame.Inverse;
+
+                var mn = modelUnion.Min;
+                var mx = modelUnion.Max;
+                double loX = double.MaxValue, loY = double.MaxValue, loZ = double.MaxValue;
+                double hiX = double.MinValue, hiY = double.MinValue, hiZ = double.MinValue;
+
+                for (int i = 0; i < 8; i++)
+                {
+                    var corner = new XYZ(
+                        (i & 1) == 0 ? mn.X : mx.X,
+                        (i & 2) == 0 ? mn.Y : mx.Y,
+                        (i & 4) == 0 ? mn.Z : mx.Z);
+                    var p = inv.OfPoint(corner);
+                    if (p.X < loX) loX = p.X; if (p.X > hiX) hiX = p.X;
+                    if (p.Y < loY) loY = p.Y; if (p.Y > hiY) hiY = p.Y;
+                    if (p.Z < loZ) loZ = p.Z; if (p.Z > hiZ) hiZ = p.Z;
+                }
+
+                var marginFt = marginMm / 304.8;
+                loX -= marginFt; hiX += marginFt;
+                loY -= marginFt; hiY += marginFt;
+
+                // Depth stays as the view had it — widening a crop's Z can
+                // pull unrelated geometry into a section.
+                if (current != null) { loZ = current.Min.Z; hiZ = current.Max.Z; }
+                if (hiZ - loZ < 1e-6) { loZ -= 1.0; hiZ += 1.0; }
+
+                return new BoundingBoxXYZ
+                {
+                    Transform = frame,
+                    Min = new XYZ(loX, loY, loZ),
+                    Max = new XYZ(hiX, hiY, hiZ),
+                };
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Crop frame conversion: {ex.Message}");
+                return null;
+            }
         }
 
         private static BoundingBoxXYZ GetOrComputeUnion(Document doc, View view, List<string> warnings)
@@ -240,13 +302,15 @@ namespace StingTools.Core.Drawing
                 }
                 if (union == null) { warnings.Add("RoomBoundary: no room bboxes."); return; }
 
-                var marginFt = (marginMm / 304.8);
-                union.Min = union.Min - new XYZ(marginFt, marginFt, 0);
-                union.Max = union.Max + new XYZ(marginFt, marginFt, 0);
+                // E-2: same model-space-into-crop-frame conversion as
+                // TightBbox. The room union is gathered in model space; the
+                // margin is applied in frame coords inside the helper.
+                var cropBox = ApplyUnionToCropFrame(view, union, marginMm, warnings);
+                if (cropBox == null) return;
 
                 view.CropBoxActive  = true;
                 view.CropBoxVisible = true;
-                view.CropBox        = union;
+                view.CropBox        = cropBox;
             }
             catch (Exception ex) { warnings.Add($"RoomBoundary: {ex.Message}"); }
         }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -119,7 +119,11 @@ namespace StingTools.Core.Drawing
                 {
                     var dtId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID) ?? string.Empty;
                     var pkgId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? string.Empty;
-                    if (!string.IsNullOrEmpty(dtId)) s[SheetKey(dtId, pkgId)] = sheet.Id;
+                    // null (parameter not bound) indexes as "" — the slow
+                    // path in CreateOrFindSheet then distinguishes
+                    // not-bound from bound-but-blank.
+                    var shtCtx = DrawingTypeStamper.ReadSheetContext(sheet) ?? string.Empty;
+                    if (!string.IsNullOrEmpty(dtId)) s[SheetKey(dtId, pkgId, shtCtx)] = sheet.Id;
                     if (pkg.TryGetValue(pkgId, out var n)) pkg[pkgId] = n + 1;
                     else pkg[pkgId] = 1;
                 }
@@ -148,8 +152,15 @@ namespace StingTools.Core.Drawing
         private static string ViewKey(string dtId, string ctxTag, int ruleIdx)
             => (dtId ?? string.Empty) + "|" + (ctxTag ?? string.Empty) + "|" + ruleIdx;
 
-        private static string SheetKey(string dtId, string pkgId)
-            => (dtId ?? string.Empty) + "|" + (pkgId ?? string.Empty);
+        // Sheet identity is (drawing type, package, production context).
+        // Without the context component a per-level batch resolved every
+        // level to the same sheet, so ProduceViewsPerLevelCommand over N
+        // levels produced 1 sheet carrying N stacked viewports instead of
+        // N sheets. The view key has always carried the context tag, which
+        // is why the views were minted correctly and then all placed in
+        // the same slot on the same sheet.
+        private static string SheetKey(string dtId, string pkgId, string sheetCtx)
+            => (dtId ?? string.Empty) + "|" + (pkgId ?? string.Empty) + "|" + (sheetCtx ?? string.Empty);
 
         public static ProduceResult ProduceView(Document doc, DrawingType dt, DrawingContext ctx, ProduceOptions opts)
             => ProduceAllViews(doc, dt, ctx, opts);
@@ -497,24 +508,58 @@ namespace StingTools.Core.Drawing
         private static ElementId CreateOrFindSheet(Document doc, DrawingType dt, DrawingContext ctx, ProduceOptions opts, ProduceResult result)
         {
             string effectivePackage = ctx.PackageId ?? dt.PackageId ?? "";
+            string sheetCtx = BuildContextTag(ctx);
             try
             {
                 // GAP-L: per-batch cache hit, fall back to fresh collector.
                 if (_existingSheetCache != null
                     && CacheMatchesDoc(doc)
-                    && _existingSheetCache.TryGetValue(SheetKey(dt.Id, effectivePackage), out var cachedSheetId))
+                    && _existingSheetCache.TryGetValue(SheetKey(dt.Id, effectivePackage, sheetCtx), out var cachedSheetId))
                 {
                     if (doc.GetElement(cachedSheetId) is ViewSheet vsCached && vsCached.IsValidObject)
                         return vsCached.Id;
-                    _existingSheetCache.Remove(SheetKey(dt.Id, effectivePackage));
+                    _existingSheetCache.Remove(SheetKey(dt.Id, effectivePackage, sheetCtx));
                 }
-                var existing = new FilteredElementCollector(doc)
+
+                var candidates = new FilteredElementCollector(doc)
                     .OfClass(typeof(ViewSheet))
                     .Cast<ViewSheet>()
-                    .FirstOrDefault(s =>
+                    .Where(s =>
                         string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID), dt.Id, StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal));
-                if (existing != null) return existing.Id;
+                        string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal))
+                    .ToList();
+
+                // Same drawing type, same package, same production context.
+                var exact = candidates.FirstOrDefault(s =>
+                    string.Equals(DrawingTypeStamper.ReadSheetContext(s), sheetCtx, StringComparison.Ordinal));
+                if (exact != null) return exact.Id;
+
+                // A sheet produced before the context stamp existed carries
+                // no context. Claim it only for an empty-context request —
+                // a per-level request must never adopt it, or level 1 would
+                // swallow the whole batch exactly as before.
+                if (string.IsNullOrEmpty(sheetCtx))
+                {
+                    var legacyBlank = candidates.FirstOrDefault(s =>
+                        string.IsNullOrEmpty(DrawingTypeStamper.ReadSheetContext(s)));
+                    if (legacyBlank != null) return legacyBlank.Id;
+                }
+
+                // ReadSheetContext returns null when STING_SHEET_CONTEXT_TXT
+                // is not bound in this project at all, so contexts cannot be
+                // told apart. Fall back to the pre-context (type, package)
+                // match: that reproduces the old stacking behaviour, but the
+                // alternative is minting a fresh duplicate sheet on every
+                // run. Surfaced as a warning so the fix is actionable.
+                var unstampable = candidates.FirstOrDefault(s => DrawingTypeStamper.ReadSheetContext(s) == null);
+                if (unstampable != null)
+                {
+                    result.Warnings.Add(
+                        $"{DrawingTypeStamper.PARAM_SHEET_CONTEXT} is not bound in this project, so sheets cannot be " +
+                        $"matched per level / scope box. Reusing sheet {unstampable.Id} for context '{sheetCtx}'. " +
+                        "Run LoadSharedParams to bind it, then re-run production.");
+                    return unstampable.Id;
+                }
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
 
@@ -584,6 +629,14 @@ namespace StingTools.Core.Drawing
             }
             DrawingTypeStamper.Stamp(sheet, dt.Id);
             DrawingTypeStamper.StampPackage(sheet, effectivePackage);
+            // Completes the sheet's production identity so the next run
+            // finds this exact sheet for this exact context instead of
+            // reusing it for every level in the batch.
+            if (!DrawingTypeStamper.StampSheetContext(sheet, sheetCtx) && !string.IsNullOrEmpty(sheetCtx))
+                result.Warnings.Add(
+                    $"Could not stamp {DrawingTypeStamper.PARAM_SHEET_CONTEXT} on sheet {sheet.Id} " +
+                    $"(context '{sheetCtx}'); re-running production may not match this sheet. " +
+                    "Run LoadSharedParams to bind the parameter.");
 
             try
             {
@@ -626,7 +679,7 @@ namespace StingTools.Core.Drawing
                 DrawingTypeStamper.StampSheetSequence(sheet, seq);
                 // Newly-created sheet should be discoverable next time.
                 if (_existingSheetCache != null)
-                    _existingSheetCache[SheetKey(dt.Id, effectivePackage)] = sheet.Id;
+                    _existingSheetCache[SheetKey(dt.Id, effectivePackage, sheetCtx)] = sheet.Id;
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
 

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -465,17 +465,78 @@ namespace StingTools.Core.Drawing
             }
         }
 
+        /// <summary>
+        /// P-5: build a real section frame. THE single constructor for section
+        /// bounding boxes — the producer's default and the "along grid lines"
+        /// batch command both come here, because they previously disagreed on
+        /// which axis carried height (producer: Y with Transform.Identity;
+        /// command: Z, also with an implicit Identity) and neither built the
+        /// frame that ViewSection.CreateSection actually consumes.
+        ///
+        /// CreateSection reads the box's Transform as the section's own
+        /// coordinate system and its Min/Max as extents IN THAT FRAME:
+        ///   BasisX — along the cut, i.e. the drawing's horizontal
+        ///   BasisY — model +Z, i.e. the drawing's vertical
+        ///   BasisZ — BasisX × BasisY, the horizontal direction the section
+        ///            looks along
+        /// With Transform.Identity the frame is the model frame, so BasisY is
+        /// model +Y — horizontal — and the result is a downward "plan-section"
+        /// rather than a vertical cut.
+        ///
+        /// <paramref name="bottomZ"/> / <paramref name="topZ"/> are absolute
+        /// model elevations and are converted into frame-relative Y here, so
+        /// callers never have to think about the frame. Extents are normalised
+        /// so Min &lt; Max on every axis: the grid path derived its X extent by
+        /// adding a perpendicular vector whose components go negative for
+        /// north-south grids, which inverted the box and made CreateSection
+        /// throw.
+        /// </summary>
+        internal static BoundingBoxXYZ BuildSectionBox(
+            XYZ origin, XYZ cutDirection, double halfWidthFt,
+            double bottomZ, double topZ, double depthFt)
+        {
+            origin = origin ?? XYZ.Zero;
+
+            // Horizontal component of the cut direction; fall back to model +X
+            // for a degenerate (vertical or zero-length) input.
+            var flat = new XYZ(cutDirection?.X ?? 0, cutDirection?.Y ?? 0, 0);
+            var bx = flat.GetLength() > 1e-9 ? flat.Normalize() : XYZ.BasisX;
+            var by = XYZ.BasisZ;
+            var bz = bx.CrossProduct(by);
+
+            var t = Transform.Identity;
+            t.Origin = origin;
+            t.BasisX = bx;
+            t.BasisY = by;
+            t.BasisZ = bz;
+
+            double halfW = Math.Abs(halfWidthFt);
+            double depth = Math.Abs(depthFt);
+            double yLo = Math.Min(bottomZ, topZ) - origin.Z;
+            double yHi = Math.Max(bottomZ, topZ) - origin.Z;
+            if (yHi - yLo < 1e-6) yHi = yLo + 1.0;   // never a zero-height box
+
+            return new BoundingBoxXYZ
+            {
+                Transform = t,
+                Min = new XYZ(-halfW, yLo, -depth),
+                Max = new XYZ( halfW, yHi, 0.0),
+            };
+        }
+
         private static BoundingBoxXYZ BuildDefaultSectionBbox(DrawingContext ctx)
         {
-            // 10m × 5m × 10m default box at level elevation (or origin).
+            // 10 m wide × 5 m tall × 10 m deep default cut at the context
+            // level's elevation, looking along model +Y.
+            const double mToFt = 1.0 / 0.3048;
             double elevFt = ctx?.Level?.Elevation ?? 0;
-            var bb = new BoundingBoxXYZ
-            {
-                Transform = Transform.Identity,
-                Min = new XYZ(-5.0 * 3.281, elevFt - 1.0 * 3.281, -5.0 * 3.281),
-                Max = new XYZ( 5.0 * 3.281, elevFt + 4.0 * 3.281,  5.0 * 3.281)
-            };
-            return bb;
+            return BuildSectionBox(
+                origin:       new XYZ(0, 0, elevFt),
+                cutDirection: XYZ.BasisX,
+                halfWidthFt:  5.0 * mToFt,
+                bottomZ:      elevFt - 1.0 * mToFt,
+                topZ:         elevFt + 4.0 * mToFt,
+                depthFt:      10.0 * mToFt);
         }
 
         private static BoundingBoxXYZ BuildDefaultDetailBbox(DrawingContext ctx)

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -939,6 +939,15 @@ namespace StingTools.Core.Drawing
 
             // {seq:Dn} at whatever width the pattern asks for, then bare {seq}
             // at the historical 4-digit default.
+            //
+            // Note the extras sweep above may already have consumed a bare
+            // {seq}: DrawingTokenContext.Build emits a "seq" key formatted
+            // with its seqWidth parameter, which defaults to 4 and which
+            // BuildTokenDict does not override — so the two paths agree, and
+            // whichever runs first yields the same string. {seq:Dn} is a
+            // different literal so the sweep never touches it. If a caller
+            // ever passes a non-default seqWidth, format that value the same
+            // way here or the two paths will silently disagree.
             p = _seqWidthRegex.Replace(p, m => seq.ToString("D" + m.Groups[1].Value));
             p = p.Replace("{seq}", seq.ToString("D4"));
             return p;

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -607,14 +607,31 @@ namespace StingTools.Core.Drawing
             try { sheet = ViewSheet.Create(doc, titleBlockId); }
             catch (Exception ex) { result.Warnings.Add($"CreateSheet: {ex.Message}"); return ElementId.InvalidElementId; }
 
+            // The sequence has to be resolved BEFORE the number is built —
+            // the pattern's {seq} / {seq:Dn} needs it. It used to be consumed
+            // further down, after numbering, and only stamped into
+            // STING_SHEET_SEQUENCE_INT, so {seq} fell back to parsing
+            // ctx.Tag — a level name in every batch command — and every sheet
+            // in a package numbered 0001.
+            int seq = ResolveSheetSequence(doc, dt, effectivePackage);
+
+            // One token dict for the number, the name and the title-block
+            // cells, built with the REAL doc handle so {project} /
+            // {originator} resolve from ProjectInformation instead of coming
+            // back blank.
+            var tokens = BuildTokenDict(doc, dt, ctx, seq);
+
             try
             {
-                sheet.SheetNumber = opts.OverrideSheetNumber ?? SubstituteTokens(dt.SheetNumberPattern, dt, ctx, doc);
+                var number = opts.OverrideSheetNumber ?? SubstituteTokens(dt.SheetNumberPattern, dt, ctx, seq, tokens);
+                // Revit rejects a duplicate sheet number outright, and the
+                // catch below would leave the sheet on its default number.
+                sheet.SheetNumber = EnsureUniqueSheetNumber(doc, number, sheet.Id, result);
             }
             catch (Exception ex) { result.Warnings.Add($"SheetNumber: {ex.Message}"); }
             try
             {
-                sheet.Name = opts.OverrideSheetName ?? SubstituteTokens(dt.SheetNamePattern, dt, ctx, doc);
+                sheet.Name = opts.OverrideSheetName ?? SubstituteTokens(dt.SheetNamePattern, dt, ctx, seq, tokens);
             }
             catch (Exception ex) { result.Warnings.Add($"SheetName: {ex.Message}"); }
 
@@ -640,42 +657,6 @@ namespace StingTools.Core.Drawing
 
             try
             {
-                // Phase 169 — persisted sequence counter via ExtensibleStorage on
-                // ProjectInfo, granular by (DT, package, discipline, vol). Falls
-                // back to the per-batch cache (and ultimately a sheet count) when
-                // ES is unavailable. Survives Revit restarts and the renumber
-                // command's compaction so deleted sheets don't regrow gaps.
-                int seq;
-                bool used = false;
-                try
-                {
-                    seq = SheetSequenceStore.Next(doc, dt.Id, effectivePackage,
-                        dt.Discipline ?? "", dt.IsoNaming?.Volume ?? "");
-                    used = true;
-                }
-                catch (Exception ex2)
-                {
-                    seq = 0;
-                    StingTools.Core.StingLog.Warn($"SheetSequenceStore.Next: {ex2.Message}");
-                }
-                if (!used)
-                {
-                    // Legacy fallback path — preserves prior behaviour for
-                    // documents where ExtensibleStorage isn't writable.
-                    if (_packageSheetCount != null && CacheMatchesDoc(doc))
-                    {
-                        _packageSheetCount.TryGetValue(effectivePackage, out var n);
-                        seq = n + 1;
-                        _packageSheetCount[effectivePackage] = seq;
-                    }
-                    else
-                    {
-                        seq = new FilteredElementCollector(doc)
-                            .OfClass(typeof(ViewSheet))
-                            .Cast<ViewSheet>()
-                            .Count(s => string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal));
-                    }
-                }
                 DrawingTypeStamper.StampSheetSequence(sheet, seq);
                 // Newly-created sheet should be discoverable next time.
                 if (_existingSheetCache != null)
@@ -687,7 +668,6 @@ namespace StingTools.Core.Drawing
             {
                 try
                 {
-                    var tokens = BuildTokenDict(dt, ctx);
                     var tbResult = TitleBlockParamApplier.Apply(doc, sheet, dt, tokens);
                     foreach (var w in tbResult.Warnings)
                         result.Warnings.Add("TitleBlockParams: " + w);
@@ -815,32 +795,153 @@ namespace StingTools.Core.Drawing
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return false; }
         }
 
-        private static string SubstituteTokens(string pattern, DrawingType dt, DrawingContext ctx, Document doc)
+        /// <summary>
+        /// Resolve the next sheet sequence for this (drawing type, package).
+        /// Extracted so numbering can consume it before the sheet number is
+        /// built. Behaviour is unchanged: persisted ES counter first, then the
+        /// per-batch cache, then a package sheet count.
+        /// </summary>
+        private static int ResolveSheetSequence(Document doc, DrawingType dt, string effectivePackage)
+        {
+            // Phase 169 — persisted sequence counter via ExtensibleStorage on
+            // ProjectInfo, granular by (DT, package, discipline, vol). Falls
+            // back to the per-batch cache (and ultimately a sheet count) when
+            // ES is unavailable. Survives Revit restarts and the renumber
+            // command's compaction so deleted sheets don't regrow gaps.
+            try
+            {
+                return SheetSequenceStore.Next(doc, dt.Id, effectivePackage,
+                    dt.Discipline ?? "", dt.IsoNaming?.Volume ?? "");
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"SheetSequenceStore.Next: {ex.Message}");
+            }
+
+            // Legacy fallback path — preserves prior behaviour for documents
+            // where ExtensibleStorage isn't writable.
+            try
+            {
+                if (_packageSheetCount != null && CacheMatchesDoc(doc))
+                {
+                    _packageSheetCount.TryGetValue(effectivePackage, out var n);
+                    var next = n + 1;
+                    _packageSheetCount[effectivePackage] = next;
+                    return next;
+                }
+                return new FilteredElementCollector(doc)
+                    .OfClass(typeof(ViewSheet))
+                    .Cast<ViewSheet>()
+                    .Count(s => string.Equals(StingTools.Core.ParameterHelpers.GetString(s, DrawingTypeStamper.PARAM_DRAWING_PACKAGE_ID) ?? "", effectivePackage, StringComparison.Ordinal));
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"ResolveSheetSequence fallback: {ex.Message}");
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Revit rejects a duplicate sheet number, so a collision would throw
+        /// and leave the sheet on its auto-assigned default. Mirrors
+        /// ShopDrawingComposer.EnsureUniqueSheetNumber (-A … -Z, then a short
+        /// random suffix) and additionally ignores the sheet being numbered.
+        /// </summary>
+        private static string EnsureUniqueSheetNumber(Document doc, string baseNumber, ElementId excludeId, ProduceResult result)
+        {
+            if (string.IsNullOrEmpty(baseNumber)) return baseNumber;
+            var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)))
+                {
+                    if (el is ViewSheet vs && vs.Id != excludeId && !string.IsNullOrEmpty(vs.SheetNumber))
+                        existing.Add(vs.SheetNumber);
+                }
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"EnsureUniqueSheetNumber: {ex.Message}");
+                return baseNumber;
+            }
+            if (!existing.Contains(baseNumber)) return baseNumber;
+
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                var candidate = baseNumber + "-" + c;
+                if (!existing.Contains(candidate))
+                {
+                    result?.Warnings.Add($"Sheet number '{baseNumber}' already exists; used '{candidate}'.");
+                    return candidate;
+                }
+            }
+            var fallback = baseNumber + "-" + Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
+            result?.Warnings.Add($"Sheet number '{baseNumber}' and all -A..-Z variants exist; used '{fallback}'.");
+            return fallback;
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex _seqWidthRegex
+            = new System.Text.RegularExpressions.Regex(@"\{seq:D(\d+)\}",
+                System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        private static string SubstituteTokens(string pattern, DrawingType dt, DrawingContext ctx,
+            int seq, IDictionary<string, string> extras)
+            => ApplyTokenPattern(
+                pattern,
+                disc:    dt?.Discipline ?? "",
+                lvl:     ctx?.Level?.Name ?? "",
+                sys:     dt?.System ?? "",   // P4 — system code into {sys} for number/name patterns
+                mark:    ctx?.Tag ?? "",
+                spool:   ctx?.Tag ?? "",
+                purpose: dt?.Purpose ?? "",
+                seq:     seq,
+                extras:  extras);
+
+        /// <summary>
+        /// The token substitution itself, with no Revit types in its
+        /// signature so it can be exercised outside Revit. Callers resolve
+        /// the field values; this only does the string work.
+        /// </summary>
+        internal static string ApplyTokenPattern(string pattern,
+            string disc, string lvl, string sys, string mark, string spool, string purpose,
+            int seq, IDictionary<string, string> extras)
         {
             if (string.IsNullOrEmpty(pattern)) return pattern;
-            string disc  = dt?.Discipline ?? "";
-            string lvl   = ctx?.Level?.Name ?? "";
-            string sys   = dt?.System ?? "";   // P4 — system code into {sys} for number/name patterns
-            string mark  = ctx?.Tag ?? "";
-            string spool = ctx?.Tag ?? "";
 
-            string Replace(string p)
+            var p = pattern;
+            // Producer-specific shaping first (SafeShort sanitises and caps at
+            // 8 chars). Doing these before the extras sweep keeps the existing
+            // behaviour for these six tokens rather than letting the raw
+            // dictionary values through.
+            p = p.Replace("{disc}", SafeShort(disc));
+            p = p.Replace("{discipline}", disc);
+            p = p.Replace("{lvl}", SafeShort(lvl));
+            p = p.Replace("{sys}", SafeShort(sys));
+            p = p.Replace("{mark}", SafeShort(mark));
+            p = p.Replace("{spool}", SafeShort(spool));
+            p = p.Replace("{purpose}", purpose ?? "");
+
+            // ISO 19650 tokens — {project} {originator} {vol} {type} {role}
+            // {suit} {rev} and anything else the canonical builder supplies.
+            // 13 corporate drawing types carry these in their
+            // sheetNumberPattern; the producer knew none of them, so they
+            // survived as literal braces, which are illegal in a Revit sheet
+            // number — the assignment threw, was caught, and the sheet kept
+            // its default number. Same sweep ShopDrawingComposer already did.
+            if (extras != null)
             {
-                p = p.Replace("{disc}", SafeShort(disc));
-                p = p.Replace("{discipline}", disc);
-                p = p.Replace("{lvl}", SafeShort(lvl));
-                p = p.Replace("{sys}", SafeShort(sys));
-                p = p.Replace("{mark}", SafeShort(mark));
-                p = p.Replace("{spool}", SafeShort(spool));
-                p = p.Replace("{purpose}", dt?.Purpose ?? "");
-                // {seq:Dn}
-                int seq = (ctx?.Tag != null && int.TryParse(ctx.Tag, out var s)) ? s : 1;
-                for (int width = 1; width <= 6; width++)
-                    p = p.Replace($"{{seq:D{width}}}", seq.ToString("D" + width));
-                p = p.Replace("{seq}", seq.ToString("D4"));
-                return p;
+                foreach (var kv in extras)
+                {
+                    if (string.IsNullOrEmpty(kv.Key)) continue;
+                    p = p.Replace("{" + kv.Key + "}", kv.Value ?? "");
+                }
             }
-            return Replace(pattern);
+
+            // {seq:Dn} at whatever width the pattern asks for, then bare {seq}
+            // at the historical 4-digit default.
+            p = _seqWidthRegex.Replace(p, m => seq.ToString("D" + m.Groups[1].Value));
+            p = p.Replace("{seq}", seq.ToString("D4"));
+            return p;
         }
 
         private static string SafeShort(string s)
@@ -849,17 +950,26 @@ namespace StingTools.Core.Drawing
             return new string(s.Where(c => char.IsLetterOrDigit(c) || c == '_' || c == '-').Take(8).ToArray());
         }
 
-        private static Dictionary<string, string> BuildTokenDict(DrawingType dt, DrawingContext ctx)
+        private static Dictionary<string, string> BuildTokenDict(Document doc, DrawingType dt, DrawingContext ctx, int seq)
         {
             // INT-06: route through the canonical builder so SheetManager,
             // ShopDrawingComposer and the production engine all feed the
             // exact same token set into TitleBlockParamApplier.
+            //
+            // doc was previously passed as null with a comment claiming the
+            // producer had no handle — CreateOrFindSheet has had one all
+            // along. With null, DrawingTokenContext.ReadProjectInfo returned
+            // empty for {project} and {originator}, so producer-path
+            // title-block cells came back blank while the fabrication and
+            // SheetManager paths filled them from the same profile. seq was
+            // likewise never supplied, leaving "{seq:Dn}" literal in cells.
             var d = DrawingTokenContext.Build(
-                doc:        null,        // producer is invoked without a doc handle here
+                doc:        doc,
                 dt:         dt,
                 discCode:   dt?.Discipline,
                 discipline: dt?.Discipline,
                 levelCode:  ctx?.Level?.Name,
+                seq:        seq,
                 spool:      ctx?.Tag,
                 mark:       ctx?.Tag);
             d["package"] = ctx?.PackageId ?? dt?.PackageId ?? string.Empty;

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -566,40 +566,81 @@ namespace StingTools.Core.Drawing
             ElementId titleBlockId = ElementId.InvalidElementId;
             try
             {
-                var (tbFamily, tbSymbol) = DrawingDispatcher.ResolveTitleBlockVariant(dt);
+                var (declaredFamily, tbSymbol) = DrawingDispatcher.ResolveTitleBlockVariant(dt);
                 // P5 — map the profile's logical / dangling family name to the
                 // concrete built family (STING_TB_<size>[_PORT]_<BIM|NONBIM>_v2.0
                 // / …_ASSEMBLY_*_v1.0 / …_PRESENT_A1_v1.0) before looking it up.
-                tbFamily = TitleBlockResolver.ToConcreteFamily(doc, dt, tbFamily);
+                // ToConcreteFamily is best-effort: it returns the declared name
+                // unchanged for A2/A4 and for unknown vocabulary, and can return
+                // blank when the profile declares no family and no size can be
+                // derived. So treat its output as possibly-still-logical.
+                var tbFamily = TitleBlockResolver.ToConcreteFamily(doc, dt, declaredFamily);
 
-                List<FamilySymbol> CollectMatches() => new FilteredElementCollector(doc)
-                    .OfClass(typeof(FamilySymbol))
-                    .OfCategory(BuiltInCategory.OST_TitleBlocks)
-                    .Cast<FamilySymbol>()
-                    .Where(s => string.IsNullOrEmpty(tbFamily) ||
-                                string.Equals(s.FamilyName, tbFamily, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                // A blank family name used to satisfy the match predicate via an
+                // `IsNullOrEmpty(tbFamily) ||` clause, so ANY loaded title block
+                // matched and the first one won — silently, before any fallback
+                // warning could fire. Blank now matches nothing and is reported.
+                bool haveName = !string.IsNullOrWhiteSpace(tbFamily);
+                if (!haveName)
+                    result.Warnings.Add(
+                        $"Drawing type '{dt.Id}' resolved no title-block family name " +
+                        $"(declared '{declaredFamily ?? ""}'). The sheet will use whatever title block " +
+                        "is available — set titleBlockFamily on the profile, or a paper size the " +
+                        "resolver can derive from.");
+
+                List<FamilySymbol> CollectMatches() => !haveName
+                    ? new List<FamilySymbol>()
+                    : new FilteredElementCollector(doc)
+                        .OfClass(typeof(FamilySymbol))
+                        .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                        .Cast<FamilySymbol>()
+                        .Where(s => string.Equals(s.FamilyName, tbFamily, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
 
                 var familyMatches = CollectMatches();
                 // P5 delivery — if the concrete family was built but not yet
-                // loaded, load it from Families/TitleBlocks/ on demand so the
-                // producer never falls back to an arbitrary title block.
-                if (familyMatches.Count == 0 && !string.IsNullOrEmpty(tbFamily)
+                // loaded, load it from Families/TitleBlocks/ on demand.
+                if (familyMatches.Count == 0 && haveName
                     && TitleBlockResolver.EnsureFamilyLoaded(doc, tbFamily))
                     familyMatches = CollectMatches();
 
                 FamilySymbol picked = null;
                 if (!string.IsNullOrWhiteSpace(tbSymbol))
+                {
                     picked = familyMatches.FirstOrDefault(s =>
                         string.Equals(s.Name, tbSymbol, StringComparison.OrdinalIgnoreCase));
+                    if (picked == null && familyMatches.Count > 0)
+                        result.Warnings.Add(
+                            $"Title-block type '{tbSymbol}' not found in family '{tbFamily}' " +
+                            $"for drawing type '{dt.Id}'; used '{familyMatches[0].Name}' instead.");
+                }
                 if (picked == null) picked = familyMatches.FirstOrDefault();
                 titleBlockId = picked?.Id ?? ElementId.InvalidElementId;
+
                 if (titleBlockId == ElementId.InvalidElementId)
-                    titleBlockId = new FilteredElementCollector(doc)
+                {
+                    // The comment here used to claim "the producer never falls
+                    // back to an arbitrary title block" immediately above code
+                    // that did exactly that, with no warning — so a batch could
+                    // issue sheets carrying the wrong corporate identity and
+                    // report success. Still falls back (a sheet with some title
+                    // block beats no sheet), but says so.
+                    var any = new FilteredElementCollector(doc)
                         .OfClass(typeof(FamilySymbol))
                         .OfCategory(BuiltInCategory.OST_TitleBlocks)
                         .Cast<FamilySymbol>()
-                        .FirstOrDefault()?.Id ?? ElementId.InvalidElementId;
+                        .FirstOrDefault();
+                    titleBlockId = any?.Id ?? ElementId.InvalidElementId;
+                    if (any != null && haveName)
+                        result.Warnings.Add(
+                            $"Title-block family '{tbFamily}' (drawing type '{dt.Id}') is not loaded and " +
+                            $"could not be loaded from disk; fell back to '{any.FamilyName}'. " +
+                            "The sheet carries the wrong corporate identity until the family is loaded.");
+                    else if (any == null)
+                        result.Warnings.Add(
+                            $"No title-block family is loaded in this project; sheet for drawing type " +
+                            $"'{dt.Id}' was created without one.");
+                }
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
 

--- a/StingTools/Core/Drawing/DrawingTypeRegistry.cs
+++ b/StingTools/Core/Drawing/DrawingTypeRegistry.cs
@@ -159,20 +159,24 @@ namespace StingTools.Core.Drawing
             var m = new DrawingType { Id = leaf.Id, Name = leaf.Name, Origin = leaf.Origin, Extends = leaf.Extends };
             foreach (var p in chain)
             {
-                if (!string.IsNullOrEmpty(p.Description))      m.Description = p.Description;
-                if (!string.IsNullOrEmpty(p.Purpose))          m.Purpose = p.Purpose;
-                if (!string.IsNullOrEmpty(p.Discipline))       m.Discipline = p.Discipline;
-                if (!string.IsNullOrEmpty(p.Phase))            m.Phase = p.Phase;
-                if (!string.IsNullOrEmpty(p.PaperSize))        m.PaperSize = p.PaperSize;
-                if (!string.IsNullOrEmpty(p.TitleBlockFamily)) m.TitleBlockFamily = p.TitleBlockFamily;
-                if (!string.IsNullOrEmpty(p.Orientation))      m.Orientation = p.Orientation;
-                if (p.Scale > 0)                               m.Scale = p.Scale;
-                if (!string.IsNullOrEmpty(p.DetailLevel))      m.DetailLevel = p.DetailLevel;
-                if (!string.IsNullOrEmpty(p.ViewTemplateName)) m.ViewTemplateName = p.ViewTemplateName;
-                if (!string.IsNullOrEmpty(p.ViewportTypeName)) m.ViewportTypeName = p.ViewportTypeName;
-                if (!string.IsNullOrEmpty(p.SheetNumberPattern)) m.SheetNumberPattern = p.SheetNumberPattern;
-                if (!string.IsNullOrEmpty(p.SheetNamePattern))   m.SheetNamePattern = p.SheetNamePattern;
-                if (!string.IsNullOrEmpty(p.ViewStylePackId))    m.ViewStylePackId = p.ViewStylePackId;
+                // Carry every field not explicitly merged below. Without
+                // this the fold dropped TitleBlockParams,
+                // TitleBlockParamsBySymbol, TitleBlockSymbolType,
+                // IsoNaming, System, MaterialPack, OptionScope,
+                // ProductionRules, PackageId, TitleBlockVariantRules and
+                // TagTextSizeMm — including the leaf's own values, since
+                // the leaf is just the last link of this same chain. A
+                // project profile using the documented inheritance
+                // produced sheets with empty title-block cells and no ISO
+                // naming, silently.
+                ExtendsMerge.Overlay(p, m, _overlayProps);
+
+                // Object / collection fields keep their hand-written
+                // guards: their POCO defaults are freshly-constructed
+                // instances, so no value comparison can tell "child left
+                // this unset" from "child set it to something equal to
+                // the default". A child therefore still replaces these
+                // wholesale, exactly as before.
                 if (p.Crop != null)          m.Crop = p.Crop;
                 if (p.SectionMarker != null) m.SectionMarker = p.SectionMarker;
                 if (p.Slots != null && p.Slots.Count > 0) m.Slots = p.Slots;
@@ -182,6 +186,39 @@ namespace StingTools.Core.Drawing
             }
             return m;
         }
+
+        // Fields the fold above merges by hand: identity taken from the
+        // leaf, plus the object/collection fields whose defaults are
+        // fresh instances. Every other field — including the scalars the
+        // old fold enumerated — is carried by ExtendsMerge.Overlay, which
+        // treats "equal to a fresh instance's value" as unset.
+        //
+        // That last point also fixes a second inheritance defect the
+        // hand-written guards had: fields with a non-null POCO default
+        // (Purpose "Plan", Discipline/Phase "*", PaperSize "A1",
+        // Orientation "Landscape", Scale 100, DetailLevel "Medium", both
+        // sheet patterns) passed !IsNullOrEmpty on a child that never
+        // declared them, so a child could never inherit any of them — an
+        // A0 parent always came back A1. Known limitation of the
+        // default-as-sentinel approach: a child that explicitly restates
+        // a default (e.g. "discipline": "*") is indistinguishable from
+        // one that omits it and will inherit the parent's value instead.
+        private static readonly HashSet<string> _overlaySkip = new HashSet<string>(StringComparer.Ordinal)
+        {
+            nameof(DrawingType.Id),
+            nameof(DrawingType.Name),
+            nameof(DrawingType.Origin),
+            nameof(DrawingType.Extends),
+            nameof(DrawingType.Crop),
+            nameof(DrawingType.SectionMarker),
+            nameof(DrawingType.Slots),
+            nameof(DrawingType.Annotation),
+            nameof(DrawingType.TokenProfile),
+            nameof(DrawingType.Print),
+        };
+
+        private static readonly System.Reflection.PropertyInfo[] _overlayProps
+            = ExtendsMerge.OverlayProps(typeof(DrawingType), _overlaySkip);
 
         public static IReadOnlyList<DrawingType> ListAll(Document doc)
             => GetLibrary(doc).DrawingTypes;

--- a/StingTools/Core/Drawing/DrawingTypeStamper.cs
+++ b/StingTools/Core/Drawing/DrawingTypeStamper.cs
@@ -30,6 +30,7 @@ namespace StingTools.Core.Drawing
         public const string PARAM_STYLE_LOCKED      = "STING_STYLE_LOCKED_BOOL";
         public const string PARAM_DRAWING_PACKAGE_ID = "STING_DRAWING_PACKAGE_ID_TXT";
         public const string PARAM_SHEET_SEQUENCE    = "STING_SHEET_SEQUENCE_INT";
+        public const string PARAM_SHEET_CONTEXT     = "STING_SHEET_CONTEXT_TXT";
 
         // Phase 183 — crop stamps written by DrawingCropApplier so the
         // DriftDetector can spot a profile whose crop kind / margin has
@@ -282,6 +283,59 @@ namespace StingTools.Core.Drawing
                 StingTools.Core.StingLog.Warn(
                     $"DrawingTypeStamper.StampPackage({el.Id}, '{packageId}'): {ex.Message}");
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Stamp the production context (level / scope box / room) a sheet
+        /// was produced for. With the drawing-type id and package id this
+        /// completes a sheet's production identity, so a per-level batch
+        /// gets one sheet per level instead of stacking every level onto
+        /// the first sheet. Idempotent. Requires an active transaction.
+        /// </summary>
+        public static bool StampSheetContext(Element el, string context)
+        {
+            if (el == null) return false;
+            if (!IsEditable(el)) return false;
+            try
+            {
+                var p = el.LookupParameter(PARAM_SHEET_CONTEXT);
+                if (p == null || p.IsReadOnly || p.StorageType != StorageType.String) return false;
+                var val = context ?? string.Empty;
+                if (string.Equals(p.AsString() ?? string.Empty, val, StringComparison.Ordinal)) return true;
+                p.Set(val);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn(
+                    $"DrawingTypeStamper.StampSheetContext({el.Id}, '{context}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Read a sheet's production context stamp.
+        /// Returns null when the parameter is not bound in this project at
+        /// all — callers must treat that as "cannot tell" and fall back to
+        /// the pre-context matching rather than assume an empty context,
+        /// which would otherwise mint a duplicate sheet on every run.
+        /// Returns "" when the parameter exists but was never stamped.
+        /// </summary>
+        public static string ReadSheetContext(Element el)
+        {
+            if (el == null) return null;
+            try
+            {
+                var p = el.LookupParameter(PARAM_SHEET_CONTEXT);
+                if (p == null || p.StorageType != StorageType.String) return null;
+                return p.AsString() ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn(
+                    $"DrawingTypeStamper.ReadSheetContext({el.Id}): {ex.Message}");
+                return null;
             }
         }
 

--- a/StingTools/Core/Drawing/ExtendsMerge.cs
+++ b/StingTools/Core/Drawing/ExtendsMerge.cs
@@ -1,0 +1,117 @@
+// StingTools — Drawing Template Manager
+//
+// ExtendsMerge — shared field overlay for the `extends` chain folds in
+// DrawingTypeRegistry and ViewStylePackRegistry.
+//
+// Both registries used to fold a chain by hand-enumerating the fields to
+// copy into a fresh instance. Every field the enumeration missed was
+// silently dropped — including the leaf's own value, because the leaf is
+// just the last link of the same chain. DrawingTypeRegistry dropped 12
+// fields (titleBlockParams, isoNaming, packageId, …) and
+// ViewStylePackRegistry dropped 14 (templateMode, managedFields,
+// worksetVisibility, …). Since all 35 shipped style packs declare
+// `extends`, the pack fold ran on every Get() and `templateMode:
+// "managed"` could never survive it — the managed-template branch in
+// DrawingTypePresentation was unreachable.
+//
+// Rather than re-enumerate (and drift again on the next field added),
+// the folds now overlay every remaining public read/write property
+// generically. A property is treated as "set" when its value differs
+// from the value a freshly-constructed instance carries, so a child that
+// simply omits a key does not clobber its parent with a C# default or a
+// POCO default such as Discipline = "*" or PaperSize = "A1".
+//
+// Fields whose merge semantics are not a plain overwrite — collections
+// that accumulate (Filters) or merge by key (VgOverrides, TagFamilies)
+// — stay explicitly handled by the callers and are passed in the skip
+// set.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace StingTools.Core.Drawing
+{
+    internal static class ExtendsMerge
+    {
+        private static readonly object _lock = new object();
+
+        // Keyed by type only: each POCO has exactly one fold site, so its
+        // skip set is fixed. Callers pass a static readonly set.
+        private static readonly Dictionary<Type, PropertyInfo[]> _propCache
+            = new Dictionary<Type, PropertyInfo[]>();
+        private static readonly Dictionary<Type, object> _defaultCache
+            = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Public instance properties of <paramref name="t"/> that the
+        /// generic overlay should carry: readable, writable, non-indexed,
+        /// and not explicitly handled by the caller.
+        /// </summary>
+        internal static PropertyInfo[] OverlayProps(Type t, ISet<string> skip)
+        {
+            lock (_lock)
+            {
+                if (_propCache.TryGetValue(t, out var cached)) return cached;
+                var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(p => p.CanRead
+                             && p.CanWrite
+                             && p.GetIndexParameters().Length == 0
+                             && !skip.Contains(p.Name))
+                    .ToArray();
+                _propCache[t] = props;
+                return props;
+            }
+        }
+
+        /// <summary>
+        /// Copy every property in <paramref name="props"/> from
+        /// <paramref name="src"/> onto <paramref name="dst"/> when the
+        /// source value differs from a fresh instance's value for that
+        /// property. Call parent-first so later (child) links win.
+        /// </summary>
+        internal static void Overlay(object src, object dst, PropertyInfo[] props)
+        {
+            if (src == null || dst == null || props == null) return;
+            var blank = Blank(src.GetType());
+            foreach (var pi in props)
+            {
+                try
+                {
+                    var v = pi.GetValue(src);
+                    if (v == null) continue;
+                    if (v is string s && s.Length == 0) continue;
+                    if (blank != null && Equals(v, pi.GetValue(blank))) continue; // unset
+                    pi.SetValue(dst, v);
+                }
+                catch (Exception ex)
+                {
+                    StingTools.Core.StingLog.Warn(
+                        $"ExtendsMerge: could not carry '{pi.Name}' on {src.GetType().Name} — {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>A cached freshly-constructed instance used as the
+        /// "unset" reference. Null when the type has no usable
+        /// parameterless constructor, in which case only null / empty
+        /// -string values are treated as unset.</summary>
+        private static object Blank(Type t)
+        {
+            lock (_lock)
+            {
+                if (_defaultCache.TryGetValue(t, out var cached)) return cached;
+                object inst = null;
+                try { inst = Activator.CreateInstance(t); }
+                catch (Exception ex)
+                {
+                    StingTools.Core.StingLog.Warn(
+                        $"ExtendsMerge: no default instance for {t.Name} — {ex.Message}");
+                }
+                _defaultCache[t] = inst;
+                return inst;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
+++ b/StingTools/Core/Drawing/ManagedTemplateSyncer.cs
@@ -159,6 +159,22 @@ namespace StingTools.Core.Drawing
             return seed;
         }
 
+        /// <summary>
+        /// Delete an element created moments ago that turned out unusable, so
+        /// a failed mint leaves nothing behind to accumulate. Best-effort:
+        /// a failure here is logged, never thrown.
+        /// </summary>
+        private static void TryDelete(Document doc, ElementId id)
+        {
+            if (doc == null || id == null || id == ElementId.InvalidElementId) return;
+            try { doc.Delete(id); }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn(
+                    $"ManagedTemplateSyncer: could not clean up element {id} after a failed mint — {ex.Message}");
+            }
+        }
+
         internal static string GetManagedTemplateName(string packId, ViewType vt)
             => $"STING:{packId}:{vt}";
 
@@ -329,40 +345,69 @@ namespace StingTools.Core.Drawing
                 return ElementId.InvalidElementId;
             }
 
-            // 4. Copy seed
+            // 4. Mint the template from the seed.
+            //
+            // ResolveSeed falls back to a NON-template live view when the
+            // project has no "STING - " seed template — a fresh project, i.e.
+            // the common case. CopyElement on a live view yields another live
+            // view, not a template: SetViewTemplateId then rejects it, the
+            // IsTemplate-filtered lookup at step 2 can never find it again, and
+            // the next run re-minted it as _(2), _(3), … Revit's actual API for
+            // this is View.CreateViewTemplate(), which returns a real template.
             ElementId newId;
             try
             {
-                var copied = ElementTransformUtils.CopyElement(doc, seed.Id, XYZ.Zero);
-                if (copied == null || copied.Count == 0)
+                if (seed.IsTemplate)
                 {
-                    result.Warnings.Add("ManagedTemplateSyncer: seed copy returned no elements.");
-                    return ElementId.InvalidElementId;
+                    // Copying a template yields a template — correct as-is.
+                    var copied = ElementTransformUtils.CopyElement(doc, seed.Id, XYZ.Zero);
+                    if (copied == null || copied.Count == 0)
+                    {
+                        result.Warnings.Add("ManagedTemplateSyncer: seed copy returned no elements.");
+                        return ElementId.InvalidElementId;
+                    }
+                    newId = copied.First();
                 }
-                newId = copied.First();
+                else
+                {
+                    var made = seed.CreateViewTemplate();
+                    if (made == null)
+                    {
+                        result.Warnings.Add(
+                            $"ManagedTemplateSyncer: CreateViewTemplate returned null for seed '{seed.Name}' ({viewType}).");
+                        return ElementId.InvalidElementId;
+                    }
+                    newId = made.Id;
+                }
             }
             catch (Exception ex)
             {
-                result.Warnings.Add($"ManagedTemplateSyncer: seed copy failed — {ex.Message}");
+                result.Warnings.Add($"ManagedTemplateSyncer: minting template from seed '{seed.Name}' failed — {ex.Message}");
                 return ElementId.InvalidElementId;
             }
 
             var newView = doc.GetElement(newId) as View;
-            if (newView == null)
+            if (newView == null || !newView.IsTemplate)
             {
-                result.Warnings.Add("ManagedTemplateSyncer: copy did not yield a View.");
+                result.Warnings.Add(
+                    $"ManagedTemplateSyncer: minting did not yield a view template for pack '{pack.Id}' / {viewType}.");
+                TryDelete(doc, newId);
                 return ElementId.InvalidElementId;
             }
 
             try { newView.Name = templateName; }
-            catch
+            catch (Exception exName)
             {
-                try { newView.Name = templateName + "_(2)"; }
-                catch (Exception ex2)
-                {
-                    result.Warnings.Add($"ManagedTemplateSyncer: rename failed — {ex2.Message}");
-                    return ElementId.InvalidElementId;
-                }
+                // Previously this fell back to templateName + "_(2)", which is
+                // how junk accumulated: the suffixed view never matches the
+                // step-2 lookup, so every run minted another one. Fail loudly
+                // and clean up instead — the name is the template's identity.
+                result.Warnings.Add(
+                    $"ManagedTemplateSyncer: could not name the managed template '{templateName}' " +
+                    $"({exName.Message}). Another view is probably already using that name — " +
+                    "rename or delete it, then re-run. No template was created.");
+                TryDelete(doc, newId);
+                return ElementId.InvalidElementId;
             }
 
             ApplyPackToTemplate(doc, newView, pack, result);
@@ -564,11 +609,35 @@ namespace StingTools.Core.Drawing
                 catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
             }
 
-            // Revit's API exposes SetNonControlledTemplateParameterIds (inverse
-            // logic). For Phase 137 the value writes done via SetIntBip /
-            // SetElementIdBip / SetDoubleBip already pin the managed values
-            // onto the template; we leave Revit's "controlled by template"
-            // flags at their defaults rather than computing the complement.
+            // Revit exposes the inverse: SetNonControlledTemplateParameterIds
+            // takes the parameters the template does NOT control. Phase 137
+            // built the managed list above and then discarded it, leaving the
+            // seed's own control flags in place. That was tolerable while the
+            // managed path was unreachable, but now that packs actually reach
+            // it a seed controlling VIEW_SCALE overrides the per-profile
+            // DrawingType.Scale the pipeline just wrote — "scale" is
+            // deliberately absent from DefaultManagedFields for exactly that
+            // reason (see the list at the top of this file).
+            //
+            // Complement = every template parameter minus the managed ones, so
+            // the pack controls precisely what it declares and nothing else.
+            try
+            {
+                var all = template.GetTemplateParameterIds();
+                if (all != null)
+                {
+                    var managed = new HashSet<ElementId>(paramIds);
+                    var nonControlled = all.Where(id => !managed.Contains(id)).ToList();
+                    template.SetNonControlledTemplateParameterIds(nonControlled);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Non-fatal: the template still carries the values written by
+                // ApplyPackToTemplate, it just keeps the seed's control flags.
+                StingTools.Core.StingLog.Warn(
+                    $"ManagedTemplateSyncer.SetManagedTemplateParameterIds('{pack.Id}'): {ex.Message}");
+            }
         }
 
         // ── Helpers ──
@@ -588,14 +657,22 @@ namespace StingTools.Core.Drawing
         private static int ResolveViewDiscipline(string discipline)
         {
             if (string.IsNullOrEmpty(discipline)) return -1;
+            // Read off Autodesk.Revit.DB.ViewDiscipline rather than hardcoded
+            // integers. The previous literals had Mechanical/Electrical/
+            // Plumbing as 4096/4097/4098, which are not members of the enum —
+            // VIEW_DISCIPLINE is a bit-flag parameter (Architectural 1,
+            // Structural 2, Mechanical 4, Electrical 8, Plumbing 16) and
+            // Coordination 4095 is the all-bits union. So the three MEP
+            // disciplines silently wrote invalid values, while Architectural,
+            // Structural and Coordination happened to be right.
             switch (discipline.Trim().ToLowerInvariant())
             {
-                case "architectural": return 1;
-                case "structural":    return 2;
-                case "mechanical":    return 4096;
-                case "electrical":    return 4097;
-                case "plumbing":      return 4098;
-                case "coordination":  return 4095;
+                case "architectural": return (int)ViewDiscipline.Architectural;
+                case "structural":    return (int)ViewDiscipline.Structural;
+                case "mechanical":    return (int)ViewDiscipline.Mechanical;
+                case "electrical":    return (int)ViewDiscipline.Electrical;
+                case "plumbing":      return (int)ViewDiscipline.Plumbing;
+                case "coordination":  return (int)ViewDiscipline.Coordination;
                 default:              return -1;
             }
         }

--- a/StingTools/Core/Drawing/MatchLineEngine.cs
+++ b/StingTools/Core/Drawing/MatchLineEngine.cs
@@ -384,6 +384,35 @@ namespace StingTools.Core.Drawing
             return "";
         }
 
+        /// <summary>
+        /// A-6: collapse a stamped match-line key to its pair key.
+        ///
+        /// PlaceCurve stamps dog-leg segments as
+        /// "&lt;scopePairGuid&gt;:&lt;viewA&gt;:&lt;viewB&gt;:segN" but
+        /// PlaceOrUpdatePair looks the pair up by the bare
+        /// "&lt;scopePairGuid&gt;:&lt;viewA&gt;:&lt;viewB&gt;". Indexing the
+        /// stamped key verbatim therefore never matched for any multi-segment
+        /// boundary: `existed` came back false every sweep, nothing was
+        /// deleted, and the curves duplicated — directly contradicting the
+        /// file header's "re-runs find the existing pair and update in place".
+        /// Grouping every segment under the pair key makes the lookup hit and
+        /// the delete-then-replace path remove all segments together.
+        ///
+        /// Only a trailing ":segN" is stripped — the pair key itself contains
+        /// colons, so splitting on the first one would be wrong here.
+        /// PruneOrphans keeps working unchanged: it takes the scope-pair GUID
+        /// from the first colon-delimited field, which is identical in both
+        /// the stamped and the collapsed key.
+        /// </summary>
+        private static string BasePairKey(string stampedKey)
+        {
+            if (string.IsNullOrEmpty(stampedKey)) return stampedKey;
+            int i = stampedKey.LastIndexOf(":seg", StringComparison.OrdinalIgnoreCase);
+            if (i > 0 && int.TryParse(stampedKey.Substring(i + 4), out _))
+                return stampedKey.Substring(0, i);
+            return stampedKey;
+        }
+
         /// <summary>Indexes existing match-line DetailCurves by their
         /// STING_MATCH_LINE_GUID stamp so re-runs can find them in
         /// O(1) and update in place.</summary>
@@ -397,7 +426,7 @@ namespace StingTools.Core.Drawing
                     if (!(el is DetailCurve dc)) continue;
                     var p = dc.LookupParameter(ParamRegistry.MATCH_LINE_GUID);
                     if (p == null || !p.HasValue) continue;
-                    var key = p.AsString();
+                    var key = BasePairKey(p.AsString());
                     if (string.IsNullOrEmpty(key)) continue;
                     if (!idx.TryGetValue(key, out var list))
                         idx[key] = list = new List<CurveElement>();
@@ -582,15 +611,26 @@ namespace StingTools.Core.Drawing
                     var noteTypeId = ResolveTextNoteTypeId(doc, cfg.Captions.FallbackTextNoteTypeName);
                     if (noteTypeId != null && noteTypeId != ElementId.InvalidElementId)
                     {
-                        if (string.Equals(cfg.Captions.TipPlacement, "BothEnds", StringComparison.OrdinalIgnoreCase))
+                        bool bothEnds = string.Equals(cfg.Captions.TipPlacement, "BothEnds", StringComparison.OrdinalIgnoreCase);
+                        var points = bothEnds
+                            ? new List<XYZ> { a, b }
+                            : new List<XYZ> { (a + b) / 2 };
+
+                        // A-7: the pair's curves are deleted and re-placed on
+                        // every update, but captions were only ever created —
+                        // so MatchLine_Sync (recommended after every renumber)
+                        // stacked another "see XXX" note per end, per run.
+                        // Clear the ones this placement is about to replace
+                        // first. Matched on view + note type + exact caption
+                        // text + proximity to the placement point, so a user's
+                        // own annotation and a different pair's caption are
+                        // both left alone.
+                        RemoveExistingCaptions(doc, view, noteTypeId, caption, points, r);
+
+                        foreach (var pt in points)
                         {
-                            try { TextNote.Create(doc, view.Id, a, caption, noteTypeId); r.TipCaptionsPlaced++; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
-                            try { TextNote.Create(doc, view.Id, b, caption, noteTypeId); r.TipCaptionsPlaced++; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
-                        }
-                        else
-                        {
-                            var mid = (a + b) / 2;
-                            try { TextNote.Create(doc, view.Id, mid, caption, noteTypeId); r.TipCaptionsPlaced++; } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                            try { TextNote.Create(doc, view.Id, pt, caption, noteTypeId); r.TipCaptionsPlaced++; }
+                            catch (Exception ex) { StingLog.Warn($"Caption create: {ex.Message}"); }
                         }
                     }
                 }
@@ -702,6 +742,58 @@ namespace StingTools.Core.Drawing
             }
             catch (Exception ex) { StingLog.Warn($"ResolveLineStyleId '{styleName}': {ex.Message}"); }
             return null;
+        }
+
+        /// <summary>
+        /// A-7 helper: delete the caption notes this placement is replacing.
+        ///
+        /// Captions cannot carry the pair stamp the curves use —
+        /// STING_MATCH_LINE_GUID_TXT is a group-27 parameter bound through the
+        /// universal category set, which covers Detail Items but not Text
+        /// Notes, so the write would silently no-op. Rather than provision a
+        /// new binding, identity here is (view + note type + exact caption text
+        /// + proximity to the point being written). That is precise enough to
+        /// leave a user's own note and a different pair's caption untouched.
+        ///
+        /// Residual: if the boundary geometry moved since the last sweep, the
+        /// old caption sits outside the tolerance and is left behind as an
+        /// orphan rather than deleted. That is strictly better than the
+        /// previous behaviour, which orphaned one on EVERY sweep regardless.
+        /// </summary>
+        private static void RemoveExistingCaptions(Document doc, View view, ElementId noteTypeId,
+            string caption, IList<XYZ> points, MatchLineRunResult r)
+        {
+            if (doc == null || view == null || points == null || points.Count == 0) return;
+            const double tolFt = 2.0;   // ~600 mm — captions sit at/near the point
+            try
+            {
+                var doomed = new List<ElementId>();
+                foreach (var el in new FilteredElementCollector(doc, view.Id).OfClass(typeof(TextNote)))
+                {
+                    if (!(el is TextNote tn)) continue;
+                    if (tn.GetTypeId() != noteTypeId) continue;
+                    var text = (tn.Text ?? "").TrimEnd('\r', '\n');
+                    if (!string.Equals(text, caption, StringComparison.Ordinal)) continue;
+                    XYZ c;
+                    try { c = tn.Coord; } catch { continue; }
+                    if (c == null) continue;
+                    foreach (var p in points)
+                    {
+                        if (p != null && c.DistanceTo(p) <= tolFt) { doomed.Add(tn.Id); break; }
+                    }
+                }
+                foreach (var id in doomed)
+                {
+                    try { doc.Delete(id); }
+                    catch (Exception ex) { StingLog.Warn($"Caption prune {id}: {ex.Message}"); }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail open: a failed prune means a possible duplicate caption,
+                // not a failed sweep.
+                r?.Warnings.Add($"Could not clear prior captions in '{view.Name}': {ex.Message}");
+            }
         }
 
         private static ElementId ResolveTextNoteTypeId(Document doc, string typeName)

--- a/StingTools/Core/Drawing/MatchLineEngine.cs
+++ b/StingTools/Core/Drawing/MatchLineEngine.cs
@@ -621,11 +621,11 @@ namespace StingTools.Core.Drawing
                         // so MatchLine_Sync (recommended after every renumber)
                         // stacked another "see XXX" note per end, per run.
                         // Clear the ones this placement is about to replace
-                        // first. Matched on view + note type + exact caption
-                        // text + proximity to the placement point, so a user's
+                        // first. Matched on view + note type + caption template
+                        // shape + proximity to the placement point, so a user's
                         // own annotation and a different pair's caption are
                         // both left alone.
-                        RemoveExistingCaptions(doc, view, noteTypeId, caption, points, r);
+                        RemoveExistingCaptions(doc, view, noteTypeId, cfg.Captions.TipFormat, points, r);
 
                         foreach (var pt in points)
                         {
@@ -755,16 +755,28 @@ namespace StingTools.Core.Drawing
         /// + proximity to the point being written). That is precise enough to
         /// leave a user's own note and a different pair's caption untouched.
         ///
+        /// Matching is on the caption TEMPLATE's shape, not the rendered text.
+        /// The caption embeds the target sheet number, so after a renumber the
+        /// text this sweep writes differs from the text already on the view —
+        /// exact-text matching would miss every stale caption and orphan one
+        /// per end, per renumber. That is the flagship case for this code:
+        /// MatchLine_Sync is the recommended follow-up to a renumber.
+        ///
         /// Residual: if the boundary geometry moved since the last sweep, the
         /// old caption sits outside the tolerance and is left behind as an
         /// orphan rather than deleted. That is strictly better than the
         /// previous behaviour, which orphaned one on EVERY sweep regardless.
         /// </summary>
         private static void RemoveExistingCaptions(Document doc, View view, ElementId noteTypeId,
-            string caption, IList<XYZ> points, MatchLineRunResult r)
+            string tipFormat, IList<XYZ> points, MatchLineRunResult r)
         {
             if (doc == null || view == null || points == null || points.Count == 0) return;
+            if (string.IsNullOrEmpty(tipFormat)) return;
             const double tolFt = 2.0;   // ~600 mm — captions sit at/near the point
+
+            var shape = BuildCaptionMatcher(tipFormat);
+            if (shape == null) return;
+
             try
             {
                 var doomed = new List<ElementId>();
@@ -773,7 +785,7 @@ namespace StingTools.Core.Drawing
                     if (!(el is TextNote tn)) continue;
                     if (tn.GetTypeId() != noteTypeId) continue;
                     var text = (tn.Text ?? "").TrimEnd('\r', '\n');
-                    if (!string.Equals(text, caption, StringComparison.Ordinal)) continue;
+                    if (!shape.IsMatch(text)) continue;
                     XYZ c;
                     try { c = tn.Coord; } catch { continue; }
                     if (c == null) continue;
@@ -793,6 +805,49 @@ namespace StingTools.Core.Drawing
                 // Fail open: a failed prune means a possible duplicate caption,
                 // not a failed sweep.
                 r?.Warnings.Add($"Could not clear prior captions in '{view.Name}': {ex.Message}");
+            }
+        }
+
+        // Cache: caption template -> compiled shape matcher. One config is
+        // shared by an entire sweep, so this is built once per run in practice.
+        private static readonly Dictionary<string, System.Text.RegularExpressions.Regex> _captionMatchers
+            = new Dictionary<string, System.Text.RegularExpressions.Regex>(StringComparer.Ordinal);
+        private static readonly object _captionMatcherLock = new object();
+
+        /// <summary>
+        /// Turn a caption template such as "see {paired_ref} →" into a matcher
+        /// that recognises any rendered instance of it, whatever sheet number
+        /// it carries: everything outside the token is matched literally, the
+        /// token itself becomes a non-greedy wildcard.
+        ///
+        /// Anchored, so a note merely CONTAINING the caption is not swept up,
+        /// and the wildcard requires at least one character, so a template
+        /// that is nothing but the token cannot degenerate into "match every
+        /// note of this type".
+        /// </summary>
+        private static System.Text.RegularExpressions.Regex BuildCaptionMatcher(string tipFormat)
+        {
+            if (string.IsNullOrEmpty(tipFormat)) return null;
+            lock (_captionMatcherLock)
+            {
+                if (_captionMatchers.TryGetValue(tipFormat, out var cached)) return cached;
+                System.Text.RegularExpressions.Regex rx = null;
+                try
+                {
+                    const string token = "{paired_ref}";
+                    var parts = tipFormat.Split(new[] { token }, StringSplitOptions.None);
+                    var pattern = string.Join(".+?",
+                        parts.Select(System.Text.RegularExpressions.Regex.Escape));
+                    rx = new System.Text.RegularExpressions.Regex(
+                        "^" + pattern + "$",
+                        System.Text.RegularExpressions.RegexOptions.Compiled);
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"BuildCaptionMatcher('{tipFormat}'): {ex.Message}");
+                }
+                _captionMatchers[tipFormat] = rx;
+                return rx;
             }
         }
 

--- a/StingTools/Core/Drawing/TitleBlockParamApplier.cs
+++ b/StingTools/Core/Drawing/TitleBlockParamApplier.cs
@@ -29,6 +29,8 @@ namespace StingTools.Core.Drawing
     {
         public int ParamsWritten { get; set; }
         public int ParametersDeclared { get; set; }
+        /// <summary>Title-block instances skipped because PRJ_TB_LOCK_BOOL was set.</summary>
+        public int LockedSkipped { get; set; }
         public List<string> ParametersMissing { get; } = new List<string>();
         public List<string> Warnings { get; } = new List<string>();
     }
@@ -72,6 +74,23 @@ namespace StingTools.Core.Drawing
 
             foreach (var tb in tbs)
             {
+                // T-3: PRJ_TB_LOCK_BOOL is documented in MR_PARAMETERS.txt as
+                // "prevents TitleBlockParamApplier from overwriting manually
+                // set values on this sheet", but nothing in the declarative
+                // pipeline read it — only the legacy TitleBlockPopulate
+                // command did. Hand-authored cells were therefore clobbered by
+                // Heal / RevisionSync / Migrate. Skip and report, never skip
+                // silently: an unreported skip looks identical to a
+                // successful write in the result dialog.
+                if (IsTitleBlockLocked(tb))
+                {
+                    r.LockedSkipped++;
+                    r.Warnings.Add(
+                        $"Sheet '{sheet.SheetNumber}' title block is locked ({ParamRegistry.TB_LOCK}); " +
+                        "left untouched.");
+                    continue;
+                }
+
                 // GAP-M: a secondary title block (e.g. a North arrow or a
                 // fabrication-only stamp on the same sheet) typically has
                 // zero of the declared keys. Skip silently rather than
@@ -149,6 +168,33 @@ namespace StingTools.Core.Drawing
         /// helpers. No actual batching is performed — Apply() is
         /// lightweight enough to call per-sheet.
         /// </summary>
+        /// <summary>
+        /// True when the user has frozen this title block with
+        /// PRJ_TB_LOCK_BOOL. Read off the title-block instance, matching the
+        /// legacy TitleBlockPopulate gate; the sheet itself is checked as a
+        /// fallback for projects that bound the parameter to Sheets instead.
+        /// Single definition so the applier, the revision syncer and the heal
+        /// command cannot drift apart on what "locked" means.
+        /// </summary>
+        public static bool IsTitleBlockLocked(Element titleBlock, ViewSheet sheet = null)
+        {
+            try
+            {
+                if (titleBlock != null &&
+                    StingTools.Core.ParameterHelpers.GetInt(titleBlock, ParamRegistry.TB_LOCK, 0) != 0)
+                    return true;
+                if (sheet != null &&
+                    StingTools.Core.ParameterHelpers.GetInt(sheet, ParamRegistry.TB_LOCK, 0) != 0)
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                // Fail open: an unreadable lock flag must not block production.
+                StingTools.Core.StingLog.Warn($"IsTitleBlockLocked: {ex.Message}");
+            }
+            return false;
+        }
+
         public static IDisposable Batch() => NoOpScope.Instance;
 
         private sealed class NoOpScope : IDisposable

--- a/StingTools/Core/Drawing/TitleBlockRevisionSyncer.cs
+++ b/StingTools/Core/Drawing/TitleBlockRevisionSyncer.cs
@@ -10,9 +10,8 @@
 //   - on the ViewSheet:            SHT_REV_TXT, SHT_REV_DATE_TXT
 //   - on each title-block instance: PRJ_TB_REVISION_NR_TXT,
 //                                   PRJ_TB_REVISION_DATE_TXT,
-//                                   PRJ_TB_REVISION_DESCRIPTION_TXT,
-//                                   PRJ_TB_ISSUE_SUMMARY_TXT
-// Those four TB params are the ones STING_TITLE_BLOCKS.json actually
+//                                   PRJ_TB_REVISION_DESCRIPTION_TXT
+// Those three TB params are the ones STING_TITLE_BLOCKS.json actually
 // binds labels to, so the writes are visible on the drawing.
 //
 // The value written is Revision.RevisionNumber (e.g. "P01"), NEVER the
@@ -182,10 +181,34 @@ namespace StingTools.Core.Drawing
             // Revision box on every title-block instance on this sheet.
             foreach (var tb in CollectTitleBlocks(doc, sheet))
             {
+                // T-3: honour the user's freeze. The sheet-level SHT_REV_*
+                // stamps above are STING-owned and feed schedules / exports,
+                // so they keep syncing; the title-block cells are the
+                // hand-authorable ones the lock is named for, and they are
+                // left exactly as the user set them. Reported, never silent.
+                if (TitleBlockParamApplier.IsTitleBlockLocked(tb, sheet))
+                {
+                    result.SheetsSkipped++;
+                    result.Warnings.Add(
+                        $"Sheet '{sheet.SheetNumber}' title block is locked ({ParamRegistry.TB_LOCK}); " +
+                        "revision box left untouched (sheet-level revision stamps still updated).");
+                    continue;
+                }
+
                 if (WriteParamIfExists(tb, TbRevNrParam,   revNr))   result.ParamsWritten++;
                 if (WriteParamIfExists(tb, TbRevDateParam, revDate)) result.ParamsWritten++;
                 if (WriteParamIfExists(tb, TbRevDescParam, revDesc)) result.ParamsWritten++;
-                if (WriteParamIfExists(tb, ParamRegistry.TB_ISSUE_SUMMARY, revDesc)) result.ParamsWritten++;
+
+                // T-12: PRJ_TB_ISSUE_SUMMARY_TXT is NOT a revision field. The
+                // registry defines it as "Short free-text summary of the issue
+                // purpose (e.g. 'For Construction')" — author-owned, and
+                // distinct from PRJ_TB_REVISION_DESCRIPTION_TXT ("Brief
+                // description of what changed in the current revision"), which
+                // is written on the line above. Writing revDesc into it
+                // destroyed the user's issue purpose on every single sync, on
+                // every unlocked sheet. Removed rather than gated: the correct
+                // value already reaches the correct parameter, so there is
+                // nothing here worth preserving behind a flag.
             }
 
             result.SheetsProcessed++;

--- a/StingTools/Core/Drawing/ViewStylePack.cs
+++ b/StingTools/Core/Drawing/ViewStylePack.cs
@@ -66,6 +66,21 @@ namespace StingTools.Core.Drawing
 
         [JsonProperty("filters")] public List<StyleFilterRule> Filters { get; set; } = new List<StyleFilterRule>();
 
+        // Phase 139 alias pattern, applied one level down. The corporate
+        // STING_VIEW_STYLE_PACKS.json keys filter rules under "filterRules"
+        // on 11 of 35 packs (corp-base, corp-clarification,
+        // corp-demolition-phase and all 8 corp-healthcare-*) — 78 rules that
+        // the "filters"-only binding dropped silently, so healthcare
+        // pressure / MGPS / fire drawings rendered with no filter colour
+        // coding at all. No pack declares both keys, so this write-only
+        // alias is order-independent. Canonical Filters still serialises
+        // under "filters".
+        [JsonProperty("filterRules", NullValueHandling = NullValueHandling.Ignore)]
+        public List<StyleFilterRule> FilterRulesAlias
+        {
+            set { if (value != null && value.Count > 0) Filters = value; }
+        }
+
         /// <summary>
         /// Category-name → graphic override. Keys match Revit Category
         /// localised names (Walls / Grids / Rooms / etc.) or BIC strings.
@@ -244,7 +259,18 @@ namespace StingTools.Core.Drawing
         // (fire compartments, system colour washes, escape-route highlights).
         [JsonProperty("projectionLinePattern", NullValueHandling = NullValueHandling.Ignore)] public string ProjectionLinePattern { get; set; }
         [JsonProperty("cutLinePattern",        NullValueHandling = NullValueHandling.Ignore)] public string CutLinePattern { get; set; }
-        [JsonProperty("surfaceFgColor",        NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgColor { get; set; }
+        [JsonIgnore] public string SurfaceFgColor { get; set; }
+
+        // Short-form aliases for the two extended fields the corporate file
+        // actually uses: "surfFgColor" (15×) and "projLinePattern" (5×).
+        // The Phase 139 pass aliased projColor/projWeight/cutColor/cutWeight
+        // but stopped short of these, so they bound nowhere.
+        [JsonProperty("surfaceFgColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceFgColorLong { get => SurfaceFgColor; set { if (!string.IsNullOrEmpty(value)) SurfaceFgColor = value; } }
+        [JsonProperty("surfFgColor", NullValueHandling = NullValueHandling.Ignore)]
+        public string SurfaceFgColorShort { get => null; set { if (!string.IsNullOrEmpty(value)) SurfaceFgColor = value; } }
+        [JsonProperty("projLinePattern", NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjLinePatternShort { get => null; set { if (!string.IsNullOrEmpty(value)) ProjectionLinePattern = value; } }
         [JsonProperty("surfaceFgPattern",      NullValueHandling = NullValueHandling.Ignore)] public string SurfaceFgPattern { get; set; }
         [JsonProperty("surfaceBgColor",        NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgColor { get; set; }
         [JsonProperty("surfaceBgPattern",      NullValueHandling = NullValueHandling.Ignore)] public string SurfaceBgPattern { get; set; }
@@ -268,11 +294,42 @@ namespace StingTools.Core.Drawing
     public sealed class StyleVgOverride
     {
         [JsonProperty("halftone",              NullValueHandling = NullValueHandling.Ignore)] public bool?   Halftone { get; set; }
-        [JsonProperty("projectionLineWeight",  NullValueHandling = NullValueHandling.Ignore)] public int?    ProjectionLineWeight { get; set; }
-        [JsonProperty("projectionLineColor",   NullValueHandling = NullValueHandling.Ignore)] public string  ProjectionLineColor { get; set; }
-        [JsonProperty("cutLineWeight",         NullValueHandling = NullValueHandling.Ignore)] public int?    CutLineWeight { get; set; }
-        [JsonProperty("cutLineColor",          NullValueHandling = NullValueHandling.Ignore)] public string  CutLineColor { get; set; }
         [JsonProperty("transparency",          NullValueHandling = NullValueHandling.Ignore)] public int?    Transparency { get; set; }
+
+        // Phase 139 alias pattern (as on StyleFilterRule). The corporate
+        // vgOverrides blocks mix both spellings across packs — long form
+        // projectionLineColor/projectionLineWeight/cutLineColor/cutLineWeight
+        // (107/107/45/45 occurrences) and short form
+        // projColor/projWeight/cutColor/cutWeight (188/209/9/14). Only the
+        // long form bound, so ~420 authored line colours/weights were
+        // dropped silently and most packs lost their line graphics. No
+        // single override object declares both spellings, so these
+        // write-only aliases are order-independent. The canonical fields
+        // still serialise under the long names.
+        [JsonIgnore] public int?   ProjectionLineWeight { get; set; }
+        [JsonIgnore] public string ProjectionLineColor  { get; set; }
+        [JsonIgnore] public int?   CutLineWeight        { get; set; }
+        [JsonIgnore] public string CutLineColor         { get; set; }
+
+        [JsonProperty("projectionLineWeight",  NullValueHandling = NullValueHandling.Ignore)]
+        public int?   ProjLineWeightLong  { get => ProjectionLineWeight; set { if (value.HasValue) ProjectionLineWeight = value; } }
+        [JsonProperty("projWeight",            NullValueHandling = NullValueHandling.Ignore)]
+        public int?   ProjLineWeightShort { get => null; set { if (value.HasValue) ProjectionLineWeight = value; } }
+
+        [JsonProperty("projectionLineColor",   NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjLineColorLong  { get => ProjectionLineColor; set { if (!string.IsNullOrEmpty(value)) ProjectionLineColor = value; } }
+        [JsonProperty("projColor",             NullValueHandling = NullValueHandling.Ignore)]
+        public string ProjLineColorShort { get => null; set { if (!string.IsNullOrEmpty(value)) ProjectionLineColor = value; } }
+
+        [JsonProperty("cutLineWeight",         NullValueHandling = NullValueHandling.Ignore)]
+        public int?   CutLineWeightLong  { get => CutLineWeight; set { if (value.HasValue) CutLineWeight = value; } }
+        [JsonProperty("cutWeight",             NullValueHandling = NullValueHandling.Ignore)]
+        public int?   CutLineWeightShort { get => null; set { if (value.HasValue) CutLineWeight = value; } }
+
+        [JsonProperty("cutLineColor",          NullValueHandling = NullValueHandling.Ignore)]
+        public string CutLineColorLong  { get => CutLineColor; set { if (!string.IsNullOrEmpty(value)) CutLineColor = value; } }
+        [JsonProperty("cutColor",              NullValueHandling = NullValueHandling.Ignore)]
+        public string CutLineColorShort { get => null; set { if (!string.IsNullOrEmpty(value)) CutLineColor = value; } }
 
         // Optional visibility flag — true = show, false = hide. Null = leave as-is.
         // Phase 113+ presentation packs use this to hide MEP / structural framing

--- a/StingTools/Core/Drawing/ViewStylePackApplier.cs
+++ b/StingTools/Core/Drawing/ViewStylePackApplier.cs
@@ -514,7 +514,18 @@ namespace StingTools.Core.Drawing
                     catch (Exception ex) { StingTools.Core.StingLog.WarnRateLimited("MatClassFilter.Rule", $"Rule build: {ex.Message}"); }
                 }
                 if (rules.Count == 0) return existing;
-                ElementParameterFilter elemFilter = new ElementParameterFilter(rules, false /* OR semantics across the rules */);
+
+                // One ElementParameterFilter per rule, OR-ed together.
+                // ElementParameterFilter's second argument is `inverted`,
+                // not "use OR" — multiple FilterRules handed to a single
+                // ElementParameterFilter are AND-ed. This filter asks
+                // "material is any of these N materials in the class", so
+                // the AND form (material == A AND material == B) could
+                // never match anything once a class had more than one
+                // material. Mirrors AecFilterFactory.BuildFilter.
+                ElementFilter elemFilter = rules.Count == 1
+                    ? (ElementFilter)new ElementParameterFilter(rules[0])
+                    : new LogicalOrFilter(rules.Select(r => (ElementFilter)new ElementParameterFilter(r)).ToList());
 
                 ParameterFilterElement built;
                 if (existing == null)

--- a/StingTools/Core/Drawing/ViewStylePackRegistry.cs
+++ b/StingTools/Core/Drawing/ViewStylePackRegistry.cs
@@ -207,9 +207,19 @@ namespace StingTools.Core.Drawing
 
             // Fold parent → child. Later entries overwrite earlier.
             chain.Reverse();
-            var merged = new ViewStylePack { Id = leaf.Id, Name = leaf.Name, Origin = leaf.Origin };
+            var merged = new ViewStylePack { Id = leaf.Id, Name = leaf.Name, Origin = leaf.Origin, Extends = leaf.Extends };
             foreach (var p in chain)
             {
+                // Carry every field not explicitly merged below. Without
+                // this the fold dropped templateMode / managedFields /
+                // discipline / visualStyle / viewRange / worksetVisibility /
+                // linkOverrides / colorFillSchemes / categoryDepths /
+                // categoryTag7Sections / viewTemplate / detailLevel /
+                // scaleHint / colorScheme — and since all 35 shipped packs
+                // declare `extends`, that ran on every Get(), which is why
+                // IsManaged never survived to DrawingTypePresentation.
+                ExtendsMerge.Overlay(p, merged, _overlayProps);
+
                 if (p.LineWeightScale != 0) merged.LineWeightScale = p.LineWeightScale;
                 if (!string.IsNullOrEmpty(p.TextStyle))      merged.TextStyle      = p.TextStyle;
                 if (!string.IsNullOrEmpty(p.DimensionStyle)) merged.DimensionStyle = p.DimensionStyle;
@@ -229,9 +239,53 @@ namespace StingTools.Core.Drawing
                         merged.CategoryTagStyles = new Dictionary<string, string>();
                     foreach (var kv in p.CategoryTagStyles) merged.CategoryTagStyles[kv.Key] = kv.Value;
                 }
+
+                // Phase 177 per-category maps — merge by key like their
+                // siblings above rather than letting the child's whole
+                // dictionary replace the parent's.
+                if (p.CategoryDepths != null)
+                {
+                    if (merged.CategoryDepths == null)
+                        merged.CategoryDepths = new Dictionary<string, int>();
+                    foreach (var kv in p.CategoryDepths) merged.CategoryDepths[kv.Key] = kv.Value;
+                }
+                if (p.CategoryTag7Sections != null)
+                {
+                    if (merged.CategoryTag7Sections == null)
+                        merged.CategoryTag7Sections = new Dictionary<string, bool>();
+                    foreach (var kv in p.CategoryTag7Sections) merged.CategoryTag7Sections[kv.Key] = kv.Value;
+                }
             }
             return merged;
         }
+
+        // Fields the fold above merges by hand — collections with
+        // accumulate / merge-by-key semantics, plus the identity fields
+        // taken from the leaf and the scalars whose existing guards are
+        // preserved verbatim. Everything else is carried by
+        // ExtendsMerge.Overlay.
+        private static readonly HashSet<string> _overlaySkip = new HashSet<string>(StringComparer.Ordinal)
+        {
+            nameof(ViewStylePack.Id),
+            nameof(ViewStylePack.Name),
+            nameof(ViewStylePack.Origin),
+            nameof(ViewStylePack.Extends),
+            nameof(ViewStylePack.LineWeightScale),
+            nameof(ViewStylePack.TextStyle),
+            nameof(ViewStylePack.DimensionStyle),
+            nameof(ViewStylePack.HatchPalette),
+            nameof(ViewStylePack.TagColorScheme),
+            nameof(ViewStylePack.DefaultTagStyle),
+            nameof(ViewStylePack.Filters),
+            nameof(ViewStylePack.VgOverrides),
+            nameof(ViewStylePack.TagFamilies),
+            nameof(ViewStylePack.CategoryTagStyles),
+            nameof(ViewStylePack.CategoryDepths),
+            nameof(ViewStylePack.CategoryTag7Sections),
+        };
+
+        private static readonly System.Reflection.PropertyInfo[] _overlayProps
+            = ExtendsMerge.OverlayProps(typeof(ViewStylePack), _overlaySkip);
 
         private static string DocKey(Document doc)
         {

--- a/StingTools/Core/Fabrication/ShopDrawingComposer.cs
+++ b/StingTools/Core/Fabrication/ShopDrawingComposer.cs
@@ -133,7 +133,7 @@ namespace StingTools.Core.Fabrication
             else
             {
                 // 1) DrawingType profile (corporate spool A1 etc.)
-                tbId = ResolveTitleBlockFromDrawingType(doc, drawingType);
+                tbId = ResolveTitleBlockFromDrawingType(doc, drawingType, result);
                 // 2) Project Setup Wizard router — single source of truth
                 //    populated by ProjectSetupCommand. Honoured here so the
                 //    fabrication path obeys the same per-discipline policy
@@ -767,30 +767,80 @@ namespace StingTools.Core.Fabrication
         }
 
         private static ElementId ResolveTitleBlockFromDrawingType(
-            Document doc, StingTools.Core.Drawing.DrawingType dt)
+            Document doc, StingTools.Core.Drawing.DrawingType dt, FabricationResult result)
         {
             if (dt == null || string.IsNullOrWhiteSpace(dt.TitleBlockFamily))
                 return ElementId.InvalidElementId;
             try
             {
-                // Mirror DrawingTypeSheetAdapter.ResolveTitleBlock so the
-                // optional TitleBlockSymbolType variant (Tender / Construction
-                // / As-Built etc.) is honoured on the fabrication path too.
-                var matches = new FilteredElementCollector(doc)
-                    .OfCategory(BuiltInCategory.OST_TitleBlocks)
-                    .OfClass(typeof(FamilySymbol))
-                    .Cast<FamilySymbol>()
-                    .Where(fs => string.Equals(
-                        fs.FamilyName, dt.TitleBlockFamily, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-                if (!string.IsNullOrWhiteSpace(dt.TitleBlockSymbolType))
+                var declared = dt.TitleBlockFamily;
+
+                // T-1: this tier used to literal-match the profile's declared
+                // name against loaded family names. Drawing types declare
+                // logical names (STING_TB_ASSEMBLY_PIPE) while TitleBlockFactory
+                // saves versioned families (STING_TB_ASSEMBLY_PIPE_v1.0), so the
+                // match never hit and every spool sheet fell through to the
+                // discipline dictionary and ultimately "first title block in the
+                // project". TitleBlockResolver exists precisely for this
+                // mapping; the composer was simply never wired to it.
+                //
+                // Its output is best-effort, not guaranteed concrete: A2/A4 and
+                // unknown vocabulary come back unchanged, and a PRESENT name
+                // resolves to the A1 presentation family regardless of paper
+                // size (review T-6). So try the resolved name, then the declared
+                // one, before giving up.
+                var concrete = StingTools.Core.Drawing.TitleBlockResolver.ToConcreteFamily(doc, dt, declared);
+
+                List<FamilySymbol> Collect(string family) =>
+                    string.IsNullOrWhiteSpace(family)
+                        ? new List<FamilySymbol>()
+                        : new FilteredElementCollector(doc)
+                            .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                            .OfClass(typeof(FamilySymbol))
+                            .Cast<FamilySymbol>()
+                            .Where(fs => string.Equals(fs.FamilyName, family, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+
+                var candidates = new List<string>();
+                foreach (var c in new[] { concrete, declared })
+                    if (!string.IsNullOrWhiteSpace(c) &&
+                        !candidates.Any(x => string.Equals(x, c, StringComparison.OrdinalIgnoreCase)))
+                        candidates.Add(c);
+
+                foreach (var candidate in candidates)
                 {
-                    var picked = matches.FirstOrDefault(fs => string.Equals(
-                        fs.Name, dt.TitleBlockSymbolType, StringComparison.OrdinalIgnoreCase));
-                    if (picked != null) return picked.Id;
+                    var matches = Collect(candidate);
+                    // Built but not yet loaded — pull it from disk on demand,
+                    // same as the production path does.
+                    if (matches.Count == 0 &&
+                        StingTools.Core.Drawing.TitleBlockResolver.EnsureFamilyLoaded(doc, candidate))
+                        matches = Collect(candidate);
+                    if (matches.Count == 0) continue;
+
+                    // Mirror DrawingTypeSheetAdapter.ResolveTitleBlock so the
+                    // optional TitleBlockSymbolType variant (Tender /
+                    // Construction / As-Built etc.) is honoured here too.
+                    if (!string.IsNullOrWhiteSpace(dt.TitleBlockSymbolType))
+                    {
+                        var picked = matches.FirstOrDefault(fs => string.Equals(
+                            fs.Name, dt.TitleBlockSymbolType, StringComparison.OrdinalIgnoreCase));
+                        if (picked != null) return picked.Id;
+                        result?.Warnings.Add(
+                            $"Title-block type '{dt.TitleBlockSymbolType}' not found in family " +
+                            $"'{candidate}'; used '{matches[0].Name}'.");
+                    }
+                    return matches[0].Id;
                 }
-                var fallback = matches.FirstOrDefault();
-                if (fallback != null) return fallback.Id;
+
+                // Falling through here is not fatal — the caller still tries the
+                // project title-block router and the per-discipline dictionary —
+                // but it was previously silent, which is how spool sheets ended
+                // up on an arbitrary title block with no indication.
+                result?.Warnings.Add(
+                    $"Drawing type '{dt.Id}' declares title block '{declared}'" +
+                    (string.Equals(concrete, declared, StringComparison.OrdinalIgnoreCase)
+                        ? "" : $" (resolved to '{concrete}')") +
+                    " but no such family is loaded or loadable; falling back to the project router.");
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1507,6 +1507,22 @@ namespace StingTools.Core
                 case "Routing_PlaceSleeveConnectors": return new Commands.Routing.PlaceSleeveConnectorsCommand();
                 case "Routing_PlaceSleeveConnectorsAuto": return new Commands.Routing.PlaceSleeveConnectorsAutoCommand();
                 case "Validation_RunAll":        return new Commands.Validation.RunAllValidatorsCommand();
+
+                // Penetration pipeline — same "green build, dead runtime"
+                // trap as the rough-in steps above. These three tags existed
+                // only in StingCommandHandler's switch, so every step of
+                // WORKFLOW_PenetrationSweep.json and
+                // WORKFLOW_PenetrationRegister.json that used them resolved
+                // to null and reported FAILED.
+                //
+                // DrawingTypes_FromScopeBoxes resolves to the real command
+                // class; the dock-panel button for that tag runs a separate
+                // inline reimplementation in the handler (see W-5 in the
+                // drawings-production review) — converging the two is
+                // deliberately left out of this P0 pass.
+                case "Penetrations_DetectAndPlace":    return new Commands.Routing.PenetrationsDetectAndPlaceCommand();
+                case "Validation_PenetrationCoverage": return new Commands.Validation.PenetrationCoverageCommand();
+                case "DrawingTypes_FromScopeBoxes":    return new Commands.Drawing.GenerateFromScopeBoxesCommand();
                 case "Symbols_CreateCompound":      return new Commands.Symbols.CreateCompoundSymbolsCommand();
                 case "Symbols_CreateSLD_IEEE":      return new Commands.Symbols.CreateSLDSymbolsIEEECommand();
                 case "Symbols_CreateSLD_BS":        return new Commands.Symbols.CreateSLDSymbolsBSCommand();

--- a/StingTools/Data/LABEL_DEFINITIONS.json
+++ b/StingTools/Data/LABEL_DEFINITIONS.json
@@ -1,13 +1,13 @@
 {
   "version": "5.12",
-  "description": "STING Seed Tag v5.9 â€” master label specification. Paragraph tiers 1..10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.9: backfilled 12 CSV-only families and enriched 39 Revit-category entries with CSV-derived tier_1/2/3 rows. Total 138 categories covering 142 tag families. Naming note: Revit BuiltInCategory display names are plural â€” CSVs use singular family names â€” csv_family_alias field links the two.) | v5.10: tier_5 cost rows extended with 14 currency-neutral / payment-cert / variation params (Phase 184 P0.2 + P5) on 19 cost-bound categories; tier_7 fab rows extended with HVAC sizing audit-trail params (Phase 182-183) on 14 MEP categories | v5.11: +76 entries (Phase 187) â€” 58 healthcare + 9 LPS (6 base + 3 reuse) + 7 ARCH/STR variants (Curtain Panel/Mullion, Railing, Architectural Column, Structural Connection/Slab/Wall) + 2 Tie-In Pipe variants (FP Pipe, Gas Pipe). Aligns category_labels with the 204-family TagFamilyConfig (CategoryTemplateMap + variants + HealthcareVariantFamilies). | v5.12: removed 10 stale entries (Phase 187 dedup) â€” 4 plural duplicates (Curtain Panels, Curtain Wall Mullions, Railings, Structural Connections â€” superseded by singular forms) and 6 entries for families the creator never emits (Analytical Duct/Pipe Segments, Area Based Loads, MEP Ancillary, Temporary Structures, Wash).",
+  "description": "STING Seed Tag v5.9 — master label specification. Paragraph tiers 1..10. All BOOL parameters referenced inside tag-family Calculated Values are stored as TEXT in MR_PARAMETERS v5.3+ (Revit label formulas cannot reference YESNO params inside if(...)). Includes 99 threshold warnings with all columns populated. (v5.9: backfilled 12 CSV-only families and enriched 39 Revit-category entries with CSV-derived tier_1/2/3 rows. Total 138 categories covering 142 tag families. Naming note: Revit BuiltInCategory display names are plural — CSVs use singular family names — csv_family_alias field links the two.) | v5.10: tier_5 cost rows extended with 14 currency-neutral / payment-cert / variation params (Phase 184 P0.2 + P5) on 19 cost-bound categories; tier_7 fab rows extended with HVAC sizing audit-trail params (Phase 182-183) on 14 MEP categories | v5.11: +76 entries (Phase 187) — 58 healthcare + 9 LPS (6 base + 3 reuse) + 7 ARCH/STR variants (Curtain Panel/Mullion, Railing, Architectural Column, Structural Connection/Slab/Wall) + 2 Tie-In Pipe variants (FP Pipe, Gas Pipe). Aligns category_labels with the 204-family TagFamilyConfig (CategoryTemplateMap + variants + HealthcareVariantFamilies). | v5.12: removed 10 stale entries (Phase 187 dedup) — 4 plural duplicates (Curtain Panels, Curtain Wall Mullions, Railings, Structural Connections — superseded by singular forms) and 6 entries for families the creator never emits (Analytical Duct/Pipe Segments, Area Based Loads, MEP Ancillary, Temporary Structures, Wash).",
   "presentation_modes": {
     "Compact": {
       "state_1": true,
       "state_2": false,
       "state_3": false,
       "warnings": false,
-      "description": "Basic identification â€” tag code + type name only",
+      "description": "Basic identification — tag code + type name only",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -21,7 +21,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": true,
-      "description": "Engineering documentation â€” key properties + threshold warnings",
+      "description": "Engineering documentation — key properties + threshold warnings",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -35,7 +35,7 @@
       "state_2": true,
       "state_3": true,
       "warnings": true,
-      "description": "Complete specification â€” all tiers + paragraph + warnings",
+      "description": "Complete specification — all tiers + paragraph + warnings",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -49,7 +49,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": false,
-      "description": "Client presentation â€” clean tags without warning text",
+      "description": "Client presentation — clean tags without warning text",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -63,7 +63,7 @@
       "state_2": true,
       "state_3": false,
       "warnings": false,
-      "description": "Bill of Quantities â€” identity + quantities for cost schedules",
+      "description": "Bill of Quantities — identity + quantities for cost schedules",
       "state_4": false,
       "state_5": false,
       "state_6": false,
@@ -84,7 +84,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": false,
-      "description": "FM handover â€” identity + commissioning + maintenance (T1-T4)"
+      "description": "FM handover — identity + commissioning + maintenance (T1-T4)"
     },
     "Procurement": {
       "state_1": true,
@@ -98,7 +98,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": false,
-      "description": "Procurement / cost manager â€” identity + cost roll-up (T1-T5)"
+      "description": "Procurement / cost manager — identity + cost roll-up (T1-T5)"
     },
     "Carbon": {
       "state_1": true,
@@ -112,7 +112,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Sustainability audit â€” identity + carbon stages A1-C4 (T1-T3+T6)"
+      "description": "Sustainability audit — identity + carbon stages A1-C4 (T1-T3+T6)"
     },
     "Fabrication": {
       "state_1": true,
@@ -126,7 +126,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Shop drawings / fab package â€” identity + fab+QC (T1-T3+T7)"
+      "description": "Shop drawings / fab package — identity + fab+QC (T1-T3+T7)"
     },
     "Coordination": {
       "state_1": true,
@@ -140,7 +140,7 @@
       "state_9": false,
       "state_10": false,
       "warnings": true,
-      "description": "Clash / coordination review â€” identity + clash triage (T1-T3+T8)"
+      "description": "Clash / coordination review — identity + clash triage (T1-T3+T8)"
     },
     "AsBuilt": {
       "state_1": true,
@@ -154,7 +154,7 @@
       "state_9": true,
       "state_10": false,
       "warnings": false,
-      "description": "As-built model â€” identity + commissioning + asbuilt/health (T1-T4+T9)"
+      "description": "As-built model — identity + commissioning + asbuilt/health (T1-T4+T9)"
     },
     "Audit": {
       "state_1": true,
@@ -168,60 +168,60 @@
       "state_9": true,
       "state_10": true,
       "warnings": true,
-      "description": "Full audit trail â€” every tier + warnings (T1-T10)"
+      "description": "Full audit trail — every tier + warnings (T1-T10)"
     }
   },
   "calculated_value_templates": {
     "cv_show_tier2": {
       "name": "Show Tier 2",
       "formula": "if(TAG_PARA_STATE_2_BOOL, <param>, \"\")",
-      "description": "Gates tier 2 parameters â€” visible at Standard or above"
+      "description": "Gates tier 2 parameters — visible at Standard or above"
     },
     "cv_show_tier3": {
       "name": "Show Tier 3",
       "formula": "if(TAG_PARA_STATE_3_BOOL, <param>, \"\")",
-      "description": "Gates tier 3 parameters â€” visible at Comprehensive"
+      "description": "Gates tier 3 parameters — visible at Comprehensive"
     },
     "cv_show_warning": {
       "name": "Show Warning",
       "formula": "if(TAG_WARN_VISIBLE_BOOL, <param>, \"\")",
-      "description": "Gates warning text â€” visible when warnings enabled. Respects TAG_WARN_SEVERITY_FILTER_TXT"
+      "description": "Gates warning text — visible when warnings enabled. Respects TAG_WARN_SEVERITY_FILTER_TXT"
     },
-    "_comment": "Calculated Value templates that tag family labels plug in to. CONDITION-FORM CONTRACT: every BOOL gate referenced by one of these templates is stored as YESNO in MR_PARAMETERS v5.4+ â€” YESNO is Revit's native type for an if()/and()/or() condition, so the gate is written BARE: `if(gate, <param>, \"\")`. Do NOT compare a YESNO gate to \"Yes\" â€” Revit rejects `gate` on a YESNO parameter with 'Inconsistent Units'. The VALUE parameter in the <param> position must stay TEXT (a Revit label can only emit a TEXT result). The emitter (TagConfig.GateToken via FamilyLabelAuthor) picks the form per storage type â€” it emits bare for YESNO and stays the safety net for any legacy family still holding a gate as TEXT. The file-declared gate type (MR_PARAMETERS.txt) must equal the type bound in the project and in the tag family.",
+    "_comment": "Calculated Value templates that tag family labels plug in to. CONDITION-FORM CONTRACT: every BOOL gate referenced by one of these templates is stored as YESNO in MR_PARAMETERS v5.4+ — YESNO is Revit's native type for an if()/and()/or() condition, so the gate is written BARE: `if(gate, <param>, \"\")`. Do NOT compare a YESNO gate to \"Yes\" — Revit rejects `gate` on a YESNO parameter with 'Inconsistent Units'. The VALUE parameter in the <param> position must stay TEXT (a Revit label can only emit a TEXT result). The emitter (TagConfig.GateToken via FamilyLabelAuthor) picks the form per storage type — it emits bare for YESNO and stays the safety net for any legacy family still holding a gate as TEXT. The file-declared gate type (MR_PARAMETERS.txt) must equal the type bound in the project and in the tag family.",
     "cv_show_tier4": {
       "name": "Show Tier 4",
       "formula": "if(TAG_PARA_STATE_4_BOOL, <param>, \"\")",
-      "description": "Gates tier 4 â€” Commissioning & handover data"
+      "description": "Gates tier 4 — Commissioning & handover data"
     },
     "cv_show_tier5": {
       "name": "Show Tier 5",
       "formula": "if(TAG_PARA_STATE_5_BOOL, <param>, \"\")",
-      "description": "Gates tier 5 â€” Cost & procurement roll-up"
+      "description": "Gates tier 5 — Cost & procurement roll-up"
     },
     "cv_show_tier6": {
       "name": "Show Tier 6",
       "formula": "if(TAG_PARA_STATE_6_BOOL, <param>, \"\")",
-      "description": "Gates tier 6 â€” Carbon & sustainability (A1-A3 / A4 / A5 / B6 / C1-C4)"
+      "description": "Gates tier 6 — Carbon & sustainability (A1-A3 / A4 / A5 / B6 / C1-C4)"
     },
     "cv_show_tier7": {
       "name": "Show Tier 7",
       "formula": "if(TAG_PARA_STATE_7_BOOL, <param>, \"\")",
-      "description": "Gates tier 7 â€” Fabrication & QC (spool, weld/bolt/flange counts, QC inspector)"
+      "description": "Gates tier 7 — Fabrication & QC (spool, weld/bolt/flange counts, QC inspector)"
     },
     "cv_show_tier8": {
       "name": "Show Tier 8",
       "formula": "if(TAG_PARA_STATE_8_BOOL, <param>, \"\")",
-      "description": "Gates tier 8 â€” Clash & coordination (triage score, severity, resolution action)"
+      "description": "Gates tier 8 — Clash & coordination (triage score, severity, resolution action)"
     },
     "cv_show_tier9": {
       "name": "Show Tier 9",
       "formula": "if(TAG_PARA_STATE_9_BOOL, <param>, \"\")",
-      "description": "Gates tier 9 â€” As-built & model health metrics"
+      "description": "Gates tier 9 — As-built & model health metrics"
     },
     "cv_show_tier10": {
       "name": "Show Tier 10",
       "formula": "if(TAG_PARA_STATE_10_BOOL, <param>, \"\")",
-      "description": "Gates tier 10 â€” Compliance / audit trail (RGL_*, IFC_PSET_OVERRIDE_TXT)"
+      "description": "Gates tier 10 — Compliance / audit trail (RGL_*, IFC_PSET_OVERRIDE_TXT)"
     },
     "cv_show_section_a": {
       "name": "Show TAG7 Section A",
@@ -265,7 +265,7 @@
       "prefix": "",
       "suffix": "",
       "label": "Scheme Tag (project grammar)",
-      "note": "Project-grammar rendering of the canonical tokens (TagSchemeEngine) â€” e.g. ISO 19650 KUT-ZZZ-XX-XX-M3-A-0001. Add this as a label row on an annotation tag family to display the scheme identifier on drawings. Derived, never hand-edited."
+      "note": "Project-grammar rendering of the canonical tokens (TagSchemeEngine) — e.g. ISO 19650 KUT-ZZZ-XX-XX-M3-A-0001. Add this as a label row on an annotation tag family to display the scheme identifier on drawings. Derived, never hand-edited."
     },
     "ASS_TAG_2_TXT": {
       "prefix": "",
@@ -275,7 +275,7 @@
         "tier_2": "underline",
         "tier_3": "bold underline"
       },
-      "note": "Heading line in TAG7 â€” underlined in State 2, bold+underlined in State 3. Style controlled via batch command."
+      "note": "Heading line in TAG7 — underlined in State 2, bold+underlined in State 3. Style controlled via batch command."
     },
     "ASS_TAG_4_TXT": {
       "prefix": "",
@@ -354,7 +354,7 @@
     },
     "BLE_ROOF_SLOPE_DEG": {
       "prefix": "Slope: ",
-      "suffix": "Â°",
+      "suffix": "°",
       "label": "Roof Slope"
     },
     "BLE_ROOF_COVERING_MAT_TXT": {
@@ -394,7 +394,7 @@
     },
     "BLE_WINDOW_U_VALUE_W_M_2K_NR": {
       "prefix": "U=",
-      "suffix": " W/mÂ²K",
+      "suffix": " W/m²K",
       "label": "Window U-Value"
     },
     "BLE_WINDOW_FRAME_MAT_TXT": {
@@ -464,12 +464,12 @@
     },
     "PER_THERM_U_VALUE_W_M2K": {
       "prefix": "U=",
-      "suffix": " W/mÂ²K",
+      "suffix": " W/m²K",
       "label": "Thermal U-Value"
     },
     "PER_THERM_R_VALUE_M2K_W": {
       "prefix": "R=",
-      "suffix": " mÂ²K/W",
+      "suffix": " m²K/W",
       "label": "Thermal R-Value"
     },
     "PER_THERM_CONDENSATION_RISK_TXT": {
@@ -609,7 +609,7 @@
     },
     "FLS_SFTY_COVERAGE_AREA_SQ_M": {
       "prefix": "Coverage: ",
-      "suffix": " mÂ²",
+      "suffix": " m²",
       "label": "Sprinkler Coverage"
     },
     "FLS_SFTY_K_FACTOR_NR": {
@@ -664,10 +664,10 @@
     },
     "PER_SUST_EMBODIED_CARBON_KG": {
       "prefix": "",
-      "suffix": " kgCOâ‚‚e",
+      "suffix": " kgCO₂e",
       "label": "Embodied Carbon"
     },
-    "_paragraph_comment": "TAG7 paragraph containers â€” tier_3 natural-language specification paragraphs. No prefix/suffix needed as content is a pre-assembled descriptive statement from the formula engine.",
+    "_paragraph_comment": "TAG7 paragraph containers — tier_3 natural-language specification paragraphs. No prefix/suffix needed as content is a pre-assembled descriptive statement from the formula engine.",
     "ARCH_TAG_7_PARA_WALL_TXT": {
       "prefix": "",
       "suffix": "",
@@ -890,7 +890,7 @@
     },
     "ELC_CBL_FEEDER_SZ_MM2": {
       "prefix": "Feeder: ",
-      "suffix": " mmÂ²",
+      "suffix": " mm²",
       "label": "Feeder Cable Size"
     },
     "ELC_PNL_SHORT_CIRCUIT_RATING_KA": {
@@ -955,7 +955,7 @@
     },
     "ASS_ROOM_AREA_SQ_M": {
       "prefix": "",
-      "suffix": " mÂ²",
+      "suffix": " m²",
       "label": "Room Area"
     },
     "MEP_TIE_POINT_ID_TXT": {
@@ -964,20 +964,20 @@
       "label": "MEP Tie-Point Identifier"
     },
     "WARN_BLE_RAMP_SLOPE_PCT_RAMPS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Ramp Slope"
     },
     "WARN_ELC_LPS_NO_CLASS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: LPS Class Missing",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-1:2011 Â§8",
+      "standard": "BS EN 62305-1:2011 §8",
       "severity": "CRITICAL"
     },
     "WARN_ELC_LPS_DOWN_COND_INSUFFICIENT": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Insufficient Down Conductors",
       "data_type": "TEXT",
@@ -985,15 +985,15 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_EARTH_RESISTANCE_HIGH": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
-      "label": "Warning: Earth Resistance > 10 Î©",
+      "label": "Warning: Earth Resistance > 10 Ω",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 Â§5.4.1",
+      "standard": "BS EN 62305-3:2011 §5.4.1",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_RISK_ASSESSMENT": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: No Risk Assessment",
       "data_type": "TEXT",
@@ -1001,23 +1001,23 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_SEPARATION_FAIL": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Separation Distance Fail",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 Â§6.3",
+      "standard": "BS EN 62305-3:2011 §6.3",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_INSPECTION_OVERDUE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Inspection Overdue",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 Â§E.7",
+      "standard": "BS EN 62305-3:2011 §E.7",
       "severity": "MEDIUM"
     },
     "WARN_ELC_LPS_CONDUCTOR_CROSS_SECT_LOW": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Cross-Section Below Min",
       "data_type": "TEXT",
@@ -1025,15 +1025,15 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_BONDING": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: No Bonding Type",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-3:2011 Â§6.2",
+      "standard": "BS EN 62305-3:2011 §6.2",
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_MESH_SIZE_EXCEEDED": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Mesh Exceeds Class",
       "data_type": "TEXT",
@@ -1041,11 +1041,11 @@
       "severity": "HIGH"
     },
     "WARN_ELC_LPS_NO_ZONE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: LPZ Not Assigned",
       "data_type": "TEXT",
-      "standard": "BS EN 62305-4:2011 Â§4.1",
+      "standard": "BS EN 62305-4:2011 §4.1",
       "severity": "MEDIUM"
     },
     "ELC_LPS_CLASS_TXT": {
@@ -1069,8 +1069,8 @@
       "label": "Air Termination Mesh Size"
     },
     "ELC_LPS_PROTECTION_ANGLE_DEG": {
-      "prefix": "Î±:",
-      "suffix": "Â°",
+      "prefix": "α:",
+      "suffix": "°",
       "label": "Protection Angle"
     },
     "ELC_LPS_AIR_TERMINAL_COUNT_NR": {
@@ -1090,7 +1090,7 @@
     },
     "ELC_LPS_EARTH_RESISTANCE_OHM": {
       "prefix": "R:",
-      "suffix": " Î©",
+      "suffix": " Ω",
       "label": "Earth Resistance"
     },
     "ELC_LPS_EARTH_TYPE_TXT": {
@@ -1115,7 +1115,7 @@
     },
     "ELC_LPS_CONDUCTOR_CROSS_SECT_MM2": {
       "prefix": "A:",
-      "suffix": " mmÂ²",
+      "suffix": " mm²",
       "label": "Conductor Cross-Section"
     },
     "ELC_LPS_CONDUCTOR_MATERIAL_TXT": {
@@ -1150,7 +1150,7 @@
     },
     "ELC_LPS_PROJECT_NG_OVERRIDE_NR": {
       "prefix": "Ng:",
-      "suffix": " /kmÂ²/yr",
+      "suffix": " /km²/yr",
       "label": "Ground Flash Density"
     },
     "ELC_LPS_AIRTERM_TAG_TXT": {
@@ -1209,272 +1209,272 @@
       "label": "Circuit Label Override (SLD)"
     },
     "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Voltage Drop"
     },
     "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Sprinkler Coverage"
     },
     "WARN_HVC_DCT_SOUNDLVL_DB": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Sound Level"
     },
     "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Efficiency Ratio"
     },
     "WARN_HVC_VEL_MPS_FLEX_DUCTS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Flex Duct Velocity"
     },
     "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Carbon Footprint"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Floor U-Value"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Roof U-Value"
     },
     "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Wall U-Value"
     },
     "WARN_PLM_PPE_FLW_LPS_PIPES__HOT_WATE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Pipe Flow Rate"
     },
     "WARN_RGL_ACCESS_CLEAR_WIDTH_MM_DOORS__RAMPS__C": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Access Clear Width"
     },
     "WARN_ASS_ROOM_AREA_MIN": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Room Area Minimum"
     },
     "WARN_ASS_ROOM_VENTILATION": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Room Ventilation"
     },
     "WARN_BLE_CW_PANEL_SHGC": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Curtain Panel SHGC"
     },
     "WARN_BLE_CW_PANEL_U_VALUE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Curtain Panel U-Value"
     },
     "WARN_BLE_DOOR_ACOUSTIC": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Door Acoustic Rating"
     },
     "WARN_BLE_FLR_LD_CAP_KPA": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Floor Load Capacity"
     },
     "WARN_BLE_RAIL_HEIGHT_MM": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Railing Height"
     },
     "WARN_BLE_RAIL_LOAD_KN_M": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Railing Load"
     },
     "WARN_BLE_ROOF_SLOPE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Roof Slope"
     },
     "WARN_BLE_STAIR_GOING": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Stair Going"
     },
     "WARN_BLE_STAIR_RISE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Stair Rise"
     },
     "WARN_BLE_STRUCT_FDN_BEARING": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Foundation Bearing"
     },
     "WARN_BLE_STRUCT_LD_CAP": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Structural Load Capacity"
     },
     "WARN_BLE_VERT_CIRC_LOAD": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Vertical Circulation Load"
     },
     "WARN_BLE_WINDOW_SHGC": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Window SHGC"
     },
     "WARN_BLE_WINDOW_U_VALUE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Window U-Value"
     },
     "WARN_DOOR_FRR": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Door Fire Rating"
     },
     "WARN_ELC_CDT_FILL_RATIO": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Conduit Fill Ratio"
     },
     "WARN_ELC_CTR_FILL_RATIO": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Cable Tray Fill Ratio"
     },
     "WARN_ELC_PNL_SHORT_CIRCUIT": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Short Circuit Rating"
     },
     "WARN_ELC_PNL_SPARE_WAYS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Panel Spare Ways"
     },
     "WARN_FAB_HANGER_LOAD_KN": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Hanger Load"
     },
     "WARN_FLS_PROT_COVERAGE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Fire Protection Coverage"
     },
     "WARN_FLS_SFTY_SPACING": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Sprinkler Spacing"
     },
     "WARN_HVC_VEL_MPS_DUCTS": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Duct Velocity"
     },
     "WARN_INS_THICKNESS_MM": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Insulation Thickness"
     },
     "WARN_LTG_ILLUMINANCE": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Illuminance Level"
     },
     "WARN_MEP_SPC_LIGHTING": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Space Lighting"
     },
     "WARN_PLM_EQP_PRESSURE_KPA": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Equipment Pressure"
     },
     "WARN_PLM_FIXTURE_FLOW": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Fixture Flow Rate"
     },
     "WARN_PLM_PIPE_GRADIENT": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Pipe Gradient"
     },
     "WARN_PLM_VEL_MPS_PIPES": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Pipe Velocity"
     },
     "WARN_ROAD_GRADIENT_PCT": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Road Gradient"
     },
     "WARN_SITE_BEARING_CAP_KPA": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Site Bearing Capacity"
     },
     "WARN_STR_BLT_PROOF_LOAD_KN": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Bolt Proof Load"
     },
     "WARN_STR_CONN_CAPACITY_KN": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Connection Capacity"
     },
     "WARN_STR_FABRIC_SPEC": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Fabric Specification"
     },
     "WARN_STR_RBR_COVER_MM": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Rebar Cover"
     },
     "WARN_STR_RBR_LAP_LENGTH_MM": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Rebar Lap Length"
     },
     "WARN_STR_TRUSS_SPAN": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Truss Span"
     },
     "WARN_STR_WIR_TENSILE_MPA": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Wire Tensile Strength"
     },
     "WARN_STR_WLD_STRENGTH_MPA": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Weld Strength"
     },
     "WARN_STR_WLD_THROAT_MM": {
-      "prefix": "âš  ",
+      "prefix": "⚠ ",
       "suffix": "",
       "label": "Warning: Weld Throat"
     },
@@ -1657,7 +1657,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -1734,7 +1734,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " mÂ²",
+          "suffix_override": " m²",
           "note": "Casework area"
         },
         {
@@ -1779,13 +1779,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_CASEWORK_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -1798,7 +1798,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -2018,7 +2018,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -2284,7 +2284,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2295,7 +2295,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2306,7 +2306,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2382,7 +2382,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -2468,7 +2468,7 @@
     "Ceilings": {
       "family_name": "STING - Ceiling Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_CEIL_TXT",
-      "paragraph_template": "This ceiling is finished with {material} at a height of {height} mm above finished floor level, covering an area of {area} mÂ². Fire resistance: {FRR} minutes. Acoustic absorption coefficient: {NRC}. The ceiling system is {suspension_type} with {access} access. Located in {room} ({room_number}) on level {level} in the {zone} zone, serving the {department} department. Assembly code: {assembly_code}. Manufacturer: {manufacturer}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This ceiling is finished with {material} at a height of {height} mm above finished floor level, covering an area of {area} m². Fire resistance: {FRR} minutes. Acoustic absorption coefficient: {NRC}. The ceiling system is {suspension_type} with {access} access. Located in {room} ({room_number}) on level {level} in the {zone} zone, serving the {department} department. Assembly code: {assembly_code}. Manufacturer: {manufacturer}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -2591,7 +2591,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -2685,7 +2685,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2696,7 +2696,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2707,7 +2707,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -2783,7 +2783,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -2876,7 +2876,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "Âµg/mÂ³",
+          "unit": "µg/m³",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -2929,7 +2929,7 @@
           "param": "BLE_DOOR_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Ã— H:",
+          "prefix_override": "× H:",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -3133,7 +3133,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3144,7 +3144,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3155,7 +3155,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3231,7 +3231,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -3335,7 +3335,7 @@
     "Floors": {
       "family_name": "STING - Floor Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_FLOOR_TXT",
-      "paragraph_template": "This {function} floor is {thickness} mm thick covering an area of {area} mÂ², constructed with {material} using {method} construction. The floor achieves a thermal transmittance of {U-value} W/mÂ²K and provides {FRR} minutes of fire resistance with an impact insulation class of {IIC} dB. The imposed load capacity is {load} kPa. Located on level {level} in {room}, {zone} zone. Embodied carbon: {carbon} kgCOâ‚‚e, recyclability: {recycle}%. Structural type: {struct_type}. Assembly code: {assembly_code}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This {function} floor is {thickness} mm thick covering an area of {area} m², constructed with {material} using {method} construction. The floor achieves a thermal transmittance of {U-value} W/m²K and provides {FRR} minutes of fire resistance with an impact insulation class of {IIC} dB. The imposed load capacity is {load} kPa. Located on level {level} in {room}, {zone} zone. Embodied carbon: {carbon} kgCO₂e, recyclability: {recycle}%. Structural type: {struct_type}. Assembly code: {assembly_code}. Phase: {phase}. Maintenance: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -3385,7 +3385,7 @@
           "param": "BLE_FLR_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3394,7 +3394,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/mÂ²K",
+          "suffix_override": "W/m²K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3458,7 +3458,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Load:",
-          "suffix_override": "kN/mÂ²",
+          "suffix_override": "kN/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3494,7 +3494,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -3588,7 +3588,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3599,7 +3599,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3610,7 +3610,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -3686,7 +3686,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -3752,7 +3752,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/mÂ²K",
+          "unit": "W/m²K",
           "description": "Floor U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_FLOORS, \"\")"
@@ -3761,7 +3761,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -3806,7 +3806,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "Âµg/mÂ³",
+          "unit": "µg/m³",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -3830,7 +3830,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -3907,7 +3907,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " mÂ²",
+          "suffix_override": " m²",
           "note": "Footprint area"
         },
         {
@@ -3952,13 +3952,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FURNITURE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -3971,7 +3971,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -4191,7 +4191,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -4457,7 +4457,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4468,7 +4468,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4479,7 +4479,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -4555,7 +4555,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -4639,7 +4639,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "Âµg/mÂ³",
+          "unit": "µg/m³",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -4664,7 +4664,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -4740,7 +4740,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area: ",
-          "suffix_override": " mÂ²",
+          "suffix_override": " m²",
           "note": "System area"
         },
         {
@@ -4785,13 +4785,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FURN_SYS_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive"
+          "note": "Natural language paragraph — purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -4804,7 +4804,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -5024,7 +5024,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -5149,7 +5149,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5160,7 +5160,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5171,7 +5171,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5247,7 +5247,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -5346,7 +5346,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -5459,13 +5459,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PARKING_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive"
+          "note": "Natural language paragraph — purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -5478,7 +5478,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -5698,7 +5698,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -5823,7 +5823,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5834,7 +5834,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5845,7 +5845,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -5921,7 +5921,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6190,7 +6190,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6201,7 +6201,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6212,7 +6212,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6288,7 +6288,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6356,7 +6356,7 @@
           "threshold": "8.33",
           "unit": "%",
           "description": "Ramp gradient accessibility limit (1:12 max)",
-          "standard": "BS 8300:2018 Â§7.2 / ADA Â§405.2",
+          "standard": "BS 8300:2018 §7.2 / ADA §405.2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, \"\")"
         },
         {
@@ -6374,7 +6374,7 @@
     "Roofs": {
       "family_name": "STING - Roof Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_ROOF_TXT",
-      "paragraph_template": "This {function} roof has a total thickness of {thickness} mm with a slope of {slope}Â°, covering an area of {area} mÂ². The primary material is {material} with {insulation} insulation achieving a U-value of {U-value} W/mÂ²K. Fire resistance: {FRR} minutes. Drainage is via {drainage}. Located on level {level} in the {zone} zone. Embodied carbon: {carbon} kgCOâ‚‚e, recyclability: {recycle}%. Structural load capacity: {load} kPa. Assembly code: {assembly_code}. Phase: {phase}. Expected life: {life} years. Compliant with {standard}.",
+      "paragraph_template": "This {function} roof has a total thickness of {thickness} mm with a slope of {slope}°, covering an area of {area} m². The primary material is {material} with {insulation} insulation achieving a U-value of {U-value} W/m²K. Fire resistance: {FRR} minutes. Drainage is via {drainage}. Located on level {level} in the {zone} zone. Embodied carbon: {carbon} kgCO₂e, recyclability: {recycle}%. Structural load capacity: {load} kPa. Assembly code: {assembly_code}. Phase: {phase}. Expected life: {life} years. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -6424,7 +6424,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/mÂ²K",
+          "suffix_override": "W/m²K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6443,7 +6443,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Slope:",
-          "suffix_override": "Â°",
+          "suffix_override": "°",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6452,7 +6452,7 @@
           "param": "BLE_ROOF_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6506,7 +6506,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -6609,7 +6609,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6620,7 +6620,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6631,7 +6631,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -6707,7 +6707,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -6773,7 +6773,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/mÂ²K",
+          "unit": "W/m²K",
           "description": "Roof U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_ROOFS, \"\")"
@@ -6782,7 +6782,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -6843,7 +6843,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Area:",
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -7040,7 +7040,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7051,7 +7051,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7062,7 +7062,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7138,7 +7138,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -7204,7 +7204,7 @@
           "param": "WARN_ASS_ROOM_AREA_MIN",
           "severity": "HIGH",
           "threshold": "7.0",
-          "unit": "mÂ²",
+          "unit": "m²",
           "description": "Room minimum area compliance",
           "standard": "Building Regs / Space Standards",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_AREA_MIN, \"\")"
@@ -7264,7 +7264,7 @@
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_RGL_ACCESSIBLE_WC, \"\")"
         }
       ],
-      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} mÂ² and volume of {volume} mÂ³, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}.",
+      "paragraph_template": "This is {room_name} (Room {room_number}) with a floor area of {area} m² and volume of {volume} m³, located on level {level} in the {zone} zone within the {department} department. The room has a ceiling height of {height} mm with {finishes} finishes. Design lighting level: {lux} lux. Ventilation rate: {ventilation} L/s per person. Acoustic requirement: {noise} dB background noise maximum. Fire escape travel distance: {travel} m. Occupancy load: {occupancy} persons. Grid reference: {grid}. Phase: {phase}. Workset: {workset}. Compliant with {standard}.",
       "csv_family_alias": "Room"
     },
     "Site": {
@@ -7284,7 +7284,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -7398,19 +7398,19 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SITE_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive"
+          "note": "Natural language paragraph — purely descriptive"
         },
         {
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -7424,7 +7424,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -7644,7 +7644,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -7769,7 +7769,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7780,7 +7780,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7791,7 +7791,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -7867,7 +7867,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8155,7 +8155,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8166,7 +8166,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8177,7 +8177,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8253,7 +8253,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8375,7 +8375,7 @@
     "Walls": {
       "family_name": "STING - Wall Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_WALL_TXT",
-      "paragraph_template": "This {function} wall is {thickness} mm thick and {height} mm high with a total length of {length} mm, constructed using {method} with {material} as the primary material. The wall is classified as {type} under the {assembly_code} Uniformat classification, and achieves a thermal transmittance of {U-value} W/mÂ²K with a thermal resistance of {R-value} mÂ²K/W, assessed as {condensation} condensation risk. It provides {FRR} minutes of fire resistance with an acoustic rating of {STC} dB STC. The assembly incorporates {recycled}% recycled content with an embodied carbon of {carbon} kgCOâ‚‚e per unit and an expected service life of {life} years. It is situated in {room} on level {level} within the {zone} zone. The wall was created during the {phase} phase under {workset} workset. Manufacturer: {manufacturer}, Model: {model}. Maintenance frequency: {maint_freq}. Compliant with {standard}.",
+      "paragraph_template": "This {function} wall is {thickness} mm thick and {height} mm high with a total length of {length} mm, constructed using {method} with {material} as the primary material. The wall is classified as {type} under the {assembly_code} Uniformat classification, and achieves a thermal transmittance of {U-value} W/m²K with a thermal resistance of {R-value} m²K/W, assessed as {condensation} condensation risk. It provides {FRR} minutes of fire resistance with an acoustic rating of {STC} dB STC. The assembly incorporates {recycled}% recycled content with an embodied carbon of {carbon} kgCO₂e per unit and an expected service life of {life} years. It is situated in {room} on level {level} within the {zone} zone. The wall was created during the {phase} phase under {workset} workset. Manufacturer: {manufacturer}, Model: {model}. Maintenance frequency: {maint_freq}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -8425,7 +8425,7 @@
           "param": "BLE_ELE_AREA_SQ_M",
           "spaces": 0,
           "break": true,
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8434,7 +8434,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/mÂ²K",
+          "suffix_override": "W/m²K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8533,7 +8533,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -8655,7 +8655,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8666,7 +8666,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8677,7 +8677,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -8753,7 +8753,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -8819,7 +8819,7 @@
           "param": "WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/mÂ²K",
+          "unit": "W/m²K",
           "description": "Wall U-value thermal transmittance limit",
           "standard": "Building Regs Part L / Uganda ES / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_THERM_U_VALUE_W_M2K_NR_WALLS, \"\")"
@@ -8828,7 +8828,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -8882,7 +8882,7 @@
           "param": "WARN_PER_VOC_EMISSIONS",
           "severity": "HIGH",
           "threshold": "250",
-          "unit": "Âµg/mÂ³",
+          "unit": "µg/m³",
           "description": "VOC emissions limit for indoor air quality",
           "standard": "WELL Building Standard / EN 16516",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_VOC_EMISSIONS, \"\")"
@@ -8893,7 +8893,7 @@
     "Windows": {
       "family_name": "STING - Window Tag",
       "paragraph_container": "ARCH_TAG_7_PARA_WIN_TXT",
-      "paragraph_template": "This is a {width} by {height} millimetre {type} window with a sill height of {sill_height} mm above finished floor level, constructed from {frame_material} framing with {glazing_type} glazing. The window achieves a U-value of {U-value} W/mÂ²K with a solar heat gain coefficient (SHGC) of {SHGC} and visible light transmittance of {VLT}%. Located in {room} on level {level} in the {zone} zone. Assembly code: {assembly_code}. Manufacturer: {manufacturer}, Model: {model}. Expected life: {life} years. Compliant with {standard}.",
+      "paragraph_template": "This is a {width} by {height} millimetre {type} window with a sill height of {sill_height} mm above finished floor level, constructed from {frame_material} framing with {glazing_type} glazing. The window achieves a U-value of {U-value} W/m²K with a solar heat gain coefficient (SHGC) of {SHGC} and visible light transmittance of {VLT}%. Located in {room} on level {level} in the {zone} zone. Assembly code: {assembly_code}. Manufacturer: {manufacturer}, Model: {model}. Expected life: {life} years. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -8935,7 +8935,7 @@
           "param": "BLE_WINDOW_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Ã— H:",
+          "prefix_override": "× H:",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -8963,7 +8963,7 @@
           "param": "PER_THERM_U_VALUE_W_M2K",
           "spaces": 0,
           "break": true,
-          "suffix_override": "W/mÂ²K",
+          "suffix_override": "W/m²K",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -9019,7 +9019,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Vent:",
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -9122,7 +9122,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9133,7 +9133,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9144,7 +9144,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9220,7 +9220,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -9286,7 +9286,7 @@
           "param": "WARN_BLE_WINDOW_U_VALUE",
           "severity": "HIGH",
           "threshold": "0.30",
-          "unit": "W/mÂ²K",
+          "unit": "W/m²K",
           "description": "U-value thermal transmittance check",
           "standard": "Building Regs Part L / ASHRAE 90.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_WINDOW_U_VALUE, \"\")"
@@ -9319,7 +9319,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -9425,7 +9425,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_REBAR_TXT",
@@ -9437,14 +9437,14 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
           "param": "WARN_STR_RBR_LAP_LENGTH_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_LAP_LENGTH_MM, \"\")"
         },
         {
@@ -9458,7 +9458,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -9678,7 +9678,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -9803,7 +9803,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9814,7 +9814,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9825,7 +9825,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -9901,7 +9901,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -9969,7 +9969,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 Â§4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -9978,7 +9978,7 @@
           "threshold": "500",
           "unit": "mm",
           "description": "Rebar lap length minimum",
-          "standard": "BS EN 1992-1-1 Â§4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_LAP_LENGTH_MM, \"\")"
         },
         {
@@ -10008,7 +10008,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -10114,7 +10114,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_AREAS_TXT",
@@ -10133,7 +10133,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -10353,7 +10353,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -10478,7 +10478,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10489,7 +10489,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10500,7 +10500,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -10576,7 +10576,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -10642,7 +10642,7 @@
           "param": "WARN_ASS_ROOM_AREA_MIN",
           "severity": "HIGH",
           "threshold": "7.0",
-          "unit": "mÂ²",
+          "unit": "m²",
           "description": "Room minimum area compliance",
           "standard": "Building Regs / Space Standards",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_ROOM_AREA_MIN, \"\")"
@@ -10665,7 +10665,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -10771,7 +10771,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SPACES_TXT",
@@ -10783,7 +10783,7 @@
           "param": "WARN_MEP_SPC_LIGHTING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_SPC_LIGHTING, \"\")"
         },
         {
@@ -10797,7 +10797,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -11017,7 +11017,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -11142,7 +11142,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11153,7 +11153,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11164,7 +11164,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11240,7 +11240,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -11306,7 +11306,7 @@
           "param": "WARN_MEP_SPC_LIGHTING",
           "severity": "MEDIUM",
           "threshold": "10",
-          "unit": "W/mÂ²",
+          "unit": "W/m²",
           "description": "Space lighting power density limit",
           "standard": "CIBSE SLL LG7 / BS EN 15193",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_MEP_SPC_LIGHTING, \"\")"
@@ -11329,7 +11329,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -11442,7 +11442,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_COLUMNS_TXT",
@@ -11461,7 +11461,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -11681,7 +11681,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -11806,7 +11806,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11817,7 +11817,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11828,7 +11828,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -11904,7 +11904,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -11972,7 +11972,7 @@
           "threshold": "30",
           "unit": "ratio",
           "description": "Column slenderness ratio limit",
-          "standard": "BS EN 1992-1-1 Â§5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_COLUMN_SLENDERNESS, \"\")"
         }
       ]
@@ -11993,7 +11993,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -12099,7 +12099,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ASSEMBLIES_TXT",
@@ -12118,7 +12118,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -12338,7 +12338,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -12463,7 +12463,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12474,7 +12474,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12485,7 +12485,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -12561,7 +12561,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -12627,7 +12627,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -12650,7 +12650,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -12756,7 +12756,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_DETAIL_ITEMS_TXT",
@@ -12775,7 +12775,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -12995,7 +12995,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -13120,7 +13120,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13131,7 +13131,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13142,7 +13142,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13218,7 +13218,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -13307,7 +13307,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -13413,7 +13413,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ENTOURAGE_TXT",
@@ -13432,7 +13432,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -13652,7 +13652,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -13777,7 +13777,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13788,7 +13788,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13799,7 +13799,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -13875,7 +13875,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -13964,7 +13964,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -14070,7 +14070,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_FOOD_EQUIP_TXT",
@@ -14089,7 +14089,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -14309,7 +14309,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -14434,7 +14434,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14445,7 +14445,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14456,7 +14456,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -14532,7 +14532,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -14630,7 +14630,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -14736,7 +14736,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_HARDSCAPE_TXT",
@@ -14748,7 +14748,7 @@
           "param": "WARN_BLE_RAMP_SLOPE_PCT_RAMPS",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAMP_SLOPE_PCT_RAMPS, \"\")"
         },
         {
@@ -14762,7 +14762,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -14982,7 +14982,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -15107,7 +15107,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15118,7 +15118,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15129,7 +15129,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15205,7 +15205,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -15294,7 +15294,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -15400,7 +15400,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_MASS_TXT",
@@ -15419,7 +15419,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -15639,7 +15639,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -15764,7 +15764,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15775,7 +15775,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15786,7 +15786,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -15862,7 +15862,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -15928,7 +15928,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -15951,7 +15951,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -16057,7 +16057,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_MODEL_GROUPS_TXT",
@@ -16076,7 +16076,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -16296,7 +16296,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -16421,7 +16421,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16432,7 +16432,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16443,7 +16443,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -16519,7 +16519,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -16585,7 +16585,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -16608,7 +16608,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -16714,7 +16714,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PADS_TXT",
@@ -16726,7 +16726,7 @@
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -16740,7 +16740,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -16960,7 +16960,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -17085,7 +17085,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17096,7 +17096,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17107,7 +17107,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17183,7 +17183,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -17272,7 +17272,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -17378,7 +17378,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PARTS_TXT",
@@ -17397,7 +17397,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -17617,7 +17617,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -17742,7 +17742,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17753,7 +17753,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17764,7 +17764,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -17840,7 +17840,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -17906,7 +17906,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -17929,7 +17929,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -18035,7 +18035,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PLANTING_TXT",
@@ -18054,7 +18054,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -18274,7 +18274,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -18399,7 +18399,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18410,7 +18410,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18421,7 +18421,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -18497,7 +18497,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -18586,7 +18586,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -18692,7 +18692,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROFILES_TXT",
@@ -18711,7 +18711,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -18931,7 +18931,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -19056,7 +19056,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19067,7 +19067,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19078,7 +19078,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19154,7 +19154,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -19243,7 +19243,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -19349,7 +19349,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROPERTY_LINES_TXT",
@@ -19368,7 +19368,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -19588,7 +19588,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -19713,7 +19713,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19724,7 +19724,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19735,7 +19735,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -19811,7 +19811,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -19900,7 +19900,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -20006,7 +20006,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ROADS_TXT",
@@ -20018,7 +20018,7 @@
           "param": "WARN_ROAD_GRADIENT_PCT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ROAD_GRADIENT_PCT, \"\")"
         },
         {
@@ -20032,7 +20032,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -20252,7 +20252,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -20377,7 +20377,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20388,7 +20388,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20399,7 +20399,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -20475,7 +20475,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -20564,7 +20564,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -20670,7 +20670,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_SIGNAGE_TXT",
@@ -20689,7 +20689,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -20909,7 +20909,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -21034,7 +21034,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21045,7 +21045,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21056,7 +21056,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21132,7 +21132,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -21230,7 +21230,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -21336,7 +21336,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_TOPOSOLID_TXT",
@@ -21348,7 +21348,7 @@
           "param": "WARN_SITE_BEARING_CAP_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_SITE_BEARING_CAP_KPA, \"\")"
         },
         {
@@ -21362,7 +21362,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -21582,7 +21582,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -21707,7 +21707,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21718,7 +21718,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21729,7 +21729,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -21805,7 +21805,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -21894,7 +21894,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -22000,7 +22000,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_VERT_CIRC_TXT",
@@ -22012,7 +22012,7 @@
           "param": "WARN_BLE_VERT_CIRC_LOAD",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_VERT_CIRC_LOAD, \"\")"
         },
         {
@@ -22026,7 +22026,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -22246,7 +22246,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -22371,7 +22371,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22382,7 +22382,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22393,7 +22393,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -22469,7 +22469,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -22535,7 +22535,7 @@
           "param": "WARN_BLE_VERT_CIRC_LOAD",
           "severity": "HIGH",
           "threshold": "5.0",
-          "unit": "kN/mÂ²",
+          "unit": "kN/m²",
           "description": "Vertical circulation structural load check",
           "standard": "Building Regs Part K / BS EN 81-20",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_VERT_CIRC_LOAD, \"\")"
@@ -22567,7 +22567,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -22673,7 +22673,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_ZONES_TXT",
@@ -22692,7 +22692,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -22912,7 +22912,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -23037,7 +23037,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23048,7 +23048,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23059,7 +23059,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23135,7 +23135,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -23224,7 +23224,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -23330,7 +23330,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_RVT_LINKS_TXT",
@@ -23349,7 +23349,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -23569,7 +23569,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -23694,7 +23694,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23705,7 +23705,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23716,7 +23716,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -23792,7 +23792,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -23858,7 +23858,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -23881,7 +23881,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -23987,7 +23987,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_FASCIA_TXT",
@@ -24006,7 +24006,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -24226,7 +24226,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -24351,7 +24351,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24362,7 +24362,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24373,7 +24373,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -24449,7 +24449,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -24515,7 +24515,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -24538,7 +24538,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -24644,7 +24644,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_GUTTER_TXT",
@@ -24663,7 +24663,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -24883,7 +24883,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -25008,7 +25008,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25019,7 +25019,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25030,7 +25030,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25106,7 +25106,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -25195,7 +25195,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -25301,7 +25301,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_HANDRAILS_TXT",
@@ -25313,14 +25313,14 @@
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_HEIGHT_MM, \"\")"
         },
         {
           "param": "WARN_BLE_RAIL_LOAD_KN_M",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
         },
         {
@@ -25334,7 +25334,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -25554,7 +25554,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -25679,7 +25679,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25690,7 +25690,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25701,7 +25701,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -25777,7 +25777,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -25875,7 +25875,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -25981,7 +25981,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_ROOF_SOFFITS_TXT",
@@ -26000,7 +26000,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -26220,7 +26220,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -26345,7 +26345,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26356,7 +26356,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26367,7 +26367,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -26443,7 +26443,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -26518,7 +26518,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -26541,7 +26541,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -26647,7 +26647,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_SLAB_EDGES_TXT",
@@ -26666,7 +26666,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -26886,7 +26886,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -27011,7 +27011,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27022,7 +27022,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27033,7 +27033,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27109,7 +27109,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -27175,7 +27175,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -27198,7 +27198,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -27304,7 +27304,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_LANDINGS_TXT",
@@ -27323,7 +27323,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -27543,7 +27543,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -27668,7 +27668,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27679,7 +27679,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27690,7 +27690,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -27766,7 +27766,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -27855,7 +27855,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -27961,7 +27961,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_RUNS_TXT",
@@ -27973,14 +27973,14 @@
           "param": "WARN_BLE_STAIR_RISE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_RISE, \"\")"
         },
         {
           "param": "WARN_BLE_STAIR_GOING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STAIR_GOING, \"\")"
         },
         {
@@ -27994,7 +27994,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -28214,7 +28214,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -28339,7 +28339,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28350,7 +28350,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28361,7 +28361,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -28437,7 +28437,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -28553,7 +28553,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -28659,7 +28659,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_STAIR_SUPPORTS_TXT",
@@ -28671,7 +28671,7 @@
           "param": "WARN_BLE_STRUCT_LD_CAP",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
         },
         {
@@ -28685,7 +28685,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -28905,7 +28905,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -29030,7 +29030,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29041,7 +29041,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29052,7 +29052,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29128,7 +29128,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -29217,7 +29217,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -29323,7 +29323,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_TOP_RAILS_TXT",
@@ -29335,14 +29335,14 @@
           "param": "WARN_BLE_RAIL_HEIGHT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_HEIGHT_MM, \"\")"
         },
         {
           "param": "WARN_BLE_RAIL_LOAD_KN_M",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_RAIL_LOAD_KN_M, \"\")"
         },
         {
@@ -29356,7 +29356,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -29576,7 +29576,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -29701,7 +29701,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29712,7 +29712,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29723,7 +29723,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -29799,7 +29799,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -29897,7 +29897,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -30003,7 +30003,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "BLE_TAG_7_PARA_WALL_SWEEPS_TXT",
@@ -30022,7 +30022,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -30242,7 +30242,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -30367,7 +30367,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30378,7 +30378,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30389,7 +30389,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30465,7 +30465,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -30531,7 +30531,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -30712,7 +30712,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -30834,7 +30834,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30845,7 +30845,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30856,7 +30856,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -30932,7 +30932,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -31009,7 +31009,7 @@
           "threshold": "30",
           "unit": "ratio",
           "description": "Column slenderness ratio limit",
-          "standard": "BS EN 1992-1-1 Â§5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_COLUMN_SLENDERNESS, \"\")"
         },
         {
@@ -31018,7 +31018,7 @@
           "threshold": "15",
           "unit": "mm",
           "description": "Column eccentricity limit",
-          "standard": "BS EN 1992-1-1 Â§5.8 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §5.8 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_COL_ECCENTRICITY, \"\")"
         }
       ],
@@ -31106,7 +31106,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "Bearing:",
-          "suffix_override": "kN/mÂ²",
+          "suffix_override": "kN/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -31225,7 +31225,7 @@
           "param": "PER_SUST_EMBODIED_CARBON_KG",
           "spaces": 0,
           "break": true,
-          "suffix_override": "kgCOâ‚‚/mÂ²",
+          "suffix_override": "kgCO₂/m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -31347,7 +31347,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31358,7 +31358,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31369,7 +31369,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -31445,7 +31445,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -31554,7 +31554,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "BLE_STRUCT_BEAM_SZ_TXT",
@@ -31706,54 +31706,54 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_BEAM_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "WARN_BLE_STRUCT_LD_CAP",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_BLE_STRUCT_LD_CAP, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_WEB_OPENING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_WEB_OPENING, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_NOTCH",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_NOTCH, \"\")"
         },
         {
           "param": "WARN_STR_BEAM_PENETRATION_REVIEW",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BEAM_PENETRATION_REVIEW, \"\")"
         },
         {
           "param": "WARN_STR_TRANSFER_BEAM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_TRANSFER_BEAM, \"\")"
         },
         {
           "param": "WARN_STR_COMPOSITE_SHEAR_STUD",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_COMPOSITE_SHEAR_STUD, \"\")"
         },
         {
@@ -31767,7 +31767,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -31987,7 +31987,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -32112,7 +32112,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32123,7 +32123,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32134,7 +32134,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32210,7 +32210,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -32317,7 +32317,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -32423,7 +32423,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_FABRIC_REINF_TXT",
@@ -32435,7 +32435,7 @@
           "param": "WARN_STR_FABRIC_SPEC",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_FABRIC_SPEC, \"\")"
         },
         {
@@ -32449,7 +32449,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -32669,7 +32669,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -32794,7 +32794,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32805,7 +32805,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32816,7 +32816,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -32892,7 +32892,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -32981,7 +32981,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -33087,7 +33087,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_LINKS_TXT",
@@ -33106,7 +33106,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -33326,7 +33326,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -33451,7 +33451,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33462,7 +33462,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33473,7 +33473,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -33549,7 +33549,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -33638,7 +33638,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -33744,7 +33744,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_MEMBERS_TXT",
@@ -33763,7 +33763,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -33983,7 +33983,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -34108,7 +34108,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34119,7 +34119,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34130,7 +34130,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34206,7 +34206,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -34295,7 +34295,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -34401,7 +34401,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_NODES_TXT",
@@ -34420,7 +34420,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -34640,7 +34640,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -34765,7 +34765,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34776,7 +34776,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34787,7 +34787,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -34863,7 +34863,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -34952,7 +34952,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -35058,7 +35058,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_OPENINGS_TXT",
@@ -35077,7 +35077,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -35297,7 +35297,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -35422,7 +35422,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35433,7 +35433,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35444,7 +35444,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -35520,7 +35520,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -35609,7 +35609,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -35715,7 +35715,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_ANAL_PANELS_TXT",
@@ -35734,7 +35734,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -35954,7 +35954,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -36079,7 +36079,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36090,7 +36090,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36101,7 +36101,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36177,7 +36177,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -36266,7 +36266,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -36372,7 +36372,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_AREA_LOADS_TXT",
@@ -36391,7 +36391,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -36611,7 +36611,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -36736,7 +36736,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36747,7 +36747,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36758,7 +36758,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -36834,7 +36834,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -36923,7 +36923,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -37029,7 +37029,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_LINE_LOADS_TXT",
@@ -37048,7 +37048,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -37268,7 +37268,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -37393,7 +37393,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37404,7 +37404,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37415,7 +37415,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -37491,7 +37491,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -37580,7 +37580,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -37686,7 +37686,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_POINT_LOADS_TXT",
@@ -37705,7 +37705,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -37925,7 +37925,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -38050,7 +38050,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38061,7 +38061,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38072,7 +38072,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38148,7 +38148,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -38237,7 +38237,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -38343,7 +38343,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_AREA_LOADS_TXT",
@@ -38362,7 +38362,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -38582,7 +38582,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -38707,7 +38707,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38718,7 +38718,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38729,7 +38729,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -38805,7 +38805,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -38894,7 +38894,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -39000,7 +39000,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_LINE_LOADS_TXT",
@@ -39019,7 +39019,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -39239,7 +39239,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -39364,7 +39364,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39375,7 +39375,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39386,7 +39386,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -39462,7 +39462,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -39551,7 +39551,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -39657,7 +39657,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_INT_POINT_LOADS_TXT",
@@ -39676,7 +39676,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -39896,7 +39896,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -40021,7 +40021,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40032,7 +40032,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40043,7 +40043,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40119,7 +40119,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -40275,7 +40275,7 @@
           "param": "WARN_STR_BLT_PROOF_LOAD_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_BLT_PROOF_LOAD_KN, \"\")"
         },
         {
@@ -40289,7 +40289,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -40509,7 +40509,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -40634,7 +40634,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40645,7 +40645,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40656,7 +40656,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -40732,7 +40732,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -40888,14 +40888,14 @@
           "param": "WARN_STR_WLD_STRENGTH_MPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_STRENGTH_MPA, \"\")"
         },
         {
           "param": "WARN_STR_WLD_THROAT_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_THROAT_MM, \"\")"
         },
         {
@@ -40909,7 +40909,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -41129,7 +41129,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -41254,7 +41254,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41265,7 +41265,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41276,7 +41276,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41352,7 +41352,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -41420,7 +41420,7 @@
           "threshold": "6",
           "unit": "mm",
           "description": "Weld throat thickness minimum",
-          "standard": "BS EN 1993-1-8 Â§4.5 / AWS D1.1",
+          "standard": "BS EN 1993-1-8 §4.5 / AWS D1.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_THROAT_MM, \"\")"
         },
         {
@@ -41429,7 +41429,7 @@
           "threshold": "250",
           "unit": "MPa",
           "description": "Weld strength minimum",
-          "standard": "BS EN 1993-1-8 Â§4.5 / AWS D1.1",
+          "standard": "BS EN 1993-1-8 §4.5 / AWS D1.1",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WLD_STRENGTH_MPA, \"\")"
         }
       ]
@@ -41517,7 +41517,7 @@
           "param": "WARN_STR_WIR_TENSILE_MPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_WIR_TENSILE_MPA, \"\")"
         },
         {
@@ -41531,7 +41531,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -41751,7 +41751,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -41876,7 +41876,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41887,7 +41887,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41898,7 +41898,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -41974,7 +41974,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -42063,7 +42063,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -42169,7 +42169,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_AREA_REINF_TXT",
@@ -42181,7 +42181,7 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -42195,7 +42195,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -42415,7 +42415,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -42540,7 +42540,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42551,7 +42551,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42562,7 +42562,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -42638,7 +42638,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -42706,7 +42706,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 Â§4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         }
       ]
@@ -42727,7 +42727,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -42833,7 +42833,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_PATH_REINF_TXT",
@@ -42845,7 +42845,7 @@
           "param": "WARN_STR_RBR_COVER_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         },
         {
@@ -42859,7 +42859,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -43079,7 +43079,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -43204,7 +43204,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43215,7 +43215,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43226,7 +43226,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43302,7 +43302,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -43370,7 +43370,7 @@
           "threshold": "25",
           "unit": "mm",
           "description": "Rebar concrete cover minimum",
-          "standard": "BS EN 1992-1-1 Â§4.4 / Eurocode 2",
+          "standard": "BS EN 1992-1-1 §4.4 / Eurocode 2",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_RBR_COVER_MM, \"\")"
         }
       ]
@@ -43391,7 +43391,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -43497,7 +43497,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_REBAR_COUPLERS_TXT",
@@ -43509,7 +43509,7 @@
           "param": "WARN_STR_CONN_CAPACITY_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_CONN_CAPACITY_KN, \"\")"
         },
         {
@@ -43523,7 +43523,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -43743,7 +43743,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -43868,7 +43868,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43879,7 +43879,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43890,7 +43890,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -43966,7 +43966,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -44055,7 +44055,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -44161,7 +44161,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_BEAM_SYSTEMS_TXT",
@@ -44180,7 +44180,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -44400,7 +44400,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -44525,7 +44525,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44536,7 +44536,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44547,7 +44547,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -44623,7 +44623,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -44712,7 +44712,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -44818,7 +44818,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_STIFFENERS_TXT",
@@ -44837,7 +44837,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -45057,7 +45057,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -45182,7 +45182,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45193,7 +45193,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45204,7 +45204,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45280,7 +45280,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -45369,7 +45369,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -45475,7 +45475,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "STR_TAG_7_PARA_STR_TRUSSES_TXT",
@@ -45487,7 +45487,7 @@
           "param": "WARN_STR_TRUSS_SPAN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_STR_TRUSS_SPAN, \"\")"
         },
         {
@@ -45501,7 +45501,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -45721,7 +45721,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -45846,7 +45846,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45857,7 +45857,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45868,7 +45868,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -45944,7 +45944,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -46363,7 +46363,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46374,7 +46374,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46385,7 +46385,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46521,7 +46521,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -46735,7 +46735,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46746,7 +46746,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46757,7 +46757,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -46893,7 +46893,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -47117,7 +47117,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47128,7 +47128,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47139,7 +47139,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47275,7 +47275,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -47479,7 +47479,7 @@
           "param": "HVC_DUCT_AREA_SQ_M",
           "spaces": 1,
           "break": true,
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47488,7 +47488,7 @@
           "param": "HVC_DUCT_FLOWRATE_M3H",
           "spaces": 1,
           "break": true,
-          "suffix_override": "mÂ³/h",
+          "suffix_override": "m³/h",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47587,7 +47587,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| Area:",
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -47692,7 +47692,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47703,7 +47703,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47714,7 +47714,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -47850,7 +47850,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -48008,7 +48008,7 @@
           "param": "HVC_DUCT_FLOWRATE_M3H",
           "spaces": 1,
           "break": true,
-          "suffix_override": "mÂ³/h",
+          "suffix_override": "m³/h",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -48104,7 +48104,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48115,7 +48115,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48126,7 +48126,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -48262,7 +48262,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -48363,7 +48363,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -48539,19 +48539,19 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_SPEC_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_HVC_EFF_RATIO_NR_MECHANICAL_EQUI, \"\")"
         },
         {
@@ -48565,7 +48565,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -48785,7 +48785,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -49061,7 +49061,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49072,7 +49072,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49083,7 +49083,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49231,7 +49231,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -49482,7 +49482,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49493,7 +49493,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49504,7 +49504,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49630,7 +49630,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -49846,7 +49846,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49857,7 +49857,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49868,7 +49868,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -49994,7 +49994,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -50229,7 +50229,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50240,7 +50240,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50251,7 +50251,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50377,7 +50377,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -50782,7 +50782,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50793,7 +50793,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50804,7 +50804,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -50930,7 +50930,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -51448,7 +51448,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51459,7 +51459,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51470,7 +51470,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51596,7 +51596,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -51700,7 +51700,7 @@
     "Fire Alarm Devices": {
       "family_name": "STING - Fire Alarm Device Tag",
       "paragraph_container": "FLS_TAG_7_PARA_FA_TXT",
-      "paragraph_template": "This {device_type} fire alarm device provides detection coverage of {coverage} mÂ² with a maximum spacing of {spacing} m. Sensitivity: {sensitivity}. Power supply: {power}. Loop address: {address}. Circuit: {circuit}. Located in {room} on level {level} in the {zone} zone. Maximum detector spacing for this room type: {max_spacing} m. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Commissioning status: {commissioning}. Compliant with {standard}.",
+      "paragraph_template": "This {device_type} fire alarm device provides detection coverage of {coverage} m² with a maximum spacing of {spacing} m. Sensitivity: {sensitivity}. Power supply: {power}. Loop address: {address}. Circuit: {circuit}. Located in {room} on level {level} in the {zone} zone. Maximum detector spacing for this room type: {max_spacing} m. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Commissioning status: {commissioning}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -51933,7 +51933,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51944,7 +51944,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -51955,7 +51955,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52031,7 +52031,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -52097,7 +52097,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "mÂ²",
+          "unit": "m²",
           "description": "Fire safety device coverage limit",
           "standard": "Building Regs Part B / BS 9999",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
@@ -52117,7 +52117,7 @@
     "Sprinklers": {
       "family_name": "STING - Sprinkler Tag",
       "paragraph_container": "FLS_TAG_7_PARA_SPR_TXT",
-      "paragraph_template": "This {type} sprinkler head has a K-factor of {k_factor} with a temperature rating of {temp_rating}Â°C ({response} response). Coverage area: {coverage} mÂ². Spacing: {spacing} m. Operating pressure: {pressure} kPa. Orientation: {orientation}. Connected to {system} system. Located in {room} on level {level} in the {zone} zone. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Compliant with {standard}.",
+      "paragraph_template": "This {type} sprinkler head has a K-factor of {k_factor} with a temperature rating of {temp_rating}°C ({response} response). Coverage area: {coverage} m². Spacing: {spacing} m. Operating pressure: {pressure} kPa. Orientation: {orientation}. Connected to {system} system. Located in {room} on level {level} in the {zone} zone. Manufacturer: {manufacturer}, Model: {model}. Assembly code: {assembly_code}. Compliant with {standard}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -52142,7 +52142,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "Coverage:",
-          "suffix_override": "mÂ²",
+          "suffix_override": "m²",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -52198,7 +52198,7 @@
           "param": "FLS_SFTY_TEMP_RATING_C",
           "spaces": 0,
           "break": true,
-          "suffix_override": "Â°C",
+          "suffix_override": "°C",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -52519,7 +52519,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52530,7 +52530,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52541,7 +52541,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52617,7 +52617,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -52683,7 +52683,7 @@
           "param": "WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "mÂ²",
+          "unit": "m²",
           "description": "Sprinkler coverage area limit",
           "standard": "BS 9251:2021 / BS EN 12845",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_SFTY_COVERAGE_AREA_SQ_M_SPRINKLERS__FIR, \"\")"
@@ -52839,7 +52839,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52850,7 +52850,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52861,7 +52861,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -52937,7 +52937,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -53005,7 +53005,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 Â§522 / BS EN 61386",
+          "standard": "BS 7671 §522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
@@ -53386,7 +53386,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53397,7 +53397,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53408,7 +53408,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53484,7 +53484,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -53552,7 +53552,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 Â§522 / BS EN 61386",
+          "standard": "BS 7671 §522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ],
@@ -53700,7 +53700,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53711,7 +53711,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53722,7 +53722,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -53798,7 +53798,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -53866,7 +53866,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 Â§522 / BS EN 61386",
+          "standard": "BS 7671 §522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
@@ -53937,7 +53937,7 @@
           "param": "ELC_CBL_DEST_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": "â†’",
+          "prefix_override": "→",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0"
@@ -54299,7 +54299,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54310,7 +54310,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54321,7 +54321,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -54397,7 +54397,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -54465,7 +54465,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 Â§522 / BS EN 61386",
+          "standard": "BS 7671 §522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CDT_FILL_RATIO, \"\")"
         }
       ],
@@ -54496,7 +54496,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ELC_PNL_DESIGNATION_NAME_TXT",
@@ -54579,7 +54579,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "Feeder: ",
-          "suffix_override": " mmÂ²",
+          "suffix_override": " mm²",
           "note": "Feeder cable"
         },
         {
@@ -54715,54 +54715,54 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_PANEL_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_VLT_DROP_PCT_ELECTRICAL_EQUI, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SHORT_CIRCUIT",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SHORT_CIRCUIT, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SPARE_WAYS",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SPARE_WAYS, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_SCHEDULE_MISSING",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_SCHEDULE_MISSING, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_LOAD_BALANCE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_LOAD_BALANCE, \"\")"
         },
         {
           "param": "WARN_ELC_PNL_FEEDER_UNDERSIZED",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_PNL_FEEDER_UNDERSIZED, \"\")"
         },
         {
@@ -54776,7 +54776,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -54996,7 +54996,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -55272,7 +55272,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55283,7 +55283,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55294,7 +55294,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55370,7 +55370,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -55465,7 +55465,7 @@
           "threshold": "TN-S",
           "unit": "type",
           "description": "Earthing system type compliance",
-          "standard": "BS 7671 Â§411 / IEC 60364",
+          "standard": "BS 7671 §411 / IEC 60364",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_EARTHING_TYPE, \"\")"
         },
         {
@@ -55847,7 +55847,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55858,7 +55858,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55869,7 +55869,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -55945,7 +55945,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -56022,7 +56022,7 @@
           "threshold": "1200",
           "unit": "mm",
           "description": "Fixture mounting height standard",
-          "standard": "BS 7671 Â§559 / Building Regs Part M",
+          "standard": "BS 7671 §559 / Building Regs Part M",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_FIXTURE_MOUNTING_HEIGHT, \"\")"
         },
         {
@@ -56196,7 +56196,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56207,7 +56207,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56218,7 +56218,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56294,7 +56294,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -56802,7 +56802,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56813,7 +56813,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56824,7 +56824,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -56900,7 +56900,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -57331,7 +57331,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57342,7 +57342,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57353,7 +57353,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57429,7 +57429,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -57793,7 +57793,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57804,7 +57804,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57815,7 +57815,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -57891,7 +57891,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -58248,7 +58248,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58259,7 +58259,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58270,7 +58270,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58346,7 +58346,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -58712,7 +58712,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58723,7 +58723,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58734,7 +58734,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -58810,7 +58810,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -58901,7 +58901,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -59023,13 +59023,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ICT_TAG_7_PARA_TEL_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive"
+          "note": "Natural language paragraph — purely descriptive"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -59042,7 +59042,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -59262,7 +59262,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -59528,7 +59528,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59539,7 +59539,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59550,7 +59550,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -59626,7 +59626,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -60076,7 +60076,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60087,7 +60087,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60098,7 +60098,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60174,7 +60174,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -60265,7 +60265,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -60403,13 +60403,13 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” bold underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — bold underlined in family"
         },
         {
           "param": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Natural language paragraph â€” purely descriptive, no technical codes"
+          "note": "Natural language paragraph — purely descriptive, no technical codes"
         },
         {
           "param": "ASS_UNIFORMAT_TXT",
@@ -60422,7 +60422,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -60642,7 +60642,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -60908,7 +60908,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60919,7 +60919,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -60930,7 +60930,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61006,7 +61006,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -61082,7 +61082,7 @@
     "Specialty Equipment Asset": {
       "family_name": "STING - Specialty Equipment Tag Asset",
       "paragraph_container": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
-      "paragraph_template": "Asset {asset_id} ({description}) â€” serial {serial}. Installed: {install_date}. Expected life: {life} yr. Maintenance frequency: {maint} months. Warranty: {warranty}. Criticality: {criticality}/5. Status: {status}.",
+      "paragraph_template": "Asset {asset_id} ({description}) — serial {serial}. Installed: {install_date}. Expected life: {life} yr. Maintenance frequency: {maint} months. Warranty: {warranty}. Criticality: {criticality}/5. Status: {status}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -61409,7 +61409,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61420,7 +61420,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61431,7 +61431,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61507,7 +61507,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -61575,7 +61575,7 @@
           "data_type": "TEXT",
           "threshold": "Criticality rating > 3 without commissioning plan",
           "standard": "ISO 55000 / PAS 1192-3",
-          "description": "Asset criticality rating exceeds threshold â€” commissioning plan required",
+          "description": "Asset criticality rating exceeds threshold — commissioning plan required",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ASS_CRITICALITY_SPECIALTY_EQUIP, \"\")"
         },
         {
@@ -61593,7 +61593,7 @@
     "Specialty Equipment General": {
       "family_name": "STING - Specialty Equipment Tag General",
       "paragraph_container": "ASS_TAG_7_PARA_EQUIPMENT_TXT",
-      "paragraph_template": "{description} â€” function {func}, system {system}. Manufacturer: {mfr}, model {model}. Standard: {standard}. Status: {status}.",
+      "paragraph_template": "{description} — function {func}, system {system}. Manufacturer: {mfr}, model {model}. Standard: {standard}. Status: {status}.",
       "tier_1": [
         {
           "param": "ASS_TAG_1_TXT",
@@ -61897,7 +61897,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61908,7 +61908,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61919,7 +61919,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -61995,7 +61995,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -62063,7 +62063,7 @@
           "data_type": "TEXT",
           "threshold": "ASS_SYSTEM_TYPE_TXT empty",
           "standard": "ISO 19650-2 / CIBSE",
-          "description": "System type not assigned â€” required for equipment register",
+          "description": "System type not assigned — required for equipment register",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_GEN_SPEC_EQUIP_NO_SYS, \"\")"
         },
         {
@@ -62094,7 +62094,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -62206,7 +62206,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_DUCT_INSULATION_TXT",
@@ -62218,7 +62218,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -62232,7 +62232,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -62452,7 +62452,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -62577,7 +62577,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62588,7 +62588,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62599,7 +62599,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -62675,7 +62675,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -62764,7 +62764,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -62870,7 +62870,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_DUCT_LINING_TXT",
@@ -62882,7 +62882,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -62896,7 +62896,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -63116,7 +63116,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -63241,7 +63241,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63252,7 +63252,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63263,7 +63263,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63339,7 +63339,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -63428,7 +63428,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -63540,7 +63540,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_PIPE_INSULATION_TXT",
@@ -63552,7 +63552,7 @@
           "param": "WARN_INS_THICKNESS_MM",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_INS_THICKNESS_MM, \"\")"
         },
         {
@@ -63566,7 +63566,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -63786,7 +63786,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -63911,7 +63911,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63922,7 +63922,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -63933,7 +63933,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64009,7 +64009,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -64098,7 +64098,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -64204,7 +64204,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_PLM_EQUIP_TXT",
@@ -64216,7 +64216,7 @@
           "param": "WARN_PLM_EQP_PRESSURE_KPA",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PLM_EQP_PRESSURE_KPA, \"\")"
         },
         {
@@ -64230,7 +64230,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -64450,7 +64450,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -64716,7 +64716,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64727,7 +64727,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64738,7 +64738,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -64864,7 +64864,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -64980,7 +64980,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -65086,7 +65086,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_MECH_CTRL_DEV_TXT",
@@ -65105,7 +65105,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -65325,7 +65325,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -65450,7 +65450,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65461,7 +65461,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65472,7 +65472,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -65548,7 +65548,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -65637,7 +65637,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -65743,7 +65743,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_MECH_EQUIP_SETS_TXT",
@@ -65762,7 +65762,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -65982,7 +65982,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -66107,7 +66107,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66118,7 +66118,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66129,7 +66129,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66205,7 +66205,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -66294,7 +66294,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -66400,7 +66400,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_ELC_CONNECTORS_TXT",
@@ -66419,7 +66419,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -66639,7 +66639,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -66764,7 +66764,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66775,7 +66775,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66786,7 +66786,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -66862,7 +66862,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -66951,7 +66951,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -67057,7 +67057,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "FLS_TAG_7_PARA_FIRE_PROT_TXT",
@@ -67069,7 +67069,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
         },
         {
@@ -67083,7 +67083,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -67303,7 +67303,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -67428,7 +67428,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67439,7 +67439,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67450,7 +67450,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -67526,7 +67526,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -67592,7 +67592,7 @@
           "param": "WARN_FLS_PROT_COVERAGE",
           "severity": "CRITICAL",
           "threshold": "12.0",
-          "unit": "mÂ²",
+          "unit": "m²",
           "description": "Fire safety device coverage limit",
           "standard": "Building Regs Part B / BS 9999",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FLS_PROT_COVERAGE, \"\")"
@@ -67615,7 +67615,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -67721,7 +67721,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ELC_TAG_7_PARA_FAB_CONTAINMENT_TXT",
@@ -67740,7 +67740,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -67960,7 +67960,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -68085,7 +68085,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68096,7 +68096,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68107,7 +68107,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68183,7 +68183,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -68251,7 +68251,7 @@
           "threshold": "40",
           "unit": "%",
           "description": "Conduit/tray fill ratio maximum",
-          "standard": "BS 7671 Â§522 / BS EN 61386",
+          "standard": "BS 7671 §522 / BS EN 61386",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_ELC_CTR_FILL_RATIO, \"\")"
         }
       ]
@@ -68272,7 +68272,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -68378,7 +68378,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_FAB_DUCTWORK_TXT",
@@ -68397,7 +68397,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -68617,7 +68617,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -68742,7 +68742,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68753,7 +68753,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68764,7 +68764,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -68840,7 +68840,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -68929,7 +68929,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -69035,7 +69035,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "HVC_TAG_7_PARA_FAB_DCT_STIFFENERS_TXT",
@@ -69054,7 +69054,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -69274,7 +69274,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -69399,7 +69399,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69410,7 +69410,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69421,7 +69421,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -69497,7 +69497,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -69586,7 +69586,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -69705,7 +69705,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "MEP_TAG_7_PARA_FAB_HANGERS_TXT",
@@ -69717,7 +69717,7 @@
           "param": "WARN_FAB_HANGER_LOAD_KN",
           "spaces": 0,
           "break": true,
-          "note": "Conditional warning â€” visible when TAG_WARN_VISIBLE_BOOL is true",
+          "note": "Conditional warning — visible when TAG_WARN_VISIBLE_BOOL is true",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_FAB_HANGER_LOAD_KN, \"\")"
         },
         {
@@ -69731,7 +69731,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -69951,7 +69951,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -70076,7 +70076,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70087,7 +70087,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70098,7 +70098,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70174,7 +70174,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -70263,7 +70263,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -70369,7 +70369,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "PLM_TAG_7_PARA_FAB_PIPEWORK_TXT",
@@ -70388,7 +70388,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -70608,7 +70608,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -70733,7 +70733,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70744,7 +70744,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70755,7 +70755,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -70831,7 +70831,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -70920,7 +70920,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -71026,7 +71026,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "PROP_TAG_7_PARA_MATERIALS_TXT",
@@ -71045,7 +71045,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -71265,7 +71265,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -71390,7 +71390,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71401,7 +71401,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71412,7 +71412,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -71488,7 +71488,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -71554,7 +71554,7 @@
           "param": "WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__",
           "severity": "MEDIUM",
           "threshold": "500",
-          "unit": "kgCOâ‚‚e/mÂ²",
+          "unit": "kgCO₂e/m²",
           "description": "Embodied carbon footprint limit per unit",
           "standard": "RIBA 2030 Climate Challenge / EN 15978",
           "formula": "if(TAG_WARN_VISIBLE_BOOL, WARN_PER_SUST_CARBON_FOOTPRINT_KG_WALLS__FLOORS__, \"\")"
@@ -71577,7 +71577,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -71683,7 +71683,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ICT_TAG_7_PARA_AV_DEV_TXT",
@@ -71702,7 +71702,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -71922,7 +71922,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -72047,7 +72047,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72058,7 +72058,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72069,7 +72069,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72145,7 +72145,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -72234,7 +72234,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -72340,7 +72340,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "MED_TAG_7_PARA_MED_EQUIP_TXT",
@@ -72359,7 +72359,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -72579,7 +72579,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -72704,7 +72704,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72715,7 +72715,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72726,7 +72726,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -72802,7 +72802,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -72900,7 +72900,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -73006,7 +73006,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_PROPERTY_LINE_SEGMENTS_TXT",
@@ -73025,7 +73025,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -73245,7 +73245,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -73370,7 +73370,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73381,7 +73381,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73392,7 +73392,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -73468,7 +73468,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -73557,7 +73557,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading (FUNC-PROD-SEQ) â€” underlined in family"
+          "note": "Short tag heading (FUNC-PROD-SEQ) — underlined in family"
         },
         {
           "param": "ASS_DESCRIPTION_TXT",
@@ -73663,7 +73663,7 @@
           "param": "ASS_TAG_2_TXT",
           "spaces": 0,
           "break": true,
-          "note": "Short tag heading â€” bold underlined in family"
+          "note": "Short tag heading — bold underlined in family"
         },
         {
           "param": "ARCH_TAG_7_PARA_TOPOSOLID_LINKS_TXT",
@@ -73682,7 +73682,7 @@
           "param": "ASS_UNIFORMAT_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Uniformat description"
         },
         {
@@ -73902,7 +73902,7 @@
           "param": "ASS_ASSEMBLY_DESC_TXT",
           "spaces": 0,
           "break": true,
-          "prefix_override": " â€” ",
+          "prefix_override": " — ",
           "note": "Assembly description"
         },
         {
@@ -74027,7 +74027,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Product-stage embodied carbon (BS EN 15978)",
           "style": "ITALIC",
           "color": "GREEN",
@@ -74038,7 +74038,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": " kgCOâ‚‚e",
+          "suffix_override": " kgCO₂e",
           "note": "T6 Transport-stage carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -74049,7 +74049,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": " kgCOâ‚‚e/yr",
+          "suffix_override": " kgCO₂e/yr",
           "note": "T6 Operational energy carbon",
           "style": "ITALIC",
           "color": "GREEN",
@@ -74125,7 +74125,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": " mm",
           "note": "T9 As-built deviation vs design",
           "style": "ITALIC",
@@ -74333,7 +74333,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74343,7 +74343,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74353,7 +74353,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74422,7 +74422,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -74479,8 +74479,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_ARCH.csv"
     },
-    "Tie-In Point Tag (Pipe â€” Plumbing & Hydraulic)": {
-      "family_name": "STING - Tie-In Point Tag (Pipe â€” Plumbing & Hydraulic)",
+    "Tie-In Point Tag (Pipe — Plumbing & Hydraulic)": {
+      "family_name": "STING - Tie-In Point Tag (Pipe — Plumbing & Hydraulic)",
       "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -74698,7 +74698,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74708,7 +74708,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74718,7 +74718,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -74787,7 +74787,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -74844,8 +74844,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Duct â€” HVAC)": {
-      "family_name": "STING - Tie-In Point Tag (Duct â€” HVAC)",
+    "Tie-In Point Tag (Duct — HVAC)": {
+      "family_name": "STING - Tie-In Point Tag (Duct — HVAC)",
       "paragraph_container": "HVC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -75062,7 +75062,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75072,7 +75072,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75082,7 +75082,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75151,7 +75151,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75208,8 +75208,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Conduit â€” Electrical LV/ELV)": {
-      "family_name": "STING - Tie-In Point Tag (Conduit â€” Electrical LV/ELV)",
+    "Tie-In Point Tag (Conduit — Electrical LV/ELV)": {
+      "family_name": "STING - Tie-In Point Tag (Conduit — Electrical LV/ELV)",
       "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -75224,7 +75224,7 @@
           "param": "ELC_CDT_SZ_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "âˆ…",
+          "prefix_override": "∅",
           "style": "NOM",
           "color": "BLACK",
           "size": "2.5"
@@ -75399,7 +75399,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75409,7 +75409,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75419,7 +75419,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75488,7 +75488,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75545,8 +75545,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Cable Tray â€” Electrical)": {
-      "family_name": "STING - Tie-In Point Tag (Cable Tray â€” Electrical)",
+    "Tie-In Point Tag (Cable Tray — Electrical)": {
+      "family_name": "STING - Tie-In Point Tag (Cable Tray — Electrical)",
       "paragraph_container": "ELC_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -75735,7 +75735,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75745,7 +75745,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75755,7 +75755,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -75824,7 +75824,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -75881,8 +75881,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Fire Protection â€” Sprinkler / Suppression)": {
-      "family_name": "STING - Tie-In Point Tag (Fire Protection â€” Sprinkler / Suppression)",
+    "Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)": {
+      "family_name": "STING - Tie-In Point Tag (Fire Protection — Sprinkler / Suppression)",
       "paragraph_container": "FLS_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -76082,7 +76082,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76092,7 +76092,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76102,7 +76102,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76171,7 +76171,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76228,8 +76228,8 @@
       ],
       "source_csv": "STING_TAG_CONFIG_v5_0_MEP.csv"
     },
-    "Tie-In Point Tag (Gas â€” Medical / Industrial / Natural Gas)": {
-      "family_name": "STING - Tie-In Point Tag (Gas â€” Medical / Industrial / Natural Gas)",
+    "Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)": {
+      "family_name": "STING - Tie-In Point Tag (Gas — Medical / Industrial / Natural Gas)",
       "paragraph_container": "PLM_TAG_7_PARA_TIEIN_TXT",
       "tier_1": [
         {
@@ -76437,7 +76437,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76447,7 +76447,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76457,7 +76457,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76526,7 +76526,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76718,7 +76718,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76728,7 +76728,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76738,7 +76738,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -76807,7 +76807,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -76889,7 +76889,7 @@
           "param": "SLV_SZ_MM",
           "spaces": 0,
           "break": true,
-          "prefix_override": "Ã˜",
+          "prefix_override": "Ø",
           "suffix_override": "mm",
           "style": "NOM",
           "color": "BLACK",
@@ -77042,7 +77042,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77052,7 +77052,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77062,7 +77062,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -77131,7 +77131,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -77264,7 +77264,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection air terminal â€” LPS class {class}, zone {zone}. Compliant with BS EN 62305-3 Â§5.2."
+      "paragraph_template": "Lightning protection air terminal — LPS class {class}, zone {zone}. Compliant with BS EN 62305-3 §5.2."
     },
     "LPS Down Conductor": {
       "family_name": "STING - LPS Down Conductor Tag",
@@ -77333,7 +77333,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection down conductor â€” LPS class {class}. Compliant with BS EN 62305-3 Â§5.3."
+      "paragraph_template": "Lightning protection down conductor — LPS class {class}. Compliant with BS EN 62305-3 §5.3."
     },
     "LPS Earth Electrode": {
       "family_name": "STING - LPS Earth Electrode Tag",
@@ -77402,7 +77402,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection earth electrode â€” LPS class {class}. Compliant with BS EN 62305-3 Â§5.4."
+      "paragraph_template": "Lightning protection earth electrode — LPS class {class}. Compliant with BS EN 62305-3 §5.4."
     },
     "LPS Bond": {
       "family_name": "STING - LPS Bond Tag",
@@ -77678,7 +77678,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection earth â€” structural foundation reuse. Compliant with BS EN 62305-3."
+      "paragraph_template": "Lightning protection earth — structural foundation reuse. Compliant with BS EN 62305-3."
     },
     "LPS Natural Air Termination (Architectural Reuse)": {
       "family_name": "STING - LPS Natural Air Termination (Architectural Reuse) Tag",
@@ -77747,7 +77747,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Lightning protection air termination â€” architectural element reuse (roof / parapet / fascia). Compliant with BS EN 62305-3 Â§5.2."
+      "paragraph_template": "Lightning protection air termination — architectural element reuse (roof / parapet / fascia). Compliant with BS EN 62305-3 §5.2."
     },
     "LPS Generic Component": {
       "family_name": "STING - LPS Generic Component Tag",
@@ -78024,7 +78024,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78034,7 +78034,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78044,7 +78044,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78113,7 +78113,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78305,7 +78305,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78315,7 +78315,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78325,7 +78325,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78394,7 +78394,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78604,7 +78604,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "A1-A3:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78614,7 +78614,7 @@
           "spaces": 0,
           "break": false,
           "prefix_override": "| A4:",
-          "suffix_override": "kgCOâ‚‚e",
+          "suffix_override": "kgCO₂e",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78624,7 +78624,7 @@
           "spaces": 0,
           "break": true,
           "prefix_override": "| B6:",
-          "suffix_override": "kgCOâ‚‚e/yr",
+          "suffix_override": "kgCO₂e/yr",
           "style": "ITALIC",
           "color": "GREEN",
           "size": "2.0"
@@ -78693,7 +78693,7 @@
           "param": "ASBUILT_DEVIATION_MM",
           "spaces": 0,
           "break": false,
-          "prefix_override": "Î”:",
+          "prefix_override": "Δ:",
           "suffix_override": "mm",
           "style": "ITALIC",
           "color": "GREY",
@@ -78796,7 +78796,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "prefix_override": "Î”P:"
+          "prefix_override": "ΔP:"
         },
         {
           "param": "CLN_DESIGN_ACH_INT",
@@ -79001,7 +79001,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "prefix_override": "Î”P:"
+          "prefix_override": "ΔP:"
         },
         {
           "param": "RGL_STD_TXT",
@@ -79665,7 +79665,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray shielded door â€” lead equivalent {Pb} mm (NCRP 147). Compliant with {standard}."
+      "paragraph_template": "X-ray shielded door — lead equivalent {Pb} mm (NCRP 147). Compliant with {standard}."
     },
     "X-ray Window": {
       "family_name": "STING - X-ray Window Tag",
@@ -79735,7 +79735,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray shielded viewing window â€” lead equivalent {Pb} mm (NCRP 147)."
+      "paragraph_template": "X-ray shielded viewing window — lead equivalent {Pb} mm (NCRP 147)."
     },
     "X-ray Barrier": {
       "family_name": "STING - X-ray Barrier Tag",
@@ -79814,7 +79814,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "X-ray protective barrier wall â€” {Pb} mm lead equivalent, type {type}. Compliant with NCRP 147."
+      "paragraph_template": "X-ray protective barrier wall — {Pb} mm lead equivalent, type {type}. Compliant with NCRP 147."
     },
     "MRI Faraday Cage": {
       "family_name": "STING - MRI Faraday Cage Tag",
@@ -79883,7 +79883,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "MRI Faraday cage wall â€” RF shield for zone {zone}. Compliant with MHRA DB2007(03)."
+      "paragraph_template": "MRI Faraday cage wall — RF shield for zone {zone}. Compliant with MHRA DB2007(03)."
     },
     "Linac Maze": {
       "family_name": "STING - Linac Maze Tag",
@@ -79962,7 +79962,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Linear accelerator maze wall â€” {type} construction, {Pb} mm lead equivalent. Compliant with NCRP 151."
+      "paragraph_template": "Linear accelerator maze wall — {type} construction, {Pb} mm lead equivalent. Compliant with NCRP 151."
     },
     "Anti-Ligature (Lighting Fixture)": {
       "family_name": "STING - Anti-Ligature (Lighting Fixture) Tag",
@@ -82555,7 +82555,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Hyperbaric oxygen chamber. Compliant with NFPA 99 Â§14."
+      "paragraph_template": "Hyperbaric oxygen chamber. Compliant with NFPA 99 §14."
     },
     "IVF Workstation": {
       "family_name": "STING - IVF Workstation Tag",
@@ -82948,7 +82948,7 @@
           "style": "NOM",
           "color": "BLACK",
           "size": "2.0",
-          "suffix_override": "W/mÂ²K"
+          "suffix_override": "W/m²K"
         },
         {
           "param": "RGL_STD_TXT",
@@ -82978,7 +82978,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Curtain wall panel â€” {thickness} mm, U-value {U-value} W/mÂ²K. Compliant with {standard}."
+      "paragraph_template": "Curtain wall panel — {thickness} mm, U-value {U-value} W/m²K. Compliant with {standard}."
     },
     "Curtain Wall Mullion": {
       "family_name": "STING - Curtain Wall Mullion Tag",
@@ -83417,7 +83417,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Fire protection pipe tie-in point â€” DN{DN}."
+      "paragraph_template": "Fire protection pipe tie-in point — DN{DN}."
     },
     "Tie-In Gas Pipe": {
       "family_name": "STING - Tie-In Gas Pipe Tag",
@@ -83495,7 +83495,7 @@
           "size": "2.0"
         }
       ],
-      "paragraph_template": "Gas pipe tie-in point â€” {gas}, DN{DN}."
+      "paragraph_template": "Gas pipe tie-in point — {gas}, DN{DN}."
     }
   },
   "tag7_heading_style": {
@@ -83505,14 +83505,14 @@
       "bold": false,
       "italic": false,
       "underline": true,
-      "note": "Underlined in State 2 (Technical) â€” functional emphasis without visual dominance"
+      "note": "Underlined in State 2 (Technical) — functional emphasis without visual dominance"
     },
     "tier_3_heading": {
       "param": "ASS_TAG_2_TXT",
       "bold": true,
       "italic": false,
       "underline": true,
-      "note": "Bold + Underlined in State 3 (Full Specification) â€” primary heading treatment"
+      "note": "Bold + Underlined in State 3 (Full Specification) — primary heading treatment"
     },
     "batch_control": {
       "description": "Use the Set TAG7 Heading Style command to batch-update the heading format across all tag families. Supported styles: bold, italic, underline, bold+underline, bold+italic, all.",
@@ -83548,7 +83548,7 @@
       "TAG_WARN_SEVERITY_FILTER_TXT"
     ],
     "text_style_matrix": {
-      "_comment": "128 combinations â€” 4 sizes x 4 styles x 8 colors. Exactly one BOOL set to Yes per element type.",
+      "_comment": "128 combinations — 4 sizes x 4 styles x 8 colors. Exactly one BOOL set to Yes per element type.",
       "sizes": [
         "2",
         "2.5",

--- a/StingTools/Data/MR_PARAMETERS.csv
+++ b/StingTools/Data/MR_PARAMETERS.csv
@@ -2601,6 +2601,7 @@ Views,STING_DRAWING_PACKAGE_ID_TXT,a7c0b2e4-4d91-4a55-9c7e-aa0001000002,TEXT,STI
 Views,STING_AUTO_PLACED_BOOL,a7c0b2e4-4d91-4a55-9c7e-aa0001000003,YESNO,STING_DRAWING,Instance,Flags views auto-placed onto sheets by the STING production engine [STING DT v137],False,,,MULTI,1,0
 Sheets,STING_PRODUCTION_RULE_IDX_INT,a7c0b2e4-4d91-4a55-9c7e-aa0001000004,INTEGER,STING_DRAWING,Instance,ProductionRule index that produced this view [STING DT v137],False,,,MULTI,1,0
 Sheets,STING_SHEET_SEQUENCE_INT,a7c0b2e4-4d91-4a55-9c7e-aa0001000005,INTEGER,STING_DRAWING,Instance,Production sheet sequence number [STING DT v137],False,,,MULTI,1,0
+Sheets,STING_SHEET_CONTEXT_TXT,a7c0b2e4-4d91-4a55-9c7e-aa0001000006,TEXT,STING_DRAWING,Instance,Production context (level / scope box / room) this sheet was produced for [STING DT v137],False,,,MULTI,1,0
 Project Information,HANDOVER_MODE_HANDOVER_BOOL,a8f3c1d2-4e56-7890-abcd-ef1234567801,YESNO,COMMISSIONING,Instance,Pattern selector — Handover / FM T4-T10 payload visible [STING Phase 165],False,,,MULTI,1,0
 Project Information,HANDOVER_MODE_DC_BOOL,a8f3c1d2-4e56-7890-abcd-ef1234567802,YESNO,COMMISSIONING,Instance,Pattern selector — Design & Construction T4-T10 payload visible [STING Phase 165],False,,,MULTI,1,0
 Project Information,HANDOVER_MODE_CUSTOM_BOOL,a8f3c1d2-4e56-7890-abcd-ef1234567803,YESNO,COMMISSIONING,Instance,Pattern selector — Custom (user-defined) T4-T10 payload visible [STING Phase 165],False,,,MULTI,1,0

--- a/StingTools/Data/MR_PARAMETERS.txt
+++ b/StingTools/Data/MR_PARAMETERS.txt
@@ -2697,6 +2697,7 @@ PARAM	a7c0b2e4-4d91-4a55-9c7e-aa0001000002	STING_DRAWING_PACKAGE_ID_TXT	TEXT		27
 PARAM	a7c0b2e4-4d91-4a55-9c7e-aa0001000003	STING_AUTO_PLACED_BOOL	YESNO		27	1	Flags views auto-placed onto sheets by the STING production engine [STING DT v137]	1	0
 PARAM	a7c0b2e4-4d91-4a55-9c7e-aa0001000004	STING_PRODUCTION_RULE_IDX_INT	INTEGER		27	1	ProductionRule index that produced this view [STING DT v137]	1	0
 PARAM	a7c0b2e4-4d91-4a55-9c7e-aa0001000005	STING_SHEET_SEQUENCE_INT	INTEGER		27	1	Production sheet sequence number [STING DT v137]	1	0
+PARAM	a7c0b2e4-4d91-4a55-9c7e-aa0001000006	STING_SHEET_CONTEXT_TXT	TEXT		27	1	Production context (level / scope box / room) this sheet was produced for [STING DT v137]	1	0
 PARAM	a8f3c1d2-4e56-7890-abcd-ef1234567801	HANDOVER_MODE_HANDOVER_BOOL	YESNO		25	1	Pattern selector -- Handover / FM T4-T10 payload visible [STING Phase 165]	1	0
 PARAM	a8f3c1d2-4e56-7890-abcd-ef1234567802	HANDOVER_MODE_DC_BOOL	YESNO		25	1	Pattern selector -- Design & Construction T4-T10 payload visible [STING Phase 165]	1	0
 PARAM	a8f3c1d2-4e56-7890-abcd-ef1234567803	HANDOVER_MODE_CUSTOM_BOOL	YESNO		25	1	Pattern selector -- Custom (user-defined) T4-T10 payload visible [STING Phase 165]	1	0

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -19791,6 +19791,18 @@
       "curated": true
     },
     {
+      "param_name": "STING_SHEET_CONTEXT_TXT",
+      "guid": "a7c0b2e4-4d91-4a55-9c7e-aa0001000006",
+      "description": "Production context (level / scope box / room) this sheet was produced for [STING DT v137]",
+      "datatype": "TEXT",
+      "group_id": 27,
+      "group_name": "STING_DRAWING",
+      "binding": "project",
+      "required": false,
+      "discipline": "STING",
+      "curated": true
+    },
+    {
       "param_name": "PRJ_ORG_PROJECT_NAME_TXT",
       "guid": "33188c51-0a4f-52e7-ad2a-37e68ca7ddda",
       "description": "Project name shown on the title block [STING Phase 171]",

--- a/StingTools/Data/STING_AEC_FILTERS.json
+++ b/StingTools/Data/STING_AEC_FILTERS.json
@@ -7339,7 +7339,7 @@
       "rule": {
         "param": "PLM_DEAD_LEG_LENGTH_M",
         "kind": "shared",
-        "op": "greater_than",
+        "op": "greater",
         "value": "0",
         "type": "double"
       },
@@ -7391,9 +7391,8 @@
         "OST_PipeAccessory"
       ],
       "rule": {
-        "kind": "compound",
-        "op": "or",
-        "operands": [
+        "logic": "or",
+        "rules": [
           {
             "param": "PLM_PRESSURE_ZONE_TXT",
             "kind": "shared",
@@ -7433,9 +7432,8 @@
         "OST_PipeAccessory"
       ],
       "rule": {
-        "kind": "compound",
-        "op": "or",
-        "operands": [
+        "logic": "or",
+        "rules": [
           {
             "param": "PLM_FLUID_CATEGORY_TXT",
             "kind": "shared",
@@ -7507,7 +7505,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Bedhead"
       },
@@ -7531,7 +7529,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Pendant"
       },
@@ -7554,7 +7552,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Scrub"
       },
@@ -7646,7 +7644,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Manifold"
       },
@@ -7718,7 +7716,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Generator"
       },
@@ -7741,7 +7739,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "ATS"
       },
@@ -7846,7 +7844,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Temp Sensor"
       },
@@ -7870,7 +7868,7 @@
         "OST_GenericModel"
       ],
       "rule": {
-        "param": "Family Name",
+        "param": "ALL_MODEL_FAMILY_NAME",
         "op": "contains",
         "value": "Calorifier"
       },
@@ -8216,7 +8214,7 @@
           },
           {
             "param": "ELC_LPS_BOND_TYPE_TXT",
-            "op": "isNotEmpty",
+            "op": "hasValue",
             "value": ""
           }
         ]

--- a/StingTools/Data/WORKFLOW_PenetrationRegister.json
+++ b/StingTools/Data/WORKFLOW_PenetrationRegister.json
@@ -6,53 +6,53 @@
   "steps": [
     {
       "id": "build-seeds",
-      "name": "Build seed families (idempotent)",
-      "command": "BuildSeedFamilies",
+      "label": "Build seed families (idempotent)",
+      "commandTag": "Seeds_Build",
       "skipIfFamilyLoaded": "STING_SEED_SpecialityEquipment",
       "_notes": "First-time setup. Builds STING_SEED_SpecialityEquipment, STING_SEED_FireDamper, STING_SEED_AcousticSeal from JSON specs. No-op when all three seed families are already loaded."
     },
     {
       "id": "load-shared-params",
-      "name": "Load shared parameters (PEN_* + ASS_*)",
-      "command": "LoadSharedParams",
+      "label": "Load shared parameters (PEN_* + ASS_*)",
+      "commandTag": "LoadSharedParams",
       "_notes": "Binds PEN_* penetration parameters and ASS_TAG_* containers to Specialty Equipment and the routed MEP categories so the detector, placer, and auto-tagger can read and write them."
     },
     {
       "id": "detect-and-place",
-      "name": "Detect crossings and place / update penetration families",
-      "command": "Penetrations_DetectAndPlace",
+      "label": "Detect crossings and place / update penetration families",
+      "commandTag": "Penetrations_DetectAndPlace",
       "_notes": "Runs SlabPenetrationDetector + WallPenetrationDetector + BeamPenetrationDetector across every MEP curve in the active view. PenetrationProductSelector picks the right seed family and type variant (FR30–FR240, round/rect, combined fire+smoke, acoustic, sleeve). FrpPenetrationPlacer drops face-based instances and stamps the PEN_* parameter pack. Idempotent — re-runs update existing instances rather than duplicating."
     },
     {
       "id": "auto-tag",
-      "name": "Auto-tag penetration family instances",
-      "command": "AutoTag",
+      "label": "Auto-tag penetration family instances",
+      "commandTag": "AutoTag",
       "_notes": "Runs the standard STING tag pipeline on every newly placed or updated penetration family instance: TypeTokenInherit → PopulateAll → NativeParamMapper → FormulaEngine → BuildAndWriteTag → WriteContainers → WriteTag7. Each instance gets a unique DISC-LOC-ZONE-LVL-SYS-FUNC-PROD-SEQ reference visible in the register schedule."
     },
     {
       "id": "coverage-audit",
-      "name": "Audit firestop coverage + structural review",
-      "command": "Validation_PenetrationCoverage",
+      "label": "Audit firestop coverage + structural review",
+      "commandTag": "Validation_PenetrationCoverage",
       "_notes": "Read-only audit. Surfaces orphan members (MEP curves crossing rated barriers with no penetration family), orphan penetration families (instances with no matching MEP curve), and beam structural review findings (STRUCT_REVIEW / STRUCT_FAIL). Results appear in the result panel; no model changes."
     },
     {
       "id": "build-register-schedule",
-      "name": "Build / refresh Penetration Register schedule",
-      "command": "BatchSchedules",
+      "label": "Build / refresh Penetration Register schedule",
+      "commandTag": "BatchSchedules",
       "scheduleNameFilter": "STING - Penetration Register",
       "_notes": "Creates or refreshes the 'STING - Penetration Register' Revit schedule from MR_SCHEDULES.csv. The schedule includes PEN_CONTROL_NR, PEN_HOST_REF, PEN_FIRE_RATING, PEN_PRODUCT_FAMILY, PEN_TYPE_VARIANT, PEN_OD_MM, PEN_SLAB_THICK_MM, PEN_INSTALL_DATE, PEN_INSPECTOR, and the ASS_TAG_1 asset reference — one row per penetration family instance, grouped by host type."
     },
     {
       "id": "place-on-sheet",
-      "name": "Place register schedule on A1 sheet",
-      "command": "DrawingTypes_FromScopeBoxes",
+      "label": "Place register schedule on A1 sheet",
+      "commandTag": "DrawingTypes_FromScopeBoxes",
       "drawingTypeId": "penetration-register-A1",
       "_notes": "Creates or updates the A1 Penetration Register sheet using the 'penetration-register-A1' drawing type profile. The schedule is placed in the single Main slot. Idempotent — re-running on an existing sheet refreshes the viewport without creating a duplicate."
     },
     {
       "id": "export-register",
-      "name": "Export Penetration Register to PDF + CSV",
-      "command": "ExportSheetRegister",
+      "label": "Export Penetration Register to PDF + CSV",
+      "commandTag": "ExportSheetRegister",
       "sheetNumberFilter": "FP-PEN",
       "_notes": "Exports all FP-PEN-* sheets to PDF (ISO A1, black-and-white) and writes a flat CSV of the schedule data to <project>/_BIM_COORD/exports/PenetrationRegister_<date>.csv. Both outputs are ready for client delivery and COBie FM handover."
     }

--- a/StingTools/Data/WORKFLOW_PenetrationSweep.json
+++ b/StingTools/Data/WORKFLOW_PenetrationSweep.json
@@ -6,33 +6,33 @@
   "steps": [
     {
       "id": "build-seeds",
-      "name": "Build seed families (idempotent)",
-      "command": "BuildSeedFamilies",
+      "label": "Build seed families (idempotent)",
+      "commandTag": "Seeds_Build",
       "skipIfFamilyLoaded": "STING_SEED_SpecialityEquipment",
       "_notes": "First-time setup. No-op when the seed family is already in the project."
     },
     {
       "id": "load-shared-params",
-      "name": "Load shared parameters (PEN_*)",
-      "command": "LoadSharedParams",
+      "label": "Load shared parameters (PEN_*)",
+      "commandTag": "LoadSharedParams",
       "_notes": "Binds the 19 PEN_* shared params to Specialty Equipment + the routed MEP categories so the detector and placer can stamp them."
     },
     {
       "id": "detect-and-place",
-      "name": "Detect crossings and place / update FRP instances",
-      "command": "Penetrations_DetectAndPlace",
+      "label": "Detect crossings and place / update FRP instances",
+      "commandTag": "Penetrations_DetectAndPlace",
       "_notes": "Runs SlabPenetrationDetector + WallPenetrationDetector + BeamPenetrationDetector against every MEP curve in the active view. FrpPenetrationPlacer drops face-based instances at each crossing and stamps the parameter pack. Idempotent — re-runs update existing instances rather than duplicate."
     },
     {
       "id": "coverage-audit",
-      "name": "Audit firestop coverage + structural review",
-      "command": "Validation_PenetrationCoverage",
+      "label": "Audit firestop coverage + structural review",
+      "commandTag": "Validation_PenetrationCoverage",
       "_notes": "Read-only audit. Surfaces orphan members, orphan FRP instances, and beam STRUCT_FAIL / STRUCT_REVIEW findings."
     },
     {
       "id": "schedule",
-      "name": "Build / refresh Penetration Register schedule",
-      "command": "BatchSchedules",
+      "label": "Build / refresh Penetration Register schedule",
+      "commandTag": "BatchSchedules",
       "scheduleNameFilter": "STING - Penetration Register",
       "_notes": "Builds the Penetration Register from MR_SCHEDULES.csv — one row per FRP instance, grouped by host type."
     }

--- a/StingTools/Docs/TitleBlockCommands.cs
+++ b/StingTools/Docs/TitleBlockCommands.cs
@@ -1068,7 +1068,7 @@ namespace StingTools.Docs
                 $"Synced {result.SheetsProcessed} sheet(s), {result.ParamsWritten} parameter(s) written.\n" +
                 $"Skipped: {result.SheetsSkipped}.\n\n" +
                 "Wrote SHT_REV_TXT / SHT_REV_DATE_TXT on sheets and\n" +
-                "PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT / PRJ_TB_ISSUE_SUMMARY_TXT\n" +
+                "PRJ_TB_REVISION_NR_TXT / _DATE_TXT / _DESCRIPTION_TXT\n" +
                 "on title blocks." + warn);
             return Result.Succeeded;
         }

--- a/StingTools/Tags/LegendBuilderCommands.cs
+++ b/StingTools/Tags/LegendBuilderCommands.cs
@@ -1309,7 +1309,10 @@ namespace StingTools.Tags
         /// For each category, shows: discipline swatch | category name | tag family name | sample tag.
         /// Attempts to place actual annotation instances (Strategy 2), falls back to drawn text.
         /// </summary>
-        private static void PopulateTagLegendContent(Document doc, View legendView,
+        // internal (was private) so UpdateLegendCommand can refresh a tag
+        // legend IN PLACE instead of deleting its content and telling the user
+        // to rebuild it by hand (A-3).
+        internal static void PopulateTagLegendContent(Document doc, View legendView,
             List<TagLegendEntry> entries, string title, string groupBy)
         {
             FillPatternElement solidFill = FindSolidFill(doc);
@@ -3285,14 +3288,29 @@ namespace StingTools.Tags
 
                     if (name.Contains("Tag Families") || name.Contains("Tag Legend"))
                     {
-                        // Tag legend — rebuild
+                        // A-3: refresh IN PLACE. This branch used to delete the
+                        // view's content, mint a SECOND "(Refreshed)" view, and
+                        // log "use Create Tag Legend to rebuild" — so the view
+                        // actually placed on sheets was left permanently blank
+                        // while a duplicate carried the content nowhere.
                         var entries = LegendBuilder.CollectTagFamilies(doc);
-                        if (entries.Count > 0)
-                            LegendBuilder.CreateTagLegendView(doc, entries, "Tag Families (Refreshed)", "Discipline");
-                        // We can't easily re-populate an existing tag legend view without recreating
-                        // So just log and continue — the view content was deleted and will appear blank
-                        // until they use CreateTagLegend again
-                        StingLog.Info($"UpdateLegend: cleared tag legend '{name}' — use Create Tag Legend to rebuild");
+                        if (entries != null && entries.Count > 0)
+                        {
+                            try
+                            {
+                                LegendBuilder.PopulateTagLegendContent(doc, legendView, entries, name, "Discipline");
+                                updated++;
+                                StingLog.Info($"UpdateLegend: refreshed tag legend '{name}' in place.");
+                            }
+                            catch (Exception ex)
+                            {
+                                StingLog.Warn($"UpdateLegend: failed to refresh tag legend '{name}': {ex.Message}");
+                            }
+                        }
+                        else
+                        {
+                            StingLog.Info($"UpdateLegend: no tag families found — '{name}' left empty.");
+                        }
                     }
                     else
                     {
@@ -3379,20 +3397,18 @@ namespace StingTools.Tags
 
                         if (entries != null && entries.Count > 0 && config != null)
                         {
-                            // Re-populate the existing view (don't create a new one)
-                            // Use reflection-style approach: call PopulateLegendContent directly
-                            // Since it's private, we call CreateLegendView which creates a new view,
-                            // but we already deleted content — so just populate this view
+                            // A-3: populate the EXISTING view. The previous code
+                            // called CreateLegendView on the belief that
+                            // PopulateLegendContent was private — it is
+                            // `internal static`, callable from here. Minting a
+                            // new view left the original (the one actually
+                            // placed on sheets) permanently blank, gave it a
+                            // "(1)" suffixed twin, and still reported success.
                             try
                             {
-                                // Workaround: create a temporary new view, but we actually want
-                                // to reuse the existing view. Let's use the public API instead.
-                                var newView = LegendBuilder.CreateLegendView(doc, entries, config);
-                                if (newView != null)
-                                {
-                                    updated++;
-                                    StingLog.Info($"UpdateLegend: refreshed '{name}' (created new '{newView.Name}')");
-                                }
+                                LegendBuilder.PopulateLegendContent(doc, legendView, entries, config);
+                                updated++;
+                                StingLog.Info($"UpdateLegend: refreshed '{name}' in place.");
                             }
                             catch (Exception ex)
                             {
@@ -3408,8 +3424,8 @@ namespace StingTools.Tags
             TaskDialog.Show("Update Legend",
                 $"Processed {toUpdate.Count} legends.\n" +
                 $"Updated: {updated}\n\n" +
-                "Legend views have been refreshed with current project data.\n" +
-                "Sheet placements are preserved.");
+                "Each legend was refreshed in place with current project data.\n" +
+                "Sheet placements stay live — no new views were created.");
 
             return Result.Succeeded;
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
-#### Completed (Phase 223 — drawings-production P0)
+#### Completed (Phase 223 — drawings-production P0 + managed-template hardening)
 
 The P0 tier of the drawings-production deep review
 ([`DRAWINGS_PRODUCTION_REVIEW.md`](DRAWINGS_PRODUCTION_REVIEW.md), ~85 findings). Six fixes,
@@ -59,12 +59,28 @@ exercised inside Revit yet — see the smoke-test list at the end.
   only by an empty-context request; and if the parameter is not bound at all the producer falls
   back to the old behaviour **with a warning** rather than minting a duplicate sheet per run.
 
+- **`ManagedTemplateSyncer` hardened before managed mode goes live (E-3, E-4, E-6).** The C-2
+  fix took the managed-template path from unreachable to live for 14 packs, so its known bugs had
+  to be cleared in the same series or the fix would have shipped a regression. Non-template seeds
+  now mint via `View.CreateViewTemplate()` instead of `CopyElement` (which yielded live views that
+  could never be found again and were re-minted as `_(2)`, `_(3)`, …); the `_(2)` rename fallback
+  is gone, replaced by a loud failure that cleans up after itself. The discipline map now reads
+  `ViewDiscipline` members instead of hardcoded ints — note the review had this backwards: 4095
+  (Coordination) was already correct and 4096 (Mechanical) was not, the real defect being
+  Mechanical/Electrical/Plumbing, which should be 4/8/16. And
+  `SetManagedTemplateParameterIds` now computes the complement Revit's API wants
+  (`SetNonControlledTemplateParameterIds`) instead of discarding the list it built, which is what
+  keeps a seed template from overriding the per-profile `DrawingType.Scale`.
+
 **Needs a Revit smoke test before merge** — none of the above has run inside Revit:
 
 | Area | What to check |
 |---|---|
 | Style packs (C-1) | Apply a `corp-healthcare-*` pack: filter colour coding appears where it previously did not |
 | Extends fold (C-2) | A pack with `templateMode: "managed"` engages the managed-template path |
+| **Managed minting (E-3)** | **Apply a `templateMode:"managed"` pack on a fresh project with no `STING - ` seed templates: a real view template is created, and repeated runs add no `_(2)` / `_(3)` junk views** |
+| Discipline (E-4) | A managed `corp-standard-hvac` / `-elec` / `-plumb` template shows the right discipline in Revit, not a blank or odd value |
+| Template control (E-6) | With a managed pack applied, the per-profile `DrawingType.Scale` still wins over the seed template's scale |
 | Workflows (W-1) | Run Penetration Sweep and Penetration Register end to end |
 | Filters (V-3/V-7/V-8) | The 12 repaired filters mint; a multi-material class filter selects elements |
 | Producer (C-3) | Run `LoadSharedParams` first, then produce per level over ≥2 levels: expect one sheet per level, and a re-run that reuses them rather than adding more |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,6 +85,9 @@ exercised inside Revit yet — see the smoke-test list at the end.
 | Filters (V-3/V-7/V-8) | The 12 repaired filters mint; a multi-material class filter selects elements |
 | Producer (C-3) | Run `LoadSharedParams` first, then produce per level over ≥2 levels: expect one sheet per level, and a re-run that reuses them rather than adding more |
 | Labels (A-11) | A medical-gas tag renders CO₂ / N₂O with a real subscript and warnings with ⚠ |
+| Numbering (D-1/P-2) | Produce over ≥2 sheets in one package: ISO-pattern types get real numbers, and the sequence increments instead of every sheet reading 0001 |
+| **ISO params unset (D-1)** | **On a project with `PRJ_PROJECT_COD_TXT` / `PRJ_ORG_ORIGINATOR_CODE_TXT` empty, confirm the leading empty segments (`--01-…`) are acceptable, or set both before producing.** Previously the whole assignment failed, so this case was invisible |
+| Collisions (P-2) | Two profiles sharing a pattern on the same level: second sheet gets a warned `-A` suffix rather than keeping its default number |
 
 #### Completed (Phase 222 — the handoff test now tests the code, not a copy of it)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -111,6 +111,10 @@ exercised inside Revit yet — see the smoke-test list at the end.
 | Annotation idempotency (C-4) | Run annotation twice on one view: second pass places nothing and reports skips (tags, grid/level dims, north arrow) |
 | Floor/ceiling tags (A-9) | Tag a floor-heavy view: tags land at element centres instead of erroring per element |
 | Match lines (A-6/A-7) | Run `MatchLine_Sync` twice over a **dog-leg** boundary: no new curves, no extra captions |
+| Match lines after renumber (A-7) | Renumber sheets, then `MatchLine_Sync`: old captions are replaced, not left beside the new ones |
+| Legends (A-3) | Place a legend on a sheet, run Update Legend: viewport still shows content, no "(1)" view appears |
+| Sections (P-5) | Produce a section along a **north-south** grid: a vertical cut, not a plan-like box, and no throw |
+| Crops (E-2) | TightBbox on a **rotated plan** and on a **section**: crop frames the geometry rather than landing arbitrarily |
 
 #### Completed (Phase 222 — the handoff test now tests the code, not a copy of it)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
-#### Completed (Phase 223 — drawings-production P0 + managed-template hardening)
+#### Completed (Phase 223 — drawings-production P0 + P1)
 
 The P0 tier of the drawings-production deep review
 ([`DRAWINGS_PRODUCTION_REVIEW.md`](DRAWINGS_PRODUCTION_REVIEW.md), ~85 findings). Six fixes,
@@ -72,6 +72,23 @@ exercised inside Revit yet — see the smoke-test list at the end.
   (`SetNonControlledTemplateParameterIds`) instead of discarding the list it built, which is what
   keeps a seed template from overriding the per-profile `DrawingType.Scale`.
 
+- **P1 — issued-output correctness (D-1/P-2/P-10, T-1/T-2/T-3/T-12, C-4/A-6/A-7/A-8/A-9).**
+  Producer numbering unified: the sequence is resolved before the number is built (it was
+  consumed only after, so `{seq}` fell back to parsing a level name and every sheet read 0001),
+  ISO tokens now resolve (13 corporate types previously kept their default number because
+  literal braces are illegal in a Revit sheet number), `doc: null` fixed so `{project}` /
+  `{originator}` fill, and a collision ladder added. Title blocks: the fabrication path routes
+  through `TitleBlockResolver` at last, the blank-name clause that matched *any* loaded title
+  block is gone, the arbitrary fallback warns instead of issuing wrong corporate identity
+  silently, and `PRJ_TB_LOCK_BOOL` is honoured by the declarative pipeline (skip-and-report).
+  `PRJ_TB_ISSUE_SUMMARY_TXT` is no longer clobbered with the revision description on every sync.
+  Annotation is idempotent for the first time: tags honour `skipIfTagged` against a per-view
+  index, dimensions detect an existing chain by what it references, the decorative pass checks
+  for an existing instance, match-line dog-legs collapse to their pair key so they update in
+  place, and captions replace rather than stack.
+  Also hardened `ManagedTemplateSyncer` (E-3/E-4/E-6) before the C-2 fix made managed mode
+  reachable for 14 packs.
+
 **Needs a Revit smoke test before merge** — none of the above has run inside Revit:
 
 | Area | What to check |
@@ -88,6 +105,12 @@ exercised inside Revit yet — see the smoke-test list at the end.
 | Numbering (D-1/P-2) | Produce over ≥2 sheets in one package: ISO-pattern types get real numbers, and the sequence increments instead of every sheet reading 0001 |
 | **ISO params unset (D-1)** | **On a project with `PRJ_PROJECT_COD_TXT` / `PRJ_ORG_ORIGINATOR_CODE_TXT` empty, confirm the leading empty segments (`--01-…`) are acceptable, or set both before producing.** Previously the whole assignment failed, so this case was invisible |
 | Collisions (P-2) | Two profiles sharing a pattern on the same level: second sheet gets a warned `-A` suffix rather than keeping its default number |
+| Title blocks (T-1/T-2) | Compose a spool sheet: it lands on the profile's title block, not "first available"; a missing family warns |
+| TB lock (T-3) | Set `PRJ_TB_LOCK_BOOL` on a sheet, run Heal and Rev Sync: cells untouched, skip reported, sheet-level `SHT_REV_*` still updates |
+| Issue summary (T-12) | Run Rev Sync twice: `PRJ_TB_ISSUE_SUMMARY_TXT` keeps its authored value |
+| Annotation idempotency (C-4) | Run annotation twice on one view: second pass places nothing and reports skips (tags, grid/level dims, north arrow) |
+| Floor/ceiling tags (A-9) | Tag a floor-heavy view: tags land at element centres instead of erroring per element |
+| Match lines (A-6/A-7) | Run `MatchLine_Sync` twice over a **dog-leg** boundary: no new curves, no extra captions |
 
 #### Completed (Phase 222 — the handoff test now tests the code, not a copy of it)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,74 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 223 — drawings-production P0)
+
+The P0 tier of the drawings-production deep review
+([`DRAWINGS_PRODUCTION_REVIEW.md`](DRAWINGS_PRODUCTION_REVIEW.md), ~85 findings). Six fixes,
+one commit each. Every one built clean against Revit 2025 (0 warnings, 0 errors); none has been
+exercised inside Revit yet — see the smoke-test list at the end.
+
+- **Style-pack JSON keys the POCOs never bound (C-1).** The corporate file keys filter rules
+  under `filterRules` on 11 of 35 packs — including all 8 healthcare packs — while the loader
+  bound only `filters`; `StyleVgOverride` bound only long-form names while the data uses
+  `projColor` / `projWeight` / `cutColor` / `cutWeight`. Fixed with setter-only aliases
+  following the Phase 139 pattern, so the corporate baseline stays diff-clean. Verified by
+  compiling the POCO standalone (it has no Revit dependency) against the real JSON:
+  **filter rules bound 19 → 97**, `corp-healthcare-pressure` 0 → 6 rules, vgOverride
+  `projColor` 107 → 295, `projWeight` 107 → 316. Also found and fixed two keys the review
+  missed: `surfFgColor` (15×) and `projLinePattern` (5×).
+- **`ResolveExtends` stripped fields off the folded result (C-2, E-1).** Both folds
+  hand-enumerated the fields to copy, dropping everything else — including the leaf's own
+  values, since the leaf is the last link of the same chain. All 35 packs declare `extends`, so
+  the pack fold ran on every `Get()` and `templateMode: "managed"` could never survive it,
+  making the managed branch in `DrawingTypePresentation` unreachable. Replaced the enumeration
+  with a generic `ExtendsMerge` overlay that treats "equal to a fresh instance's value" as
+  unset, so the folds cannot drift again. Verified against the built assembly: **0 of 14 packs
+  that declare managed now lose it** (3 more correctly inherit it from a managed parent), and a
+  child retains a parent's `titleBlockParams` / `isoNaming` / `packageId` / `system` /
+  `materialPack` / `tagTextSizeMm` / `titleBlockSymbolType` while its own values still win.
+- **Two penetration workflow presets were entirely inert (W-1).** They were the only 2 of 32
+  workflow files using per-step `"command"` / `"name"` instead of `"commandTag"` / `"label"`,
+  so every step deserialised with a null tag and failed validation. Renamed the keys, fixed
+  `BuildSeedFamilies` → `Seeds_Build`, and added `ResolveCommand` cases for
+  `Penetrations_DetectAndPlace`, `Validation_PenetrationCoverage` and
+  `DrawingTypes_FromScopeBoxes`. All 13 steps across both files now resolve.
+- **`LABEL_DEFINITIONS.json` mojibake (A-11).** 530 double-encoded strings across 1,171
+  characters in 15 distinct patterns — wider than the review recorded. Beyond em-dashes it
+  covers `₂` (413×, chemical formulae in medical-gas labels), `Δ` (132×), `⚠` (65×, the leading
+  glyph of every warning label), `§`, `²`, `³`, `°`, `µ`, `Ω`, `×`, `Ø`, `→`, `∅`, `α`. Six of
+  the corrupt strings are dictionary **keys** — the `Tie-In Point Tag` family names — and the
+  `.rfa` files, content manifest, MEP CSV and `PerFamilyTierMap.cs` all already used the clean
+  spelling, so this file was the only one out of step and its family-name matching could never
+  hit. Repaired at text level rather than by re-serialising, which keeps the diff to the
+  affected lines and avoids corrupting the 5 characters in the file that were already correct.
+- **Filter construction and filter data (V-3, V-7, V-8).**
+  `ElementParameterFilter(rules, false)` was commented as OR semantics; the second argument is
+  `inverted` and multiple rules AND together, so multi-material class filters could never match.
+  Replaced with `LogicalOrFilter`, mirroring `AecFilterFactory`. In the data, 12 filters could
+  never mint: 8 using the non-existent `Family Name` parameter, 2 invalid ops, and 2 using a
+  third compound-rule schema (`kind`/`op`/`operands` instead of `logic`/`rules`) that binds to
+  neither leaf nor compound — the last pair not in the review.
+- **Producer sheet identity ignored context (C-3).** Sheets were found and cached by
+  (drawingType, package) only, so a per-level batch resolved every level to the same sheet:
+  10 levels produced 1 sheet with 10 stacked viewports. Sheet identity now includes the same
+  context tag the view key already used, persisted through a new `STING_SHEET_CONTEXT_TXT`
+  stamp provisioned exactly like `STING_DRAWING_PACKAGE_ID_TXT`. Matching is tiered so no
+  existing project regresses: exact match wins; a sheet with a blank context stamp is claimed
+  only by an empty-context request; and if the parameter is not bound at all the producer falls
+  back to the old behaviour **with a warning** rather than minting a duplicate sheet per run.
+
+**Needs a Revit smoke test before merge** — none of the above has run inside Revit:
+
+| Area | What to check |
+|---|---|
+| Style packs (C-1) | Apply a `corp-healthcare-*` pack: filter colour coding appears where it previously did not |
+| Extends fold (C-2) | A pack with `templateMode: "managed"` engages the managed-template path |
+| Workflows (W-1) | Run Penetration Sweep and Penetration Register end to end |
+| Filters (V-3/V-7/V-8) | The 12 repaired filters mint; a multi-material class filter selects elements |
+| Producer (C-3) | Run `LoadSharedParams` first, then produce per level over ≥2 levels: expect one sheet per level, and a re-run that reuses them rather than adding more |
+| Labels (A-11) | A medical-gas tag renders CO₂ / N₂O with a real subscript and warnings with ⚠ |
+
 #### Completed (Phase 222 — the handoff test now tests the code, not a copy of it)
 
 - **`HandoffProvisioningSqliteTests` calls the real method.** It previously

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,19 @@ Found while fixing P0, **not** in the review:
 - **Duplicated `OST_Sheets` insertion** in `LoadSharedParamsCommand` (two identical try blocks,
   ~lines 333–349). Harmless, not fixed.
 
+### P1 — managed-template hardening (done, prerequisite of C-2)
+
+| Finding | Status |
+|---|---|
+| E-3 `CopyElement` on a non-template seed → junk views re-minted each run | ✅ fixed — `View.CreateViewTemplate()` + cleanup on failure |
+| E-4 hardcoded `VIEW_DISCIPLINE` ints | ✅ fixed — reads `ViewDiscipline` members |
+| E-6 discarded managed parameter-id list | ✅ fixed — `SetNonControlledTemplateParameterIds` complement |
+
+The review mis-stated E-4: `Coordination = 4095` was already correct and `Mechanical = 4096` was
+not. `VIEW_DISCIPLINE` is a bit-flag parameter (Architectural 1, Structural 2, Mechanical 4,
+Electrical 8, Plumbing 16; Coordination 4095 = all bits). The genuine defects were Mechanical,
+Electrical and Plumbing.
+
 ### P1 / P2 — still open
 
 Everything else in the review remains open, notably: D-1/P-2/P-10 token substitution and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,47 @@ not. `VIEW_DISCIPLINE` is a bit-flag parameter (Architectural 1, Structural 2, M
 Electrical 8, Plumbing 16; Coordination 4095 = all bits). The genuine defects were Mechanical,
 Electrical and Plumbing.
 
-### P1 / P2 — still open
+### P1 — issued-output correctness (done)
+
+| Finding | Status |
+|---|---|
+| D-1 / P-2 / P-10 producer token substitution + numbering | ✅ fixed |
+| T-1 composer never called `ToConcreteFamily` | ✅ fixed |
+| T-2 blank-name match-anything + silent arbitrary fallback | ✅ fixed (two defects) |
+| T-3 `PRJ_TB_LOCK_BOOL` unread by the declarative pipeline | ✅ fixed (skip-and-report) |
+| T-12 issue summary clobbered by revision description | ✅ fixed (write removed) |
+| C-4 AnnotationRunner had no idempotency | ✅ fixed (tags / dims / decorative) |
+| A-6 dog-leg pair key never matched on re-run | ✅ fixed |
+| A-7 captions stacked every sync | ✅ fixed |
+| A-8 silent tag-family fallback | ✅ fixed (warns) |
+| A-9 `GetElementCentre` null passed to `IndependentTag.Create` | ✅ fixed (bbox centre) |
+
+Corrections to the review found while fixing these:
+
+- **E-4 was wrong in both directions.** `VIEW_DISCIPLINE` is a bit-flag parameter —
+  Architectural 1, Structural 2, Mechanical 4, Electrical 8, Plumbing 16, Coordination 4095
+  (all bits). So the shipped 4095 the review flagged as invalid was correct, and the 4096 it
+  called "the only correct one" was not. Real defect: Mechanical / Electrical / Plumbing.
+- **A-6's second clause is incorrect.** `PruneOrphans` does not need the segment-key
+  discipline: it takes the scope-pair GUID from the first colon-delimited field, identical in
+  the stamped and collapsed forms, so orphan segments pruned correctly before the fix.
+- **T-2 is two defects.** The `IsNullOrEmpty(tbFamily) ||` clause matched any loaded title
+  block and returned before the documented silent-fallback path could run.
+- **T-7's `Family Name` filters carry no `kind` field at all**, rather than `kind: builtin`.
+
+Deliberately deferred, with reasons:
+
+- **Dimension idempotency uses reference-category detection, not a stamped marker.** A marker
+  needs a new parameter bound to Dimensions (4-file provisioning). Residual: a dimension
+  reporting `AreReferencesAvailable == false` is treated as unknown, so a duplicate remains
+  possible if every dimension in a view is unreadable AND a prior chain exists.
+- **Match-line captions are identified by (view + type + text + proximity)**, since
+  `STING_MATCH_LINE_GUID_TXT` does not bind to Text Notes. Residual: a caption whose boundary
+  geometry moved is orphaned rather than deleted.
+- **`IFamilyLoadOptions` `overwriteParameterValues` disagreement** (resolver false,
+  TitleBlockSlotCommands true) — untouched, since no loading behaviour changed.
+
+### P2 — still open
 
 Everything else in the review remains open, notably: D-1/P-2/P-10 token substitution and
 numbering; T-1/T-2/T-3 title-block resolution, silent fallback and `PRJ_TB_LOCK_BOOL`;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,6 +67,9 @@ Electrical and Plumbing.
 | A-7 captions stacked every sync | ✅ fixed |
 | A-8 silent tag-family fallback | ✅ fixed (warns) |
 | A-9 `GetElementCentre` null passed to `IndependentTag.Create` | ✅ fixed (bbox centre) |
+| A-3 legend refresh minted a blank twin | ✅ fixed (in-place, both branches) |
+| P-5 section frames wrong and divergent | ✅ fixed (one shared builder) |
+| E-2 crop assigned in model space | ✅ fixed (converted to crop frame) |
 
 Corrections to the review found while fixing these:
 
@@ -87,9 +90,16 @@ Deliberately deferred, with reasons:
   needs a new parameter bound to Dimensions (4-file provisioning). Residual: a dimension
   reporting `AreReferencesAvailable == false` is treated as unknown, so a duplicate remains
   possible if every dimension in a view is unreadable AND a prior chain exists.
-- **Match-line captions are identified by (view + type + text + proximity)**, since
-  `STING_MATCH_LINE_GUID_TXT` does not bind to Text Notes. Residual: a caption whose boundary
-  geometry moved is orphaned rather than deleted.
+- **Match-line captions are identified by (view + type + caption-template shape + proximity)**,
+  since `STING_MATCH_LINE_GUID_TXT` does not bind to Text Notes. Template-shape matching (not
+  exact text) is what makes the post-renumber case work — the caption embeds the sheet number,
+  so exact text would miss every stale caption after a renumber, which is precisely when
+  `MatchLine_Sync` is run. Residual: a caption whose boundary geometry moved is orphaned rather
+  than deleted.
+- **P-5 / E-2 could not be verified outside Revit.** Both take Revit geometry types and
+  RevitAPI.dll is mixed-mode, so it will not load in a bare host. Testing a re-implementation
+  would assert against a copy, not the shipped code, so they rest on structural argument plus
+  the Revit smoke test.
 - **`IFamilyLoadOptions` `overwriteParameterValues` disagreement** (resolver false,
   TitleBlockSlotCommands true) — untouched, since no loading behaviour changed.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,52 @@
 
 Open automation gaps, future-enhancement tables, and deep-review findings for the StingTools plugin. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`CHANGELOG.md`](CHANGELOG.md) for the history of closed items.
 
+## Drawings-production deep review (2026-07-20)
+
+Full-surface review of the Drawing Type engine, corporate catalogue, View Style Packs + AEC
+filters, title blocks, annotation/legends/match lines, sheet production pipeline, and command
+wiring: **~85 findings (5 Critical / 27 High)** with a prioritised P0–P2 remediation plan.
+See [`DRAWINGS_PRODUCTION_REVIEW.md`](DRAWINGS_PRODUCTION_REVIEW.md).
+
+### P0 — CLOSED (see CHANGELOG Phase 223)
+
+| Finding | Status |
+|---|---|
+| C-1 unbound style-pack JSON keys (`filterRules`, short-form vgOverrides) | ✅ fixed — POCO aliases; filter rules bound 19 → 97 |
+| C-2 / E-1 both `ResolveExtends` folds strip fields | ✅ fixed — generic default-aware overlay |
+| C-3 producer sheet key ignores context | ✅ fixed — `STING_SHEET_CONTEXT_TXT` in the sheet key |
+| W-1 two penetration workflow presets inert | ✅ fixed — step keys + 3 `ResolveCommand` cases |
+| A-11 `LABEL_DEFINITIONS.json` mojibake | ✅ fixed — 530 strings / 1,171 chars repaired |
+| V-3 material-class filter AND-ed instead of OR-ed | ✅ fixed — `LogicalOrFilter` |
+| V-7 / V-8 dead filter definitions | ✅ fixed — 12 filters (8 `Family Name`, 2 ops, 2 compound schema) |
+
+Found while fixing P0, **not** in the review:
+
+- **`surfFgColor` (15×) and `projLinePattern` (5×) were also unbound** on `StyleFilterRule` —
+  the Phase 139 alias pass covered the four line keys and stopped short of these. Fixed with C-1.
+- **`plumb-high-pressure-zone` and `plumb-backflow-risk` use a third rule schema**
+  (`{"kind":"compound","op":"or","operands":[…]}`) that binds to neither `IsLeaf` nor
+  `IsCompound`, so `BuildFilter` returned null silently. Fixed with V-8.
+- **`DrawingType.extends` could never inherit any field with a non-null POCO default**
+  (`PaperSize` "A1", `Discipline`/`Phase` "*", `Purpose` "Plan", `Orientation` "Landscape",
+  `Scale` 100, `DetailLevel` "Medium", both sheet patterns): the old `!IsNullOrEmpty` guard
+  treats a child's default as a value, so an A0 parent always resolved back to A1. Fixed with
+  E-1. Known residual limitation: a child that explicitly restates a default is
+  indistinguishable from one that omits it and will inherit the parent's value.
+- **`ViewStylePack`'s six already-working scalars keep their original guards** — that path runs
+  on every `Get()` and changing `lineWeightScale` merge semantics would alter rendering. The
+  same default-clobbers-parent issue therefore remains open for style packs specifically.
+- **Duplicated `OST_Sheets` insertion** in `LoadSharedParamsCommand` (two identical try blocks,
+  ~lines 333–349). Harmless, not fixed.
+
+### P1 / P2 — still open
+
+Everything else in the review remains open, notably: D-1/P-2/P-10 token substitution and
+numbering; T-1/T-2/T-3 title-block resolution, silent fallback and `PRJ_TB_LOCK_BOOL`;
+C-4/A-6/A-7 annotation and match-line idempotency; A-3 legend in-place refresh; P-5/E-2 section
+frame and crop coordinates; C-5 inert corporate-lock checksums; W-2 unreachable MatchLine suite;
+W-3/W-4/W-5/W-6 wiring and documentation drift.
+
 ## Revision system — deferred items (Phase 199)
 
 Recorded while aligning the revision subsystem (see CHANGELOG Phase 199).


### PR DESCRIPTION
Implements the **P0** tier of the drawings-production deep review (`docs/DRAWINGS_PRODUCTION_REVIEW.md`, PR #447 — ~85 findings, 5 Critical). One numbered fix per commit.

Every commit builds clean against Revit 2025 (`0 Warning(s), 0 Error(s)`, matching the repo baseline). **Nothing here has run inside Revit** — smoke-test list at the bottom.

## Findings fixed

| # | Finding | Fix |
|---|---|---|
| P0-1 | **C-1** most style-pack payload runtime-dead | Setter-only JSON aliases on `ViewStylePack` / `StyleVgOverride` / `StyleFilterRule` |
| P0-2 | **C-2 + E-1** both `ResolveExtends` folds strip fields | New `ExtendsMerge` generic default-aware overlay |
| P0-3 | **W-1** two penetration workflow presets inert | Step-key rename + 3 new `ResolveCommand` cases |
| P0-4 | **A-11** `LABEL_DEFINITIONS.json` mojibake | Text-level repair of 530 strings / 1,171 chars |
| P0-5 | **V-3, V-7, V-8** filter construction + data | `LogicalOrFilter`; 12 dead filter definitions repaired |
| P0-6 | **C-3** producer sheet identity ignores context | `STING_SHEET_CONTEXT_TXT` added to the sheet key |

## Measured results

Where a claim could be tested outside Revit, it was. `ViewStylePack.cs` has no Revit dependency, so it compiles standalone; `ResolveExtends` and `SheetKey` take only POCOs/strings, so they were invoked on the built assembly via reflection.

**C-1** — deserialising the real corporate JSON, before → after:

| | main | fixed |
|---|---|---|
| filter rules bound | 19 | **97** |
| `corp-healthcare-pressure` rules | 0 | **6** |
| vgOverride `projColor` / `projWeight` | 107 / 107 | **295 / 316** |
| vgOverride `cutColor` / `cutWeight` | 45 / 45 | **54 / 59** |
| rule `surfFgColor` / `projLinePattern` | 0 / 0 | **15 / 5** |

Each figure equals that key's exact count in the JSON, and a serialize/deserialize round-trip preserves all 97 rules.

**C-2 / E-1** — 14 packs declare `templateMode: "managed"`; **0 now lose it** through the fold (was: all 14). 3 more correctly *inherit* managed from a managed parent. A child retains a parent's `titleBlockParams`, `isoNaming`, `packageId`, `system`, `materialPack`, `tagTextSizeMm`, `titleBlockSymbolType`, while its own values and overrides still win.

**W-1** — all 13 step tags across both files resolve, checked against the 495 `ResolveCommand` cases parsed out of `WorkflowEngine.cs`.

**A-11** — JSON re-parses, key count unchanged at 62,745, zero residual mojibake markers, every remaining non-ASCII run is a single clean codepoint.

**V-3/V-7/V-8** — across all 298 filters: 0 leaf rules with an op outside the factory's 14-op grammar, 0 nodes that are neither leaf nor compound, 0 remaining `Family Name` params.

**C-3** — per-level contexts produce distinct, stable sheet keys that don't collide with each other, with the empty-context key, or across packages.

## Findings the review missed, fixed here

- **`surfFgColor` (15×) and `projLinePattern` (5×) were also unbound.** The Phase 139 alias pass covered the four line keys and stopped short of these. Found by diffing *every* key in the JSON against every bound `JsonProperty`, rather than only checking the keys the review named.
- **`plumb-high-pressure-zone` and `plumb-backflow-risk` use a third rule schema** — `{"kind":"compound","op":"or","operands":[…]}` instead of `{"logic":"or","rules":[…]}`. Those nodes satisfy neither `IsLeaf` nor `IsCompound`, so `BuildFilter` returned null silently. The review found 2 invalid leaf ops; these are 2 more dead filters.
- **`DrawingType.extends` could never inherit a field with a non-null POCO default** (`PaperSize` "A1", `Discipline`/`Phase` "*", `Purpose` "Plan", `Orientation` "Landscape", `Scale` 100, `DetailLevel` "Medium", both sheet patterns). The old `!IsNullOrEmpty` guard treats a child's *default* as a value, so an A0 parent always resolved back to A1. Caught by a test assertion, not by reading. Safe to change: 0 of 93 shipped types use `extends`.
- **`LABEL_DEFINITIONS.json` damage is much wider than "em-dashes and mÂ²"** — 15 patterns including `₂` (413×, chemical formulae in medical-gas labels), `⚠` (65×, the leading glyph of every warning label) and `Δ` (132×). Also, **5 characters in the file were already correct**, so the review's suggested whole-string re-encode would have corrupted them; repaired the 15 known-bad runs instead.

## Deliberate scope calls

- **`ViewStylePack`'s six already-working scalars keep their original guards.** That fold runs on every `Get()`, and changing `lineWeightScale` merge semantics would alter rendering. The default-clobbers-parent issue is therefore fixed for `DrawingType` (dormant path) but still open for style packs — recorded in ROADMAP.
- **C-3 falls back rather than duplicating.** If `STING_SHEET_CONTEXT_TXT` is not bound, `ReadSheetContext` returns `null` (not `""`) and the producer reuses the old (type, package) match **with a warning naming the parameter**. Reproducing the old stacking is bad; silently minting a duplicate sheet on every run would be worse.
- **`DrawingTypes_FromScopeBoxes` resolves to `GenerateFromScopeBoxesCommand`.** The dock-panel button for that tag runs a separate inline reimplementation in the handler — that's review finding **W-5**, left for a later pass and noted in a comment at the new case.
- **Nothing skipped as wrong or already-fixed.** Every P0 finding reproduced. Two were slightly mis-described — C-1's short-form keys are on `StyleVgOverride` (the `StyleFilterRule` ones were already aliased in Phase 139), and V-7's 8 filters carry *no* `kind` field rather than `kind: builtin` — but the defects and the fixes stand in both cases.

## Must be smoke-tested in Revit before merge

| Area | Check |
|---|---|
| Style packs (C-1) | Apply a `corp-healthcare-*` pack — filter colour coding appears where it previously did not |
| Extends fold (C-2) | A pack with `templateMode: "managed"` engages the managed-template path |
| Workflows (W-1) | Run Penetration Sweep and Penetration Register end to end |
| Filters (V-3/V-7/V-8) | The 12 repaired filters mint; a multi-material class filter actually selects elements |
| Producer (C-3) | Run `LoadSharedParams` **first**, then produce per level over ≥2 levels: one sheet per level, and a re-run reuses them rather than adding more |
| Labels (A-11) | A medical-gas tag renders CO₂ / N₂O with a real subscript, and warnings with ⚠ |

`LoadSharedParams` must run once per project before C-3 behaves correctly — that is what binds the new `STING_SHEET_CONTEXT_TXT`.

P1 was not started; the full P1/P2 tail is listed as open in `docs/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
