### PR TITLE
fix(nlp): emit dispatchable tags for 11 broken intents; correct drawings doc drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ When you finish a piece of work, log it in `docs/CHANGELOG.md` rather than exten
 | `StingTools/Data/Fabrication/` | STING_FAB_RULES.json (6 disciplines) + STING_FAB_RULES_EXT.json + STING_ISO_SYMBOLS_INDEX.csv (180+ symbols) |
 | `StingTools/Data/Parameters/` | STING_PARAMS_V4.txt · STING_PARAMS_V6.txt · STING_ELEC_WIRE_PARAMS.txt · STING_HANGER_PARAMS.txt · STING_SLEEVE_PARAMS.txt |
 | `StingTools/Data/Seeds/` | 16 seed JSON specs |
-| `Families/AssemblyTitleBlocks/` | 7 title block parameter spec stubs + README |
+| `Families/AssemblyTitleBlocks/` | 8 title block parameter spec stubs + README |
 
 ### New namespaces
 
@@ -441,7 +441,7 @@ The Symbol Library is a data-driven engine that creates, maintains, and swaps pa
 - **3 new disciplines** (`H` Healthcare, `MG` Medical Gas, `RP` Radiation Protection); ~30 healthcare PROD codes; 60 tag families in `STING_TAG_CONFIG_v5_0_HEALTH.csv`
 - **16 healthcare validators** under `Core/Validation/Healthcare/` gated through `HealthcareValidatorGate` against `PRJ_ORG_HEALTH_PACK_PROFILE_TXT` (FULL / ACUTE / COMMUNITY / DENTAL / IMAGING-ONLY / MENTAL-HEALTH)
 - **7 standards modules** under `StingTools.Standards/{HTM, HBN, FGI, NFPA99, NCRP147, ASHRAE170, USP797800}` — stateless lookup tables + checklist generators + NCRP 147 W·U·T → mm-Pb calculator
-- **22 corporate Drawing Types** with routing rules; 8 ViewStylePacks; 58 healthcare filters in `STING_AEC_FILTERS.json`
+- **22 corporate Drawing Types** with routing rules; 8 ViewStylePacks; 81 healthcare filters in `STING_AEC_FILTERS.json`
 - **MGPS package** (`Core/MedGas/`) — `MgasNetwork` graph builder, `MgasFlowSolver` (NFPA 99 §5.1.13), `MgasVerificationLog` (12-step NFPA 99 §5.1.12)
 - **RDS engine** (`Docs/Templates/Rds*`) — token-context builder + MiniWord renderer
 - **40+ commands** under `Commands/Healthcare/`, `Commands/MedGas/`, `Commands/Adjacency/`, `Commands/Twin/`, `Commands/Radiation/`
@@ -758,17 +758,19 @@ Framework (AVF) heatmaps using Revit's built-in display style engine.
 
 `DrawingType.cs` · `DrawingTypePresentation.cs` · `DrawingTypeRegistry.cs` · `DrawingDispatcher.cs` · `DrawingTypeValidator.cs` · `DrawingTypeStamper.cs` · `DrawingDriftDetector.cs` · `DrawingCropApplier.cs` · `ViewStylePack.cs` · `ViewStylePackRegistry.cs` · `ViewStylePackApplier.cs` · `ManagedTemplateSyncer.cs` · `AecFilterDefinition.cs` · `AecFilterRegistry.cs` · `AecFilterFactory.cs` · `ScopeBoxBinder.cs` · `TitleBlockParamApplier.cs` · `TokenProfileApplier.cs` · `AnnotationRunner.cs` · `DrawingProducer.cs` · `DrawingPackageManager.cs` · `TitleBlockFactory.cs` · `TitleBlockSpec.cs` · `MatchLineEngine.cs` · `DrawingTokenContext.cs` · `DrawingProductionPreset.cs` · `ProductionPresetRegistry.cs` · `DrawingThumbnailService.cs` · `SheetPlacementBridge.cs` · `SheetSequenceStore.cs` · `Iso19650Vocabulary.cs` · plus dimensioning sub-engine (`GridDimensioner`, `MEPDimensioner`, `DrainageInvertDimensioner`, `DimensionStrategy`).
 
-### Commands (20+)
+### Commands (25+)
 
-`DrawingTypes_Inspect`, `DrawingTypes_Reload`, `DrawingTypes_BrowserOrganize`, `DrawingTypes_SyncStyles`, `DrawingTypes_FromScopeBoxes`, `DrawingTypes_Produce`, `DrawingTypes_Doctor`, `DrawingTypes_HealTitleBlocks`, `DrawingTypes_Renumber`, `DrawingTypes_BatchProduce`, `AecFilters_Create`, `AecFilters_Inspect`, `AecFilters_Reload`, `ManagedTemplates_Convert`, `ManagedTemplates_Detach`, `ManagedTemplates_Regenerate`, `TitleBlocks_Factory`, `TitleBlocks_MigrateCsv`, `TitleBlocks_Migrate`, `MatchLines_Create`, `PresentationStyle_Setup`.
+Tags as dispatched by `StingCommandHandler` (exact-match, case-sensitive):
 
