### PR TITLE
fix(server): reuse shared Redis multiplexer, isolate test cache, throttle outage logs (#448 review)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Authorization/ProjectAccessAttribute.cs
+++ b/Planscape.Server/src/Planscape.API/Authorization/ProjectAccessAttribute.cs
@@ -27,6 +27,27 @@ public class ProjectAccessAttribute : Attribute, IAsyncActionFilter
 {
     public string RouteParam { get; set; } = "projectId";
 
+    // A Redis outage fires the cache-failure paths below on essentially every
+    // gated request. Without a throttle that is two full-stack-trace warnings
+    // per request for the whole outage — a log storm that buries everything
+    // else. The signal ("Redis is down") is identical each time, so warn at
+    // most once per interval across all requests. Interlocked keeps it correct
+    // under the concurrent requests an action filter sees.
+    // 0 (not long.MinValue) so the first failure's (now - last) stays a large
+    // positive tick count rather than overflowing long — the first outage
+    // warning must get through before suppression kicks in.
+    private static long _lastCacheWarnTicks;
+    private static readonly long CacheWarnIntervalTicks = TimeSpan.FromMinutes(1).Ticks;
+
+    private static bool ShouldWarnCacheFailure()
+    {
+        var now = DateTime.UtcNow.Ticks;
+        var last = Interlocked.Read(ref _lastCacheWarnTicks);
+        if (now - last < CacheWarnIntervalTicks) return false;
+        // Only the thread that wins the swap logs; the rest stay quiet.
+        return Interlocked.CompareExchange(ref _lastCacheWarnTicks, now, last) == last;
+    }
+
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
         // Phase 175 audit P1-17 — only look up the explicitly-named route
@@ -88,8 +109,9 @@ public class ProjectAccessAttribute : Attribute, IAsyncActionFilter
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger?.LogWarning(ex,
-                    "Project-visibility cache read failed; falling back to the database (decision unaffected).");
+                if (ShouldWarnCacheFailure())
+                    logger?.LogWarning(ex,
+                        "Project-visibility cache read failed; falling back to the database (decision unaffected). Further cache warnings suppressed for up to 1 minute.");
             }
 
             if (cached == "1") { await next(); return; }
@@ -104,7 +126,10 @@ public class ProjectAccessAttribute : Attribute, IAsyncActionFilter
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger?.LogWarning(ex,
+                // The decision was already served correctly from the database and
+                // simply not cached — Debug, not Warning, so an outage can't storm
+                // the log with a second warning per request.
+                logger?.LogDebug(ex,
                     "Project-visibility cache write failed; decision served from the database and not cached.");
             }
         }

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -449,11 +449,6 @@ builder.Services.AddSingleton<Planscape.Core.Interfaces.INotificationService, Pl
 
 // ── Redis ──
 var redisConn = builder.Configuration["Redis:Connection"] ?? "localhost:6379";
-builder.Services.AddStackExchangeRedisCache(options =>
-{
-    options.Configuration = redisConn;
-    options.InstanceName = "Planscape:";
-});
 // Phase 175 — single shared multiplexer reused by the SignalR
 // backplane, the cache, the permission-revocation store, AND the
 // Redis-backed rate limiter below. Avoid creating a second connection
