### PR TITLE
fix(params) [CAPTURE — do not merge as-is]: #338 unit-conversion + mirror correctness for regeneration

### DIFF
--- a/StingTools/Commands/Lightning/LightningProtectionCommands.cs
+++ b/StingTools/Commands/Lightning/LightningProtectionCommands.cs
@@ -135,11 +135,36 @@ namespace StingTools.Commands.Lightning
             {
                 var p = el?.LookupParameter(paramName);
                 if (p == null || p.IsReadOnly) return;
-                if (p.StorageType == StorageType.Double) p.Set(valueInRevitDisplay);
+                if (p.StorageType == StorageType.Double)
+                {
+                    // tools/transform_mr_params.py flips *_MM / *_M params from TEXT to
+                    // native LENGTH, which Revit stores INTERNALLY IN FEET. The caller
+                    // passes the value in millimetres (*_MM) or metres (*_M), so it must
+                    // be converted to internal units before p.Set — otherwise a 45 m
+                    // radius is stored as 45 ft (a 304.8x / 3.28x corruption). *_NR
+                    // (NUMBER) and other non-length params are unitless: written as-is.
+                    p.Set(ToInternalLength(paramName, valueInRevitDisplay));
+                }
                 else if (p.StorageType == StorageType.String) p.Set(valueInRevitDisplay.ToString("F2"));
                 else if (p.StorageType == StorageType.Integer) p.Set((int)Math.Round(valueInRevitDisplay));
             }
             catch (Exception ex) { StingLog.Warn($"SetDouble {paramName}: {ex.Message}"); }
+        }
+
+        /// <summary>
+        /// Convert a display-unit length to Revit internal units (feet) based on the
+        /// param-name suffix (*_MM → mm, *_M → m). Non-length params (e.g. *_NR) are
+        /// returned unchanged. Shared guard for the LPS SetDouble helpers so native
+        /// LENGTH writes are never corrupted after the TEXT→LENGTH type flip.
+        /// </summary>
+        private static double ToInternalLength(string paramName, double value)
+        {
+            if (paramName == null) return value;
+            if (paramName.EndsWith("_MM", StringComparison.Ordinal))
+                return UnitUtils.ConvertToInternalUnits(value, UnitTypeId.Millimeters);
+            if (paramName.EndsWith("_M", StringComparison.Ordinal))
+                return UnitUtils.ConvertToInternalUnits(value, UnitTypeId.Meters);
+            return value;
         }
 
         private static void SetInt(Element el, string paramName, int value)
@@ -1959,7 +1984,19 @@ namespace StingTools.Commands.Lightning
             {
                 var p = el?.LookupParameter(paramName);
                 if (p == null || p.IsReadOnly) return;
-                if (p.StorageType == StorageType.Double) p.Set(value);
+                if (p.StorageType == StorageType.Double)
+                {
+                    // *_MM / *_M params are native LENGTH after tools/transform_mr_params.py,
+                    // stored internally in FEET — convert the caller's mm/m display value
+                    // to internal units first, or the write is corrupted (e.g. separation
+                    // distance in mm stored as feet). Non-length params (*_NR) are unitless.
+                    if (paramName != null && paramName.EndsWith("_MM", StringComparison.Ordinal))
+                        p.Set(UnitUtils.ConvertToInternalUnits(value, UnitTypeId.Millimeters));
+                    else if (paramName != null && paramName.EndsWith("_M", StringComparison.Ordinal))
+                        p.Set(UnitUtils.ConvertToInternalUnits(value, UnitTypeId.Meters));
+                    else
+                        p.Set(value);
+                }
                 else if (p.StorageType == StorageType.String) p.Set(value.ToString("F4"));
                 else if (p.StorageType == StorageType.Integer) p.Set((int)Math.Round(value));
             }

--- a/StingTools/Core/ParameterHelpers.cs
+++ b/StingTools/Core/ParameterHelpers.cs
@@ -459,8 +459,13 @@ namespace StingTools.Core
 
         /// <summary>
         /// Returns the _TXT mirror param name for a native-typed param