-### AEC/FM Corporate Filter Library (Phase 166 — 199 filters)
+`DrawingTypes_Inspect`, `DrawingTypes_Reload`, `Drawing_BrowserOrganize`, `DrawingTypes_SyncStyles`, `DrawingTypes_FromScopeBoxes`, `DrawingTypes_ProducePerLevel`, `DrawingTypes_ProduceSections`, `DrawingTypes_ProduceInteriorElevations`, `DrawingTypes_ProduceExteriorElevations`, `DrawingTypes_ProduceFromScopeBoxes`, `DrawingTypes_ProduceAndExport`, `DrawingTypes_Doctor`, `DrawingTypes_HealTitleBlocks`, `DrawingTypes_Renumber`, `AecFilters_Create`, `AecFilters_Inspect`, `AecFilters_Reload`, `DrawingTypes_ConvertToManaged`, `DrawingTypes_DetachManaged`, `DrawingTypes_RegenerateTemplates`, `TitleBlock_Create`, `TitleBlock_CreateAll`, `TitleBlock_MigrateLegacy`, `DrawingTypes_MigrateCsv`, `DrawingTypes_MigrateParams`, `DrawingTypes_PresentationSetup`, plus the MatchLine suite (`MatchLine_Generate`, `MatchLine_Sync`, `MatchLine_Validate`, `MatchLine_ValidateBundle`, `MatchLine_Inspect` — handler cases exist; no dock-panel buttons yet, see review finding W-2).
 
-`Data/STING_AEC_FILTERS.json`: 47 Arch · 33 HVAC · 31 Struct · 30 Fire · 27 Elec · 18 Plumb · 11 FM/COBie · 8 ISO 19650 · 8 Coord/LOD · 5 VT · 5 QA. `ViewStylePackApplier.ApplyFilterRules` now lazy-creates missing filters from the registry.
+### AEC/FM Corporate Filter Library (Phase 166/184f — 298 filters)
+
+`Data/STING_AEC_FILTERS.json`: 298 filters, 81 of them healthcare. The Phase 166 baseline shipped 199 (47 Arch · 33 HVAC · 31 Struct · 30 Fire · 27 Elec · 18 Plumb · 11 FM/COBie · 8 ISO 19650 · 8 Coord/LOD · 5 VT · 5 QA); healthcare and QA-gate phases grew it to 298. `ViewStylePackApplier.ApplyFilterRules` lazy-creates missing filters from the registry.
 
 ---
 
-Save button routes to the active tab: `drawing_types.json` (tab 0, existing) or `view_style_packs.json` (tab 1, new). Only project-origin entries are written — corporate baseline on disk stays pristine. Edits to corporate packs silently flip `origin` to `project` via `ViewStylePackRegistry.ComputeChecksums` drift detection, same mechanism Drawing Types use.
+Save button routes to the active tab: `drawing_types.json` (tab 0, existing) or `view_style_packs.json` (tab 1, new). Only project-origin entries are written — corporate baseline on disk stays pristine. Note: View Style Packs have **no** checksum drift detection (`ViewStylePackRegistry` has no `ComputeChecksums`; `ViewStylePack.Checksum` is never computed or verified) — corporate pack edits are accepted as corporate. See finding C-5 in `docs/DRAWINGS_PRODUCTION_REVIEW.md`.
 
 The tab is a pure UI layer on top of the Week 2 data model — no changes to `ViewStylePack` / `ViewStylePackRegistry` / `ViewStylePackApplier`.
 
