### PR TITLE
docs(changelog): Phase 195 deploy/clobber post-mortem, rebased onto main (supersedes #326)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6918,6 +6918,61 @@ that `CreateTagFamilies` completes with no "cannot be added" modal and produces
 working tag families (gates render, tiers toggle), including against a TEXT
 `MR_PARAMETERS.txt` to prove the resilience.
 
+#### Completed (Phase 195 — deploy/clobber post-mortem: why the Yes/No fix kept "relapsing")
+
+Operational lesson, not a code change. After Phase 193/194 made the
+gate params Yes/No in the repo, the tag-creation error
+(`shared parameter … cannot be added with type "Text" because it
+conflicts with the existing "Yes/No"`) **kept recurring in Revit** even
+though the committed data was correct. The repeated failures were never
+a logic / canonical-type problem — they were a **runtime data-path
+problem** that was never verified.
+
+**Root cause.** STING resolves its data via
+`DataPath = <folder of the loaded StingTools.dll>\data`
+(`StingToolsApp.cs`), and `TagFamilyCreatorCommand.AddSharedParameters`
+reads each param's *type straight from whatever `MR_PARAMETERS.txt` that
+`DataPath` resolves to* (it is not hardcoded). On this machine both
+Revit add-ins load `C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`, so
+the live `DataPath` is `CompiledPlugin\data` — and that folder kept
+being **overwritten back to a stale TEXT `MR_PARAMETERS.txt` by a
+parallel build** (the Export Centre `build.bat`, building from a branch
+cut before the Yes/No fix). So `LoadSharedParams` could report 0
+conflicts one moment and `CreateTagFamilies` 141 conflicts minutes
+later — the file on disk at `DataPath` had been re-clobbered in between.
+Every "fix" edited repo files while the runtime kept reading the
+clobbered copy.
+
+**Resolution (what finally worked).**
+1. **Merge the canonical Yes/No data to `main`** (PR #324 — as finally
+   merged, #324 carried the Phase 194 Yes/No correction, so the Phase 194
+   entry below and this step describe the same merged commit, not the
+   original Text-canonical draft) so no branch build can reintroduce
+   TEXT, and pull `main` into the parallel Export Centre branch (#322) so
+   its build carries Yes/No too.
+2. **Deploy to the exact loaded `DataPath`** (`CompiledPlugin\data`),
+   not just `%APPDATA%\…\Addins\2025\data`.
+3. **Verify the loaded file is Yes/No at runtime before recreating** —
+   read the `MR_PARAMETERS.txt` that sits at `DataPath` (and the
+   `Data path:` line in `StingTools.log`), confirm `TAG_PARA_STATE_2_BOOL`
+   etc. read `YESNO` and the tag-config CSV is the current set. Do not
+   assume the deploy reached the loaded path.
+
+After deploying Yes/No to `CompiledPlugin\data` and fully restarting
+Revit, `LoadSharedParams` reported **0 type conflicts** and tag
+families recreated clean.
+
+**Guardrail for next time.** The hazard is multiple `StingTools.dll` +
+`data\` copies on one machine plus a *shared* `CompiledPlugin` deploy
+target that parallel builds overwrite. Keep one install, deploy from
+`main`, and confirm the live `DataPath`'s `MR_PARAMETERS.txt` matches the
+intended type before any tag-family operation. (`FindDataFile` already
+resolves `DataPath\file` directly first and only falls back to a
+recursive first-match when that direct file is absent — so a stale nested
+copy wins only when the intended file is missing at the root, never ahead
+of it. The genuine gap is visibility, not precedence: a future hardening
+could log the resolved path on every load.)
+
 #### Completed (Phase 194 — Yes/No-canonical gates — corrects PR #324's Text-canonical choice)
 
 PR #324 (Phase 193) fixed the recurring "Inconsistent Units" error by


### PR DESCRIPTION
**Supersedes #326.** #326 inserted this entry at the top of `docs/CHANGELOG.md` when main's top was Phase 194; main's top is now Phase 222+ and the Phase 194 anchor is deep in the file, so #326 no longer merges. This is based on current `main` with the entry in its correct chronological slot. **Please close #326 in favour of this.**

### What changed
- Relocates the ~50-line Phase 195 "deploy/clobber post-mortem" entry to sit directly above the Phase 194 Yes/No-canonical entry — the deploy cluster now reads **Phase 196 (inject path) → 195 (post-mortem) → 194 (Yes/No gates)** (confirmed at CHANGELOG L6865 / L6921 / L6976).
- Docs-only: `docs/CHANGELOG.md`, +55, no deletions. Does not resurrect the stray pre-H1 line main removed.

### Two P2 wording fixes from the #326 review
1. **Guardrail sentence** — `FindDataFile` already resolves the direct `DataPath\file` first and only recurses when it's absent, so the genuine gap is *logging the resolved path*, not precedence. Reworded so it no longer implies `FindDataFile` needs changing.
2. **#324 framing** — added a clause noting #324 as merged carried the Phase 194 Yes/No correction, so the adjacent Phase 194 entry and this post-mortem describe the same commit — removes the apparent contradiction.

### Fact-check (verified against current main)
- `DataPath = <dll folder>\data` (`StingToolsApp.cs:52`).
- `TagFamilyCreatorCommand` reads `MR_PARAMETERS.txt` via `FindDataFile` (`:1129`); datatype read from the file, not hardcoded.
- "141 conflicts" matches the Phase 196 inject-path entry's 141-error dialog.
- `FindDataFile` direct-then-recursive precedence confirmed (`StingToolsApp.cs:2156`).

Docs-only — no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPpJC1PYLJN4FMSguTCi8N)_