### PR TITLE
fix(drawings): spot-dim idempotency, O(M²) sheet-number scan, ctx.Tag convergence (#449 review)

### DIFF
--- a/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
@@ -169,7 +169,18 @@ namespace StingTools.Commands.Drawing
                     {
                         try
                         {
-                            var ctx = new DrawingContext { Level = level, Tag = level.Name };
+                            // P-9: the level's identity already rides on
+                            // ctx.Level — it feeds the {lvl} token and the
+                            // level component of DrawingProducer.BuildContextTag.
+                            // Setting Tag = level.Name additionally duplicated it
+                            // into the {mark}/{spool} slots and appended it to the
+                            // context key, so this command's per-level sheet
+                            // identity diverged from ProduceViewsPerLevelCommand
+                            // (which leaves Tag null) and the two produced two full
+                            // sets of sheets. Tag is reserved for an extra
+                            // distinguishing dimension (scope box / room / grid),
+                            // not the level, so leave it null here to converge.
+                            var ctx = new DrawingContext { Level = level };
                             var res = DrawingProducer.ProduceAllViews(doc, dt, ctx, opts);
 
                             stats.ViewsProduced   += res.ViewIds.Count;

--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -151,6 +151,9 @@ namespace StingTools.Core.Drawing
                     catch (Exception ex) { aux.Warnings.Add("Spot: " + ex.Message); }
                 }
                 stats.DecorativePlaced += aux.DecorativePlaced + aux.SpotsPlaced;
+                // Surface decorative + spot idempotency skips (C-4) so a no-op
+                // re-run reads as "skipped N" rather than looking like a failure.
+                stats.Skipped += aux.Skipped;
                 stats.Warnings.AddRange(aux.Warnings);
             }
 
@@ -853,9 +856,67 @@ namespace StingTools.Core.Drawing
             ProcessSpotRules(doc, view, pack.SpotCoordinateRules, isCoordinate: true, result);
         }
 