@@ -852,7 +854,7 @@ Routing table grew to 43 rules at that phase (now 118 rules across 93 types — 
 
 ### Project-scoped overrides
 
-Registry layers a project override from `<project>/_BIM_COORD/drawing_types.json` on top of the corporate baseline. Project entries win by `id`; project routing rules are **prepended** (first-match-wins). Mutating a corporate entry on disk flips its `origin` to `project` via SHA-256 checksum drift detection (see `DrawingTypeRegistry.ComputeChecksums`).
+Registry layers a project override from `<project>/_BIM_COORD/drawing_types.json` on top of the corporate baseline. Project entries win by `id`; project routing rules are **prepended** (first-match-wins). `DrawingTypeRegistry.ComputeChecksums` implements SHA-256 drift detection (a stored `checksum` mismatch flips `origin` to `project`), but the shipped corporate file carries **no** `checksum` fields and computed hashes are never persisted, so edits to the shipped baseline are currently undetected — see finding C-5 in `docs/DRAWINGS_PRODUCTION_REVIEW.md`.
 
 ### Pipeline order (final)
 

--- a/StingTools/Data/MR_PARAMETERS.csv
+++ b/StingTools/Data/MR_PARAMETERS.csv
@@ -1503,7 +1503,7 @@ Generic Models,ASS_OMNICLASS_TXT,a1b2c3d4-5022-4a01-b001-000000000134,TEXT,ASS_M
 Generic Models,ASS_SIZE_TXT,a1b2c3d4-5023-4a01-b001-000000000135,TEXT,ASS_MNG,Type,Element size description,False,,,MULTI,1,0
 Generic Models,ASS_ORIGIN_TXT,a1b2c3d4-5024-4a01-b001-000000000136,TEXT,ASS_MNG,Type,Asset origin (Manufactured/Imported/Local),False,,,MULTI,1,0
 Generic Models,ASS_PROJECT_TXT,a1b2c3d4-5025-4a01-b001-000000000137,TEXT,ASS_MNG,Type,Project name,False,,,MULTI,1,0
-Generic Models,ASS_REV_TXT,a1b2c3d4-5026-4a01-b001-000000000138,TEXT,ASS_MNG,Type,Current revision code (display label, GROUP 1). See also ASS_REV_COD_TXT (GROUP 17) for the ISO 19650 tag container token.,False,,,MULTI,1,0
+Generic Models,ASS_REV_TXT,a1b2c3d4-5026-4a01-b001-000000000138,TEXT,ASS_MNG,Type,Current revision code (display label, GROUP 1). See also ASS_REV_COD_TXT (GROUP 17) for the ISO 19650 tag container token.,False,,,MULTI,1
 Generic Models,ASS_VOL_TXT,a1b2c3d4-5027-4a01-b001-000000000139,TEXT,ASS_MNG,Type,Volume/zone code for ISO 19650 naming,False,,,MULTI,1,0
 Generic Models,ASS_ROOM_NAME_TXT,a1b2c3d4-5028-4a01-b001-000000000140,TEXT,ASS_MNG,Type,Room name from spatial lookup,False,,,MULTI,1,0
 Generic Models,ASS_ROOM_NUM_TXT,a1b2c3d4-5029-4a01-b001-000000000141,TEXT,ASS_MNG,Type,Room number from spatial lookup,False,,,MULTI,1,0
@@ -2640,7 +2640,7 @@ Electrical Equipment,ELC_CIRCUIT_LABEL_TXT,c2a7e5b1-3004-5333-9333-300000000004,
 Electrical Equipment,ELC_PNL_AIC_RATING_KA,f1d6e7c8-1001-5178-9178-100000000001,TEXT,ELC_PWR,Instance,Standardised AIC (Ampere Interrupting Capacity) tier in kA stamped to the panel for breaker / switchgear specification [STING Phase 178],False,,,ELECTRICAL,1,0
 Electrical Equipment,ELC_FEEDER_CSA_MM2,f1d6e7c8-1002-5178-9178-100000000002,TEXT,ELC_PWR,Instance,Calculated / proposed feeder cable cross-sectional area in mm² (distinct from circuit cable size) [STING Phase 178],False,,,ELECTRICAL,1,0
 Electrical Equipment,ELC_FEEDER_RATING_A,f1d6e7c8-1003-5178-9178-100000000003,TEXT,ELC_PWR,Instance,Calculated feeder breaker / fuse rating in amperes — the upstream protective device rating [STING Phase 178],False,,,ELECTRICAL,1,0
-Rooms,ELC_EMERG_COVERED_BOOL,f1d6e7c8-1004-5178-9178-100000000004,TEXT,ELC_PWR,Instance,Room has emergency lighting coverage (1=true, 0=false) [BS 5266-1 / BS 9999 / STING Phase 178],False,,,ELECTRICAL,1,0
+Rooms,ELC_EMERG_COVERED_BOOL,f1d6e7c8-1004-5178-9178-100000000004,TEXT,ELC_PWR,Instance,Room has emergency lighting coverage (1=true, 0=false) [BS 5266-1 / BS 9999 / STING Phase 178],False,,,ELECTRICAL,1
 Rooms,ELC_LPD_W_PER_M2,f1d6e7c8-1005-5178-9178-100000000005,TEXT,ELC_PWR,Instance,Calculated lighting power density of the room in W/m² [ASHRAE 90.1 / Part L 2021 / CIBSE LG7 / STING Phase 178],False,,,ELECTRICAL,1,0
 Rooms,ELC_LPD_LIMIT_W_PER_M2,f1d6e7c8-1006-5178-9178-100000000006,TEXT,ELC_PWR,Instance,Standard LPD limit for the room type in W/m² [ASHRAE 90.1 / Part L 2021 / CIBSE LG7 / STING Phase 178],False,,,ELECTRICAL,1,0
 Rooms,ELC_LPD_STATUS_TXT,f1d6e7c8-1007-5178-9178-100000000007,TEXT,ELC_PWR,Instance,LPD compliance status (PASS / FAIL / WARNING / UNCHECKED) [STING Phase 178],False,,,ELECTRICAL,1,0
@@ -2881,7 +2881,7 @@ Views,STING_STYLE_LOCKED_BOOL,d2e3f4a5-b6c7-4d8e-9f0a-b1c2d3e4f5a6,YESNO,STING_D
 Views,STING_PACK_ID_TXT,e3f4a5b6-c7d8-4e9f-a0b1-c2d3e4f5a6b7,TEXT,STING_DRAWING,Instance,ViewStylePack registry id stamped on managed view templates [Phase 137],False,,,MULTI,1,0
 Views,STING_PACK_CHECKSUM_TXT,f4a5b6c7-d8e9-4f0a-b1c2-d3e4f5a6b7c8,TEXT,STING_DRAWING,Instance,SHA-256 checksum of ViewStylePack JSON for drift detection [Phase 137],False,,,MULTI,1,0
 Views,STING_CROP_KIND_TXT,b6c7d8e9-f0a1-4b2c-3d4e-5f6a7b8c9d01,TEXT,STING_DRAWING,Instance,Crop kind stamped onto views for drift detection [Phase 183],False,,,MULTI,1,0
-Views,STING_CROP_MARGIN_MM_TXT,c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e12,TEXT,STING_DRAWING,Instance,Crop margin (mm, as string) stamped onto views for drift detection [Phase 183],False,,,MULTI,1,0
+Views,STING_CROP_MARGIN_MM_TXT,c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e12,TEXT,STING_DRAWING,Instance,Crop margin (mm, as string) stamped onto views for drift detection [Phase 183],False,,,MULTI,1
 Views,STING_CDE_STATE_TXT,a5b6c7d8-e9f0-4a1b-c2d3-e4f5a6b7c8d9,TEXT,STING_DRAWING,Instance,CDE state stamp for ISO 19650-2 document lifecycle [Phase 141],False,,,MULTI,1,0
 Medical Equipment,CLN_EQP_TAG,c1a00001-0000-4c1a-0000-000000000001,TEXT,CLN_CLINICAL,Instance,Clinical equipment ISO 19650 tag container,False,,,MULTI,1,0
 Rooms,CLN_ROOM_TAG,c1a00001-0000-4c1a-0000-000000000002,TEXT,CLN_CLINICAL,Instance,Clinical room ISO 19650 tag container,False,,,MULTI,1,0
@@ -3351,15 +3351,15 @@ Project,SUS_MAT_CARBON_KGM2_NR,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c03,NUMBER,SUS_S
 Project,SUS_MAT_ENERGY_MJ_M2_NR,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c04,NUMBER,SUS_SUSTAINABILITY,Instance,Embodied energy intensity MJ/m2 (CED EDGE materials track) from MaterialsRollup [Phase 195 EDGE/LEED],False,,,MULTI,1,0
 Project,SUS_EDGE_LEVEL_TXT,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c05,TEXT,SUS_SUSTAINABILITY,Instance,Achieved EDGE level (None / Certified / Advanced / ZeroCarbon) from SchemeEvaluator [Phase 195 EDGE/LEED],False,,,MULTI,1,0
 Multiple,SUS_EPD_REF_TXT,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c06,TEXT,SUS_SUSTAINABILITY,Instance,Type III EPD reference (ISO 14025 / EN 15804) on a material/type — resolver prefers product-specific EPD data [Phase 195 EDGE/LEED],False,,,MULTI,1,0
-Materials,MAT_COST_SUPPLY_NR,114852b0-7002-5680-80cd-930f91e8250b,NUMBER,MAT_INFO,Instance,Material supply unit cost (rate only, currency-neutral) [Material Manager RFQ],False,,,MULTI,1,0
+Materials,MAT_COST_SUPPLY_NR,114852b0-7002-5680-80cd-930f91e8250b,NUMBER,MAT_INFO,Instance,Material supply unit cost (rate only, currency-neutral) [Material Manager RFQ],False,,,MULTI,1
 Materials,MAT_COST_INSTALL_NR,0621af78-0fbf-540e-9e6d-61df9925ae90,NUMBER,MAT_INFO,Instance,Material install unit cost (labour and plant) [Material Manager RFQ],False,,,MULTI,1,0
 Materials,MAT_VAT_PCT_NR,9794f566-efc2-5622-a23f-9e65e117eb48,NUMBER,MAT_INFO,Instance,Material VAT percentage applied to supply and install [Material Manager RFQ],False,,,MULTI,1,0
-Materials,STING_EMB_CARBON_NR,800e0d61-f88d-5071-bc87-0c4ca3e51243,NUMBER,MAT_INFO,Instance,Embodied carbon kgCO2e per unit, A1-A3 GWP [Sustainability Carbon],False,,,MULTI,1,0
+Materials,STING_EMB_CARBON_NR,800e0d61-f88d-5071-bc87-0c4ca3e51243,NUMBER,MAT_INFO,Instance,Embodied carbon kgCO2e per unit, A1-A3 GWP [Sustainability Carbon],False,,,MULTI,1
 Materials,STING_MAT_EPD_SRC_TXT,2776ca48-33b8-57a8-b2a6-ee982e442767,TEXT,MAT_INFO,Instance,EPD data source / publisher reference [Sustainability Carbon],False,,,MULTI,1,0
 Materials,STING_MAT_EPD_DATE_TXT,c02ad751-5de9-50cc-a018-d7469595f8cf,TEXT,MAT_INFO,Instance,EPD publication / validity date ISO 8601 [Sustainability Carbon],False,,,MULTI,1,0
 Materials,STING_MAT_LIFECYCLE_TXT,e5455edb-f4f9-5585-a65e-363aa31f0b59,TEXT,MAT_INFO,Instance,Material spec lifecycle state Draft/Reviewed/Approved/Frozen [Material Manager],False,,,MULTI,1,0
-Plumbing Fixtures,SUS_FIXTURE_FLOW_LPM,b9c085ac-8d25-5286-bb8c-50f78c515e7c,NUMBER,PLM_DRN,Instance,Sanitary fixture flow rate l/min, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1,0
-Plumbing Fixtures,SUS_FIXTURE_FLUSH_L,733de214-c4aa-5640-896c-ff9c472c8dfd,NUMBER,PLM_DRN,Instance,WC/urinal flush volume litres, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1,0
+Plumbing Fixtures,SUS_FIXTURE_FLOW_LPM,b9c085ac-8d25-5286-bb8c-50f78c515e7c,NUMBER,PLM_DRN,Instance,Sanitary fixture flow rate l/min, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1
+Plumbing Fixtures,SUS_FIXTURE_FLUSH_L,733de214-c4aa-5640-896c-ff9c472c8dfd,NUMBER,PLM_DRN,Instance,WC/urinal flush volume litres, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1
 Electrical Equipment,ELC_CIR_REF_TXT,dd54810b-00a1-55eb-a388-8a37eea1aa9c,TEXT,ELC_PWR,Instance,Circuit reference / designation for SLD annotation [Electrical SLD],False,,,MULTI,1,0
 Electrical Equipment,ELC_CIR_VOLTAGE_TXT,a4618f96-d723-5366-8961-4acfb94e2b60,TEXT,ELC_PWR,Instance,Circuit nominal voltage for SLD annotation [Electrical SLD],False,,,MULTI,1,0
 Electrical Equipment,ELC_CIR_DESIGN_CURRENT_TXT,0a442c44-90fa-5d48-b11f-fca5d4cb4407,TEXT,ELC_PWR,Instance,Circuit design current Ib for SLD annotation [Electrical SLD],False,,,MULTI,1,0

--- a/StingTools/Data/MR_PARAMETERS.csv
+++ b/StingTools/Data/MR_PARAMETERS.csv
@@ -1,3 +1,4 @@
+# v6.11 | 20260720 | +5 mirror rows (4 STING_GATE_* universal-tag badge stamps + PRJ_SHEET_SYSTEM_TXT title-block SYSTEM cell) — realigns with MR_PARAMETERS.txt (CI data-file gate)
 # v6.10 | 20260630 | +5 STING_PLACER_* symbol-placement idempotency stamps (group 37) — aligns with MR_PARAMETERS.txt
 # v6.9 | 20260630 | +30 Tier-2 element-bound params (electrical SLD/circuit, plumbing router, design-option, sheet/view, clash, IFC) — aligns with MR_PARAMETERS.txt
 # v6.8 | 20260630 | +9 material cost/carbon/EPD + water-efficiency fixture params (Sustainability/BOQ-cost) — aligns with MR_PARAMETERS.txt
@@ -3394,3 +3395,8 @@ Detail Items,STING_PLACER_ASSY_ID_TXT,5e189877-e121-53f8-ac57-849685c272e6,TEXT,
 Detail Items,STING_PLACER_MEMBER_ID_TXT,091ab7ea-32fc-57dd-94e4-89a0af05c31c,TEXT,STING_PLACER,Instance,Source assembly-member element id for the placed symbol [Symbols],False,,,Symbols,1,0
 Detail Items,STING_PLACER_SYMBOL_CODE_TXT,f44c8c2c-5981-517e-91e0-2a1c2970a74d,TEXT,STING_PLACER,Instance,Resolved symbol code stamped on the placed symbol [Symbols],False,,,Symbols,1,0
 Detail Items,STING_PLACER_VIEW_ID_TXT,e2b1686a-8c6a-5db8-ba02-144add1cc43f,TEXT,STING_PLACER,Instance,View id where the symbol was placed (per-view idempotency) [Symbols],False,,,Symbols,1,0
+Generic Models,STING_GATE_DATA_STATUS_INT,b7f3e2a1-0002-4a01-b001-0000000a0001,INTEGER,STINGTags_ISO19650,Instance,Data-completeness gate status stamped by ComplianceScan (0=red/1=amber/2=green) — drives left universal-tag status badge,False,,,MULTI,1,0
+Generic Models,STING_GATE_QA_STATUS_INT,b7f3e2a1-0002-4a01-b001-0000000a0002,INTEGER,STINGTags_ISO19650,Instance,QA / sign-off gate status stamped by ComplianceScan (0=red/1=amber/2=green) — drives right universal-tag status badge,False,,,MULTI,1,0
+Generic Models,STING_GATE_DATA_MSG_TXT,b7f3e2a1-0002-4a01-b001-0000000a0003,TEXT,STINGTags_ISO19650,Instance,Data gate terse reason stamped by ComplianceScan (blank when green) — label next to the left status badge,False,,,MULTI,1,0
+Generic Models,STING_GATE_QA_MSG_TXT,b7f3e2a1-0002-4a01-b001-0000000a0004,TEXT,STINGTags_ISO19650,Instance,QA gate terse reason stamped by ComplianceScan (blank when green) — label next to the right status badge,False,,,MULTI,1,0
+Sheets,PRJ_SHEET_SYSTEM_TXT,972024c1-53c5-5b57-b9f7-98e89fa53572,TEXT,PRJ_INFORMATION,Instance,"MEP system/service code shown on the title block SYSTEM cell (e.g. DCW, HVAC, LV) [P4]",False,,,MULTI,1,0

--- a/StingTools/Tags/NLPCommandProcessor.cs
+++ b/StingTools/Tags/NLPCommandProcessor.cs
@@ -191,7 +191,7 @@ namespace StingTools.Tags
             (@"\b(remove\s+leader)\b", "RemoveLeaders", "RemoveLeaders", "Remove leaders from tags"),
 
             // Legends
-            (@"\b(create\s+legend|legend|color\s+legend)\b", "CreateMasterLegend", "Legend", "Create legend"),
+            (@"\b(create\s+legend|legend|color\s+legend)\b", "CreateColorLegend", "Legend", "Create legend"),
 
             // Export
             (@"\b(export\s+csv|csv\s+export|export\s+data)\b", "ExportCSV", "ExportCSV", "Export to CSV"),
@@ -296,7 +296,7 @@ namespace StingTools.Tags
             (@"\b(from\s*scope\s*box|scope\s*box\s*view|generate\s*from\s*scope)\b",
                 "DrawingTypes_FromScopeBoxes", "DrawingTypes", "Generate views from STING scope box naming convention"),
             (@"\b(browser\s*organ|view\s*browser\s*org|drawing\s*browser)\b",
-                "DrawingTypes_BrowserOrganize", "DrawingTypes", "Create browser organizer by drawing type"),
+                "Drawing_BrowserOrganize", "DrawingTypes", "Create browser organizer by drawing type"),
             (@"\b(inspect\s*drawing\s*type|drawing\s*type\s*inspect|list\s*drawing\s*type)\b",
                 "DrawingTypes_Inspect", "DrawingTypes", "Inspect all drawing types and routing rules"),
             (@"\b(reload\s*drawing\s*type|refresh\s*drawing|drawing\s*type\s*reload)\b",
@@ -492,25 +492,25 @@ namespace StingTools.Tags
 
             // ── Legends Extended ──────────────────────────────────────────────────
             (@"\b(discipline\s+legend|legend\s+disc|disc\s+legend)\b",
-                "CreateDisciplineLegend", "DisciplineLegend", "Create discipline colour-coded legend"),
+                "CreateColorLegend", "DisciplineLegend", "Create discipline colour-coded legend"),
             (@"\b(system\s+legend|legend\s+system|sys\s+legend)\b",
-                "CreateSystemLegend", "SystemLegend", "Create system type colour legend"),
+                "MepSystemLegend", "SystemLegend", "Create system type colour legend"),
             (@"\b(material\s+legend|legend\s+material|material\s+color\s+key)\b",
-                "CreateMaterialLegend", "MaterialLegend", "Create material legend from model"),
+                "MaterialLegend", "MaterialLegend", "Create material legend from model"),
             (@"\b(equipment\s+legend|legend\s+equip|equip\s+key)\b",
-                "CreateEquipmentLegend", "EquipmentLegend", "Create equipment type legend"),
+                "EquipmentLegend", "EquipmentLegend", "Create equipment type legend"),
             (@"\b(fire\s+rating\s+legend|fire\s+legend|fire\s+rating\s+key)\b",
-                "CreateFireRatingLegend", "FireRatingLegend", "Create fire rating key/legend"),
+                "FireRatingLegend", "FireRatingLegend", "Create fire rating key/legend"),
             (@"\b(tag\s+legend|legend\s+tag|iso\s+tag\s+legend)\b",
                 "CreateTagLegend", "TagLegend", "Create ISO 19650 tag format legend"),
             (@"\b(status\s+legend|legend\s+status|state\s+legend)\b",
-                "CreateStatusLegend", "StatusLegend", "Create element status legend (new/existing/demolished)"),
+                "StatusLegend", "StatusLegend", "Create element status legend (new/existing/demolished)"),
             (@"\b(phase\s+legend|legend\s+phase|demolition\s+legend)\b",
-                "CreatePhaseLegend", "PhaseLegend", "Create phase legend for demolition and new work"),
+                "StatusLegend", "PhaseLegend", "Create phase legend for demolition and new work"),
             (@"\b(symbol\s+legend|legend\s+symbol|drawing\s+key)\b",
-                "CreateSymbolLegend", "SymbolLegend", "Create symbol/notation key for drawings"),
+                "ComponentTypeLegend", "SymbolLegend", "Create symbol/notation key for drawings"),
             (@"\b(sync\s+legend|update\s+legend|refresh\s+legend)\b",
-                "SyncLegend", "SyncLegend", "Synchronize legend with current element data"),
+                "UpdateLegend", "SyncLegend", "Synchronize legend with current element data"),
             (@"\b(color\s+swatch|colour\s+swatch|swatch\s+legend)\b",
                 "CreateColorLegend", "ColorLegend", "Create colour swatch legend from current scheme"),
 

