### PR TITLE
fix(iso19650): legacy fallback for sustainability + content roots; guard partial migration (#453 review)

### DIFF
--- a/StingTools/BIMManager/CreateIssuesFromWarningsCommand.cs
+++ b/StingTools/BIMManager/CreateIssuesFromWarningsCommand.cs
@@ -29,8 +29,8 @@ namespace StingTools.BIMManager
     //            sha256(category + severity + first-100-chars-of-desc + sorted elt ids)
     //         → first 12 hex chars. Re-runs with the same warnings produce identical
     //         hashes → no duplicates.
-    //      5. For each group: build a JObject via BIMManagerEngine.CreateIssue so the
-    //         schema matches what RaiseIssueCommand / IssueDashboard / UpdateIssue
+    //      5. For each group: batch.Create(IssueSpec) via IssueStore so the schema
+    //         matches what RaiseIssueCommand / IssueDashboard / UpdateIssue
     //         expect (issue_id, type, priority, status, element_ids, comments, …).
     //      6. Tag every minted issue with the source_hash so subsequent runs can
     //         dedup in O(n).
@@ -45,12 +45,14 @@ namespace StingTools.BIMManager
     //     never appear in the classified Warnings list with severity above Medium
     //     anyway — see the scope filter below.)
     //
-    //  This file deliberately uses BIMManagerEngine.CreateIssue / LoadJsonArray /
-    //  SaveJsonFile / GetBIMManagerFilePath for schema compatibility with the rest
-    //  of the issue tracker. WarningsEngine.CreateIssuesFromWarnings (legacy, in
-    //  Core/WarningsManager.cs) writes a different, hand-rolled JSON shape that
-    //  IssueDashboard cannot read; that legacy method is left in place for the
-    //  callers documented in Core/Phase75Enhancements.cs but is NOT used here.
+    //  This file uses IssueStore.Begin / batch.Create / batch.Commit — one atomic
+    //  batch that owns issue minting, still-open dedup, the audit-chain entry and the
+    //  Planscape server push, and writes the same JSON schema the rest of the issue
+    //  tracker (RaiseIssueCommand / IssueDashboard / UpdateIssue) reads.
+    //  WarningsEngine.CreateIssuesFromWarnings (legacy, in Core/WarningsManager.cs)
+    //  writes a different, hand-rolled JSON shape that IssueDashboard cannot read; that
+    //  legacy method is left in place for the callers documented in
+    //  Core/Phase75Enhancements.cs but is NOT used here.
     // ════════════════════════════════════════════════════════════════════════════
 
     [Transaction(TransactionMode.ReadOnly)]

--- a/StingTools/Commands/Sustainability/SustainabilityCommands.cs
+++ b/StingTools/Commands/Sustainability/SustainabilityCommands.cs
@@ -43,8 +43,18 @@ namespace StingTools.Commands.Sustainability
 
         public static SustainProjectSetup LoadSetup(Document doc)
         {
-            var setup = SustainProjectSetup.Load(
-                StingPaths.Meta(doc, "_BIM_COORD", "sustainability"), out bool found);
+            // Resolve the config CONSOLIDATED-first (<root>/_data/_BIM_COORD/sustainability/)
+            // then fall back to the LEGACY sibling (<projDir>/_BIM_COORD/sustainability/) —
+            // the same consolidated-then-legacy order ClimateRegistry / MepSizingRegistry get
+            // from ProjectFolderEngine.ResolveProjectOverridePath. Without the fallback a
+            // project set up before the ISO 19650 folder consolidation is never found and the
+            // dashboard silently reverts to CreateDefault() carbon/occupancy inputs.
+            string cfgFile = ProjectFolderEngine.ResolveProjectOverridePath(
+                doc, "_BIM_COORD/sustainability/project_setup.json");
+            string sustainDir = !string.IsNullOrEmpty(cfgFile)
+                ? Path.GetDirectoryName(cfgFile)
+                : StingPaths.Meta(doc, "_BIM_COORD", "sustainability");
+            var setup = SustainProjectSetup.Load(sustainDir, out bool found);
             if (!found)
             {
                 // Seed area from the model when no setup exists yet (Spaces preferred,

--- a/StingTools/Core/Content/ContentRoots.cs
+++ b/StingTools/Core/Content/ContentRoots.cs
@@ -31,10 +31,19 @@ namespace StingTools.Core.Content
                     ? Path.GetDirectoryName(doc.PathName) : null;
                 if (!string.IsNullOrEmpty(docDir))
                 {
+                    // Consolidated <root>/_data/_BIM_COORD/… (post ISO 19650 consolidation)…
                     project.Add(StingPaths.Meta(doc, "_BIM_COORD", "Content"));
                     project.Add(StingPaths.Meta(doc, "_BIM_COORD", "Families", "Symbols"));
                     project.Add(StingPaths.Meta(doc, "_BIM_COORD", "Families", "Seeds"));
                     project.Add(StingPaths.Meta(doc, "_BIM_COORD", "Families"));
+                    // …then the legacy <projDir>/_BIM_COORD/… siblings, so families placed
+                    // before consolidation still resolve (dedup drops any overlap). Mirrors the
+                    // consolidated-first / legacy-sibling fallback the registries get from
+                    // ProjectFolderEngine.ResolveProjectOverridePath.
+                    project.Add(Path.Combine(docDir, "_BIM_COORD", "Content"));
+                    project.Add(Path.Combine(docDir, "_BIM_COORD", "Families", "Symbols"));
+                    project.Add(Path.Combine(docDir, "_BIM_COORD", "Families", "Seeds"));
+                    project.Add(Path.Combine(docDir, "_BIM_COORD", "Families"));
                 }
             }
             catch { /* unsaved doc */ }

--- a/StingTools/Core/ProjectFolderEngine.cs
+++ b/StingTools/Core/ProjectFolderEngine.cs
@@ -703,6 +703,12 @@ namespace StingTools.Core
         {
             public int FilesMoved { get; set; }
             public int FoldersRemoved { get; set; }
+
+            /// <summary>Per-file relocations that threw and did NOT complete. When &gt; 0 the
+            /// consolidation is incomplete: the breadcrumb is withheld so a later consented
+            /// run can finish the stranded files instead of being blocked by HasConsolidated.</summary>
+            public int FilesFailed { get; set; }
+
             public List<string> Warnings { get; set; } = new();
 
             /// <summary>Every file relocation, "source|destination", in the order performed.</summary>
@@ -899,7 +905,7 @@ namespace StingTools.Core
                             rep.FilesMoved++;
                             rep.Moves.Add(f + "|" + dest);
                         }
-                        catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                        catch (Exception ex) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex.Message}"); }
                     }
                     foreach (string f in Directory.GetFiles(projDir, "*_STING_SEQ.json"))
                     {
@@ -911,7 +917,7 @@ namespace StingTools.Core
                             rep.FilesMoved++;
                             rep.Moves.Add(f + "|" + dest);
                         }
