### PR TITLE
fix(placement): review follow-ups to #458 — validator read path, token hygiene, coercion

### DIFF
--- a/StingTools.Placement.Tests/PlacementRuleMaintenanceClearanceTests.cs
+++ b/StingTools.Placement.Tests/PlacementRuleMaintenanceClearanceTests.cs
@@ -1,0 +1,54 @@
+using StingTools.Core.Placement;
+using Xunit;
+
+namespace StingTools.Placement.Tests
+{
+    /// <summary>
+    /// MaintenanceClearance was retyped from double to a class-code string.
+    /// The setter coerces a purely-zero numeric to empty so that an Excel sheet
+    /// exported under the old double shape (default rendered as "0") does not
+    /// resurrect a bogus clearance on re-import — while a genuine numeric typo
+    /// such as "600" is kept so the advisory validator can still flag it.
+    /// </summary>
+    public class PlacementRuleMaintenanceClearanceTests
+    {
+        [Theory]
+        [InlineData("0")]
+        [InlineData("0.0")]
+        [InlineData("0.000")]
+        [InlineData(" 0 ")]
+        public void LegacyZeroSerialisation_IsCoercedToEmpty(string raw)
+        {
+            var r = new PlacementRule { MaintenanceClearance = raw };
+            Assert.Equal("", r.MaintenanceClearance);
+        }
+
+        [Theory]
+        [InlineData("FRONT_600")]
+        [InlineData("SIDES_300")]
+        public void ClassCode_IsPreserved(string code)
+        {
+            var r = new PlacementRule { MaintenanceClearance = code };
+            Assert.Equal(code, r.MaintenanceClearance);
+        }
+
+        [Fact]
+        public void NonZeroNumericTypo_IsKeptSoTheAdvisoryCanFlagIt()
+        {
+            // "600" is the exact mistake the old double-typed field invited and
+            // that PlacementAdvisoryValidator reports — coercion must not swallow it.
+            var r = new PlacementRule { MaintenanceClearance = "600" };
+            Assert.Equal("600", r.MaintenanceClearance);
+            Assert.Contains(
+                PlacementAdvisoryValidator.Validate(new[] { r }, null),
+                a => a.Contains("MaintenanceClearance"));
+        }
+
+        [Fact]
+        public void Null_BecomesEmpty()
+        {
+            var r = new PlacementRule { MaintenanceClearance = null };
+            Assert.Equal("", r.MaintenanceClearance);
+        }
+    }
+}

--- a/StingTools.Placement.Tests/TestHelpers/PlacementResultShim.cs
+++ b/StingTools.Placement.Tests/TestHelpers/PlacementResultShim.cs
@@ -8,8 +8,12 @@
 // If PlacementAdvisoryValidator ever starts reading more of PlacementResult,
 // this shim must grow to match or the test project stops compiling — which is
 // the intended tripwire.
+//
+// CountsByRule uses the DEFAULT (case-sensitive) comparer to match the real
+// PlacementResult in FixturePlacementEngine.cs — the engine writes and the
+// validator reads with the same MergeKey, so any case-folding here would make
+// the shim more forgiving than production and mask a real key-casing bug.
 
-using System;
 using System.Collections.Generic;
 
 namespace StingTools.Core.Placement
@@ -17,6 +21,6 @@ namespace StingTools.Core.Placement
     public class PlacementResult
     {
         public Dictionary<string, int> CountsByRule { get; }
-            = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            = new Dictionary<string, int>();
     }
 }