--- a/docs/UNREACHABLE_COMMANDS_TRIAGE.md
+++ b/docs/UNREACHABLE_COMMANDS_TRIAGE.md
@@ -7,19 +7,26 @@ button-tag dispatcher in `StingTools/UI/StingCommandHandler.cs`.
 - **Wired in `StingCommandHandler.cs`**: 1,162
 - **Not in dock-panel dispatcher**: **126**
 
-> **Phase 177 update (complete)**: All 23 original Category C commands have been
-> resolved. Summary:
+> **Phase 177 update (corrected 2026-07-20 — verified against
+> `StingCommandHandler.cs` / `StingDockPanel.xaml`; see wiring audit W-5 in
+> `DRAWINGS_PRODUCTION_REVIEW.md`)**:
 >
 > - **Wired with new tags + XAML buttons** (10): 5 AVF heatmap (`Heatmap_*`), 5 V6
->   (`V6_*`), 3 AEC filter (`AecFilters_*`), `DrawingBrowserOrganizerCommand`
->   (`DrawingTypes_BrowserOrganize`), `BCFSyncCommand` (`BCFSync`),
->   `RevisionCloudAuditCommand` (`RevisionCloudAudit`),
->   `PluginOnboardingWizardCommand` (`PlanscapeOnboarding`)
-> - **Wired with secondary alias tags only** (3): `DrawingSyncStylesCommand`
->   (`DrawingTypes_SyncStylesDirect`), `DrawingForceResyncCommand`
->   (`DrawingTypes_ForceResync`), `GenerateFromScopeBoxesCommand`
->   (`DrawingTypes_ScopeBoxesDirect`) — primary tags already had inline
->   implementations and XAML buttons
+>   (`V6_*`), 3 AEC filter (`AecFilters_*`, handler 1407-1409),
+>   `DrawingBrowserOrganizerCommand` (tag is **`Drawing_BrowserOrganize`**,
+>   handler 1410 — NOT `DrawingTypes_BrowserOrganize`, which exists nowhere),
+>   `BCFSyncCommand` (`BCFSync`), `RevisionCloudAuditCommand`
+>   (`RevisionCloudAudit`), `PluginOnboardingWizardCommand` (`PlanscapeOnboarding`)
+> - **Wired with a secondary alias tag** (1): `DrawingForceResyncCommand`
+>   (`DrawingTypes_ForceResync`, handler 1411 + XAML button)
+> - **Still bypassed** (2): `DrawingSyncStylesCommand` and
+>   `GenerateFromScopeBoxesCommand` — the previously claimed alias tags
+>   `DrawingTypes_SyncStylesDirect` / `DrawingTypes_ScopeBoxesDirect` were
+>   never added (they appear nowhere in the repo); the primary tags still run
+>   inline reimplementations in the handler. PR #449 wires
+>   `GenerateFromScopeBoxesCommand` via `WorkflowEngine.ResolveCommand`
+>   (`DrawingTypes_FromScopeBoxes`); the dock-panel button still uses the
+>   inline path. Converging class vs inline is review finding W-5.
 > - **Left as dead code** (3): `BatchPrintSheetsCommand`,
 >   `ClashDetectionCommand` (Temp variant), `PanelScheduleCommand` (Temp
 >   variant) — their dispatcher tags already route to newer commands; old
