### PR TITLE
fix(bridge): commit SB-5a pull cursor only after the push succeeds

### DIFF
--- a/StingBridge/sync/ifc_reconcile.py
+++ b/StingBridge/sync/ifc_reconcile.py
@@ -238,6 +238,7 @@ def pull_and_reconcile(
     cursor_path: Path,
     page_limit: int = 200,
     on_progress: Optional[Callable[[str], None]] = None,
+    commit_cursor: bool = True,
 ) -> dict:
     """Pull changes since this document's cursor and reconcile them locally.
 
@@ -245,9 +246,17 @@ def pull_and_reconcile(
     which is exactly the pre-SB-5a behaviour — a hub that is unreachable must
     not cost the operator their ingest.
 
-    The cursor is persisted **after** reconcile, so a crash mid-pass replays the
-    page rather than losing it. Re-applying a delta is a no-op (the engine skips
-    identical payloads); skipping one loses an edit.
+    Cursor persistence is deferred when ``commit_cursor`` is False. Advancing the
+    cursor marks the pulled deltas as consumed, but a reconciled remote win lives
+    only in ``token_map`` (and the write-back copy) until the push carries it to
+    the hub. If the cursor advanced here and the push then failed, the next drop
+    would not re-pull the change and would push the local value back over it —
+    the exact silent cross-host revert this feature exists to prevent. So the
+    watcher passes ``commit_cursor=False`` and calls :func:`commit_pending_cursor`
+    only once the push has succeeded; the value to commit is returned under
+    ``summary["_pending_cursor"]``. Direct callers keep the default (immediate
+    commit), which stays crash-safe because a replayed page re-applies as a no-op
+    (the engine skips identical payloads); skipping a page loses an edit.
     """
     from stingtools_core.sync import CursorStore, PullClient, ReconcileEngine
 
