### PR TITLE
fix(placement): correct connector-primary assignment + confirm/report instance deletion (#396 review)

### DIFF
--- a/StingTools/Core/Placement/FamilyConnectorTransfer.cs
+++ b/StingTools/Core/Placement/FamilyConnectorTransfer.cs
@@ -282,13 +282,11 @@ namespace StingTools.Core.Placement
                     spec.Height = ReadLength(ce, BuiltInParameter.CONNECTOR_HEIGHT);
                     if (spec.Height <= 0) { try { spec.Height = ce.Height; } catch { } }
 
-                    try
-                    {
-                        var pd = ce.get_Parameter(BuiltInParameter.RBS_CONNECTOR_DESCRIPTION);
-                        if (pd != null && pd.StorageType == StorageType.String)
-                            spec.Description = pd.AsString() ?? "";
-                    }
-                    catch { }
+                    // Connector description: BuiltInParameter.RBS_CONNECTOR_DESCRIPTION
+                    // is NOT a valid member of the Revit 2025/2026/2027 API, and
+                    // ConnectorElement has no Description property. If the connector
+                    // exposes a writable "Description" parameter it is now harvested by
+                    // name through HarvestWritableParams (see _dimensionParamNames).
 
                     // Conduit vs cable tray share one Domain value.
                     if (spec.Domain == Domain.DomainCableTrayConduit)
@@ -337,8 +335,10 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"ConnectorTransfer harvest params: {ex.Message}"); }
         }
 
+        // "Description" is intentionally NOT excluded here so it round-trips through
+        // the generic name-based harvest/replay (there is no BuiltInParameter for it).
         private static readonly HashSet<string> _dimensionParamNames = new HashSet<string>(
-            new[] { "Radius", "Diameter", "Width", "Height", "Description" }, StringComparer.OrdinalIgnoreCase);
+            new[] { "Radius", "Diameter", "Width", "Height" }, StringComparer.OrdinalIgnoreCase);
 
         private static double ReadLength(ConnectorElement ce, BuiltInParameter bip)
         {
@@ -609,23 +609,20 @@ namespace StingTools.Core.Placement
 
             if (spec.IsPrimary)
             {
+                // ConnectorElement.IsPrimary is read-only; AssignAsPrimary() is the
+                // documented way to flag the primary connector. There is no valid
+                // BuiltInParameter.RBS_CONNECTOR_ISPRIMARY member in the Revit
+                // 2025/2026/2027 API.
                 try
                 {
-                    var p = ce.get_Parameter(BuiltInParameter.RBS_CONNECTOR_ISPRIMARY);
-                    if (p != null && !p.IsReadOnly && p.StorageType == StorageType.Integer) p.Set(1);
+                    ce.AssignAsPrimary();
                 }
                 catch (Exception ex) { StingLog.Warn($"ConnectorTransfer set primary: {ex.Message}"); }
             }
 
-            if (!string.IsNullOrEmpty(spec.Description))
-            {
-                try
-                {
-                    var p = ce.get_Parameter(BuiltInParameter.RBS_CONNECTOR_DESCRIPTION);
-                    if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String) p.Set(spec.Description);
-                }
-                catch (Exception ex) { StingLog.Warn($"ConnectorTransfer set description: {ex.Message}"); }
-            }
+            // Connector description (if writable and captured by name) is replayed via
+            // the generic spec.Params loop below — BuiltInParameter.RBS_CONNECTOR_DESCRIPTION
+            // is not a valid member of the Revit 2025/2026/2027 API.
 
             foreach (var kv in spec.Params)
             {

--- a/StingTools/Core/Placement/FamilyConnectorTransfer.cs
+++ b/StingTools/Core/Placement/FamilyConnectorTransfer.cs
@@ -282,11 +282,13 @@ namespace StingTools.Core.Placement
                     spec.Height = ReadLength(ce, BuiltInParameter.CONNECTOR_HEIGHT);
                     if (spec.Height <= 0) { try { spec.Height = ce.Height; } catch { } }
 
-                    // Connector description: BuiltInParameter.RBS_CONNECTOR_DESCRIPTION
-                    // is NOT a valid member of the Revit 2025/2026/2027 API, and
-                    // ConnectorElement has no Description property. If the connector
-                    // exposes a writable "Description" parameter it is now harvested by
-                    // name through HarvestWritableParams (see _dimensionParamNames).
+                    try
+                    {
+                        var pd = ce.get_Parameter(BuiltInParameter.RBS_CONNECTOR_DESCRIPTION);
+                        if (pd != null && pd.StorageType == StorageType.String)
+                            spec.Description = pd.AsString() ?? "";
+                    }
+                    catch { }
 
                     // Conduit vs cable tray share one Domain value.
                     if (spec.Domain == Domain.DomainCableTrayConduit)
@@ -335,10 +337,8 @@ namespace StingTools.Core.Placement
             catch (Exception ex) { StingLog.Warn($"ConnectorTransfer harvest params: {ex.Message}"); }
         }
 