@@ -217,16 +224,14 @@ with `docs/CHANGELOG.md` before removing anything: several of these are
 documented as the "engine class" for a feature whose tag now redirects
 to a newer command.
 
-- `AecFiltersCreateCommand` — `Commands/Drawing/AecFilterCommands.cs`. Mentioned in CLAUDE.md Phase 166 but no tag wired.
-- `AecFiltersInspectCommand` — `Commands/Drawing/AecFilterCommands.cs`.
-- `AecFiltersReloadCommand` — `Commands/Drawing/AecFilterCommands.cs`.
+- ~~`AecFiltersCreateCommand` / `AecFiltersInspectCommand` / `AecFiltersReloadCommand`~~ — **now wired** (`AecFilters_*` tags, handler 1407-1409 + XAML buttons). Not deletion candidates.
 - `ApplyLabourHoursCommand` — `V6/LabourHoursCommands.cs`. V6 feature, no V6 dispatcher exists.
 - `BCFSyncCommand` — `BIMManager/PlatformLinkCommands.cs`.
 - `BatchPrintSheetsCommand` — `Docs/SheetTemplateCommands.cs`. **Replaced** — dispatcher tag `"BatchPrintSheets"` now redirects to `Docs.ExportCenterPdfCommand`.
 - `ClashDetectionCommand` — `Temp/DataPipelineCommands.cs`. **Replaced** — dispatcher tag `"ClashDetection"` now resolves to `Core.Clash.ClashRunCommand`.
 - `ClearHeatmapCommand` — `Commands/Visualization/AvfHeatmapCommands.cs`.