--- a/StingTools/Core/Placement/FixturePlacementEngine.cs
+++ b/StingTools/Core/Placement/FixturePlacementEngine.cs
@@ -293,9 +293,12 @@ namespace StingTools.Core.Placement
                     // "the standards filter didn't remove anything" is explicable.
                     if (profile.ActiveStandards != null && profile.ActiveStandards.Length > 0)
                     {
-                        int tagged = rules.Count(r => r != null
+                        // Count over non-null rules only, so a null list entry is
+                        // not miscounted as an untagged rule in the warning.
+                        int total   = rules.Count(r => r != null);
+                        int tagged  = rules.Count(r => r != null
                             && (!string.IsNullOrEmpty(r.ApplicableStandards) || !string.IsNullOrEmpty(r.StandardRef)));
-                        int untagged = rules.Count - tagged;
+                        int untagged = total - tagged;
 
                         if (tagged == 0)
                         {
@@ -305,7 +308,7 @@ namespace StingTools.Core.Placement
                         }
                         else if (untagged > 0)
                         {
-                            result.Warnings.Add($"Standards gate: {untagged} of {rules.Count} rule(s) carry neither " +
+                            result.Warnings.Add($"Standards gate: {untagged} of {total} rule(s) carry neither " +
                                                 "ApplicableStandards nor StandardRef, so they bypass the profile's " +
                                                 "ActiveStandards filter and are always included. Tag them to bring them " +
                                                 "under the gate.");

--- a/StingTools/Core/Placement/PlacementAdvisoryValidator.cs
+++ b/StingTools/Core/Placement/PlacementAdvisoryValidator.cs
@@ -52,10 +52,15 @@ namespace StingTools.Core.Placement
 
         /// <summary>
         /// Emit advisories for specification fields that are set on a rule but
-        /// cannot take effect given that rule's configuration. Only rules that
-        /// actually placed something are considered — a rule that placed nothing
-        /// already reports that through the per-rule diagnostics, and repeating
-        /// it here would be noise.
+        /// cannot take effect given that rule's configuration.
+        ///
+        /// Scoping: when the run produced placement counts
+        /// (<paramref name="result"/>.CountsByRule is non-empty) only rules that
+        /// actually fired are considered — a rule that placed nothing already
+        /// reports that through the per-rule diagnostics, and repeating it here
+        /// would be noise. When there are no counts — a null/empty result, as in
+        /// the unit tests, or a run that placed nothing at all — every rule is
+        /// considered, so a fully mis-configured pack still gets feedback.
         /// </summary>
         public static List<string> Validate(IEnumerable<PlacementRule> rules, PlacementResult result)
         {
@@ -66,7 +71,8 @@ namespace StingTools.Core.Placement
             {
                 if (rule == null) continue;
 
-                // Scope to rules that fired. CountsByRule is keyed by MergeKey.
+                // Scope to rules that fired when we have counts to scope by.
+                // CountsByRule is keyed by MergeKey.
                 if (result?.CountsByRule != null && result.CountsByRule.Count > 0)
                 {
                     var key = rule.MergeKey ?? "";

--- a/StingTools/Core/Placement/PlacementRule.cs
+++ b/StingTools/Core/Placement/PlacementRule.cs
@@ -302,8 +302,28 @@ namespace StingTools.Core.Placement
         /// Typing it as the class-code string aligns the rule with both the
         /// editor and the validator's STING_MAINT_CLEAR_TXT contract. No rule
         /// pack set this field, so there is no data to migrate.
+        ///
+        /// The setter coerces a purely-zero numeric to empty: an Excel sheet
+        /// exported under the old <c>double</c> shape carries the default as the
+        /// literal "0", and re-importing it must not resurrect a value that the
+        /// validator would then silently skip (and that Push-to-Families would
+        /// stamp as "0"). A non-zero numeric such as "600" is a genuine user
+        /// mistake and is kept, so the advisory validator can flag it.
         /// </summary>
-        public string MaintenanceClearance { get; set; } = "";
+        private string _maintenanceClearance = "";
+        public string MaintenanceClearance
+        {
+            get => _maintenanceClearance;
+            set
+            {
+                var v = (value ?? "").Trim();
+                if (double.TryParse(v, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out var d)
+                    && d == 0.0)
+                    v = "";
+                _maintenanceClearance = v;
+            }
+        }
 
         // ── Manufacturer / catalogue ─────────────────────────────────
 

--- a/StingTools/Core/Validation/MaintenanceAccessValidator.cs
+++ b/StingTools/Core/Validation/MaintenanceAccessValidator.cs
@@ -122,12 +122,35 @@ namespace StingTools.Core.Validation
         {
             try
             {
-                var p = el?.LookupParameter(paramName);
-                if (p == null || !p.HasValue) return fallback;
-                if (p.StorageType == StorageType.String) return p.AsString() ?? fallback;
+                // Instance first, then the element's type. STING_MAINT_CLEAR_TXT is
+                // written onto family types by FamilyHintsBridge.PushRuleToFamilyTypes,
+                // and an instance-side LookupParameter does not resolve a type-bound
+                // parameter — without this fallback the write would land but never be
+                // read, so the validator could still never fire.
+                var v = ReadStringFrom(el, paramName);
+                if (v != null) return v;
+
+                var typeId = el?.GetTypeId();
+                if (typeId != null && typeId != ElementId.InvalidElementId)
+                {
+                    var typeEl = el.Document?.GetElement(typeId);
+                    var tv = ReadStringFrom(typeEl, paramName);
+                    if (tv != null) return tv;
+                }
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
             return fallback;
+        }
+
+        // Returns the string value when the parameter exists, has a value and is
+        // string-typed; null when it is absent/empty so the caller can fall through
+        // to the type. Distinguishes "not found here" from a genuine empty string.
+        private static string ReadStringFrom(Element el, string paramName)
+        {
+            var p = el?.LookupParameter(paramName);
+            if (p == null || !p.HasValue) return null;
+            if (p.StorageType != StorageType.String) return null;
+            return p.AsString();
         }
     }
 }

--- a/StingTools/Data/Placement/STING_PLACEMENT_RULES.toilet-fixtures.json
+++ b/StingTools/Data/Placement/STING_PLACEMENT_RULES.toilet-fixtures.json
@@ -124,7 +124,7 @@
       "MaxPerRoom": 1,
       "Priority": 92,
       "StandardRef": "ADA \u00a7605.2 (max 432mm / 17 inch rim); BS 8300:2018",
-      "ApplicableStandards": ["ADA§605.2(max432mm", "17inchrim)", "BS8300:2018"],
+      "ApplicableStandards": ["ADA §605.2", "BS 8300"],
       "UniclassPr": "Pr_70_65_75_35",
       "Notes": "ADA-compliant urinal. Rim at max 432mm AFF. Floor-mounted or low-rim wall-hung. Min 990mm \u00d7 1525mm clear floor space centred on fixture per ADA \u00a7605.3."
     },
@@ -164,7 +164,7 @@
       "MaxPerRoom": 1,
       "Priority": 94,
       "StandardRef": "ADA \u00a7606.3 (max 865mm / 34 inch rim); BS 8300:2018 cl.12.4 (720-740mm for wheelchair)",
-      "ApplicableStandards": ["ADA§606.3(max865mm", "34inchrim)", "BS8300:2018cl.12.4(720-740mmforwheelchair)"],
+      "ApplicableStandards": ["ADA §606.3", "BS 8300"],
       "UniclassPr": "Pr_70_65_74",
       "Notes": "ADA/BS 8300 accessible basin. Rim at max 865mm AFF (USA) / 720-740mm (BS 8300 wheelchair). Wall-hung with knee clearance min 685mm AFF, 205mm deep, 760mm wide. Insulated pipes. 760mm \u00d7 1220mm clear floor space."
     },
@@ -207,7 +207,7 @@
       "RelativeTo": "first",
       "Priority": 90,
       "StandardRef": "BS 6465-1:2006; ADA \u00a7604.7 (178-229mm from front edge, 381-1219mm AFF); BS 8300",
-      "ApplicableStandards": ["BS6465-1:2006", "ADA§604.7(178-229mmfromfrontedge", "381-1219mmAFF)", "BS8300"],
+      "ApplicableStandards": ["BS 6465-1", "ADA §604.7", "BS 8300"],
       "UniclassPr": "Pr_70_65_78_60",
       "Notes": "Toilet paper holder on RIGHT side wall (right when seated, facing door). Centre 200mm from WC centreline, 150mm forward of WC front edge, 600mm AFF (UK standard) / 660mm (US). ADA: 7-9 inches (178-229mm) from front of toilet, 15-48 inches (381-1219mm) AFF."
     },
@@ -229,7 +229,7 @@
       "DependsOn": "toilet-wc-at-window-standard",
       "Priority": 85,
       "StandardRef": "BS 6465-1:2006; commercial fit-out standard",
-      "ApplicableStandards": ["BS6465-1:2006", "commercialfit-outstandard"],
+      "ApplicableStandards": ["BS 6465-1"],
       "UniclassPr": "Pr_70_65_78_60",
       "Notes": "Double-roll toilet paper holder for commercial/high-traffic facilities. Right side, 600mm AFF, 200mm from WC centreline. Reduces service frequency."
     },
@@ -271,7 +271,7 @@
       "DependsOn": "toilet-wc-at-window-standard",
       "Priority": 91,
       "StandardRef": "ADA \u00a7604.5.1 (838-965mm / 33-38 inch AFF; 1067mm long, 305mm from back wall); BS 8300:2018 cl.12.3 (800mm AFF, 680mm from back wall)",
-      "ApplicableStandards": ["ADA§604.5.1(838-965mm", "33-38inchAFF", "1067mmlong", "305mmfrombackwall)", "BS8300:2018cl.12.3(800mmAFF", "680mmfrombackwall)"],
+      "ApplicableStandards": ["ADA §604.5.1", "BS 8300"],
       "UniclassPr": "Pr_70_65_78_35",
       "Notes": "Side grab bar, right of WC. 838mm AFF (33 inches). Bar must extend from 305mm behind toilet to 762mm in front of toilet front edge (total 1067mm / 42 inches per ADA). Stainless steel 32-38mm diameter. BS 8300: 800mm AFF, min 700mm long."
     },
@@ -313,7 +313,7 @@
       "DependsOn": "toilet-wc-at-window-standard",
       "Priority": 90,
       "StandardRef": "ADA \u00a7604.5.2 (rear bar: 880-965mm / 34.5-38 inch AFF; 914mm long centred on toilet); BS 8300:2018 (200mm above seat)",
-      "ApplicableStandards": ["ADA§604.5.2(rearbar:880-965mm", "34.5-38inchAFF", "914mmlongcentredontoilet)", "BS8300:2018(200mmaboveseat)"],
+      "ApplicableStandards": ["ADA §604.5.2", "BS 8300"],
       "UniclassPr": "Pr_70_65_78_35",
       "Notes": "Rear grab bar on window/back wall, centred on WC, 880mm AFF. 914mm (36 inch) minimum total length \u2014 152mm (6 in) from centreline to one side, 762mm (30 in) to other side. Provides push-up support from seated position."
     },
