### PR TITLE
fix(data): quote 7 Descriptions that were splitting their own CSV rows

### DIFF
--- a/.github/workflows/stingtools-plugin.yml
+++ b/.github/workflows/stingtools-plugin.yml
@@ -93,6 +93,89 @@ jobs:
           sys.exit(FAIL)
           EOF
 
+      - name: Check parameter CSV row integrity (column count)
+        run: |
+          python3 - <<'EOF'
+          import csv, sys, collections
+
+          # WHY THIS EXISTS.
+          # The duplicate-GUID check above is structurally blind to field-shift
+          # corruption: it regex-scans for GUIDs anywhere on a line, so a row whose
+          # columns are all shifted one place still presents a valid, unique GUID
+          # and passes clean.
+          #
+          # The corruption it misses: an UNQUOTED comma inside Description splits
+          # that field in two and shifts every later column by one, so Discipline,
+          # User_Modifiable and Hide_When_No_Value silently read their neighbour's
+          # value. Seven rows carried this. It went unnoticed for so long because
+          # the only visible symptom — a 14-field row against the file's 13 — was
+          # itself removed by trimming the trailing column, which normalised the
+          # count and destroyed the evidence while leaving the data wrong.
+          #
+          # A per-row column count against the header catches the whole class, and
+          # is the check that would have caught it at the time.
+          PARAM_CSVS = ['StingTools/Data/MR_PARAMETERS.csv']
+          FAIL = 0
+          for path in PARAM_CSVS:
+              try:
+                  rows = [r for r in csv.reader(open(path, encoding='utf-8'))
+                          if r and not r[0].lstrip().startswith('#')]
+              except FileNotFoundError:
+                  print(f'- {path}: not found, skipped')
+                  continue
+              if not rows:
+                  print(f'- {path}: empty, skipped')
+                  continue
+              header, data = rows[0], rows[1:]
+              want = len(header)
+              bad = collections.defaultdict(list)
+              for i, r in enumerate(data, start=2):
+                  if len(r) != want:
+                      bad[len(r)].append((i, r[1] if len(r) > 1 else '?'))
+              if bad:
+                  for n, items in sorted(bad.items()):
+                      print(f'❌ {path}: {len(items)} row(s) with {n} fields, expected {want}')
+                      for line_no, name in items[:10]:
+                          print(f'     line {line_no}: {name}')
+                      if len(items) > 10:
+                          print(f'     ... and {len(items) - 10} more')
+                  print('   Most likely cause: an unquoted comma inside a quoted-worthy '
+                        'field (e.g. Description). Wrap the field in double quotes — '
+                        'do NOT delete a trailing column to make the count match.')
+                  FAIL = 1
+              else:
+                  print(f'✓ {path}: all {len(data)} rows have {want} fields')
+
+              # SECOND ARM — and the one that actually bites.
+              # A count check alone is NOT sufficient, proven empirically: the seven
+              # corrupt rows were trimmed to 13 fields, so they pass the count check
+              # while still being shifted. These columns have tight, verified value
+              # domains, so a shifted row lands text where a flag belongs and is
+              # caught regardless of how many fields the row happens to have.
+              DOMAINS = {
+                  'Has_Formula':        {'True', 'False'},
+                  'User_Modifiable':    {'0', '1'},
+                  'Hide_When_No_Value': {'0', '1'},
+              }
+              idx = {name: header.index(name) for name in DOMAINS if name in header}
+              offenders = []
+              for i, r in enumerate(data, start=2):
+                  for name, col in idx.items():
+                      if col < len(r) and r[col] not in DOMAINS[name]:
+                          offenders.append((i, r[1] if len(r) > 1 else '?', name, r[col]))
+              if offenders:
+                  print(f'❌ {path}: {len(offenders)} column(s) outside their value domain '
+                        '— almost always a field shift:')
+                  for line_no, pname, name, val in offenders[:10]:
+                      print(f'     line {line_no}: {pname}: {name} = {val!r}')
+                  if len(offenders) > 10:
+                      print(f'     ... and {len(offenders) - 10} more')
+                  FAIL = 1
+              elif idx:
+                  print(f'✓ {path}: {", ".join(sorted(idx))} all within their value domains')
+          sys.exit(FAIL)
+          EOF
+
       - name: Validate CSV structure (required columns)
         run: |
           python3 - <<'EOF'

