### PR TITLE
fix(tags): plumbing tag-pipeline audit fixes (vent→SAN, seed PROD codes, containers)

### DIFF
--- a/StingTools/Core/ISO19650Validator.cs
+++ b/StingTools/Core/ISO19650Validator.cs
@@ -590,7 +590,9 @@ namespace StingTools.Core
                     "BOL", "UPL", "FLD", "EML", "TRK", "DEC", "CDT", "CFT", "CBLT", "CTF", "SLV", "GEN" } },
                 { "P", new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
                     "PP", "PFT", "PAC", "FPP", "FIX", "WC", "WHB", "URN", "SNK", "SHW",
-                    "BTH", "DRK", "CWL", "TRP", "BID", "EWS", "MOP", "SLV", "GEN" } },
+                    "BTH", "DRK", "CWL", "TRP", "BID", "EWS", "MOP",
+                    "WCAC", "BSAC", "SHWC", "SHTR", "CALD", "CYLV", "PMPT", "PEQ",
+                    "SLV", "GEN" } },
                 { "FP", new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
                     "SPR", "FAD", "SML", "MCP", "BLL", "STB", "HTD", "FIM", "PP", "PFT",
                     "PAC", "SLV", "GEN" } },

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -1732,6 +1732,13 @@ namespace StingTools.Core
                 if (!string.IsNullOrEmpty(hwsFunc)) return hwsFunc;
             }
 
+            // For SAN, a vent/soil-vent pipe gets FUNC=VNT (validator allows SAN→VNT)
+            if (sysCode == "SAN")
+            {
+                string sanFunc = GetSanSubFunction(el);
+                if (!string.IsNullOrEmpty(sanFunc)) return sanFunc;
+            }
+
             return FuncMap.TryGetValue(sysCode, out string val) ? val : string.Empty;
         }
 
@@ -1810,6 +1817,42 @@ namespace StingTools.Core
                 if (familyName.Contains("CALORIFIER") || familyName.Contains("WATER HEATER")) return "DHW";
             }
             catch (Exception ex) { StingLog.Warn($"HWS sub-function detection failed: {ex.Message}"); }
+            return null;
+        }
+
+        /// <summary>
+        /// Detect SAN sub-function: a vent / soil-vent pipe gets FUNC=VNT
+        /// (BS EN 12056-2). Reads from connector system name, pipe system type
+        /// parameter, and family name.
+        /// </summary>
+        private static string GetSanSubFunction(Element el)
+        {
+            try
+            {
+                FamilyInstance fi = el as FamilyInstance;
+                if (fi?.MEPModel?.ConnectorManager != null)
+                {
+                    foreach (Connector conn in fi.MEPModel.ConnectorManager.Connectors)
+                    {
+                        if (conn.MEPSystem != null)
+                        {
+                            string sysName = conn.MEPSystem.Name?.ToUpperInvariant() ?? "";
+                            if (sysName.Contains("VENT")) return "VNT";
+                        }
+                    }
+                }
+
+                Parameter pipeSys = el.get_Parameter(BuiltInParameter.RBS_PIPING_SYSTEM_TYPE_PARAM);
+                if (pipeSys != null && pipeSys.HasValue)
+                {
+                    string val = pipeSys.AsValueString()?.ToUpperInvariant() ?? "";
+                    if (val.Contains("VENT")) return "VNT";
+                }
+
+                string familyName = ParameterHelpers.GetFamilyName(el).ToUpperInvariant();
+                if (familyName.Contains("VENT")) return "VNT";
+            }
+            catch (Exception ex) { StingLog.Warn($"SAN sub-function detection failed: {ex.Message}"); }
             return null;
         }
 
@@ -3218,7 +3261,11 @@ namespace StingTools.Core
             if (sysName.Contains("EXHAUST") || sysName.Contains("EXTRACT")) return "HVAC";
             if (sysName.Contains("FRESH AIR") || sysName.Contains("OUTSIDE AIR")) return "HVAC";
             if (sysName.Contains("CHILLED") || sysName.Contains("COOLING")) return "HVAC";
-            if (sysName.Contains("VENT") || sysName.Contains("VENTILATION")) return "HVAC";
+            // Air ventilation is duct/HVAC. For pipe categories, "Vent" = sanitary soil-vent
+            // pipe (BS EN 12056-2) — fall through to the SAN block below.
+            if ((sysName.Contains("VENT") || sysName.Contains("VENTILATION"))
+                && !_pipeCategories.Contains(categoryName ?? ""))
+                return "HVAC";
             // Abbreviated HVAC system names (Revit defaults and common shorthand)
             if (sysName == "SA" || sysName.StartsWith("SA ") || sysName.Contains(" SA ")) return "HVAC";
             if (sysName == "RA" || sysName.StartsWith("RA ") || sysName.Contains(" RA ")) return "HVAC";