@@ -355,7 +355,7 @@
       "DependsOn": "toilet-wc-at-window-standard",
       "Priority": 65,
       "StandardRef": "Best practice / NHSS 59 recommendations",
-      "ApplicableStandards": ["Bestpractice", "NHSS59recommendations"],
+      "ApplicableStandards": ["NHSS 59"],
       "UniclassPr": "Pr_70_65_78",
       "Notes": "Toilet brush holder, right of WC, floor-mounted against right-side wall. 300mm from WC centreline. Concealed brushes preferred in commercial fit-out; freestanding in residential. Not used in healthcare (infection control \u2014 use disposable rim blocks instead)."
     },
@@ -462,7 +462,7 @@
       "DependsOn": "toilet-basin-standard",
       "Priority": 75,
       "StandardRef": "ADA \u00a7604.7 / \u00a7606.7 (800-1000mm reach range); BS 8300 (max 1200mm AFF for accessible)",
-      "ApplicableStandards": ["ADA§604.7", "§606.7(800-1000mmreachrange)", "BS8300(max1200mmAFFforaccessible)"],
+      "ApplicableStandards": ["ADA §604.7", "ADA §606.7", "BS 8300"],
       "UniclassPr": "Pr_70_65_78_57",
       "Notes": "Towel ring near basin, 1100mm AFF (standard). ADA: max 1200mm AFF when forward reach. 150-300mm from basin front edge. Chrome or stainless steel. In accessible rooms use max 1000mm AFF for forward reach over obstruction."
     },