--- a/StingTools/Data/MR_PARAMETERS.csv
+++ b/StingTools/Data/MR_PARAMETERS.csv
@@ -1503,7 +1503,7 @@ Generic Models,ASS_OMNICLASS_TXT,a1b2c3d4-5022-4a01-b001-000000000134,TEXT,ASS_M
 Generic Models,ASS_SIZE_TXT,a1b2c3d4-5023-4a01-b001-000000000135,TEXT,ASS_MNG,Type,Element size description,False,,,MULTI,1,0
 Generic Models,ASS_ORIGIN_TXT,a1b2c3d4-5024-4a01-b001-000000000136,TEXT,ASS_MNG,Type,Asset origin (Manufactured/Imported/Local),False,,,MULTI,1,0
 Generic Models,ASS_PROJECT_TXT,a1b2c3d4-5025-4a01-b001-000000000137,TEXT,ASS_MNG,Type,Project name,False,,,MULTI,1,0
-Generic Models,ASS_REV_TXT,a1b2c3d4-5026-4a01-b001-000000000138,TEXT,ASS_MNG,Type,Current revision code (display label, GROUP 1). See also ASS_REV_COD_TXT (GROUP 17) for the ISO 19650 tag container token.,False,,,MULTI,1
+Generic Models,ASS_REV_TXT,a1b2c3d4-5026-4a01-b001-000000000138,TEXT,ASS_MNG,Type,"Current revision code (display label, GROUP 1). See also ASS_REV_COD_TXT (GROUP 17) for the ISO 19650 tag container token.",False,,,MULTI,1,0
 Generic Models,ASS_VOL_TXT,a1b2c3d4-5027-4a01-b001-000000000139,TEXT,ASS_MNG,Type,Volume/zone code for ISO 19650 naming,False,,,MULTI,1,0
 Generic Models,ASS_ROOM_NAME_TXT,a1b2c3d4-5028-4a01-b001-000000000140,TEXT,ASS_MNG,Type,Room name from spatial lookup,False,,,MULTI,1,0
 Generic Models,ASS_ROOM_NUM_TXT,a1b2c3d4-5029-4a01-b001-000000000141,TEXT,ASS_MNG,Type,Room number from spatial lookup,False,,,MULTI,1,0
@@ -2641,7 +2641,7 @@ Electrical Equipment,ELC_CIRCUIT_LABEL_TXT,c2a7e5b1-3004-5333-9333-300000000004,
 Electrical Equipment,ELC_PNL_AIC_RATING_KA,f1d6e7c8-1001-5178-9178-100000000001,TEXT,ELC_PWR,Instance,Standardised AIC (Ampere Interrupting Capacity) tier in kA stamped to the panel for breaker / switchgear specification [STING Phase 178],False,,,ELECTRICAL,1,0
 Electrical Equipment,ELC_FEEDER_CSA_MM2,f1d6e7c8-1002-5178-9178-100000000002,TEXT,ELC_PWR,Instance,Calculated / proposed feeder cable cross-sectional area in mm² (distinct from circuit cable size) [STING Phase 178],False,,,ELECTRICAL,1,0
 Electrical Equipment,ELC_FEEDER_RATING_A,f1d6e7c8-1003-5178-9178-100000000003,TEXT,ELC_PWR,Instance,Calculated feeder breaker / fuse rating in amperes — the upstream protective device rating [STING Phase 178],False,,,ELECTRICAL,1,0
-Rooms,ELC_EMERG_COVERED_BOOL,f1d6e7c8-1004-5178-9178-100000000004,TEXT,ELC_PWR,Instance,Room has emergency lighting coverage (1=true, 0=false) [BS 5266-1 / BS 9999 / STING Phase 178],False,,,ELECTRICAL,1
+Rooms,ELC_EMERG_COVERED_BOOL,f1d6e7c8-1004-5178-9178-100000000004,TEXT,ELC_PWR,Instance,"Room has emergency lighting coverage (1=true, 0=false) [BS 5266-1 / BS 9999 / STING Phase 178]",False,,,ELECTRICAL,1,0
 Rooms,ELC_LPD_W_PER_M2,f1d6e7c8-1005-5178-9178-100000000005,TEXT,ELC_PWR,Instance,Calculated lighting power density of the room in W/m² [ASHRAE 90.1 / Part L 2021 / CIBSE LG7 / STING Phase 178],False,,,ELECTRICAL,1,0
 Rooms,ELC_LPD_LIMIT_W_PER_M2,f1d6e7c8-1006-5178-9178-100000000006,TEXT,ELC_PWR,Instance,Standard LPD limit for the room type in W/m² [ASHRAE 90.1 / Part L 2021 / CIBSE LG7 / STING Phase 178],False,,,ELECTRICAL,1,0
 Rooms,ELC_LPD_STATUS_TXT,f1d6e7c8-1007-5178-9178-100000000007,TEXT,ELC_PWR,Instance,LPD compliance status (PASS / FAIL / WARNING / UNCHECKED) [STING Phase 178],False,,,ELECTRICAL,1,0