-                        catch (Exception ex) { rep.Warnings.Add($"Move {f}: {ex.Message}"); }
+                        catch (Exception ex) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex.Message}"); }
                     }
                 }
                 catch (Exception ex) { rep.Warnings.Add($"Sidecar scan: {ex.Message}"); }
@@ -940,7 +946,7 @@ namespace StingTools.Core
                                 rep.FilesMoved++;
                                 rep.Moves.Add(f + "|" + dest);
                             }
-                            catch (Exception ex2) { rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
+                            catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
                         }
                         RetireLegacyFolder(legacy, rep);
                     }
@@ -969,7 +975,7 @@ namespace StingTools.Core
                                     rep.FilesMoved++;
                                     rep.Moves.Add(f + "|" + dst);
                                 }
-                                catch (Exception ex2) { rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
+                                catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
                             }
                             RetireLegacyFolder(hiddenLegacy, rep);
                         }
@@ -990,7 +996,7 @@ namespace StingTools.Core
                         rep.FilesMoved++;
                         rep.Moves.Add(src + "|" + dst);
                     }
-                    catch (Exception ex2) { rep.Warnings.Add($"Move {src}: {ex2.Message}"); }
+                    catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {src}: {ex2.Message}"); }
                 }
 
                 // 2d. BOQ rate-source heat-map exports
@@ -1015,7 +1021,7 @@ namespace StingTools.Core
                                     rep.FilesMoved++;
                                     rep.Moves.Add(f + "|" + dst);
                                 }
-                                catch (Exception ex2) { rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
+                                catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
                             }
                             RetireLegacyFolder(boqLegacy, rep);
                         }
@@ -1040,7 +1046,7 @@ namespace StingTools.Core
                                 rep.FoldersRemoved++;
                                 rep.Moves.Add(sub + "|" + dest);
                             }
-                            catch (Exception ex2) { rep.Warnings.Add($"Move {sub}: {ex2.Message}"); }
+                            catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {sub}: {ex2.Message}"); }
                         }
                     }
                 }