+        /// <summary>
+        /// Element ids already carrying a spot elevation — or a spot coordinate,
+        /// when <paramref name="isCoordinate"/> is true — in this view. Built
+        /// once per kind and shared across every spot rule: the guard that keeps
+        /// the spot pass from re-stacking a SpotDimension on every run. Like the
+        /// dimension guard (ViewHasDimensionReferencing) it detects an existing
+        /// spot by what it REFERENCES; a spot whose references are unavailable is
+        /// treated as unknown rather than a match. Fails open with a warning so a
+        /// scan failure places spots (previous behaviour) instead of silently
+        /// omitting them.
+        /// </summary>
+        private static HashSet<ElementId> BuildSpottedElementIndex(Document doc, View view, bool isCoordinate, AnnotationResult result)
+        {
+            var set = new HashSet<ElementId>();
+            try
+            {
+                var bic = isCoordinate ? BuiltInCategory.OST_SpotCoordinates : BuiltInCategory.OST_SpotElevations;
+                foreach (var el in new FilteredElementCollector(doc, view.Id)
+                    .OfCategory(bic)
+                    .WhereElementIsNotElementType())
+                {
+                    if (!(el is SpotDimension sd)) continue;
+                    try
+                    {
+                        if (!sd.AreReferencesAvailable) continue;   // unknown — not a match
+                        var refs = sd.References;
+                        if (refs == null) continue;
+                        foreach (Reference r in refs)
+                        {
+                            var host = doc.GetElement(r);
+                            if (host != null && host.Id != ElementId.InvalidElementId) set.Add(host.Id);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"BuildSpottedElementIndex: spot {sd.Id} — {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail open: an empty index means "place every spot", i.e. the
+                // previous behaviour, rather than silently skipping requested work.
+                result.Warnings.Add($"Could not index existing spot {(isCoordinate ? "coordinates" : "elevations")} " +
+                                    $"in '{view.Name}' ({ex.Message}); duplicate spot dims are possible on this view.");
+            }
+            return set;
+        }
+
         private static void ProcessSpotRules(Document doc, View view, List<SpotAnnotationRule> rules, bool isCoordinate, AnnotationResult result)
         {
             if (rules == null || rules.Count == 0) return;
+
+            // C-4: index elements that already carry a spot dimension of this
+            // kind in the view, once and shared across every rule below, so a
+            // re-run doesn't stack a second SpotElevation / SpotCoordinate onto
+            // each element. The tag, dimension and decorative passes each got an
+            // idempotency guard; the spot pass was the one kind left uncovered,
+            // so re-running DrawingTypePresentation.Apply doubled every spot dim.
+            var spotted = BuildSpottedElementIndex(doc, view, isCoordinate, result);
+
             foreach (var r in rules)
             {
                 if (r == null || string.IsNullOrEmpty(r.Category)) continue;
@@ -886,6 +947,14 @@ namespace StingTools.Core.Drawing
                     {
                         try
                         {
+                            // C-4: skip an element that already carries a spot
+                            // dim of this kind so a re-run places nothing.
+                            if (spotted != null && spotted.Contains(el.Id))
+                            {
+                                result.Skipped++;
+                                continue;
+                            }
+
                             var bb = el.get_BoundingBox(view);
                             if (bb == null) continue;
                             var origin = new XYZ((bb.Min.X + bb.Max.X) / 2.0, (bb.Min.Y + bb.Max.Y) / 2.0, bb.Max.Z);
@@ -901,6 +970,9 @@ namespace StingTools.Core.Drawing
                                 try { sd.ChangeTypeId(symbolId); } catch { }
                             }
                             result.SpotsPlaced++;
+                            // Keep the index current so a later rule of the same
+                            // kind in this run doesn't re-spot the same element.
+                            spotted?.Add(el.Id);
                         }
                         catch (Exception ex) { result.Warnings.Add($"Spot {(isCoordinate ? "coord" : "elev")} '{r.Category}/{el.Id}': {ex.Message}"); }
                     }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -62,6 +62,11 @@ namespace StingTools.Core.Drawing
         [ThreadStatic] private static Dictionary<string, ElementId> _existingViewCache;
         [ThreadStatic] private static Dictionary<string, ElementId> _existingSheetCache;
         [ThreadStatic] private static Dictionary<string, int>       _packageSheetCount;
+        // GAP-L: the set of sheet numbers in use, primed once per batch so
+        // EnsureUniqueSheetNumber doesn't re-collect every ViewSheet on each
+        // assignment (was O(M²) across an M-sheet batch). Written back as each
+        // number is assigned so later sheets in the same batch see it.
+        [ThreadStatic] private static HashSet<string>               _sheetNumberCache;
         [ThreadStatic] private static string                        _cacheDocKey;
 
         private static string CacheDocKey(Document doc)
@@ -115,6 +120,7 @@ namespace StingTools.Core.Drawing
 
                 var s = new Dictionary<string, ElementId>(StringComparer.Ordinal);
                 var pkg = new Dictionary<string, int>(StringComparer.Ordinal);
+                var nums = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var sheet in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)).Cast<ViewSheet>())
                 {
                     var dtId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID) ?? string.Empty;
@@ -126,9 +132,13 @@ namespace StingTools.Core.Drawing
                     if (!string.IsNullOrEmpty(dtId)) s[SheetKey(dtId, pkgId, shtCtx)] = sheet.Id;
                     if (pkg.TryGetValue(pkgId, out var n)) pkg[pkgId] = n + 1;
                     else pkg[pkgId] = 1;
+                    // Same pass feeds the sheet-number cache — no extra collector.
+                    try { if (!string.IsNullOrEmpty(sheet.SheetNumber)) nums.Add(sheet.SheetNumber); }
+                    catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
                 }
                 _existingSheetCache = s;
                 _packageSheetCount  = pkg;
+                _sheetNumberCache   = nums;
             }
             catch (Exception ex)
             {
@@ -141,6 +151,7 @@ namespace StingTools.Core.Drawing
             _existingViewCache  = null;
             _existingSheetCache = null;
             _packageSheetCount  = null;
+            _sheetNumberCache   = null;
             _cacheDocKey        = null;
         }
 
@@ -952,34 +963,66 @@ namespace StingTools.Core.Drawing
         private static string EnsureUniqueSheetNumber(Document doc, string baseNumber, ElementId excludeId, ProduceResult result)
         {
             if (string.IsNullOrEmpty(baseNumber)) return baseNumber;
-            var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            try
-            {
-                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)))
-                {
-                    if (el is ViewSheet vs && vs.Id != excludeId && !string.IsNullOrEmpty(vs.SheetNumber))
-                        existing.Add(vs.SheetNumber);
-                }
-            }
-            catch (Exception ex)
-            {
-                StingTools.Core.StingLog.Warn($"EnsureUniqueSheetNumber: {ex.Message}");
-                return baseNumber;
-            }
-            if (!existing.Contains(baseNumber)) return baseNumber;
 