@@ -502,7 +502,7 @@
       "MaxPerRoom": 2,
       "Priority": 62,
       "StandardRef": "ADA \u00a7308 (max 1220mm AFF accessible reach range); standard residential 1500mm AFF",
-      "ApplicableStandards": ["ADA§308(max1220mmAFFaccessiblereachrange)", "standardresidential1500mmAFF"],
+      "ApplicableStandards": ["ADA §308"],
       "UniclassPr": "Pr_70_65_78_57",
       "Notes": "Robe/towel hook on back of door or adjacent wall. 1500mm AFF standard (residential). ADA/accessible: max 1220mm AFF. Double hook preferred. 50mm projection only. Back of door reduces wall congestion."
     },
@@ -725,7 +725,7 @@
       "MaxPerRoom": 1,
       "Priority": 86,
       "StandardRef": "ADA \u00a7607.4 (432-483mm / 17-19 inch seat AFF); BS 8300:2018 cl.12.5 (480-500mm seat AFF)",
-      "ApplicableStandards": ["ADA§607.4(432-483mm", "17-19inchseatAFF)", "BS8300:2018cl.12.5(480-500mmseatAFF)"],
+      "ApplicableStandards": ["ADA §607.4", "BS 8300"],
       "UniclassPr": "Pr_70_65_78",
       "Notes": "Fold-down shower seat at 480mm AFF when deployed. Teak or stainless non-slip. ADA: 432-483mm seat height, 426mm deep, 406mm from back wall, 152mm from side wall. BS 8300: 480-500mm. Load rated 150kg. Hinged fold-up clears 300mm when not in use. Corrosion-resistant fixings."
     },