@@ -1083,7 +1089,7 @@ namespace StingTools.Core
                                 rep.FilesMoved++;
                                 rep.Moves.Add(f + "|" + dest);
                             }
-                            catch (Exception ex2) { rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
+                            catch (Exception ex2) { rep.FilesFailed++; rep.Warnings.Add($"Move {f}: {ex2.Message}"); }
                         }
                         RetireLegacyFolder(legacy, rep);
                     }
@@ -1092,7 +1098,7 @@ namespace StingTools.Core
 
                 InvalidateFolderStatsCache();
                 WriteConsolidationBreadcrumb(doc, rep);
-                StingLog.Info($"MigrateFromLegacy: {rep.FilesMoved} files moved, {rep.FoldersRemoved} folders retired. Breadcrumb: {rep.BreadcrumbPath}");
+                StingLog.Info($"MigrateFromLegacy: {rep.FilesMoved} files moved, {rep.FoldersRemoved} folders retired, {rep.FilesFailed} failed. Breadcrumb: {(string.IsNullOrEmpty(rep.BreadcrumbPath) ? "(withheld — re-run to finish)" : rep.BreadcrumbPath)}");
             }
             catch (Exception ex)
             {
@@ -1115,6 +1121,19 @@ namespace StingTools.Core
                 // Nothing moved: leave no breadcrumb, so a project that genuinely has
                 // legacy folders later still gets its one consolidation.
                 if (rep.FilesMoved == 0 && rep.FoldersRemoved == 0) return;
+
+                // A straggler remains: at least one file threw on move (RetireLegacyFolder
+                // has already left any folder that still holds files in place). Writing the
+                // breadcrumb now would make HasConsolidated block the retry that would finish
+                // the job, stranding those files in the legacy folder forever. Leave no
+                // breadcrumb so the next consented run completes the move — already-relocated
+                // files are gone from the source, so nothing double-moves (retire-not-delete
+                // is untouched).
+                if (rep.FilesFailed > 0)
+                {
+                    StingLog.Warn($"WriteConsolidationBreadcrumb: {rep.FilesFailed} file(s) failed to move — breadcrumb withheld so the consolidation can be re-run to finish.");
+                    return;
+                }
 
                 string path = ConsolidationBreadcrumbPath(doc);
                 if (string.IsNullOrEmpty(path)) return;


### PR DESCRIPTION
Stacked on **#453** (`claude/iso19650-consolidation`). Addresses the four review findings. 4 files, +59/−19.

### P1 — sustainability config lost on pre-consolidation projects
`SustainabilityCommands.LoadSetup` read only the consolidated `StingPaths.Meta(...)` path, no legacy fallback — unlike the climate/MEP registries. An existing project whose config sits at `<projDir>/_BIM_COORD/sustainability/project_setup.json` was never found → `CreateDefault()` → the dashboard silently reverted to default carbon/occupancy inputs. **Fix:** resolve consolidated-first then legacy via `ProjectFolderEngine.ResolveProjectOverridePath` — the same order `ClimateRegistry`/`MepSizingRegistry` use; writes still target the consolidated path; a genuinely new project still falls through to `StingPaths.Meta`.

### P2 — project family/content roots lost pre-consolidation
`ContentRoots.Resolve` moved the search roots to `StingPaths.Meta` only, so families under `<projDir>/_BIM_COORD/Families` stopped resolving. **Fix:** re-added the legacy sibling roots after the consolidated ones (existing dedup drops overlap); realigns with the file's own header comment.

### P2 — partial consolidation permanently marked complete
`MigrateFromLegacy` wrote the "complete" breadcrumb whenever any file moved; failed per-file moves were only logged, and `HasConsolidated` then blocked the retry, stranding stragglers forever. **Fix:** added `MigrationReport.FilesFailed` (incremented at all 8 per-file move-failure catches); `WriteConsolidationBreadcrumb` withholds the breadcrumb when `FilesFailed > 0`, so a later consented run finishes the move. Retire-not-delete is unchanged, and already-moved files are gone from source so nothing double-moves.

### P3 — stale header comment
`CreateIssuesFromWarningsCommand`'s header claimed `BIMManagerEngine.CreateIssue/LoadJsonArray/SaveJsonFile`; the body uses `IssueStore.Begin/batch.Create/batch.Commit`. Comment corrected.

**Committed without `dotnet build`** (no .NET/Revit toolchain). All members used exist in-branch (`ResolveProjectOverridePath`, `StingPaths.Meta`, `MigrationReport`, `SustainProjectSetup.Load`). Verify in Revit before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_