-- `DrawingBrowserOrganizerCommand` — `Commands/Drawing/DrawingBrowserOrganizerCommand.cs`. Mentioned in CLAUDE.md Phase 113 Week 3, but the dock panel does not wire it.
-- `DrawingForceResyncCommand` — `Commands/Drawing/DrawingSyncStylesCommand.cs`.
+- ~~`DrawingBrowserOrganizerCommand`~~ — **now wired** (tag `Drawing_BrowserOrganize`, handler 1410 + XAML button). Not a deletion candidate.
+- ~~`DrawingForceResyncCommand`~~ — **now wired** (tag `DrawingTypes_ForceResync`, handler 1411 + XAML button). Not a deletion candidate.
 - `DrawingSyncStylesCommand` — `Commands/Drawing/DrawingSyncStylesCommand.cs`. **Bypassed** — dispatcher tag `"DrawingTypes_SyncStyles"` calls inline `DrawingTypesSyncStylesInline(app)` instead of the class.
 - `ExportLabourHoursCommand` — `V6/LabourHoursCommands.cs`. V6 feature.
 - `GenerateFromScopeBoxesCommand` — `Commands/Drawing/GenerateFromScopeBoxesCommand.cs`. **Bypassed** — dispatcher tag `"DrawingTypes_FromScopeBoxes"` calls inline `DrawingTypesFromScopeBoxesInline(app)` instead.