@@ -3261,6 +3308,7 @@ namespace StingTools.Core
             if (sysName.Contains("DRAIN") || sysName.Contains("SEWAGE") || sysName.Contains("FOUL")) return "SAN";
             // Abbreviated sanitary
             if (sysName == "SVP" || sysName == "WP" || sysName.StartsWith("SVP ") || sysName.StartsWith("WP ")) return "SAN";
+            if (sysName.Contains("VENT")) return "SAN";  // pipe vent; HVAC vent handled above
 
             // Rainwater
             if (sysName.Contains("RAINWATER") || sysName.Contains("STORM") || sysName.Contains("SURFACE WATER")) return "RWD";

--- a/StingTools/Data/PARAMETER_REGISTRY.json
+++ b/StingTools/Data/PARAMETER_REGISTRY.json
@@ -26645,7 +26645,9 @@
         "Pipe Fittings",
         "Pipe Accessories",
         "Flex Pipes",
-        "Plumbing Fixtures"
+        "Plumbing Fixtures",
+        "Plumbing Equipment",
+        "Pipe Insulation"
       ],
       "params": [
         {

--- a/StingTools/Data/Seeds/STING_SEED_PlumbingEquipment.json
+++ b/StingTools/Data/Seeds/STING_SEED_PlumbingEquipment.json
@@ -237,7 +237,7 @@
           "name": "CALORIFIER_DIRECT",
           "params": {
             "PLM_EQP_TYPE_TXT": "CALORIFIER_DIRECT",
-            "ASS_PRODCT_COD_TXT": "CAL-D",
+            "ASS_PRODCT_COD_TXT": "CALD",
             "PLM_EQP_CAPACITY_LITRES": "200",
             "PLM_EQP_HEAT_OUTPUT_KW": "9"
           }
@@ -258,7 +258,7 @@
           "name": "DHW_CYLINDER_VENTED",
           "params": {
             "PLM_EQP_TYPE_TXT": "DHW_CYLINDER_VENTED",
-            "ASS_PRODCT_COD_TXT": "CYL-V",
+            "ASS_PRODCT_COD_TXT": "CYLV",
             "PLM_EQP_CAPACITY_LITRES": "140",
             "PLM_EQP_HEAT_OUTPUT_KW": "3"
           }
@@ -286,7 +286,7 @@
           "name": "PUMP_TWIN_SET",
           "params": {
             "PLM_EQP_TYPE_TXT": "PUMP_TWIN_SET",
-            "ASS_PRODCT_COD_TXT": "PMP-T"
+            "ASS_PRODCT_COD_TXT": "PMPT"
           }
         },
         {

--- a/StingTools/Data/Seeds/STING_SEED_PlumbingFixture.json
+++ b/StingTools/Data/Seeds/STING_SEED_PlumbingFixture.json
@@ -289,7 +289,7 @@
           "name": "SHOWER_TRAY",
           "params": {
             "PLM_FIX_TYPE_TXT": "SHOWER_TRAY",
-            "ASS_PRODCT_COD_TXT": "STR",
+            "ASS_PRODCT_COD_TXT": "SHTR",
             "PLM_FIX_FLOWRATE_LMIN": "12",
             "PLM_FIX_DRAIN_DN_MM": "50"
           }
@@ -367,7 +367,7 @@
           "name": "ACCESSIBLE_WC",
           "params": {
             "PLM_FIX_TYPE_TXT": "WC",
-            "ASS_PRODCT_COD_TXT": "WC-ACC",
+            "ASS_PRODCT_COD_TXT": "WCAC",
             "PLM_FIX_FLOWRATE_LMIN": "9",
             "PLM_FIX_DRAIN_DN_MM": "100",
             "PLM_FIX_HOT_COLD_TXT": "COLD",
@@ -378,7 +378,7 @@
           "name": "ACCESSIBLE_BASIN",
           "params": {
             "PLM_FIX_TYPE_TXT": "BASIN",
-            "ASS_PRODCT_COD_TXT": "BAS-ACC",
+            "ASS_PRODCT_COD_TXT": "BSAC",
             "PLM_FIX_FLOWRATE_LMIN": "6",
             "PLM_FIX_DRAIN_DN_MM": "40",
             "PLM_FIX_HOT_COLD_TXT": "HOT_COLD",
@@ -389,7 +389,7 @@
           "name": "SHOWER_WHEELCHAIR",
           "params": {
             "PLM_FIX_TYPE_TXT": "SHOWER_WHEELCHAIR",
-            "ASS_PRODCT_COD_TXT": "SHW-WC",
+            "ASS_PRODCT_COD_TXT": "SHWC",
             "PLM_FIX_FLOWRATE_LMIN": "12",
             "PLM_FIX_DRAIN_DN_MM": "50",
             "PLM_FIX_HOT_COLD_TXT": "HOT_COLD",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1075,3 +1075,24 @@ so LookupParameter hits directly), and rekey the 998 entries; (2) add the 8 new
 command copying `PRJ_TB_* -> PRJ_ORG_*` on ProjectInformation (SetIfEmpty);
 (5) regenerate STING_TITLE_BLOCK_PARAMETERS.txt; (6) run TitleBlock_CreateAll +
 verify the stamp fills from PRJ_ORG_* in Revit.
+
+## Plumbing tag pipeline — audit follow-ups (branch claude/plumbing-tag-fixes)
+
+FIX 1–4 from the plumbing ISO-19650 tagging audit **landed** on
+`claude/plumbing-tag-fixes` (soil/vent pipes → SAN, hyphen-free seed PROD codes,
+validator PROD allow-list additions, Plumbing Equipment + Pipe Insulation containers).
+The two items below were deliberately left as follow-ups — coupling / ambiguity risk:
+
+- **BUG-2 — live auto-tagging skips pipe/duct curves.** `StingAutoTagger`'s live
+  category list (`Core/StingAutoTagger.cs`, ~line 1106-1131) omits `OST_PipeCurves`,
+  `OST_FlexPipeCurves`, and `OST_DuctCurves`, so pipe/duct/flex curves are not
+  real-time auto-tagged. Adding them is entangled with the MEP run-policy declutter
+  guard on branch `claude/mep-tag-declutter-advice` (PR #395): adding the categories
+  WITHOUT that guard would re-introduce one-tag-per-segment clutter live. Do it as a
+  follow-up on top of PR #395, not in the plumbing-tag-fixes branch.
+
+- **BUG-3 — unassigned pipes fall back to the disc-default SYS.** A pipe with no
+  assigned Revit piping system falls back to the discipline-default SYS; for the "M"
+  default that is "HVAC", so unconnected domestic-water / drainage pipes tag as
+  Mechanical. No safe automatic fix (the pipe categories are shared between mechanical
+  and plumbing) — treat as "assign piping systems before tagging". Advisory only.


### PR DESCRIPTION
End-to-end audit of the plumbing ISO-19650 tagging pipeline. Each finding was confirmed by direct code inspection. **Not verified in Revit** — build-verified only (Release build: 0 errors, 0 new warnings).

## Fixes

**FIX 1 (HIGH) — Soil/vent pipes mis-tag as HVAC instead of sanitary**
`StingTools/Core/TagConfig.cs` — `MapSystemNameToCode`. The `VENT`→`HVAC` rule ran before the sanitary block, so Revit's default sanitary "Vent" piping system (and "Soil & Vent", "SVP Stack", …) mapped to HVAC → a soil-vent stack tagged `M-…-HVAC` instead of `P-…-SAN`. Gated `VENT`→`HVAC` to non-pipe categories via the existing `_pipeCategories` set (TagConfig.cs:3221), and added a pipe-vent→`SAN` catch after the sanitary lines (TagConfig.cs:3264). Also added `GetSanSubFunction` so a SAN vent pipe gets `FUNC=VNT` (validator already allows SAN→VNT) — `GetSmartFuncCode` (TagConfig.cs:1716) + new helper.

**FIX 2 (MED) — Seed PROD codes contained the tag separator "-"**
`Data/Seeds/STING_SEED_PlumbingFixture.json` + `STING_SEED_PlumbingEquipment.json`. Hyphenated PROD codes produced a 9-segment tag that failed validation on the token-inherit (non-overwrite) path. Renamed: `WC-ACC`→`WCAC`, `BAS-ACC`→`BSAC`, `SHW-WC`→`SHWC`, `CAL-D`→`CALD`, `CYL-V`→`CYLV`, `PMP-T`→`PMPT`. BUG-5: `SHOWER_TRAY` used `STR` (validator reads as architectural/stairs → spurious cross-disc error) → `SHTR`.

**FIX 3 (LOW→MED) — Register plumbing PROD codes in the validator allow-list**
`StingTools/Core/ISO19650Validator.cs` — `ProdCodesByDisc["P"]` (ISO19650Validator.cs:591). Added `WCAC, BSAC, SHWC, SHTR, CALD, CYLV, PMPT, PEQ` (PEQ = ProdMap default for "Plumbing Equipment", previously unrecognised).

**FIX 4 (LOW) — Plumbing Equipment & Pipe Insulation get no discipline container**
`Data/PARAMETER_REGISTRY.json` — the `PLM_EQP` container group (~line 26640) omitted "Plumbing Equipment" and "Pipe Insulation" though both have tag families. Added both so they receive the `PLM_EQP_TAG_*` containers.

## Documented (not coded)
`docs/ROADMAP.md` gained a "Plumbing tag pipeline — audit follow-ups" section recording **BUG-2** (live auto-tagging omits pipe/duct curves — depends on the declutter guard in **PR #395**, do as a follow-up on top of it) and **BUG-3** (unassigned pipes fall back to disc-default SYS→HVAC; advisory only).

## Verification
- Release build: `0 Error(s)`, no new warnings (repo baseline is 0/0 per current main).
- All three edited JSON files re-parsed clean.
- Re-grep confirmed no remaining `-` in any `ASS_PRODCT_COD_TXT` value in the two plumbing seed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)