-        /// (e.g. MNT_HGT_MM → MNT_HGT_TXT), or null when no suffix matches
-        /// or the param is already TEXT/BOOL/DT.
+        /// (e.g. MNT_HGT_MM → MNT_HGT_TXT), or null when the param is already
+        /// TEXT/BOOL/DT (those have no separate mirror).
+        /// When no unit suffix matches, falls back to appending "_TXT" — this
+        /// MUST match tools/transform_mr_params.py make_mirror_name, whose own
+        /// fallback is `name + "_TXT"`. The generator emits + binds `name_TXT`
+        /// mirrors for suffix-less native params (e.g. *_MONTHS, *_YEARS, *_MIN,
+        /// *_DAYS); returning null here left those mirrors bound but never written.
         /// </summary>
         private static string TxtMirrorName(string paramName)
         {
@@ -471,7 +476,7 @@ namespace StingTools.Core
             foreach (var (suffix, _) in _suffixReplacements)
                 if (paramName.EndsWith(suffix, StringComparison.Ordinal))
                     return paramName.Substring(0, paramName.Length - suffix.Length) + "_TXT";
-            return null;
+            return paramName + "_TXT";   // aligns with transform_mr_params.py fallback
         }
 
         /// <summary>
@@ -489,9 +494,37 @@ namespace StingTools.Core
         }
 
         /// <summary>
+        /// Convert an internal-unit double (Revit stores LENGTH in feet, AREA in ft²)
+        /// to its DISPLAY value for the _TXT mirror, keyed off the param-name unit suffix
+        /// (*_MM → mm, *_M → m, *_SQ_M → m²). NUMBER / CURRENCY / INTEGER params carry
+        /// no unit conversion (internal == display) and are returned unchanged. LENGTH
+        /// and AREA are the only native double types tools/transform_mr_params.py produces
+        /// that Revit stores in non-display internal units. The _M2 area suffix is
+        /// intentionally NOT handled here because it collides with number suffixes such
+        /// as _KN_M2; those params stay unconverted (display == internal for a number).
+        /// </summary>
+        private static double InternalToDisplay(string paramName, double internalValue)
+        {
+            if (string.IsNullOrEmpty(paramName)) return internalValue;
+            if (paramName.EndsWith("_SQ_M", StringComparison.Ordinal))
+                return UnitUtils.ConvertFromInternalUnits(internalValue, UnitTypeId.SquareMeters);
+            if (paramName.EndsWith("_MM", StringComparison.Ordinal))
+                return UnitUtils.ConvertFromInternalUnits(internalValue, UnitTypeId.Millimeters);
+            if (paramName.EndsWith("_M", StringComparison.Ordinal))
+                return UnitUtils.ConvertFromInternalUnits(internalValue, UnitTypeId.Meters);
+            return internalValue;   // NUMBER / CURRENCY / INTEGER — no unit conversion
+        }
+
+        /// <summary>
         /// Set a native-typed DOUBLE parameter (NUMBER, LENGTH, AREA, CURRENCY).
         /// Also writes the formatted string to the corresponding _TXT mirror param when bound.
+        /// NOTE (PR #338 review): this method currently has ZERO callers — the ~40 native
+        /// double writes across the codebase still bypass it, so the generated _TXT mirrors
+        /// stay empty until those callers are wired to SetDouble during regeneration.
         /// </summary>
+        /// <param name="value">The value in REVIT INTERNAL units (feet for LENGTH, ft² for
+        /// AREA); passed straight to p.Set. The _TXT mirror is converted back to display
+        /// units via <see cref="InternalToDisplay"/> so it shows mm/m/m², not feet.</param>
         /// <param name="displayFormat">Format string for the _TXT mirror value. Defaults to "G".</param>
         public static bool SetDouble(Element el, string paramName, double value,
             bool overwrite = false, string displayFormat = null)
