### PR TITLE
fix(sync): adopt a blank token from the set side, per-token, before LWW

### DIFF
--- a/StingBridge/tests/e2e_ifc_pull_reconcile.py
+++ b/StingBridge/tests/e2e_ifc_pull_reconcile.py
@@ -247,6 +247,25 @@ def main() -> int:
             fail("cursor file was not written")
         ok(f"SEQ unchanged, ZERO re-minted; adopted via pull ({rec2}); cursor persisted")
 
+        # ── 2b. a FRESH re-export, dated NEWER than the server, still adopts ─
+        # The real ArchiCAD case: a new export lands with a current mtime, so it
+        # is NEWER than the server rows the last drop created. Under per-element
+        # LWW the newer local (with its blank SEQ) would win and re-mint every
+        # number — identity churn + counter burn. The per-token adopt-empty rule
+        # (P1) fills the blank SEQ from the server regardless of the newer clock,
+        # so this mints ZERO too. This is the scenario that was red before P1.
+        step("A FRESH re-export dated NEWER than the server must still adopt, not re-mint")
+        write_untagged(src)                        # brand-new export, blank tokens
+        touch(src, time.time() + 3600)             # dated an hour ahead: newest wins LWW
+        r2b = drop(src)
+        if r2b["errors"]:
+            fail(f"fresh re-export drop errored: {r2b['errors']}")
+        toks2b = read_tokens(out)
+        if (toks2b.get(GID_A, {}).get(_SEQ), toks2b.get(GID_B, {}).get(_SEQ)) != (seq_a, seq_b):
+            fail("a NEWER re-export re-minted SEQ — the adopt-empty rule did not fire "
+                 f"(was {seq_a}/{seq_b}, now {toks2b.get(GID_A,{}).get(_SEQ)}/{toks2b.get(GID_B,{}).get(_SEQ)})")
+        ok(f"newer re-export still adopted server SEQs ({seq_a}/{seq_b}); ZERO re-minted")
+
         # ── 3. server-side edit reaches the written-back IFC ────────────────
         step("Edit A's zone SERVER-side (newer) — re-drop carries it into the IFC")
         cli = _Client()
@@ -280,8 +299,13 @@ def main() -> int:
         if not local_b or local_b == "SRVOLD":
             fail(f"local inference unexpectedly produced the server value ({local_b!r})")
         rec4 = r4.get("reconcile") or {}
-        if not rec4.get("kept_local"):
-            fail(f"a newer local export did not win (reconcile={rec4})")
+        # Under the P1 per-token merge the contested ZONE resolves to the newer
+        # local value, while the blank local SEQ is adopted from the server — so
+        # the element is a merged WRITE (applied), not a bare kept_local. The
+        # proof that "local won" is therefore the recorded conflict plus the
+        # written-back/served value being the local one, not the count bucket.
+        if not rec4.get("conflicts"):
+            fail(f"the stale-server zone disagreement was not surfaced (reconcile={rec4})")
         srv_b = cli.server_zone(GID_B)
         if srv_b != local_b:
             fail(f"local value was not pushed to the server "

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 226 — reconcile: adopt a blank token from the set side, per-token, before LWW)
+
+A live verification of SB-5a surfaced a real defect in the shared reconcile
+engine (`stingtools_core/sync/reconcile.py`): it decided remote-vs-local **per
+element**, so a token that was blank on one side and set on the other was still
+run through last-writer-wins. The consequence bites every re-export: a fresh
+ArchiCAD/IFC export carries no `STING_TOKENS` pset, so **every** token is blank
+locally and the file's mtime is *newer* than the server rows the last drop
+created. Per-element LWW handed the whole element to the newer local copy — and
+its blank SEQ — so all the server's known SEQs were **re-minted from scratch on
+every re-export**: identity churn and counter burn.
+
+**The rule change.** Reconciliation is now per token. A token empty on one side
+and set on the other is **adopted from the set side regardless of timestamps**,
+and is not a conflict — filling a blank is never a loss, so it never waits on a
+clock. Only tokens set-and-differing on both sides are genuinely contested and go
+to the unchanged LWW + content-digest tiebreak. The result is a **merge**: blanks
+fill from whichever host has the value; contested tokens resolve by time. Applied
+uniformly across all `TOKEN_KEYS`, most consequentially `seq`.
+
+- **Direction matters and is symmetric.** Server has a value the file lacks →
+  adopt it into the file (and mint nothing). File has a value the server lacks →
+  keep it and the push half sends it up. Both sides set and different → LWW.
+- **The subtle case is handled:** an element can lose a genuine zone
+  disagreement to a newer local edit *and still* adopt the server's SEQ into its
+  blank — one element, one merged write, one reported conflict.
+- **Adversarial unit tests** (`tests/test_sync_reconcile.py`, +5): blank-local
+  adopts the server SEQ even when local is newer; all-blank local adopts every
+  server token and mints nothing; blank-remote keeps and pushes the local value;
+  disjoint blanks merge from both sides; a filled blank and a real conflict
+  coexist. All five are **red before this change** (verified by reverting the
+  engine) and green after. The existing 33 LWW/tiebreak tests are unchanged.
+- **Live E2E** (`e2e_ifc_pull_reconcile.py`, scenario 2b, new): seed the project
+  with one drop, regenerate the fixture **fresh and dated newer than the server**,
+  drop it — SEQ is adopted, **zero re-minted**. Red before this change (the newer
+  file re-minted); green after. Full run green against the refreshed local stack.
+
+Core suite 101 passed, StingBridge suite 170 passed. Bumped nothing; no release.
+The live-ArchiCAD path in `sync/engine.py` (SB-5b) is untouched.
+
 #### Completed (Phase 225 — SB-5a: IFC watcher wired to pull → reconcile → push)
 
 The multi-host sync engine landed in Phase 207 (corrected 214) and was verified