@@ -2882,7 +2882,7 @@ Views,STING_STYLE_LOCKED_BOOL,d2e3f4a5-b6c7-4d8e-9f0a-b1c2d3e4f5a6,YESNO,STING_D
 Views,STING_PACK_ID_TXT,e3f4a5b6-c7d8-4e9f-a0b1-c2d3e4f5a6b7,TEXT,STING_DRAWING,Instance,ViewStylePack registry id stamped on managed view templates [Phase 137],False,,,MULTI,1,0
 Views,STING_PACK_CHECKSUM_TXT,f4a5b6c7-d8e9-4f0a-b1c2-d3e4f5a6b7c8,TEXT,STING_DRAWING,Instance,SHA-256 checksum of ViewStylePack JSON for drift detection [Phase 137],False,,,MULTI,1,0
 Views,STING_CROP_KIND_TXT,b6c7d8e9-f0a1-4b2c-3d4e-5f6a7b8c9d01,TEXT,STING_DRAWING,Instance,Crop kind stamped onto views for drift detection [Phase 183],False,,,MULTI,1,0
-Views,STING_CROP_MARGIN_MM_TXT,c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e12,TEXT,STING_DRAWING,Instance,Crop margin (mm, as string) stamped onto views for drift detection [Phase 183],False,,,MULTI,1
+Views,STING_CROP_MARGIN_MM_TXT,c7d8e9f0-a1b2-4c3d-4e5f-6a7b8c9d0e12,TEXT,STING_DRAWING,Instance,"Crop margin (mm, as string) stamped onto views for drift detection [Phase 183]",False,,,MULTI,1,0
 Views,STING_CDE_STATE_TXT,a5b6c7d8-e9f0-4a1b-c2d3-e4f5a6b7c8d9,TEXT,STING_DRAWING,Instance,CDE state stamp for ISO 19650-2 document lifecycle [Phase 141],False,,,MULTI,1,0
 Medical Equipment,CLN_EQP_TAG,c1a00001-0000-4c1a-0000-000000000001,TEXT,CLN_CLINICAL,Instance,Clinical equipment ISO 19650 tag container,False,,,MULTI,1,0
 Rooms,CLN_ROOM_TAG,c1a00001-0000-4c1a-0000-000000000002,TEXT,CLN_CLINICAL,Instance,Clinical room ISO 19650 tag container,False,,,MULTI,1,0
@@ -3352,15 +3352,15 @@ Project,SUS_MAT_CARBON_KGM2_NR,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c03,NUMBER,SUS_S
 Project,SUS_MAT_ENERGY_MJ_M2_NR,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c04,NUMBER,SUS_SUSTAINABILITY,Instance,Embodied energy intensity MJ/m2 (CED EDGE materials track) from MaterialsRollup [Phase 195 EDGE/LEED],False,,,MULTI,1,0
 Project,SUS_EDGE_LEVEL_TXT,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c05,TEXT,SUS_SUSTAINABILITY,Instance,Achieved EDGE level (None / Certified / Advanced / ZeroCarbon) from SchemeEvaluator [Phase 195 EDGE/LEED],False,,,MULTI,1,0
 Multiple,SUS_EPD_REF_TXT,5d3b0f22-7e1a-5c8b-9d40-2a1e4f5b6c06,TEXT,SUS_SUSTAINABILITY,Instance,Type III EPD reference (ISO 14025 / EN 15804) on a material/type — resolver prefers product-specific EPD data [Phase 195 EDGE/LEED],False,,,MULTI,1,0
-Materials,MAT_COST_SUPPLY_NR,114852b0-7002-5680-80cd-930f91e8250b,NUMBER,MAT_INFO,Instance,Material supply unit cost (rate only, currency-neutral) [Material Manager RFQ],False,,,MULTI,1
+Materials,MAT_COST_SUPPLY_NR,114852b0-7002-5680-80cd-930f91e8250b,NUMBER,MAT_INFO,Instance,"Material supply unit cost (rate only, currency-neutral) [Material Manager RFQ]",False,,,MULTI,1,0
 Materials,MAT_COST_INSTALL_NR,0621af78-0fbf-540e-9e6d-61df9925ae90,NUMBER,MAT_INFO,Instance,Material install unit cost (labour and plant) [Material Manager RFQ],False,,,MULTI,1,0
 Materials,MAT_VAT_PCT_NR,9794f566-efc2-5622-a23f-9e65e117eb48,NUMBER,MAT_INFO,Instance,Material VAT percentage applied to supply and install [Material Manager RFQ],False,,,MULTI,1,0