@@ -505,7 +538,10 @@ namespace StingTools.Core
             try
             {
                 p.Set(value);
-                WriteTxtMirror(el, paramName, value.ToString(displayFormat ?? "G"));
+                // Mirror must show the DISPLAY value (mm/m/m²), not the raw internal-unit
+                // feet that p.Set consumes — otherwise the _TXT mirror silently diverges
+                // from the native param it shadows.
+                WriteTxtMirror(el, paramName, InternalToDisplay(paramName, value).ToString(displayFormat ?? "G"));
                 return true;
             }
             catch (Exception ex)


### PR DESCRIPTION
## ⚠️ DO NOT MERGE AS-IS — capture branch for regeneration

This branch **captures the concrete correctness fixes** from the review of **#338** (Phase 188 native-type + `_TXT` mirror) so they can be carried into a regeneration on top of **current `main`**. The review verdict was **CLOSE-AND-REGENERATE**:

- Its base (`claude/charming-fermi-5iafhf`) is ~1 month stale with **~10 unmergeable conflicts against `main`**, which this branch inherits — it is **not cleanly mergeable**.
- "Phase 188" on this line collides with `main`'s already-shipped Phase 188 (TagSchemeEngine).

Merging this is not the goal — a reviewed, minimal patch a regeneration can re-apply is. **C# committed WITHOUT `dotnet build` verification** (no .NET/Revit toolchain); verify in Revit before folding into the regenerated branch.

### Fixes (surgical — only the three review-named surfaces)

**P1 — unit corruption** (`Commands/Lightning/LightningProtectionCommands.cs`)
The file has **two** `SetDouble` helpers (`LpsClassSetupCommand.SetDouble` and `LpsCommandsHelpers.SetDouble`, the latter used by `LpsRecalcKcFactorCommand`), both writing `*_MM`/`*_M` values via `p.Set` with no conversion. `transform_mr_params.py` flips those params TEXT→native LENGTH, and Revit stores LENGTH internally in **feet**, so a 45 m radius / mm separation distance was stored 3.28× / 304.8× corrupted. Both Double-branch writes now `ConvertToInternalUnits` (mm for `*_MM`, m for `*_M`); `*_NR` numbers and the String/Integer branches are unchanged. Callers confirmed: `ROLLING_SPHERE_RADIUS_M`/`MESH_SIZE_M` pass metres, `SEPARATION_DISTANCE_MM` passes mm, `KC_FACTOR_NR`/`PROJECT_NG_OVERRIDE_NR` are unitless.

**P1 — dead/incorrect `_TXT` mirror path** (`Core/ParameterHelpers.cs`)
`SetDouble` mirrored the raw internal-unit (feet) double via `value.ToString("G")`, so the `_TXT` mirror silently diverged from the native param it shadows. Added `InternalToDisplay` (suffix-keyed `ConvertFromInternalUnits` for `*_MM`/`*_M`/`*_SQ_M`) so the mirror shows mm/m/m². **`SetDouble` still has ZERO callers** — the ~40 native double writes must be wired to it during regeneration (documented in-code; intentionally not attempted here, too large/risky uncompiled).

**P2 — Python/C# mirror-name divergence** (`Core/ParameterHelpers.cs`)
`make_mirror_name` falls back to `name + "_TXT"` for suffix-less native params; C# `TxtMirrorName` returned `null`, so those generated mirrors were bound but never written. Aligned the C# fallback to `name + "_TXT"`.

### Verification
Standalone `python3` check over all **178** `TARGET_TYPES` params: `make_mirror_name` == aligned `TxtMirrorName`, **0 mismatches**. Proves the fix is load-bearing — **6** params the old `null` fallback silently dropped now resolve: `ASS_MAINTENANCE_FREQUENCY_MONTHS`, `CST_DELIVERY_LEAD_TIME_DAYS`, `ELC_LPS_INSPECTION_INTERVAL_MONTHS`, `FLS_PROT_FLS_RESISTANCE_RATING_MINUTES_MIN`, `HVC_PEAK_HOUR`, `PER_EXPECTED_LIFE_YEARS`. The C# suffix table is identical in content and order to the Python one, so the fallback was the only divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_