@@ -745,7 +745,7 @@
       "MaxPerRoom": 2,
       "Priority": 87,
       "StandardRef": "ADA \u00a7608.3 (838mm / 33 inch AFF); BS 8300:2018 cl.12.5",
-      "ApplicableStandards": ["ADA§608.3(838mm", "33inchAFF)", "BS8300:2018cl.12.5"],
+      "ApplicableStandards": ["ADA §608.3", "BS 8300"],
       "Notes": "Horizontal shower grab bar at 838mm AFF (33 inches). Min 900mm long. Stainless 32-38mm diameter. Required on shower entry wall and side wall for accessible showers. Supports transfer and balance. BS 8300 equivalent."
     },
     {
@@ -764,7 +764,7 @@
       "MaxPerRoom": 1,
       "Priority": 62,
       "StandardRef": "BS 5386; NHS wash facility guidance",
-      "ApplicableStandards": ["BS5386", "NHSwashfacilityguidance"],
+      "ApplicableStandards": ["BS 5386"],
       "Notes": "Shower curtain rod at 1900mm AFF. Stainless steel rod 25mm. Must span full shower opening width + 200mm each side for overlap. Reinforced wall fixings (600N load). Antimicrobial curtain material preferred in healthcare."
     },
     {
@@ -783,7 +783,7 @@
       "MaxPerRoom": 1,
       "Priority": 56,
       "StandardRef": "BS 5385-4 (tile fixing); best practice",
-      "ApplicableStandards": ["BS5385-4(tilefixing)", "bestpractice"],
+      "ApplicableStandards": ["BS 5385-4"],
       "Notes": "Recessed shampoo/toiletries niche at 1300mm AFF (mid-chest). 300mm \u00d7 300mm \u00d7 100mm deep. Tiled internally. Stainless trim edge. Located on wall adjacent to shower head, 300mm from corner. Tile to full depth with grout sealant."
     },
     {
@@ -865,7 +865,7 @@
       "MaxPerRoom": 1,
       "Priority": 48,
       "StandardRef": "BS 6465-1:2006; good practice for facilities >10 persons",
-      "ApplicableStandards": ["BS6465-1:2006", "goodpracticeforfacilities>10persons"],
+      "ApplicableStandards": ["BS 6465-1"],
       "Notes": "Sanitary product vending machine in female/unisex washrooms. 1200mm AFF to dispensing slot. Recessed or surface-mounted. 240V supply required. Min 300\u00d7400mm wall space."
     },
     {
@@ -885,7 +885,7 @@
       "GuaranteeCoverage": true,
       "Priority": 88,
       "StandardRef": "Approved Doc F (2021): 6 l/s min extract for WC, 8 l/s for bathroom; BS 5720; CIBSE Guide B2",
-      "ApplicableStandards": ["ApprovedDocF(2021):6l", "sminextractforWC", "8l", "sforbathroom", "BS5720", "CIBSEGuideB2"],
+      "ApplicableStandards": ["Approved Doc F", "BS 5720", "CIBSE Guide B2"],
       "UniclassPr": "Pr_50_70_14",
       "Notes": "Ceiling extract grille for WC/bathroom mechanical ventilation. Approved Doc F: 6 l/s for WC-only rooms, 8 l/s for bathrooms, 15 l/s for en-suite with bath/shower. Continuous background rate 0.5 air changes/hour (new build). Position over toilet or shower for best capture. Duct to external or MEV heat recovery unit."
     },