@@ -269,7 +278,37 @@ def pull_and_reconcile(
 
     host_key = cursor_host_key(doc_guid)
     store = CursorStore(cursor_path)
-    cursor = store.read(project_id, host_key)
+
+    # A corrupt cursor must reset, not disable pull. CursorStore.read tolerates
+    # unparseable JSON, but a file that parses to a non-dict ("[]", "null", a
+    # hand-edit) makes its data.get() raise, and that raise is outside the pull
+    # try below — it would propagate to the watcher, degrade to push-only, and
+    # never rewrite the cursor, so pull stays dead for that folder on every
+    # future drop. Treat it as "start from the beginning": a full backfill is
+    # replayable (identical payloads no-op), and the deferred commit overwrites
+    # the bad file with a valid cursor after the next successful push.
+    try:
+        cursor = store.read(project_id, host_key)
+    except Exception as e:  # noqa: BLE001 — a corrupt cursor must not disable pull
+        summary["cursor_reset"] = str(e)
+        log.warning("Cursor unreadable (%s) — starting from the beginning; it will "
+                    "be rewritten after the next successful push", e)
+        emit("Sync cursor was unreadable — re-pulling from the beginning")
+        cursor = None
+
+    def _finish(new_cursor):
+        """Record the drained cursor, committing now or deferring to the push."""
+        summary["cursor"] = new_cursor
+        if commit_cursor:
+            store.write(project_id, host_key, new_cursor)
+        elif new_cursor:
+            summary["_pending_cursor"] = {
+                "cursor_path": str(cursor_path),
+                "project_id": project_id,
+                "host_key": host_key,
+                "cursor": new_cursor,
+            }
+        return summary
 
     try:
         puller = PullClient(ClientHttp(client), base_url, project_id, page_limit=page_limit)
@@ -294,9 +333,7 @@ def pull_and_reconcile(
     if not known:
         if deltas:
             emit(f"Pulled {len(deltas)} change(s), none for elements in this file")
-        store.write(project_id, host_key, puller.last_cursor)
-        summary["cursor"] = puller.last_cursor
-        return summary
+        return _finish(puller.last_cursor)
 
     local_index = build_local_index(token_map, file_modified_utc(ifc_path))
     sidecar = ConflictSidecar(
@@ -335,7 +372,25 @@ def pull_and_reconcile(
     if result.conflicts:
         emit(f"{len(result.conflicts)} conflict(s) recorded in {sidecar.path.name}")
 
-    # Only now — a crash before this point replays the page instead of losing it.
-    store.write(project_id, host_key, puller.last_cursor)
-    summary["cursor"] = puller.last_cursor
-    return summary
+    # Record the drained cursor. With commit_cursor=False (the watcher) this only
+    # stashes it in the summary — it is persisted by commit_pending_cursor after
+    # the push succeeds, so a push failure replays the page instead of dropping
+    # the reconciled change. A crash before this point replays it either way.
+    return _finish(puller.last_cursor)
+
+
+def commit_pending_cursor(pending: Optional[dict]) -> bool:
+    """Persist a cursor deferred by ``pull_and_reconcile(commit_cursor=False)``.
+
+    Returns True if a cursor was written. Split out so the watcher can advance
+    the cursor only *after* the push has landed the reconciled state on the hub
+    — advancing it at reconcile time meant a later push failure discarded the
+    remote edit while the cursor had already moved past it.
+    """
+    if not pending:
+        return False
+    from stingtools_core.sync import CursorStore
+
+    CursorStore(Path(pending["cursor_path"])).write(
+        pending["project_id"], pending["host_key"], pending["cursor"])
+    return True

--- a/StingBridge/tests/test_ifc_pull_reconcile.py
+++ b/StingBridge/tests/test_ifc_pull_reconcile.py
@@ -29,7 +29,7 @@ ifcopenshell = pytest.importorskip(
 
 from StingBridge.sync.ifc_reconcile import (  # noqa: E402
     CURSOR_FILENAME, build_local_index, conflict_sidecar_path, cursor_host_key,
-    file_modified_utc,
+    file_modified_utc, pull_and_reconcile,
 )
 from StingBridge.watch.ifc_watcher import IFCDropHandler  # noqa: E402
 
@@ -456,3 +456,108 @@ def test_local_index_stamps_every_element_with_the_file_mtime(tmp_path):
 def test_cursor_host_key_is_document_scoped():
     assert cursor_host_key("abc") != cursor_host_key("def")
     assert cursor_host_key("") == "ifc", "a missing doc guid must still yield a stable key"
+
+
+# ── cursor is committed only after the push (P1 regression) ────────────────────
+
+def test_a_failed_push_does_not_advance_the_cursor(tmp_path):
+    """The cursor must move only once the reconciled state has been pushed.
+
+    Regression guard. Committing the cursor at reconcile time meant a later push
+    failure left the cursor advanced past a change that never reached the hub:
+    the next drop would not re-pull it and would push the local value straight
+    back over the remote edit — the silent cross-host revert SB-5a exists to kill.
+    """
+    src = _write_ifc(tmp_path)
+    _, later, _ = _file_times(src)
+    items = [_delta(WALL_A, {"zone": "Z99"}, later)]
+
+    class _PushDown(_FakeServer):
+        def ingest_ifc_data(self, *a, **kw):
+            raise ConnectionError("hub rejected the push")
+
+    down = _PushDown(items)
+    r1 = IFCDropHandler(down, _Cfg(), cursor_dir=tmp_path).process(str(src))
+
+    assert r1["reconcile"]["applied"] == 1, "the remote edit should reconcile in memory"
+    assert r1["errors"], "the push failure must be surfaced, not swallowed"
+    assert "_pending_cursor" not in r1["reconcile"], "internal cursor plumbing leaked into the result"
+
+    cursor_file = tmp_path / CURSOR_FILENAME
+    assert not cursor_file.exists(), (
+        "the cursor advanced despite the push failing — the reconciled remote "
+        "edit is now unrecoverable on the next drop")
+
+    # The hub recovers; re-dropping the SAME source must re-pull and re-apply,
+    # not skip past the change because the cursor had already moved.
+    up = _FakeServer(items)
+    r2 = IFCDropHandler(up, _Cfg(), cursor_dir=tmp_path).process(str(src))
+
+    assert r2["reconcile"]["pulled"] == 1, "the change was skipped — the cursor had advanced"
+    assert r2["reconcile"]["applied"] == 1
+    assert _pushed(up, WALL_A)["zone"] == "Z99", "the recovered drop failed to re-apply the remote edit"
+    assert cursor_file.exists(), "the cursor should persist once the push finally succeeds"
+
+
+def test_a_successful_push_still_advances_the_cursor(tmp_path):
+    """The deferral must not break the happy path: a clean push commits the cursor."""
+    src = _write_ifc(tmp_path)
+    _, later, _ = _file_times(src)
+    items = [_delta(WALL_A, {"zone": "Z99"}, later)]
+
+    server = _FakeServer(items)
+    result = IFCDropHandler(server, _Cfg(), cursor_dir=tmp_path).process(str(src))
+
+    assert not result["errors"]
+    assert "_pending_cursor" not in result["reconcile"]
+    assert (tmp_path / CURSOR_FILENAME).exists(), "a successful push must persist the cursor"
+
+
+# ── a corrupt cursor resets rather than disabling pull (P2) ────────────────────
+
+def test_a_corrupt_cursor_file_resets_instead_of_disabling_pull(tmp_path):
+    """A cursor file that parses to a JSON non-dict must not crash reconcile into
+    permanent push-only — it should reset, re-pull, and heal after the push."""
+    src = _write_ifc(tmp_path)
+    _, later, _ = _file_times(src)
+    (tmp_path / CURSOR_FILENAME).write_text("[]", encoding="utf-8")  # valid JSON, not a dict
+
+    server = _FakeServer([_delta(WALL_A, {"zone": "Z99"}, later)])
+    result = IFCDropHandler(server, _Cfg(), cursor_dir=tmp_path).process(str(src))
+
+    rec = result["reconcile"]
+    assert rec.get("error") is None, "a corrupt cursor was treated as a pull failure — pull is now dead"
+    assert rec.get("cursor_reset"), "the corrupt cursor should be reported as reset"
+    assert rec["pulled"] == 1, "the corrupt cursor should reset and re-pull from the beginning"
+    assert rec["applied"] == 1
+
+    stored = json.loads((tmp_path / CURSOR_FILENAME).read_text(encoding="utf-8"))
+    assert isinstance(stored, dict), "the corrupt cursor was not repaired after a successful push"
+
+
+# ── an echoed push is neutralised, not re-applied (P2 test gap) ────────────────
+
+def test_an_echoed_push_is_not_re_applied_or_flagged(tmp_path):
+    """Echo/loop guard: the feed has no host/origin filter, so an element we just
+    pushed can reappear in it. When local already equals the echoed payload,
+    reconcile must short-circuit as unchanged — never a conflict, never a revert —
+    however new the echo's timestamp is."""
+    src = _write_ifc(tmp_path)
+    _, later, _ = _file_times(src)
+
+    local = {"disc": "A", "loc": "BLD1", "zone": "Z01", "lvl": "L01",
+             "sys": "", "func": "", "prod": "WALL", "seq": "0001", "status": ""}
+    token_map = {WALL_A: dict(local)}
+
+    # The hub echoes back exactly what we pushed, with a *later* timestamp.
+    server = _FakeServer([_delta(WALL_A, dict(local), later)])
+    summary = pull_and_reconcile(
+        server, token_map=token_map, ifc_path=src,
+        doc_guid="doc-echo", cursor_path=tmp_path / CURSOR_FILENAME)
+
+    assert summary["pulled"] == 1
+    assert summary["unchanged"] == 1, "an identical echo was not recognised as a no-op"
+    assert summary["applied"] == 0 and summary["kept_local"] == 0
+    assert summary["conflicts"] == 0, "an identical echo was recorded as a conflict"
+    assert token_map[WALL_A]["zone"] == "Z01", "an identical echo mutated the local tokens"
+    assert not conflict_sidecar_path(src).exists(), "an identical echo produced a spurious sidecar"

--- a/StingBridge/watch/ifc_watcher.py
+++ b/StingBridge/watch/ifc_watcher.py
@@ -263,6 +263,15 @@ class IFCDropHandler:
         result["errors"].extend(push.errors)
         self._emit(f"Synced {push.sent} elements ({push.summary()})")
 
+        # ── SB-5a: advance the pull cursor ONLY now the push has landed ──────
+        # The reconciled remote wins live in token_map (and the write-back
+        # below) but are not durable until the hub has them. Committing the
+        # cursor before the push meant a push failure left the cursor advanced
+        # past a change we then dropped — the next drop would not re-pull it and
+        # would push the local value back over it. Hold the cursor unless the
+        # push fully succeeded, so a failed push replays the page next drop.
+        self._commit_reconcile_cursor(result["reconcile"], push)
+
         # ── Write tokens back into the IFC as IfcPropertySet ─────────────────
         self._emit("Writing STING tokens back to IFC…")
         try:
@@ -326,10 +335,36 @@ class IFCDropHandler:
                 doc_guid=doc_guid,
                 cursor_path=self._cursor_path(path),
                 on_progress=self._on_progress,
+                commit_cursor=False,  # deferred to _commit_reconcile_cursor after the push
             )
         except Exception as exc:  # noqa: BLE001 — reconcile must not fail an ingest
             log.warning("Pull/reconcile skipped for %s: %s", path.name, exc)
             return {"skipped": f"{type(exc).__name__}: {exc}"}
+
+    def _commit_reconcile_cursor(self, reconcile, push) -> None:
+        """Persist the pull cursor stashed by ``pull_and_reconcile``, but only if
+        the push fully succeeded.
+
+        A partial or failed push means the reconciled remote change is not yet on
+        the hub; holding the cursor makes the next drop re-pull and re-apply it
+        (a no-op if it later turns out identical) rather than skipping past it.
+        Popping the key keeps this internal plumbing out of the user-facing
+        result summary.
+        """
+        pending = reconcile.pop("_pending_cursor", None) if isinstance(reconcile, dict) else None
+        if not pending:
+            return
+        if not push.ok:
+            log.warning("Push incomplete (%d element(s) failed) — holding the pull "
+                        "cursor so the next drop re-reconciles instead of losing the "
+                        "change", push.failed)
+            self._emit("Pull cursor held back — push incomplete, will re-reconcile next drop")
+            return
+        try:
+            from ..sync.ifc_reconcile import commit_pending_cursor
+            commit_pending_cursor(pending)
+        except Exception as exc:  # noqa: BLE001 — a cursor write must not fail an ingest
+            log.warning("Could not persist pull cursor: %s — next drop will replay", exc)
 
     def _convert_to_glb(self, ifc_path: Path, result: dict) -> Path | None:
         """Try IfcConvert → GLB. Returns GLB path or None."""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,8 +38,20 @@ testable today without an ArchiCAD licence.
   shared cursor the first file to drain the feed consumes every other file's
   changes and they are never seen again. This matches the grain the server
   already keys mappings on.
-- Written **after** reconcile, so a crash mid-pass replays the page rather than
-  losing it. Re-applying a delta is a no-op; skipping one loses an edit.
+- Committed **after the push succeeds**, not at reconcile time. A reconciled
+  remote win lives only in the token map (and the write-back) until the push
+  carries it to the hub; advancing the cursor first meant a push failure left it
+  past a change that never landed, so the next drop would not re-pull it and
+  would push the local value back over it — a silent cross-host revert. The
+  watcher now defers the write (`pull_and_reconcile(commit_cursor=False)`) and
+  calls `commit_pending_cursor` only once `push.ok`; a failed or partial push
+  holds the cursor so the next drop re-reconciles. Re-applying a delta is a
+  no-op; skipping one loses an edit. (Post-review hardening, PR review #457.)
+- A **corrupt cursor resets** rather than disabling pull: a cursor file that
+  parses to a JSON non-dict made `CursorStore.read`'s `data.get()` raise, which
+  degraded the folder to push-only *permanently* (the bad file was never
+  rewritten). The read is now guarded — an unreadable cursor starts a full
+  backfill and is repaired after the next successful push.
 
 **Local timestamps.** An IFC export carries no per-element edit time, so every
 element is stamped with the **file's mtime**. This is not merely a convenience:


### PR DESCRIPTION
Stacked fix on top of **#457** (base is `feat/sb5a-ifc-watcher-pull-reconcile`, not `main`), so this diff is only the 4 changed files. Addresses the P1 and two P2s raised in the review of #457. Merge into #457's branch before it lands on `main`.

## P1 — cursor-before-push silent revert

`pull_and_reconcile` persisted the per-document cursor at the end of reconcile, but the push of the reconciled state happens later in `IFCDropHandler._process_model`. A reconciled remote win lives only in the in-memory token map (and the `_sting.ifc` write-back) until the push carries it to the hub. If the cursor advanced first and the push then failed (hub 503 → `failed/`), the next drop would not re-pull the change and would push the local value straight back over the remote edit — the exact silent cross-host revert SB-5a exists to prevent. A *partial* push was worse: `synced>0` marked the drop successful and archived it to `done/`.

- `pull_and_reconcile` gains `commit_cursor` (default `True`, so direct callers are unchanged). When `False` it stashes the drained cursor under `summary["_pending_cursor"]` instead of writing it.
- New `commit_pending_cursor()` persists it; the watcher calls it from `_commit_reconcile_cursor` **only when `push.ok`**, after the push. A failed or partial push holds the cursor so the next drop re-reconciles. The internal key is popped so it never leaks into the user-facing result.

## P2 — a corrupt cursor disabled pull permanently

`CursorStore.read` tolerates unparseable JSON but not a file that parses to a JSON non-dict (`"[]"`, `"null"`, a hand-edit) — `data.get()` raises, and that raise was outside the pull `try`, so it propagated to the watcher, degraded the folder to push-only, and never rewrote the cursor (pull stayed dead for that folder forever). The read is now guarded: an unreadable cursor starts a full backfill (replayable) and is repaired after the next successful push. Fixed at the call site to keep the change inside StingBridge; hardening `CursorStore.read` itself (mirroring the `isinstance(dict)` guard `write` already has) would also fix the live-ArchiCAD path and is worth a follow-up in `stingtools-core`.

## P2 (test gap) — echo/loop neutralisation was untested

The feed has no host/origin filter, so an element we just pushed can reappear. Reconcile Rule 3 short-circuits identical payloads, but no test exercised it (the fake server never echoed pushed elements back). Added a direct test that a newer, identical echo is counted `unchanged` — no conflict, no revert, no sidecar.

## Tests

`StingBridge/tests/test_ifc_pull_reconcile.py`:
- `test_a_failed_push_does_not_advance_the_cursor` — P1 regression
- `test_a_successful_push_still_advances_the_cursor` — happy-path guard
- `test_a_corrupt_cursor_file_resets_instead_of_disabling_pull` — P2
- `test_an_echoed_push_is_not_re_applied_or_flagged` — P2 test gap

The two bug-targeting tests **fail on the pre-fix code and pass with the fix** (verified by stashing the source change and re-running). Full StingBridge suite green: **174 passed**. Verified with `ifcopenshell` 0.8.5; not exercised in a live watcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_