--- a/stingtools-core/python/stingtools_core/sync/reconcile.py
+++ b/stingtools-core/python/stingtools_core/sync/reconcile.py
@@ -13,25 +13,39 @@ The rules, stated once so every host behaves identically:
 3. **Equal payloads** → no-op, whatever the timestamps say. Applying a delta
    that changes nothing still costs a host write and, in Blender/Revit, an undo
    entry.
-4. **Both changed, timestamps differ** → newer wins.
-5. **Both changed, timestamps equal** → the higher **content digest** wins.
-   Preferring "local" reads as the kind choice but is the one rule that cannot
-   converge: run the same reconcile on both hosts and each keeps its own value
-   forever, with no later edit to break the tie. The digest is a pure function of
-   the token payload, so both hosts compute the *same* winner from the same pair
-   and agree on the first pass. Still reported as a conflict.
-6. **Both changed, remote timestamp missing/unparseable** → local wins. An
-   unordered remote edit cannot be shown to be newer, and silently overwriting
-   the user's work on the strength of a missing field is the worst failure here.
 
-Every conflict is *reported* whether or not it was applied, so §1.4.3's
-"surface the loser rather than clobbering silently" has something to surface.
+Then reconciliation is **per token**, not per element (see `_resolve`):
+
+4. **Blank vs set** — a token that is empty/missing on one side and set on the
+   other is **adopted from the set side, regardless of timestamps**, and is NOT
+   a conflict. This is the asymmetry that matters most for `seq`: a freshly
+   re-exported IFC carries no STING pset, so *every* token is blank locally.
+   Under a per-element LWW the newer export would "win" and the server's known
+   SEQs would be re-minted from scratch — identity churn and counter burn on
+   every re-export. Filling a blank from the other host is never a loss, so it
+   never waits on a clock. Applied uniformly to all `TOKEN_KEYS`.
+5. **Set vs set, differing** — the only genuine conflict — resolves by
+   last-writer-wins on the element's timestamps:
+   - timestamps differ → newer wins;
+   - timestamps equal → higher **content digest** wins (a pure function of the
+     payload, so both hosts pick the *same* winner and converge on the first
+     pass — preferring "local" here never converges);
+   - remote timestamp missing/unparseable → local wins (an unordered remote edit
+     cannot be shown newer, and clobbering the user on a missing field is the
+     worst failure);
+   - local timestamp missing → remote wins, and this is NOT a conflict (an
+     element the host has never written).
+
+The result is a **merge**: blanks are filled from whichever side has the value,
+and only truly contested tokens go to LWW. Every genuine conflict is *reported*
+whether or not it was applied, so §1.4.3's "surface the loser rather than
+clobbering silently" has something to surface; a blank-fill is not one.
 """
 from __future__ import annotations
 
 import hashlib
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Optional
 
@@ -148,7 +162,11 @@ class ReconcileEngine:
             resolution = self._resolve(delta, local)
 
             if resolution.winner == "remote":
-                ok = self._apply(delta)
+                # Apply what reconciliation DECIDED — the merged payload (blanks
+                # filled per token, contested tokens resolved) — not the raw
+                # remote delta, which may carry blanks this host had already
+                # filled locally.
+                ok = self._apply(resolution.delta or delta)
                 resolution.applied = ok
                 if ok:
                     result.applied += 1
@@ -188,48 +206,104 @@ class ReconcileEngine:
         if tokens_equal(local_tokens, remote_tokens):
             return Resolution(gid, "none", "payloads identical", delta=delta)
 
+        # ── Per-token classification (rules 4 & 5) ───────────────────────────
+        # A token blank on one side and set on the other is ADOPTED from the set
+        # side regardless of timestamps — never a conflict (rule 4). Only tokens
+        # set-and-differing on both sides are genuinely contested (rule 5).
+        adopt_remote, adopt_local, contested = [], [], []
+        for k in TOKEN_KEYS:
+            lv, rv = str(local_tokens.get(k) or ""), str(remote_tokens.get(k) or "")
+            if lv == rv:
+                continue
+            if not lv:
+                adopt_remote.append(k)      # remote fills a local blank
+            elif not rv:
+                adopt_local.append(k)       # local fills a remote blank
+            else:
+                contested.append(k)         # a real value-vs-value disagreement
+
+        # Contested tokens (if any) are decided by last-writer-wins on the
+        # element timestamps. Blank-fills below are applied regardless.
+        contested_winner, conflict, lww_reason = (
+            self._lww(delta, local, local_tokens, remote_tokens)
+            if contested else (None, False, None)
+        )
+
+        # Build the merged winning token map: equal → that value; blank-vs-set →
+        # the set value; contested → the LWW winner's value.
+        merged = dict(remote_tokens)
+        for k in TOKEN_KEYS:
+            lv, rv = local_tokens.get(k), remote_tokens.get(k)
+            lvs, rvs = str(lv or ""), str(rv or "")
+            if lvs == rvs or not lvs:
+                merged[k] = rv                       # equal, or adopt remote
+            elif not rvs:
+                merged[k] = lv                       # adopt local into the blank
+            else:
+                merged[k] = rv if contested_winner == "remote" else lv
+
+        reason = self._merge_reason(lww_reason, adopt_remote, adopt_local)
+
+        # If the merge leaves every token at its local value, no write is needed
+        # — the push half carries any local-only fills up to the server.
+        writes = any(str(merged.get(k) or "") != str(local_tokens.get(k) or "")
+                     for k in TOKEN_KEYS)
+        if not writes:
+            return Resolution(gid, "local", reason, conflict=conflict, delta=delta)
+
+        return Resolution(gid, "remote", reason, conflict=conflict,
+                          delta=replace(delta, payload=merged))
+
+    @staticmethod
+    def _merge_reason(lww_reason, adopt_remote, adopt_local) -> str:
+        # Kept exact for the reasons the tests pin (e.g. "remote has no usable
+        # timestamp"): when nothing was blank-filled, the reason IS the LWW
+        # reason verbatim.
+        bits = []
+        if lww_reason:
+            bits.append(lww_reason)
+        if adopt_remote:
+            bits.append(f"adopt remote for blank {','.join(adopt_remote)}")
+        if adopt_local:
+            bits.append(f"keep local for blank {','.join(adopt_local)}")
+        return "; ".join(bits) or "no change"
+
+    def _lww(self, delta: ChangeDelta, local: dict,
+             local_tokens: dict, remote_tokens: dict) -> tuple[Optional[str], bool, str]:
+        """Resolve genuinely-contested tokens. Returns (winner, conflict, reason).
+
+        `winner` is "remote" or "local"; `conflict` is whether the loser must be
+        surfaced. Preserved verbatim from the original element-level rules so the
+        set-vs-set cases behave exactly as before.
+        """
         remote_ts = parse_utc(delta.last_modified_utc)
         local_ts = parse_utc(local.get("modified_utc"))
 
-        # Rule 6 — an unordered remote edit cannot be shown to be newer.
+        # An unordered remote edit cannot be shown to be newer.
         if remote_ts is None:
-            return Resolution(gid, "local", "remote has no usable timestamp",
-                              conflict=True, delta=delta)
+            return "local", True, "remote has no usable timestamp"
 
-        # No local timestamp: the local copy cannot defend itself, so the
-        # ordered remote edit wins. This is the common case for an element the
-        # host has never written — not a real conflict.
+        # No local timestamp: the local copy cannot defend itself, so the ordered
+        # remote edit wins. Common for an element the host never wrote — not a
+        # real conflict.
         if local_ts is None:
-            return Resolution(gid, "remote", "no local timestamp", delta=delta)
+            return "remote", False, "no local timestamp"
 
-        # Rules 4 and 5.
         if remote_ts > local_ts:
-            return Resolution(gid, "remote", f"remote newer ({remote_ts.isoformat()})",
-                              conflict=True, delta=delta)
+            return "remote", True, f"remote newer ({remote_ts.isoformat()})"
         if local_ts > remote_ts:
-            return Resolution(gid, "local", f"local newer ({local_ts.isoformat()})",
-                              conflict=True, delta=delta)
-        # Rule 5 (equal timestamps) — decide by content hash, NOT by "local".
-        #
-        # Preferring local here is the one choice that cannot converge: run the
-        # same reconcile on both hosts and each keeps its own value, forever,
-        # with no further edit to break the tie. Two clocks agreeing to the
-        # second is not rare — a batch write, or a coarse timestamp column.
-        #
-        # The digest is a pure function of the token payload, so both hosts
-        # compute the SAME winner from the same pair of values and converge on
-        # the first pass. It is still reported as a conflict.
+            return "local", True, f"local newer ({local_ts.isoformat()})"
+
+        # Equal timestamps — decide by content hash, NOT by "local". Preferring
+        # local is the one choice that cannot converge; the digest is a pure
+        # function of the payload so both hosts pick the SAME winner.
         local_digest = token_digest(local_tokens)
         remote_digest = token_digest(remote_tokens)
         if remote_digest > local_digest:
-            return Resolution(gid, "remote",
-                              f"timestamps equal - remote wins content tiebreak "
-                              f"({remote_digest[:8]} > {local_digest[:8]})",
-                              conflict=True, delta=delta)
-        return Resolution(gid, "local",
-                          f"timestamps equal - local wins content tiebreak "
-                          f"({local_digest[:8]} > {remote_digest[:8]})",
-                          conflict=True, delta=delta)
+            return "remote", True, (f"timestamps equal - remote wins content tiebreak "
+                                    f"({remote_digest[:8]} > {local_digest[:8]})")
+        return "local", True, (f"timestamps equal - local wins content tiebreak "
+                               f"({local_digest[:8]} > {remote_digest[:8]})")
 
     def _apply(self, delta: ChangeDelta) -> bool:
         try:

--- a/stingtools-core/python/tests/test_sync_reconcile.py
+++ b/stingtools-core/python/tests/test_sync_reconcile.py
@@ -252,6 +252,83 @@ def test_category_and_family_are_still_excluded():
     assert adapter.applied == []
 
 
+# ── rule 4: blank-vs-set is adoption, not a conflict (P1) ─────────────────────
+
+def test_blank_local_seq_adopts_the_server_seq_even_when_local_is_newer():
+    """A fresh re-export (no STING pset, newest mtime) must NOT re-mint: the
+    server's SEQ fills the local blank regardless of the newer local timestamp."""
+    a = _Adapter()
+    local_side = tokens(seq="")                       # every inferred token, blank seq
+    r = ReconcileEngine(a).reconcile(
+        [delta(ts=NOW - timedelta(hours=1), seq="0042")],   # server OLDER…
+        {"g1": {"tokens": local_side, "modified_utc": iso(NOW), "element": "h"}})  # …local NEWER
+    assert r.applied == 1, "the blank seq must be filled from the server"
+    assert a.applied[0].payload["seq"] == "0042"
+    assert r.conflicts == [], "filling a blank is not a conflict"
+
+
+def test_all_blank_local_adopts_every_server_token_and_mints_nothing():
+    """The whole-element case: an untagged export adopts every server token."""
+    a = _Adapter()
+    blank = {k: "" for k in
+             ("disc", "loc", "zone", "lvl", "sys", "func", "prod", "seq", "status")}
+    server = tokens(seq="0007")
+    r = ReconcileEngine(a).reconcile(
+        [ChangeDelta(kind="tag", global_id="g1", payload=server,
+                     last_modified_utc=iso(NOW - timedelta(days=1)))],  # server older
+        {"g1": {"tokens": blank, "modified_utc": iso(NOW), "element": "h"}})  # local newest
+    assert r.applied == 1
+    for k in ("disc", "seq", "sys"):
+        assert a.applied[0].payload[k] == server[k]
+    assert r.conflicts == [], "adopting into blanks is not a conflict"
+
+
+def test_blank_remote_keeps_and_pushes_the_local_value():
+    """Reverse direction: the server lacks a value the file has → local kept,
+    the push half sends it up, and the server value is never blanked out."""
+    a = _Adapter()
+    remote_blank_seq = tokens(seq="")
+    r = ReconcileEngine(a).reconcile(
+        [ChangeDelta(kind="tag", global_id="g1", payload=remote_blank_seq,
+                     last_modified_utc=iso(NOW + timedelta(hours=1)))],  # server NEWER
+        {"g1": local(ts=NOW, seq="0099")})                              # file has the seq
+    assert r.kept_local == 1, "a value the server lacks must not blank out the file"
+    assert a.applied == []
+    assert r.conflicts == []
+
+
+def test_disjoint_blanks_merge_from_both_sides():
+    """Server fills seq, file fills zone — both survive, no conflict."""
+    a = _Adapter()
+    local_side = tokens(seq="", zone="Z09")      # local: zone set, seq blank
+    remote_side = tokens(seq="0042", zone="")    # remote: seq set, zone blank
+    r = ReconcileEngine(a).reconcile(
+        [ChangeDelta(kind="tag", global_id="g1", payload=remote_side,
+                     last_modified_utc=iso(NOW))],
+        {"g1": {"tokens": local_side, "modified_utc": iso(NOW), "element": "h"}})
+    assert r.applied == 1
+    assert a.applied[0].payload["seq"] == "0042", "seq adopted from the server"
+    assert a.applied[0].payload["zone"] == "Z09", "zone kept from the file"
+    assert r.conflicts == [], "disjoint blank-fills are not a conflict"
+
+
+def test_local_wins_the_contest_but_still_adopts_the_server_blank_fill():
+    """The subtle merge: local wins a genuine zone disagreement AND still adopts
+    the server's SEQ into its blank — one element, one write, one conflict."""
+    a = _Adapter()
+    local_side = tokens(seq="", zone="Z01")      # local zone Z01, seq blank
+    remote_side = tokens(seq="0042", zone="Z99")  # server zone Z99, seq set
+    r = ReconcileEngine(a).reconcile(              # LOCAL newer → local zone wins
+        [ChangeDelta(kind="tag", global_id="g1", payload=remote_side,
+                     last_modified_utc=iso(NOW))],
+        {"g1": {"tokens": local_side,
+                "modified_utc": iso(NOW + timedelta(minutes=5)), "element": "h"}})
+    assert r.applied == 1, "a write is still needed — to adopt the server's seq"
+    assert a.applied[0].payload["seq"] == "0042", "blank-fill adopted despite losing zone"
+    assert a.applied[0].payload["zone"] == "Z01", "local won the real disagreement"
+    assert len(r.conflicts) == 1, "only the zone was a genuine conflict"
+
+
 # ── rule 6: missing timestamps ───────────────────────────────────────────────
 
 def test_remote_without_a_timestamp_cannot_win():


