### PR TITLE
fix(mep-tags): observable run suppression, clarified toggle text, locale-safe policy keys (#395 review)

### DIFF
--- a/StingTools/Core/Mep/MepRunGrouper.cs
+++ b/StingTools/Core/Mep/MepRunGrouper.cs
@@ -65,6 +65,23 @@ namespace StingTools.Core.Mep
             BuiltInCategory.OST_FlexDuctCurves,
         };
 
+        // Stable, locale-independent config keys for the linear-MEP categories the
+        // visual-tag policy targets. The policy UI (SetMepTagPolicyCommand) writes these
+        // English friendly names as keys; resolving them back from the element's
+        // BuiltInCategory lets an override take effect regardless of Revit's UI language.
+        // Matching only on the localized Category.Name silently ignores a "Pipes":"All"
+        // override in a non-English office because the category reads "Rohre" /
+        // "Canalisations" there, not "Pipes".
+        private static readonly Dictionary<BuiltInCategory, string> LinearCatFriendlyKey = new Dictionary<BuiltInCategory, string>
+        {
+            { BuiltInCategory.OST_PipeCurves,     "Pipes" },
+            { BuiltInCategory.OST_DuctCurves,     "Ducts" },
+            { BuiltInCategory.OST_Conduit,        "Conduits" },
+            { BuiltInCategory.OST_CableTray,      "Cable Trays" },
+            { BuiltInCategory.OST_FlexPipeCurves, "Flex Pipes" },
+            { BuiltInCategory.OST_FlexDuctCurves, "Flex Ducts" },
+        };
+
         // A run may pass through fittings and inline accessories (couplings, elbows,
         // valves, dampers) but NOT through equipment or fixtures — a pump / tank /
         // AHU is a genuine break where a new run (and tag) begins, even if it has
@@ -135,12 +152,36 @@ namespace StingTools.Core.Mep
         /// <summary>Resolve the visual-tag policy for an element: explicit config override, else linear-MEP default.</summary>
         public static TagVisualPolicy ResolvePolicy(Element el)
         {
-            string cat = el?.Category?.Name;
-            if (!string.IsNullOrEmpty(cat)
-                && TagConfig.CategoryVisualPolicy != null
-                && TagConfig.CategoryVisualPolicy.TryGetValue(cat, out string s)
-                && Enum.TryParse(s, ignoreCase: true, out TagVisualPolicy p))
-                return p;
+            var overrides = TagConfig.CategoryVisualPolicy;
+            if (el?.Category != null && overrides != null && overrides.Count > 0)
+            {
+                // Locale-independent match first: resolve the element's BuiltInCategory
+                // and look the override up by a stable key — the English friendly name
+                // the policy UI writes (e.g. "Pipes") or the BuiltInCategory enum name
+                // (e.g. "OST_PipeCurves"). This is what makes a non-English office's
+                // "Pipes":"All" actually take effect; keying on the localized
+                // Category.Name alone drops it silently.
+                try
+                {
+                    var bic = (BuiltInCategory)el.Category.Id.Value;
+                    if (LinearCatFriendlyKey.TryGetValue(bic, out string friendly)
+                        && overrides.TryGetValue(friendly, out string sf)
+                        && Enum.TryParse(sf, ignoreCase: true, out TagVisualPolicy pf))
+                        return pf;
+                    if (overrides.TryGetValue(bic.ToString(), out string se)
+                        && Enum.TryParse(se, ignoreCase: true, out TagVisualPolicy pe))
+                        return pe;
+                }
+                catch { /* fall through to localized-name match */ }
+
+                // Back-compat + non-linear categories: match on the running session's
+                // localized Category.Name (works when the key was written in this locale).
+                string cat = el.Category.Name;
+                if (!string.IsNullOrEmpty(cat)
+                    && overrides.TryGetValue(cat, out string s)
+                    && Enum.TryParse(s, ignoreCase: true, out TagVisualPolicy p))
+                    return p;
+            }
             return IsLinearMepCategory(el) ? TagVisualPolicy.PerRun : TagVisualPolicy.All;
         }
 

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -44,6 +44,12 @@ namespace StingTools.Core
         private static readonly Queue<long> _recentlyProcessedQueue = new Queue<long>();
         private static volatile int _processedCount;
         private static bool _visualTaggingEnabled = false;
+        // Observability for MEP declutter: running count of live per-segment visual
+        // tags skipped because the element's category is under a one-tag-per-run / None
+        // policy. Previously silent (unlike Smart Place's RunSuppressed report); a
+        // throttled summary is logged so the hot path stays cheap. See the visual-tag
+        // placement block in Execute().
+        private static int _visualPolicySuppressedCount;
         private static HashSet<string> _allowedDiscs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // D1: Cached context to avoid rebuilding PopulationContext on every trigger