-Materials,STING_EMB_CARBON_NR,800e0d61-f88d-5071-bc87-0c4ca3e51243,NUMBER,MAT_INFO,Instance,Embodied carbon kgCO2e per unit, A1-A3 GWP [Sustainability Carbon],False,,,MULTI,1
+Materials,STING_EMB_CARBON_NR,800e0d61-f88d-5071-bc87-0c4ca3e51243,NUMBER,MAT_INFO,Instance,"Embodied carbon kgCO2e per unit, A1-A3 GWP [Sustainability Carbon]",False,,,MULTI,1,0
 Materials,STING_MAT_EPD_SRC_TXT,2776ca48-33b8-57a8-b2a6-ee982e442767,TEXT,MAT_INFO,Instance,EPD data source / publisher reference [Sustainability Carbon],False,,,MULTI,1,0
 Materials,STING_MAT_EPD_DATE_TXT,c02ad751-5de9-50cc-a018-d7469595f8cf,TEXT,MAT_INFO,Instance,EPD publication / validity date ISO 8601 [Sustainability Carbon],False,,,MULTI,1,0
 Materials,STING_MAT_LIFECYCLE_TXT,e5455edb-f4f9-5585-a65e-363aa31f0b59,TEXT,MAT_INFO,Instance,Material spec lifecycle state Draft/Reviewed/Approved/Frozen [Material Manager],False,,,MULTI,1,0
-Plumbing Fixtures,SUS_FIXTURE_FLOW_LPM,b9c085ac-8d25-5286-bb8c-50f78c515e7c,NUMBER,PLM_DRN,Instance,Sanitary fixture flow rate l/min, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1
-Plumbing Fixtures,SUS_FIXTURE_FLUSH_L,733de214-c4aa-5640-896c-ff9c472c8dfd,NUMBER,PLM_DRN,Instance,WC/urinal flush volume litres, WELS water efficiency [Sustainability EDGE],False,,,MULTI,1
+Plumbing Fixtures,SUS_FIXTURE_FLOW_LPM,b9c085ac-8d25-5286-bb8c-50f78c515e7c,NUMBER,PLM_DRN,Instance,"Sanitary fixture flow rate l/min, WELS water efficiency [Sustainability EDGE]",False,,,MULTI,1,0
+Plumbing Fixtures,SUS_FIXTURE_FLUSH_L,733de214-c4aa-5640-896c-ff9c472c8dfd,NUMBER,PLM_DRN,Instance,"WC/urinal flush volume litres, WELS water efficiency [Sustainability EDGE]",False,,,MULTI,1,0
 Electrical Equipment,ELC_CIR_REF_TXT,dd54810b-00a1-55eb-a388-8a37eea1aa9c,TEXT,ELC_PWR,Instance,Circuit reference / designation for SLD annotation [Electrical SLD],False,,,MULTI,1,0
 Electrical Equipment,ELC_CIR_VOLTAGE_TXT,a4618f96-d723-5366-8961-4acfb94e2b60,TEXT,ELC_PWR,Instance,Circuit nominal voltage for SLD annotation [Electrical SLD],False,,,MULTI,1,0
 Electrical Equipment,ELC_CIR_DESIGN_CURRENT_TXT,0a442c44-90fa-5d48-b11f-fca5d4cb4407,TEXT,ELC_PWR,Instance,Circuit design current Ib for SLD annotation [Electrical SLD],False,,,MULTI,1,0