--- a/StingTools/UI/PlacementCenter/PlacementCategoryCheckItem.cs
+++ b/StingTools/UI/PlacementCenter/PlacementCategoryCheckItem.cs
@@ -64,9 +64,18 @@ namespace StingTools.UI.PlacementCenter
                 // A non-placeable category can never be ticked, even if a binding
                 // or a "select all" tries: the engine would silently place nothing.
                 bool next = value && IsPlaceable;
-                if (_isChecked == next) return;
-                _isChecked = next;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+                if (_isChecked != next)
+                {
+                    _isChecked = next;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+                }
+                else if (next != value)
+                {
+                    // The requested value was coerced away (non-placeable row). Raise
+                    // anyway so a TwoWay binding reverts its visual to the coerced
+                    // state instead of showing a tick the model never accepted.
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsChecked)));
+                }
             }
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,6 +97,34 @@ field is on a consuming path.
 
 `dotnet build -t:Rebuild` **0 errors / 0 warnings**, unchanged from baseline.
 
+**Review follow-up (same PR).** Seven points from code review addressed:
+
+- **`MaintenanceAccessValidator` now reads the type as well as the instance.**
+  `PushRuleToFamilyTypes` writes `STING_MAINT_CLEAR_TXT` onto family *types*, but
+  the validator read it via an instance-side `LookupParameter`, which does not
+  resolve a type-bound parameter — so the write could land and still never be
+  read. `ReadString` now falls back to `el.Document.GetElement(el.GetTypeId())`.
+  This is what actually closes the "activates `MaintenanceAccessValidator`" loop.
+- **Backfill token hygiene.** The `StandardRef`→`ApplicableStandards` split ran on
+  prose in the toilet-fixtures pack (`/` inside `l/s` and parentheticals),
+  producing non-standard tokens like `sminextractforWC`, `17inchrim)` and
+  `standardresidential1500mmAFF`. Gating still worked (the real citations survived
+  as prefixes) but the structured field carried noise; 15 arrays re-curated to
+  clean identifiers (`["Approved Doc F", "BS 5720", "CIBSE Guide B2"]`, …).
+- **Legacy-`"0"` coercion.** `PlacementRule.MaintenanceClearance` now coerces a
+  purely-zero numeric to empty, so re-importing an Excel sheet exported under the
+  old `double` shape does not resurrect a `"0"` that the validator would skip and
+  Push-to-Families would stamp. A non-zero typo like `"600"` is kept so the
+  advisory still flags it. Pinned by `PlacementRuleMaintenanceClearanceTests`.
+- **Advisory scoping comment** corrected to state that a null/empty result (tests,
+  or a run that placed nothing) reports on all rules, matching the code.
+- **Test shim fidelity.** `PlacementResultShim.CountsByRule` uses the default
+  case-sensitive comparer, matching the real `PlacementResult`, so it can't be
+  more forgiving than production.
+- **Untagged-count** in the standards-gate warning now counts non-null rules only.
+- **`PlacementCategoryCheckItem.IsChecked`** raises `PropertyChanged` even when it
+  coerces a rejected tick, so a TwoWay binding reverts its visual.
+
 #### Completed (Phase 222 — the handoff test now tests the code, not a copy of it)
 
 - **`HandoffProvisioningSqliteTests` calls the real method.** It previously


