### PR TITLE
ci(release): repurpose plugin-release workflow (dispatch/tag trigger)

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,15 +1,19 @@
-name: Plugin Release (on [release] commit)
+name: Plugin Release
 
-# Push a commit whose message contains "[release]" to this branch to build the
-# plugin on Windows against the real Revit reference assemblies and publish a
-# GitHub Release with StingTools.dll (and the full CompiledPlugin zip) attached
-# — a clean one-click download for deploying into Revit's add-in folder.
-# The release tag is created server-side by gh (no tag push needed).
+# Build the StingTools plugin on Windows against the real Revit reference
+# assemblies and publish a GitHub Release with StingTools.dll (and the full
+# CompiledPlugin zip) attached — a one-click download for deploying into Revit's
+# add-in folder.
+#
+# Trigger it either way:
+#   • Actions tab → "Plugin Release" → Run workflow (workflow_dispatch), or
+#   • push a tag matching plugin-*  (e.g. `git tag plugin-v1.2 && git push origin plugin-v1.2`)
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - claude/export-center-sheet-settings-gkormo
+    tags:
+      - 'plugin-*'
 
 permissions:
   contents: write
@@ -23,7 +27,6 @@ jobs:
   release:
     name: Build & publish plugin release
     runs-on: windows-latest
-    if: contains(github.event.head_commit.message, '[release]')
     steps:
       - uses: actions/checkout@v4
 
@@ -69,14 +72,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          $tag = "plugin-build-${{ github.run_number }}"
+          $tag = if ("${{ github.ref_type }}" -eq "tag") { "${{ github.ref_name }}" } else { "plugin-build-${{ github.run_number }}" }
           gh release create "$tag" `
             --target "${{ github.sha }}" `
             "CompiledPlugin/StingTools.dll" `
             "StingTools-CompiledPlugin.zip" `
             --title "STING Tools plugin — $tag" `
             --notes @"
-          Prebuilt STING Tools plugin. Includes the Export Centre fixes: OnePerSheet PDF filename + reliable success + watermark, Image path robustness, ISO 19650 CDE autolocation, and Select all / Deselect all.
+          Prebuilt STING Tools plugin, built on Windows against the real Revit 2025 reference assemblies.
 
           Deploy (with Revit closed):
           1. Download **StingTools.dll** below.
@@ -84,5 +87,5 @@ jobs:
           3. Copy the downloaded StingTools.dll into that folder, overwriting the old one.
           4. Start Revit.
 
-          For a clean install use **StingTools-CompiledPlugin.zip** (DLL + dependencies + data). Only StingTools.dll changed this round.
+          For a clean install use **StingTools-CompiledPlugin.zip** (DLL + dependencies + data).
           "@


### PR DESCRIPTION
## What & why

The `plugin-release.yml` workflow was added during the Export Centre work (PR #483) to cut downloadable, Windows‑built plugin releases so the fixes could be deployed into Revit without a local build. It was wired to a **one‑off trigger** — push to the `claude/export-center-sheet-settings-gkormo` feature branch, gated on a `[release]` marker in the commit message.

Now that PR #483 is merged, that trigger points at a branch that no longer exists (or is about to be deleted) — **dead config on `main`** that can never fire.

## Change

Rather than delete the workflow, **repurpose it into a proper, reusable release pipeline** (single file, `.github/workflows/plugin-release.yml`):

- **Trigger:** `workflow_dispatch` (Actions tab → *Plugin Release* → **Run workflow**) **or** a `plugin-*` tag push. Removed the feature‑branch trigger and the `[release]` commit‑message gate.
- **Release tag:** uses the pushed tag name on a tag trigger, else `plugin-build-<run_number>` for manual dispatch (`--target` the run's SHA).
- **Notes:** genericised (no longer references the export‑centre fixes specifically).
- **Build/package/publish steps are unchanged** — still builds `StingTools.csproj` on `windows-latest` against the real Revit 2025 reference assemblies and publishes `StingTools.dll` + `StingTools-CompiledPlugin.zip` as release assets.

## Effect

`main` keeps a working "build a downloadable plugin DLL on demand" capability, and there's no dead branch reference. Nothing else changes.

## Testing

Workflow‑only change; not exercised from this PR (it won't run on `pull_request`). After merge it can be run from the Actions tab or by pushing a `plugin-*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ake5EnTuF28C2R46XjYLg

---
_Generated by [Claude Code](https://claude.ai/code/session_011ake5EnTuF28C2R46XjYLg)_