### PR DESCRIPTION
Standalone fix, straight to `main`. Found while resolving a merge conflict during the ISO IM
stack re-sync (#453) — filed there as a watch item, fixed here.

## The defect

Seven rows in `MR_PARAMETERS.csv` carry an **unquoted comma inside `Description`**. The comma
splits that field in two and shifts every later column by one:

```
STING_EMB_CARBON_NR, as parsed on main today
   Description        = 'Embodied carbon kgCO2e per unit'      <- truncated at the comma
   Has_Formula        = ' A1-A3 GWP [Sustainability Carbon]'   <- the description remainder
   Formula            = 'False'                                <- actually Has_Formula
   Discipline         = ''                                     <- should be MULTI
   User_Modifiable    = 'MULTI'                                <- should be 1
   Hide_When_No_Value = '1'                                    <- should be 0
```

Affected: `ASS_REV_TXT`, `ELC_EMERG_COVERED_BOOL`, `STING_CROP_MARGIN_MM_TXT`,
`MAT_COST_SUPPLY_NR`, `STING_EMB_CARBON_NR`, `SUS_FIXTURE_FLOW_LPM`, `SUS_FIXTURE_FLUSH_L`.

## Why it survived — the part worth reading

The corruption **predates #451**. Before it, those rows had **14** fields against the file's 13
— the one visible symptom. #451 trimmed the trailing `,0`, making the file uniformly 13.

That normalised the symptom and destroyed the evidence while leaving the data wrong. It is the
reason a column-count check alone is not the fix here (see below).

**Severity: latent, not live.** `MR_PARAMETERS.txt` — what Revit actually binds from — is
tab-delimited and completely unaffected: all 3392 `PARAM` rows at 10 fields, descriptions intact
including the commas. The only in-repo `.csv` consumer, `SyncParameterSchemaCommand.ValidateMrParameters`,
reads `cols[1]` and the GUID only. Nothing reads the shifted columns today. Worth fixing before
something starts to.

## The fix

Description quoted, trailing `,0` restored — 13 *correct* fields instead of 13 coincidental ones.
Exactly 7 lines changed (`git diff --numstat` → `7 7`).

The reconstruction is **verified, not guessed**: the script asserts each rejoined description is
byte-equal to its `MR_PARAMETERS.txt` counterpart before writing, and all 7 matched. If any had
disagreed the script would have aborted rather than write a plausible-looking guess.

## The new gate — and why one arm isn't enough

New CI step `Check parameter CSV row integrity`, ahead of the existing CSV-structure step.

**Arm 1, per-row column count.** Catches the 14-field shape.

**Arm 2, value domains.** Arm 1 is *not sufficient*, and I proved it rather than assuming:

```
RED    count arm vs main today   -> "all 3392 rows have 13 fields"   exit 0   <- MISSES IT
```

Because #451 trimmed the rows, the count check passes clean on the live defect. So arm 2 checks
three columns with tight, verified domains — `Has_Formula` (`False` on all 3392 rows),
`User_Modifiable` and `Hide_When_No_Value` (`0`/`1`). A shifted row puts prose where a flag
belongs and is caught regardless of field count:

```
RED    domain arm vs main today
       X 14 column(s) outside their value domain — almost always a field shift:
           line 1496: ASS_REV_TXT: Has_Formula = ' GROUP 1). See also ASS_REV_COD_TXT ...'
           line 1496: ASS_REV_TXT: User_Modifiable = 'MULTI'
           line 2634: ELC_EMERG_COVERED_BOOL: Has_Formula = ' 0=false) [BS 5266-1 / ...]'
           line 2634: ELC_EMERG_COVERED_BOOL: User_Modifiable = 'ELECTRICAL'
           ... all 7 rows flagged                                            exit 1

GREEN  both arms vs this branch
       + all 3392 rows have 13 fields
       + Has_Formula, Hide_When_No_Value, User_Modifiable all within their value domains
                                                                             exit 0
```

The existing duplicate-GUID gate is **structurally blind** to this class — it regex-scans for
GUIDs anywhere on a line, so a fully shifted row still presents a valid, unique GUID and passes.
That is not a criticism of that check; it is why this one is a separate step.

## Verification

| Check | Result |
|---|---|
| New row-integrity gate (both arms), extracted from the workflow and run verbatim | **red on main, green here** |
| Duplicate-GUID gate | 3392 unique per file, no within-file dupes, `.txt`/`.csv` mirror in sync, exit 0 |
| Workflow YAML parses | jobs: `validate-data`, `viewer-check`, `build` |
| Rows changed | exactly 7 |

Not run: no plugin build — this touches a data file and a workflow, no C#.

## Un-run / judgement calls

1. **The domain list is deliberately narrow.** Only the three columns whose domains I verified
   empirically across all 3392 rows. `Discipline` looks enumerable (`MULTI` / `ELECTRICAL` /
   `HEALTHCARE` / `PLUMBING` / `HVAC` / empty) but has 150 blanks, so pinning it would be a
   guess about intent rather than a check — left alone.
2. **Only `MR_PARAMETERS.csv` is covered.** Other STING CSVs may carry the same unquoted-comma
   pattern; I did not sweep them. `PARAM_CSVS` is a list so adding files is one line.
3. Nothing exercised in Revit — but the file Revit reads (`.txt`) is untouched by this PR.