-        // "Description" is intentionally NOT excluded here so it round-trips through
-        // the generic name-based harvest/replay (there is no BuiltInParameter for it).
         private static readonly HashSet<string> _dimensionParamNames = new HashSet<string>(
-            new[] { "Radius", "Diameter", "Width", "Height" }, StringComparer.OrdinalIgnoreCase);
+            new[] { "Radius", "Diameter", "Width", "Height", "Description" }, StringComparer.OrdinalIgnoreCase);
 
         private static double ReadLength(ConnectorElement ce, BuiltInParameter bip)
         {
@@ -609,10 +609,11 @@ namespace StingTools.Core.Placement
 
             if (spec.IsPrimary)
             {
-                // ConnectorElement.IsPrimary is read-only; AssignAsPrimary() is the
-                // documented way to flag the primary connector. There is no valid
-                // BuiltInParameter.RBS_CONNECTOR_ISPRIMARY member in the Revit
-                // 2025/2026/2027 API.
+                // ConnectorElement.IsPrimary is READ-ONLY (getter only), so the old
+                // path — get_Parameter(RBS_CONNECTOR_ISPRIMARY) then p.Set(1) guarded
+                // by !p.IsReadOnly — silently did nothing (the parameter is read-only,
+                // so the guard skipped the write and the connector was never actually
+                // made primary). AssignAsPrimary() is the documented API for this.
                 try
                 {
                     ce.AssignAsPrimary();
@@ -620,9 +621,15 @@ namespace StingTools.Core.Placement
                 catch (Exception ex) { StingLog.Warn($"ConnectorTransfer set primary: {ex.Message}"); }
             }
 
-            // Connector description (if writable and captured by name) is replayed via
-            // the generic spec.Params loop below — BuiltInParameter.RBS_CONNECTOR_DESCRIPTION
-            // is not a valid member of the Revit 2025/2026/2027 API.
+            if (!string.IsNullOrEmpty(spec.Description))
+            {
+                try
+                {
+                    var p = ce.get_Parameter(BuiltInParameter.RBS_CONNECTOR_DESCRIPTION);
+                    if (p != null && !p.IsReadOnly && p.StorageType == StorageType.String) p.Set(spec.Description);
+                }
+                catch (Exception ex) { StingLog.Warn($"ConnectorTransfer set description: {ex.Message}"); }
+            }
 
             foreach (var kv in spec.Params)
             {

--- a/StingTools/Core/Placement/FamilyHostConverter.cs
+++ b/StingTools/Core/Placement/FamilyHostConverter.cs
@@ -735,12 +735,18 @@ namespace StingTools.Core.Placement
                         continue;
                     }
 
+                    // Re-resolve the type from the RELOADED family by name — the
+                    // snapshot's Symbol reference was captured before the family was
+                    // rebuilt + reloaded and may point at a stale / replaced element.
+                    FamilySymbol sym = ResolveReloadedSymbol(doc, reloaded, snap.TypeName) ?? snap.Symbol;
+                    if (sym == null) { res.InstancesFailed++; continue; }
+
                     using var t = new Transaction(doc, "STING Re-place instance");
                     t.Start();
-                    if (snap.Symbol != null && !snap.Symbol.IsActive) snap.Symbol.Activate();
+                    if (!sym.IsActive) sym.Activate();
                     FamilyInstance rep = snap.Level != null
-                        ? doc.Create.NewFamilyInstance(snap.LocationPoint, snap.Symbol, snap.Level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
-                        : doc.Create.NewFamilyInstance(snap.LocationPoint, snap.Symbol, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+                        ? doc.Create.NewFamilyInstance(snap.LocationPoint, sym, snap.Level, Autodesk.Revit.DB.Structure.StructuralType.NonStructural)
+                        : doc.Create.NewFamilyInstance(snap.LocationPoint, sym, Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
                     if (rep != null)
                     {
                         StingTools.Tags.FamilyQuickEditHelpers.RestoreInstanceParams(rep, snap.Params);
@@ -762,7 +768,35 @@ namespace StingTools.Core.Placement
             tg.Assimilate();
 
             if (res.InstancesFailed > 0)
-                res.Notes.Add($"NEXT STEP: {res.InstancesFailed} instance(s) need a manual rehost — a hosted target cannot pick a host automatically in batch. Use Change Host per instance.");
+            {
+                if (!nonHostedTarget)
+                    // Free-standing instances cannot survive a switch to a hosted
+                    // placement — Revit deleted them on reload. They cannot be
+                    // rehosted (there is nothing left to rehost); they must be
+                    // re-placed from scratch on the new hosted family.
+                    res.Notes.Add($"NEXT STEP: {res.InstancesFailed} placed instance(s) were DELETED when the family switched to a hosted placement — a free-standing instance cannot exist without a host. They must be RE-PLACED from scratch on the new family (Change Host cannot recover a deleted instance).");
+                else
+                    res.Notes.Add($"NEXT STEP: {res.InstancesFailed} instance(s) could not be re-placed automatically — re-place them manually.");
+            }
+        }
+
+        // Re-resolve a family type from the reloaded family by name. The snapshot's
+        // Symbol reference was captured before the family was rebuilt + reloaded and
+        // may point at a stale / replaced element after LoadFamily.
+        private static FamilySymbol ResolveReloadedSymbol(Document doc, Family reloaded, string typeName)
+        {
+            if (doc == null || reloaded == null || string.IsNullOrEmpty(typeName)) return null;
+            try
+            {
+                foreach (var id in reloaded.GetFamilySymbolIds())
+                {
+                    if (doc.GetElement(id) is FamilySymbol fs &&
+                        string.Equals(fs.Name, typeName, StringComparison.Ordinal))
+                        return fs;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"P2 re-resolve symbol '{typeName}': {ex.Message}"); }
+            return null;
         }
 
         // ── P2 helpers ──────────────────────────────────────────────────────────

--- a/StingTools/Tags/FamilyQuickEditCommands.cs
+++ b/StingTools/Tags/FamilyQuickEditCommands.cs
@@ -266,6 +266,9 @@ namespace StingTools.Tags
     {
         public ElementId OriginalId { get; set; }
         public FamilySymbol Symbol { get; set; }
+        /// <summary>Type (symbol) name captured while the instance is live, so the
+        /// symbol can be re-resolved from a rebuilt/reloaded family by name.</summary>
+        public string TypeName { get; set; } = "";
         public Level Level { get; set; }
         public XYZ LocationPoint { get; set; }
         public double Rotation { get; set; }
@@ -283,6 +286,7 @@ namespace StingTools.Tags
             {
                 OriginalId = inst.Id,
                 Symbol = inst.Symbol,
+                TypeName = inst.Symbol?.Name ?? "",
                 Params = FamilyQuickEditHelpers.SnapshotInstanceParams(inst),
                 PlacementType = inst.Symbol?.Family?.FamilyPlacementType ?? FamilyPlacementType.Invalid,
                 OriginalHostDescription = FamilyQuickEditHelpers.DescribeHost(inst),

--- a/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
+++ b/StingTools/UI/PlacementCenter/StingPlacementCenter.xaml.cs
@@ -3378,7 +3378,13 @@ namespace StingTools.UI.PlacementCenter
                     if (r.PathHint.StartsWith("P1"))
                         panel.Text($"{r.Name}: {r.CurrentPlacementType} → {r.TargetLabel}  ·  P1 lossless (checkbox toggle — geometry/params/connectors untouched, instances survive)");
                     else
-                        panel.Text($"{r.Name}: {r.CurrentPlacementType} → {r.TargetLabel}  ·  P2 REBUILD (lossy — new .rfa from template; MEP connectors are harvested and re-created, any that cannot be placed are listed with coordinates; host-relative geometry re-anchors to template default; review after){(r.InstanceCount > 0 ? $"; {r.InstanceCount} instance(s) may need manual rehost" : "")}");
+                    {
+                        string instNote = r.InstanceCount <= 0 ? ""
+                            : IsHostedTarget(_fcTemplates?.ByLabel(r.TargetLabel))
+                                ? $"; {r.InstanceCount} instance(s) WILL BE DELETED (hosted target — re-place from scratch)"
+                                : $"; {r.InstanceCount} instance(s) will be re-placed free-standing";
+                        panel.Text($"{r.Name}: {r.CurrentPlacementType} → {r.TargetLabel}  ·  P2 REBUILD (lossy — new .rfa from template; MEP connectors are harvested and re-created, any that cannot be placed are listed with coordinates; host-relative geometry re-anchors to template default; review after){instNote}");
+                    }
                 }
                 if (pending.Any(r => r.PathHint.StartsWith("P2")))
                     panel.AddSection("NOTE").Text("Enable '⚠ Allow lossy rebuild (P2)' before Apply, or the P2 rows report as Skipped.");
@@ -3460,6 +3466,44 @@ namespace StingTools.UI.PlacementCenter
             bool rehost = chkFcRehost?.IsChecked == true;
             bool allowLossy = chkFcAllowLossy?.IsChecked == true;
 
+            // A lossy P2 rebuild to a HOSTED placement (wall/ceiling/floor/roof)
+            // cannot keep free-standing instances: Revit DELETES them on reload and
+            // they must be re-placed from scratch. Confirm the destruction explicitly
+            // — the "Allow lossy rebuild" checkbox alone is not clear enough.
+            if (allowLossy)
+            {
+                var destructive = rows.Where(r =>
+                    r != null && r.InstanceCount > 0 &&
+                    string.Equals(r.PathHint, "P2 rebuild", StringComparison.OrdinalIgnoreCase) &&
+                    IsHostedTarget(_fcTemplates?.ByLabel(r.TargetLabel))).ToList();
+
+                if (destructive.Count > 0)
+                {
+                    int totalInst = destructive.Sum(r => r.InstanceCount);
+                    var confirm = new TaskDialog("STING — Family Converter")
+                    {
+                        MainInstruction = $"{totalInst} placed instance(s) WILL BE DELETED",
+                        MainContent =
+                            $"{destructive.Count} family(ies) convert to a hosted placement (wall/ceiling/floor/roof) via a " +
+                            "lossy rebuild. A free-standing instance cannot exist without a host, so Revit DELETES the " +
+                            "existing placements on reload — they cannot be auto-rehosted and must be RE-PLACED from scratch " +
+                            "on the new family.",
+                        ExpandedContent = string.Join("\n",
+                            destructive.Select(r => $"{r.Name} — {r.InstanceCount} instance(s) → {r.TargetLabel}")),
+                        CommonButtons = TaskDialogCommonButtons.None
+                    };
+                    confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                        $"Delete {totalInst} instance(s) and rebuild", "I will re-place them from scratch afterwards.");
+                    confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Cancel — make no changes");
+                    confirm.DefaultButton = TaskDialogResult.CommandLink2;
+                    if (confirm.Show() != TaskDialogResult.CommandLink1)
+                    {
+                        Toast("Family conversion cancelled — no changes made.");
+                        return;
+                    }
+                }
+            }
+
             // Capture request data on the WPF thread; the row objects travel with
             // the jobs so statuses can be updated after each conversion.
             var jobs = rows.Select(r => (Row: r, Request: new FamilyHostConversionRequest
@@ -3475,15 +3519,12 @@ namespace StingTools.UI.PlacementCenter
                 var doc = app?.ActiveUIDocument?.Document ?? _doc;
                 var results = new List<(FamilyConverterRow Row, FamilyHostConversionResult Res)>();
 
-                // Batch: bracket the run in a TransactionGroup so it is one undo
-                // item; per-family failures are isolated (continue on error) so
-                // one bad family never aborts the whole batch.
+                // Bracket the whole run — batch OR single selection — in a
+                // TransactionGroup so it is one undo item; per-family failures are
+                // isolated (continue on error) so one bad family never aborts the run.
                 TransactionGroup grp = null;
-                if (batch)
-                {
-                    try { grp = new TransactionGroup(doc, "STING Family Convert (batch)"); grp.Start(); }
-                    catch (Exception ex) { StingLog.Warn($"FcApply batch group: {ex.Message}"); grp = null; }
-                }
+                try { grp = new TransactionGroup(doc, batch ? "STING Family Convert (batch)" : "STING Family Convert (selected)"); grp.Start(); }
+                catch (Exception ex) { StingLog.Warn($"FcApply group: {ex.Message}"); grp = null; }
                 try
                 {
                     foreach (var job in jobs)
@@ -3520,6 +3561,15 @@ namespace StingTools.UI.PlacementCenter
             });
         }
 
+        // A target host is "hosted" (deletes free-standing instances on a P2
+        // rebuild) unless it is a level-based / work-plane-based non-hosted type.
+        private static bool IsHostedTarget(FamilyHostTarget tgt)
+        {
+            if (tgt == null) return false;
+            return !string.Equals(tgt.PlacementType, "WorkPlaneBased", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(tgt.PlacementType, "OneLevelBased", StringComparison.OrdinalIgnoreCase);
+        }
+
         private static string FcStatus(FamilyHostConversionResult res)
         {
             if (res == null) return "";
@@ -3543,7 +3593,7 @@ namespace StingTools.UI.PlacementCenter
                 .Metric("Skipped", skipped.ToString())
                 .Metric("Failed", failed.ToString())
                 .Metric("Instances re-placed", rehosted.ToString())
-                .Metric("Instances needing manual rehost", rehostFail.ToString());
+                .Metric("Instances deleted / to re-place", rehostFail.ToString());
 
             panel.AddSection("PER-FAMILY");
             foreach (var (row, res) in results)


### PR DESCRIPTION
Stacked on **#396** (`claude/family-converter-7fa3c2`). **Committed without `dotnet build`** (no .NET/Revit toolchain), but the Revit API members used are **doc-verified** (Revit 2026 API help + rhino.inside-revit per-version schemas).

> ### Correction (updated after API verification)
> The review's original P1 — "`RBS_CONNECTOR_ISPRIMARY`/`RBS_CONNECTOR_DESCRIPTION` don't exist → CS0117 whole-assembly build break" — was a **false positive**. Both enum members **do exist** in Revit 2025/2026/2027 (`-1133412` / `-1140000`); the repo's note about a missing connector enum was about the *different* `RBS_CONNECTOR_DIAMETER`. So #396's original code compiled fine. This PR has been reduced accordingly.

## P1 (real) — primary connector was never actually assigned

`ConnectorElement.IsPrimary` is **read-only** (getter only — confirmed in the API docs). The original replay path was `get_Parameter(RBS_CONNECTOR_ISPRIMARY)` → `p.Set(1)` **guarded by `!p.IsReadOnly`** — since that parameter is read-only, the guard skipped the write and the connector was **silently never made primary**. Replaced with `ce.AssignAsPrimary()`, the documented API for this (confirmed to exist on `ConnectorElement`, void/no-args). The connector **description** handling is **unchanged from #396's original** (via the valid `RBS_CONNECTOR_DESCRIPTION` parameter) — the earlier draft's removal of it was reverted, since the enum is valid. Net change to `FamilyConnectorTransfer.cs`: one line (`p.Set(1)` → `AssignAsPrimary()`).

## P1 — hosted-target conversion silently deleted placed instances

Unchanged from the earlier draft, and stands on its own: a lossy P2 rebuild to a hosted target (Wall/Ceiling/Floor/Roof) makes Revit **delete** free-standing instances on reload — they can't be rehosted, only re-placed — yet the tool reported "need a manual rehost."
- Added an explicit **confirm/cancel `TaskDialog`** stating the exact count and that they **will be deleted** and must be re-placed (gated on lossy P2 + hosted target + placed instances).
- Corrected post-op wording to "deleted — must be re-placed."
- Wrapped the **Apply-Selected** path in a `TransactionGroup` for single-undo (was batch-only).
- Left the lossless P1 path (Unhosted→Face) unchanged.

## P2 — stale symbol on re-placement
Re-placement re-resolves the `FamilySymbol` from the reloaded family by type name (the snapshot symbol predates the rebuild+reload), falling back to the snapshot.

## Files
`FamilyConnectorTransfer.cs` · `FamilyHostConverter.cs` · `FamilyQuickEditCommands.cs` · `StingPlacementCenter.xaml.cs`

API members doc-verified: `ConnectorElement.AssignAsPrimary()` (void, no args), `ConnectorElement.IsPrimary` (read-only), `SpotDimension`/`Dimension` members. Still recommend a Revit `dotnet build` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)