### PR TITLE
fix(kut): culture-safe KPI health-score parse + config-driven caption + registry entries

### DIFF
--- a/StingTools/Commands/Kpi/KutKpiDashboardCommand.cs
+++ b/StingTools/Commands/Kpi/KutKpiDashboardCommand.cs
@@ -29,6 +29,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using StingTools.Core;
 using StingTools.Core.Clash;
 using StingTools.Core.Classification;

--- a/StingTools/Commands/Kpi/KutKpiDashboardCommand.cs
+++ b/StingTools/Commands/Kpi/KutKpiDashboardCommand.cs
@@ -86,9 +86,12 @@ namespace StingTools.Commands.Kpi
                     // JObject (not Dictionary<string,double>) so a "_comment" string
                     // doesn't fail the whole parse.
                     var j = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(path));
+                    // P1 fix: read the numeric straight off the JToken. Value<double?>()
+                    // returns the underlying double with no culture-sensitive ToString round-trip,
+                    // so a comma-decimal locale can't misparse the shipped "0.40" as 4.0 and peg
+                    // the health score at 100. Mirrors LoadDistToMm in AccPullClashesCommand.
                     double Num(string k, double cur) => j[k] != null && j[k].Type != Newtonsoft.Json.Linq.JTokenType.Null
-                        && double.TryParse(j[k].ToString(), System.Globalization.NumberStyles.Any,
-                            System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : cur;
+                        ? (j[k].Value<double?>() ?? cur) : cur;
                     cfg.ClashCap          = Num("clashCap", cfg.ClashCap);
                     cfg.WarningCap        = Num("warningCap", cfg.WarningCap);
                     cfg.StaleCap          = Num("staleCap", cfg.StaleCap);
@@ -350,6 +353,7 @@ namespace StingTools.Commands.Kpi
             var ctx = ParameterHelpers.GetContext(cmd);
             if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
             Document doc = ctx.Doc;
+            var cfg = KutKpiConfig.Load(doc);   // same config the health score is computed from (N-G6)
 
             var snap = KutKpiEngine.Gather(doc);
             if (snap.TotalElements == 0)
@@ -379,7 +383,7 @@ namespace StingTools.Commands.Kpi
             b.AddSection("Headline")
              .RAGBar(snap.CompliancePct, $"Tag / metadata compliance {snap.CompliancePct:F1}%")
              .Metric("Model-health score", $"{snap.HealthScore:F0}/100",
-                     "compliance 40% · clash 25% · warnings 20% · stale 15%",
+                     $"compliance {cfg.WeightCompliance * 100:F0}% · clash {cfg.WeightClash * 100:F0}% · warnings {cfg.WeightWarnings * 100:F0}% · stale {cfg.WeightStale * 100:F0}%",
                      null)
              .Metric("Open clashes", snap.OpenClashes.ToString(),
                      prev != null ? $"burn-down {KutKpiEngine.Delta(snap.OpenClashes, prev.OpenClashes, "", invert: true)}" : "no prior snapshot");

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -21415,6 +21415,30 @@
       "curated": true
     },
     {
+      "param_name": "BMS_DEVICE_ID_TXT",
+      "guid": "fb34eb23-1a98-53bd-8207-e65917c193f3",
+      "description": "Generic BMS device ID (consumed by IoTDeviceRegistry / Niagara) [N-G8]",
+      "datatype": "TEXT",
+      "group_id": 3,
+      "group_name": "COM_DAT",
+      "binding": "universal",
+      "required": false,
+      "discipline": "ICT/Data",
+      "curated": true
+    },
+    {
+      "param_name": "BMS_ENDPOINT_TXT",
+      "guid": "559f06f2-e423-5e8b-84de-59d5969b1975",
+      "description": "BMS device endpoint URI e.g. bacnet://host/instance [N-G8]",
+      "datatype": "TEXT",
+      "group_id": 3,
+      "group_name": "COM_DAT",
+      "binding": "universal",
+      "required": false,
+      "discipline": "ICT/Data",
+      "curated": true
+    },
+    {
       "param_name": "ICT_HEALTHIOT_PROTOCOL_TXT",
       "guid": "c8d4f6e2-2602-4d27-8c61-0e7a3f9c1002",
       "description": "IoT protocol BACNET/OPC-UA/MODBUS/REST/PROPRIETARY [H-20]",


### PR DESCRIPTION
Stacked fix on top of **#329** (base is `claude/kut-hardening-phase2`). Addresses the P1 and two P2s from the review. Three fixes, all in the KUT KPI dashboard surface.

## P1 — culture-sensitive health-score config parse

`KutKpiConfig.Load`'s `Num` helper parsed config values with `double.TryParse(j[k].ToString(), NumberStyles.Any, InvariantCulture, …)`. Json.NET's `JValue.ToString()` formats with the **current** culture, so on a comma-decimal locale (de-DE, fr-FR, …) the shipped weight `0.40` rendered as `"0,4"`, and `NumberStyles.Any` + invariant parse read that as `4.0` — silently pegging the client-facing model-health score at **100/100 with zero user configuration**. Now reads the numeric straight off the JToken via `j[k].Value<double?>() ?? cur` (no string round-trip, culture-independent), mirroring `LoadDistToMm` in `AccPullClashesCommand`. `NumberStyles.Any` dropped.

## P2 — health-score caption hardcoded the old weights

The dashboard caption printed `"compliance 40% · clash 25% · warnings 20% · stale 15%"` literally, even though N-G6 makes the weights configurable — so the client report documented a formula that wasn't the one computed. `Execute` now loads the same `KutKpiConfig` used for the score and renders the caption from `cfg`. (`WriteHtml` carries no weights caption, so no change was needed there.)

## P2 — new BMS params missing from the registry

`BMS_DEVICE_ID_TXT` / `BMS_ENDPOINT_TXT` were added to `MR_PARAMETERS.csv`/`.txt` but not to `PARAMETER_REGISTRY.json` (the single source of truth). Added both, mirroring the sibling `ICT_HEALTHIOT_DEVICE_ID_TXT` entry, with GUIDs verified to match `MR_PARAMETERS.txt` exactly (`fb34eb23…` / `559f06f2…`).

## Notes

- **Stacked on `claude/kut-hardening-phase2`**, which is itself stacked on `claude/kut-hardening-phase1` (not yet merged) — blocked until that stack lands; retarget to `main` afterward.
- Committed **without `dotnet build` verification** (no .NET/Revit toolchain) per repo convention — verify in Revit before merge. `PARAMETER_REGISTRY.json` validated (parses clean; both entries present once with correct GUIDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_