--- a/docs/guides/STING_ELECTRICAL_LAYMANS_GUIDE.md
+++ b/docs/guides/STING_ELECTRICAL_LAYMANS_GUIDE.md
@@ -1367,7 +1367,7 @@ For electrical risers and panel-internal sections, set `farClipMm` short
 
 ### 11.16 Browser Organizer + drift kinds
 
-`DrawingTypes_BrowserOrganize` creates `'STING - by Drawing Type'`
+`Drawing_BrowserOrganize` creates `'STING - by Drawing Type'`
 organisations for views *and* sheets, keyed off `STING_DRAWING_TYPE_ID_TXT`.
 Worth its weight in gold once you exceed 50 sheets.
 


### PR DESCRIPTION
## Summary

Implements the P2 wiring/documentation items from `docs/DRAWINGS_PRODUCTION_REVIEW.md` (merged in #447) that don't touch any file PR #449 is working in — findings **W-3, W-4, W-5, W-6**.

### W-4 — 11 broken NLP intents now dispatch (`StingTools/Tags/NLPCommandProcessor.cs`)

Every one of these emitted a tag with no case in `StingCommandHandler`'s exact-match switch, so a successful phrase match dead-ended in the "Unknown Command" dialog. Each is remapped to a real, verified handler tag (regexes and labels unchanged):

| Intent phrase family | Was | Now |
|---|---|---|
| generic "create legend / color legend" | `CreateMasterLegend` | `CreateColorLegend` |
| discipline legend | `CreateDisciplineLegend` | `CreateColorLegend` |
| system legend | `CreateSystemLegend` | `MepSystemLegend` |
| material legend | `CreateMaterialLegend` | `MaterialLegend` |
| equipment legend | `CreateEquipmentLegend` | `EquipmentLegend` |
| fire rating legend | `CreateFireRatingLegend` | `FireRatingLegend` |
| status legend | `CreateStatusLegend` | `StatusLegend` |
| phase legend | `CreatePhaseLegend` | `StatusLegend` (new/existing/demolished semantics) |
| symbol / drawing key | `CreateSymbolLegend` | `ComponentTypeLegend` |
| sync/update/refresh legend | `SyncLegend` | `UpdateLegend` |
| browser organize | `DrawingTypes_BrowserOrganize` | `Drawing_BrowserOrganize` |

The same tag typo is fixed in `docs/guides/STING_ELECTRICAL_LAYMANS_GUIDE.md`.

### W-3 / W-6 — CLAUDE.md drift

- The Drawing Template Manager command list documented 11 of 21 tags under names that exist nowhere in code (`DrawingTypes_Produce`, `ManagedTemplates_*`, `TitleBlocks_Factory`, `MatchLines_Create`, …) — replaced with the tags the dispatcher actually matches, and noted the MatchLine suite has handler cases but no UI surface yet (finding W-2).
- Counts corrected: **298** AEC filters (was "199"), **81** healthcare filters (was "58"), **8** title-block param spec stubs (was "7").
- Two false checksum claims corrected: `ViewStylePackRegistry.ComputeChecksums` does not exist, and `DrawingTypeRegistry`'s SHA-256 drift detection is inert for the shipped baseline (zero `checksum` fields, hashes never persisted) — both now reference finding C-5.

### W-5 — `docs/UNREACHABLE_COMMANDS_TRIAGE.md` corrected in both directions

- The "Phase 177 update" banner claimed alias tags `DrawingTypes_SyncStylesDirect` / `DrawingTypes_ScopeBoxesDirect` that appear nowhere in the repo — `DrawingSyncStylesCommand` and `GenerateFromScopeBoxesCommand` are in fact still bypassed by inline handler reimplementations (PR #449 wires the latter via `WorkflowEngine.ResolveCommand`).
- The deletion-candidates list still marked `AecFilters*Command` ×3, `DrawingBrowserOrganizerCommand`, and `DrawingForceResyncCommand` as dead — all five are wired with handler cases and XAML buttons (verified at `StingCommandHandler.cs:1407-1411`, `StingDockPanel.xaml:1762-1766`).

## Scope notes

- Docs plus the NLP intent table only — no Revit-behaviour change beyond routing NLP matches to commands that actually run.
- `docs/CHANGELOG.md` / `docs/ROADMAP.md` deliberately untouched to avoid merge conflicts with #449, which edits both; the changelog entry for this change should land after #449 merges.
- Committed without `dotnet build` verification (Linux sandbox — repo norm); the only code file touched is a static tuple table.

## Verification

- All 11 replacement tags grep-verified against `StingCommandHandler` case labels.
- All five "now wired" triage corrections verified against handler + XAML line numbers.
- Filter counts re-derived from `STING_AEC_FILTERS.json` by script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh

---
_Generated by [Claude Code](https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh)_