### PR DESCRIPTION
Round **P1**. A live verification of SB-5a (#457) surfaced a real defect in the shared reconcile engine.

## The bug
`stingtools_core/sync/reconcile.py` decided remote-vs-local **per element**, so a token blank on one side and set on the other still ran through last-writer-wins. Every re-export bites this: a fresh ArchiCAD/IFC export carries no `STING_TOKENS` pset (all tokens blank) and a **newer** mtime than the server rows the last drop created, so per-element LWW handed the whole element — and its blank SEQ — to the newer local copy. Result: **all the server's known SEQs re-minted on every re-export** — identity churn + counter burn.

## The fix
Reconciliation is now **per token**. A token empty on one side and set on the other is **adopted from the set side regardless of timestamps** and is not a conflict — filling a blank is never a loss, so it never waits on a clock. Only set-vs-set-differing tokens are contested and go to the unchanged LWW + content-digest tiebreak. The result is a **merge**: blanks fill from whichever host has the value; contested tokens resolve by time. Uniform across all `TOKEN_KEYS`, most consequentially `seq`.

The subtle case is handled: an element can lose a genuine zone disagreement to a newer local edit **and still** adopt the server's SEQ into its blank — one merged write, one reported conflict.

## Proof
- **+5 adversarial unit tests** (`test_sync_reconcile.py`), all **red before** the change (verified by reverting the engine) and green after. The existing **33** LWW/tiebreak tests are unchanged.
- **Live E2E** (`e2e_ifc_pull_reconcile.py` scenario 2b, new): seed via one drop, regenerate the fixture **fresh and dated newer than the server**, drop it → SEQ adopted, **zero re-minted**. Red before, green after; full live run green against the refreshed stack.
- Core **101** + StingBridge **170** pytest green.

No release. `sync/engine.py` (the live-ArchiCAD path, SB-5b) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)