@@ -775,6 +781,18 @@ namespace StingTools.Core
                                 bool visualPolicyAllows =
                                     StingTools.Core.Mep.MepRunGrouper.ResolvePolicy(el)
                                         == StingTools.Core.Mep.TagVisualPolicy.All;
+                                // Observability: record when a live per-segment tag is
+                                // gated off by run/None policy so the suppression is not
+                                // silent. Cheap running counter + throttled summary (first
+                                // hit, then every 50th) — no per-element log storm.
+                                if (_visualTaggingEnabled && !visualPolicyAllows)
+                                {
+                                    int suppressed = System.Threading.Interlocked.Increment(ref _visualPolicySuppressedCount);
+                                    if (suppressed == 1 || suppressed % 50 == 0)
+                                        StingLog.Info(
+                                            $"StingAutoTagger: {suppressed} live MEP visual tag(s) suppressed by one-tag-per-run policy; " +
+                                            "run-level tags come from Smart Place Tags.");
+                                }
                                 if (_visualTaggingEnabled && visualPolicyAllows && doc.ActiveView != null
                                     && !(doc.ActiveView is ViewSheet)
                                     && doc.ActiveView.CanBePrinted)
@@ -1270,7 +1288,9 @@ namespace StingTools.Core
 
             TaskDialog.Show("STING Auto-Tagger",
                 $"Visual tag placement: {(StingAutoTagger.IsVisualTaggingEnabled ? "ENABLED" : "DISABLED")}\n\n" +
-                "When enabled, the auto-tagger will also place visual annotation tags on newly placed elements.");
+                "When enabled, the auto-tagger will also place visual annotation tags on newly placed elements.\n" +
+                "Linear MEP runs (pipes/ducts/tray/conduit) are tagged once per run by Smart Place Tags, " +
+                "not live per-segment — token data is still written to every segment.");
             return Result.Succeeded;
         }
     }
@@ -1288,6 +1308,9 @@ namespace StingTools.Core
             sb.AppendLine($"Auto-Tagger: {(StingAutoTagger.IsEnabled ? "ENABLED" : "DISABLED")}");
             sb.AppendLine($"Visual Tags: {(StingAutoTagger.IsVisualTaggingEnabled ? "ENABLED" : "DISABLED")}");
             sb.AppendLine($"Stale Marker: {(StingStaleMarker.IsEnabled ? "ENABLED" : "DISABLED")}");
+            sb.AppendLine();
+            sb.AppendLine("Note: Linear MEP runs (pipes/ducts/tray/conduit) are tagged once per");
+            sb.AppendLine("run by Smart Place Tags, not live per-segment by the auto-tagger.");
             sb.AppendLine();
             sb.AppendLine("Discipline Filter:");
             sb.AppendLine("  M = Mechanical, E = Electrical, P = Plumbing");


### PR DESCRIPTION
Stacked on **#395** (`claude/mep-tag-declutter-advice`). Addresses the three P2 review findings. Two files, +71/−7.

### Fixes
1. **Silent suppression is now observable** (`StingAutoTagger`) — the live per-segment visual tag was skipped with no counter and no log for one-tag-per-run / None categories, unlike Smart Place's `RunSuppressed`. Added a running counter with a throttled `StingLog.Info` summary (first hit, then every 50th). Cheap, no per-element log storm; non-MEP elements (policy `All`) are never counted.
2. **Toggle/config dialog text clarified** (`StingAutoTagger`) — the dialogs said visual tagging places tags on "newly placed elements" unqualified, so a drafter draws a duct, sees nothing, assumes it's broken. Each now adds one sentence: linear MEP runs are tagged once per run by Smart Place Tags, not live per-segment; token data is still written to every segment.
3. **Locale-safe policy keys** (`MepRunGrouper.ResolvePolicy`) — `CATEGORY_VISUAL_POLICY` matched only on the localized `Category.Name`, so a non-English office's `"Pipes":"All"` was silently ignored (category reads "Rohre"/"Canalisations"). Now matches on `BuiltInCategory` first via a stable friendly-key map (the exact English keys `SetMepTagPolicyCommand` writes) plus the `OST_` enum name, with the localized-name lookup kept as a back-compat fallback. The override now takes effect in any Revit UI language.

Design note (fix 3): chose the `BuiltInCategory` match over a log-unmatched audit — it actually *fixes* the misconfiguration rather than just surfacing it, and stays within the two named files. The friendly keys were verified one-to-one against `SetMepTagPolicyCommand.LinearCatNames`.

**Committed without `dotnet build` verification** (no .NET/Revit toolchain) — verify in Revit before merge. Members used (`TagConfig.CategoryVisualPolicy`, `el.Category.Id.Value` cast, `StingLog.Info`, `Interlocked`) confirmed present in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_