### PR DESCRIPTION
Stacked on **#458** (`feat/placement-residual-gaps`) — this PR carries only the code-review follow-ups, so it reviews as a small diff on top of that work. Merge #458 first, or merge this into that branch.

## Why

A review of #458 surfaced one load-bearing gap and six smaller ones. All fixes stay inside the placement lane (`Core/Placement/`, `Core/Validation/`, `UI/PlacementCenter/`, `Data/Placement/`, the test project, docs).

## What changed

**1 — HIGH · `MaintenanceAccessValidator` never read what the PR wrote.**
`PushRuleToFamilyTypes` writes `STING_MAINT_CLEAR_TXT` onto family **types**, but the validator read it via an instance-side `LookupParameter`, which does not resolve a type-bound parameter. So the write could land and still never be read — the headline "writing `STING_MAINT_CLEAR_TXT` activates `MaintenanceAccessValidator`" claim did not actually hold. `ReadString` now falls back to `el.Document.GetElement(el.GetTypeId())`, closing the loop.

**2 — MEDIUM · Backfill wrote prose fragments into the structured field.**
The `StandardRef`→`ApplicableStandards` split ran on `/` inside prose in the toilet-fixtures pack (`6 l/s`, parentheticals), producing non-standard tokens like `sminextractforWC`, `17inchrim)`, `standardresidential1500mmAFF`. Gating still worked (the real citations survived as prefixes), but the field #458 promotes to source-of-truth carried noise. 15 arrays re-curated to clean identifiers, e.g. `["Approved Doc F", "BS 5720", "CIBSE Guide B2"]`. Verbose-but-valid tokens left untouched to keep the diff focused.

**3 — Legacy `"0"` coercion.** `PlacementRule.MaintenanceClearance` now coerces a purely-zero numeric to empty, so re-importing an Excel sheet exported under the old `double` shape doesn't resurrect a `"0"` the validator skips and Push-to-Families would stamp. A non-zero typo like `"600"` is kept so the advisory still flags it. Pinned by `PlacementRuleMaintenanceClearanceTests`.

**4 — Advisory scoping comment** corrected to state that a null/empty result (tests, or a run that placed nothing) reports on all rules, matching the code.

**5 — Test shim fidelity.** `PlacementResultShim.CountsByRule` uses the default case-sensitive comparer, matching the real `PlacementResult`, so it can't be more forgiving than production.

**6 — Untagged count** in the standards-gate warning counts non-null rules only.

**7 — `PlacementCategoryCheckItem.IsChecked`** raises `PropertyChanged` even when it coerces a rejected tick, so a TwoWay binding reverts its visual.

## Gates / caveats

- **Built without a Revit runtime** (Linux sandbox), per repo norm. All 21 placement JSON packs validated; edited C# is brace-balanced; the pure-logic `Placement.Tests` additions target the new coercion + advisory paths.
- In-Revit check to add to #458's list: verify `MaintenanceAccessValidator` **reads** after a push, not just that the push writes — confirm whichever binding scope (instance vs type) the project uses resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdEn1AcXwhixhSYoipB3pi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdEn1AcXwhixhSYoipB3pi)_