-            for (char c = 'A'; c <= 'Z'; c++)
+            // GAP-L: reuse the per-batch sheet-number set when it is primed for
+            // this doc, so an M-sheet batch no longer re-collects every ViewSheet
+            // on each assignment (was O(M²)). The number chosen below is written
+            // back into the cache so a later sheet in the same batch sees it —
+            // matching the old per-call scan, which saw sheets numbered earlier
+            // in the same run. The just-created sheet (excludeId) carries only a
+            // default number that was never added to the cache, so excluding it
+            // is implicit. Falls back to a fresh scan when no batch cache is live.
+            bool useCache = _sheetNumberCache != null && CacheMatchesDoc(doc);
+            HashSet<string> existing;
+            if (useCache)
             {
-                var candidate = baseNumber + "-" + c;
-                if (!existing.Contains(candidate))
+                existing = _sheetNumberCache;
+            }
+            else
+            {
+                existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                try
                 {
-                    result?.Warnings.Add($"Sheet number '{baseNumber}' already exists; used '{candidate}'.");
-                    return candidate;
+                    foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)))
+                    {
+                        if (el is ViewSheet vs && vs.Id != excludeId && !string.IsNullOrEmpty(vs.SheetNumber))
+                            existing.Add(vs.SheetNumber);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingTools.Core.StingLog.Warn($"EnsureUniqueSheetNumber: {ex.Message}");
+                    return baseNumber;
                 }
             }
-            var fallback = baseNumber + "-" + Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
-            result?.Warnings.Add($"Sheet number '{baseNumber}' and all -A..-Z variants exist; used '{fallback}'.");
-            return fallback;
+
+            string chosen;
+            if (!existing.Contains(baseNumber))
+            {
+                chosen = baseNumber;
+            }
+            else
+            {
+                chosen = null;
+                for (char c = 'A'; c <= 'Z'; c++)
+                {
+                    var candidate = baseNumber + "-" + c;
+                    if (!existing.Contains(candidate))
+                    {
+                        result?.Warnings.Add($"Sheet number '{baseNumber}' already exists; used '{candidate}'.");
+                        chosen = candidate;
+                        break;
+                    }
+                }
+                if (chosen == null)
+                {
+                    chosen = baseNumber + "-" + Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
+                    result?.Warnings.Add($"Sheet number '{baseNumber}' and all -A..-Z variants exist; used '{chosen}'.");
+                }
+            }
+
+            if (useCache) _sheetNumberCache.Add(chosen);
+            return chosen;
         }
 
         private static readonly System.Text.RegularExpressions.Regex _seqWidthRegex


### PR DESCRIPTION
Stacked on **#449** (`fix/drawings-production-p0`). Addresses the three P2 review findings. Each fix is confined to the file the finding names; +145/−19.

### P2-1 — AnnotationRunner spot idempotency
The C-4 idempotency fix guarded tags, grid/level dimensions and decorative instances, but the **spot** pass was uncovered — a pack with `spotElevationRules`/`spotCoordinateRules` re-run with `SkipSpots=false` stacked a duplicate `SpotDimension` per element each run. Added `BuildSpottedElementIndex` (mirrors the dimension guard `ViewHasDimensionReferencing`): indexes elements already carrying a spot of that kind (`OST_SpotElevations`/`OST_SpotCoordinates`) by what each spot references, once per kind, shared across rules. `ProcessSpotRules` now skips already-spotted elements and records newly placed ones so a later rule can't double-spot in the same run. Fails open. Also folds `aux.Skipped` into `stats.Skipped` in `Apply` so decorative + spot skips actually surface.

### P2-2 — DrawingProducer O(M²) sheet-number scan
`EnsureUniqueSheetNumber` re-collected every `ViewSheet` on each assignment → O(M²) for an M-sheet batch. Added a per-batch `_sheetNumberCache` alongside the existing GAP-L `[ThreadStatic]` caches: primed in the **same** `ViewSheet` pass `PrimeBatchCaches` already runs (no extra collector), reset in `ResetBatchCaches`, consulted when primed for the active doc, and written back as each number is assigned so later sheets in the batch see it (correctness preserved). Falls back to the original scan when no batch cache is live. Both batch entry points already prime the caches.

### P2-3 — ctx.Tag divergence (P-9)
`DrawingProduceAndExportCommand` set `ctx.Tag = level.Name` while `ProduceViewsPerLevelCommand` leaves it null. With C-3 folding `BuildContextTag` (incl `ctx.Tag`) into the sheet key, the two commands computed different per-level sheet identities and produced two full sets of sheets. The level's identity already rides on `ctx.Level` (feeds `{lvl}` + the level component of the context key); `Tag = level.Name` only duplicated it into the `{mark}`/`{spool}` slots. **Converged by removing the redundant `Tag` from the outlier** — `Tag` is reserved for an extra distinguishing dimension (scope box / room / grid), and this keeps the canonical `ProduceViewsPerLevelCommand` behaviour unchanged (lowest regression risk).

### Verification
**Committed without `dotnet build`** (no .NET/Revit toolchain). All members used already appear in-branch (`SpotDimension.AreReferencesAvailable`/`.References`, `OST_Spot*`, the GAP-L cache lifecycle, `DrawingContext.Tag`/`.Level`). Suggested Revit smoke tests: re-run annotation twice on one view (no duplicate spots), a per-level batch of M sheets (unique numbering intact, no per-sheet full scan), and run both `ProducePerLevel` and `ProduceAndExport` on the same levels (one set of sheets, not two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_