@@ -465,6 +460,8 @@ builder.Services.AddStackExchangeRedisCache(options =>
 // Add a 5s ConnectTimeout so the app doesn't hang on startup if the
 // DNS/network is slow. A blanket try/catch wraps the whole thing as a
 // last-resort guard against any other unexpected failure mode.
+// Built BEFORE the distributed cache so the cache can reuse this exact
+// multiplexer (see ConnectionMultiplexerFactory below).
 ConnectionMultiplexer redisMux;
 try
 {
@@ -495,6 +492,22 @@ catch (Exception ex)
     redisMux = ConnectionMultiplexer.Connect(fallbackOptions);
 }
 builder.Services.AddSingleton<IConnectionMultiplexer>(redisMux);
+
+// Distributed cache MUST reuse the shared multiplexer above via
+// ConnectionMultiplexerFactory. Feeding AddStackExchangeRedisCache a raw
+// connection string instead makes RedisCache build its OWN multiplexer with
+// the library defaults (AbortOnConnectFail=true, 5s ConnectTimeout) — so
+// during a Redis outage every cache Get/Set pays its own multi-second connect
+// timeout instead of failing fast against the already-disconnected shared mux
+// (which was created with AbortOnConnectFail=false). InstanceName stays as the
+// key prefix; Configuration is intentionally omitted because it is ignored once
+// a factory is supplied.
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.InstanceName = "Planscape:";
+    options.ConnectionMultiplexerFactory =
+        () => Task.FromResult<IConnectionMultiplexer>(redisMux);
+});
 
 builder.Services.AddSignalR().AddStackExchangeRedis(redisConn, options =>
 {

--- a/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
+++ b/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Distributed;
 using Planscape.Infrastructure.Data;
 using Planscape.Core.Entities;
 using System.Net.Http.Headers;
@@ -90,6 +91,22 @@ public class PlanscapeWebApplicationFactory : WebApplicationFactory<Program>
             // Add InMemory database
             services.AddDbContext<PlanscapeDbContext>(options =>
                 options.UseInMemoryDatabase(_dbName));
+
+            // Redis-backed IDistributedCache → in-process memory. With real Redis
+            // in CI, the fixed test GUIDs plus the shared "Planscape:" InstanceName
+            // mean a project-visibility verdict cached by one test class
+            // ("pv:{tenant}:{user}:{project}") is a live cross-test hit for a
+            // parallel class that has different DB state — a flaky, order-dependent
+            // false pass/fail. Give every factory instance its own
+            // MemoryDistributedCache so there is nothing to bleed between hosts.
+            // (The cache-outage regression test builds its own host without this
+            // factory, so its coverage is unaffected.) AddDistributedMemoryCache
+            // uses TryAdd, so the Redis registration must be removed first.
+            var cacheDescriptors = services
+                .Where(d => d.ServiceType == typeof(IDistributedCache))
+                .ToList();
+            foreach (var d in cacheDescriptors) services.Remove(d);
+            services.AddDistributedMemoryCache();
 
             // Build the service provider and seed test data
             var sp = services.BuildServiceProvider();

--- a/Planscape.Server/tests/check-new-failures.sh
+++ b/Planscape.Server/tests/check-new-failures.sh
@@ -26,7 +26,7 @@ BASELINE="$(dirname "$0")/known-failing-tests.txt"
 # "Test Run Failed." / "Total tests: N". Matching just the former made this
 # gate abort with "the run did not complete" on every solution-level run that
 # had failures, which is precisely when its diff is worth reading.
-if ! grep -qE "^\s*(Passed!|Failed!|Test Run (Successful|Failed)\.|Total tests:)" "$OUTPUT"; then
+if ! grep -qE "^[[:space:]]*(Passed!|Failed!|Test Run (Successful|Failed)\.|Total tests:)" "$OUTPUT"; then
   echo "::error::no test summary in output — the run did not complete"
   tail -30 "$OUTPUT"
   exit 1
@@ -35,7 +35,7 @@ fi
 grep -o "Planscape\.Tests\.[A-Za-z0-9_.]*\ \[FAIL\]" "$OUTPUT" \
   | sed 's/ \[FAIL\]//' | sort -u > /tmp/actual-failures.txt
 
-grep -vE '^\s*(#|$)' "$BASELINE" | sort -u > /tmp/baseline-failures.txt
+grep -vE '^[[:space:]]*(#|$)' "$BASELINE" | sort -u > /tmp/baseline-failures.txt
 
 NEW=$(comm -13 /tmp/baseline-failures.txt /tmp/actual-failures.txt)
 FIXED=$(comm -23 /tmp/baseline-failures.txt /tmp/actual-failures.txt)


### PR DESCRIPTION
Stacked on **#448** (`claude/im-phase0-ci-redis`). #448 made a Redis outage degrade to the DB (404, not 500); this closes the P2/P3 findings from that review.

### P2 — cache didn't reuse the shared multiplexer (`Program.cs`)
`AddStackExchangeRedisCache` was fed a raw connection string, so `RedisCache` built its **own** multiplexer with library defaults (`AbortOnConnectFail=true`, 5s `ConnectTimeout`) — not the shared `redisMux` (`AbortOnConnectFail=false`) despite the nearby comment. During an outage every cache `Get`/`Set` paid its own multi-second connect timeout, turning a cache outage into a perceived API outage. Fix: build `redisMux` first, then wire it in via `ConnectionMultiplexerFactory` so cache ops fail fast on the shared, already-disconnected mux. `Configuration` dropped (ignored once a factory is set); `InstanceName` kept as the key prefix.

### P2 — CI cache-bleed between test classes (`PlanscapeWebApplicationFactory.cs`)
With real Redis in CI, fixed test GUIDs + the shared `"Planscape:"` InstanceName mean a `pv:{tenant}:{user}:{project}` verdict cached by one test class is a live cross-test hit for a parallel class with different DB state — an order-dependent flaky pass/fail. Fix: give each test host its own `MemoryDistributedCache` (remove the Redis `IDistributedCache` descriptor, then `AddDistributedMemoryCache()`). The outage regression test builds its own host without this factory, so its coverage is unaffected.

### P3 — log storm during an outage (`ProjectAccessAttribute.cs`)
Two full-exception `LogWarning` per gated request for the whole outage. Fix: demote the cache-**write** failure to `Debug` (decision already served from the DB), and throttle the cache-**read** `Warning` to at most once per minute via a thread-safe `Interlocked` gate (initialised to `0` so the first outage warning still gets through).

### P3 — non-portable grep (`check-new-failures.sh`)
`\s` is a GNU extension that breaks the MSBuild-summary detection on macOS/BSD grep. Fix: POSIX `[[:space:]]` in both the summary detection and the baseline comment filter.

### Verification
- **`check-new-failures.sh`: bash-verified here** — the POSIX pattern matches indented `  Total tests:` / `Passed!` / `Test Run Failed.`, rejects non-summary lines, the baseline filter still strips comments/blanks, `bash -n` OK.
- **C# not built** (Linux sandbox, no .NET). `ConnectionMultiplexerFactory`/`IConnectionMultiplexer`, `AddDistributedMemoryCache`, and `Interlocked` usage checked against StackExchange.Redis + Caching.StackExchangeRedis 8.0.11. **Run `dotnet build` + `dotnet test` on CI before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_