### PR TITLE
fix(drawings): rescue #473 — spot-dim idempotency + O(M²) sheet-number scan

### DIFF
--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -152,6 +152,9 @@ namespace StingTools.Core.Drawing
                     catch (Exception ex) { aux.Warnings.Add("Spot: " + ex.Message); }
                 }
                 stats.DecorativePlaced += aux.DecorativePlaced + aux.SpotsPlaced;
+                // Surface decorative + spot idempotency skips (C-4) so a no-op
+                // re-run reads as "skipped N" rather than looking like a failure.
+                stats.Skipped += aux.Skipped;
                 stats.Warnings.AddRange(aux.Warnings);
             }
 
@@ -1030,9 +1033,67 @@ namespace StingTools.Core.Drawing
             ProcessSpotRules(doc, view, pack.SpotCoordinateRules, isCoordinate: true, result);
         }
 
+        /// <summary>
+        /// Element ids already carrying a spot elevation — or a spot coordinate,
+        /// when <paramref name="isCoordinate"/> is true — in this view. Built
+        /// once per kind and shared across every spot rule: the guard that keeps
+        /// the spot pass from re-stacking a SpotDimension on every run. Like the
+        /// dimension guard (ViewHasDimensionReferencing) it detects an existing
+        /// spot by what it REFERENCES; a spot whose references are unavailable is
+        /// treated as unknown rather than a match. Fails open with a warning so a
+        /// scan failure places spots (previous behaviour) instead of silently
+        /// omitting them.
+        /// </summary>
+        private static HashSet<ElementId> BuildSpottedElementIndex(Document doc, View view, bool isCoordinate, AnnotationResult result)
+        {
+            var set = new HashSet<ElementId>();
+            try
+            {
+                var bic = isCoordinate ? BuiltInCategory.OST_SpotCoordinates : BuiltInCategory.OST_SpotElevations;
+                foreach (var el in new FilteredElementCollector(doc, view.Id)
+                    .OfCategory(bic)
+                    .WhereElementIsNotElementType())
+                {
+                    if (!(el is SpotDimension sd)) continue;
+                    try
+                    {
+                        if (!sd.AreReferencesAvailable) continue;   // unknown — not a match
+                        var refs = sd.References;
+                        if (refs == null) continue;
+                        foreach (Reference r in refs)
+                        {
+                            var host = doc.GetElement(r);
+                            if (host != null && host.Id != ElementId.InvalidElementId) set.Add(host.Id);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"BuildSpottedElementIndex: spot {sd.Id} — {ex.Message}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fail open: an empty index means "place every spot", i.e. the
+                // previous behaviour, rather than silently skipping requested work.
+                result.Warnings.Add($"Could not index existing spot {(isCoordinate ? "coordinates" : "elevations")} " +
+                                    $"in '{view.Name}' ({ex.Message}); duplicate spot dims are possible on this view.");
+            }
+            return set;
+        }
+
         private static void ProcessSpotRules(Document doc, View view, List<SpotAnnotationRule> rules, bool isCoordinate, AnnotationResult result)
         {
             if (rules == null || rules.Count == 0) return;
+
+            // C-4: index elements that already carry a spot dimension of this
+            // kind in the view, once and shared across every rule below, so a
+            // re-run doesn't stack a second SpotElevation / SpotCoordinate onto
+            // each element. The tag, dimension and decorative passes each got an
+            // idempotency guard; the spot pass was the one kind left uncovered,
+            // so re-running DrawingTypePresentation.Apply doubled every spot dim.
+            var spotted = BuildSpottedElementIndex(doc, view, isCoordinate, result);
+
             foreach (var r in rules)
             {
                 if (r == null || string.IsNullOrEmpty(r.Category)) continue;
@@ -1063,6 +1124,14 @@ namespace StingTools.Core.Drawing
                     {
                         try
                         {
+                            // C-4: skip an element that already carries a spot
+                            // dim of this kind so a re-run places nothing.
+                            if (spotted != null && spotted.Contains(el.Id))
+                            {
+                                result.Skipped++;
+                                continue;
+                            }
+
                             var bb = el.get_BoundingBox(view);
                             if (bb == null) continue;
                             var origin = new XYZ((bb.Min.X + bb.Max.X) / 2.0, (bb.Min.Y + bb.Max.Y) / 2.0, bb.Max.Z);
@@ -1078,6 +1147,9 @@ namespace StingTools.Core.Drawing
                                 try { sd.ChangeTypeId(symbolId); } catch { }
                             }
                             result.SpotsPlaced++;
+                            // Keep the index current so a later rule of the same
+                            // kind in this run doesn't re-spot the same element.
+                            spotted?.Add(el.Id);
                         }
                         catch (Exception ex) { result.Warnings.Add($"Spot {(isCoordinate ? "coord" : "elev")} '{r.Category}/{el.Id}': {ex.Message}"); }
                     }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -70,6 +70,11 @@ namespace StingTools.Core.Drawing
         [ThreadStatic] private static Dictionary<string, ElementId> _existingViewCache;
         [ThreadStatic] private static Dictionary<string, ElementId> _existingSheetCache;
         [ThreadStatic] private static Dictionary<string, int>       _packageSheetCount;
+        // GAP-L: the set of sheet numbers in use, primed once per batch so
+        // EnsureUniqueSheetNumber doesn't re-collect every ViewSheet on each
+        // assignment (was O(M²) across an M-sheet batch). Written back as each
+        // number is assigned so later sheets in the same batch see it.
+        [ThreadStatic] private static HashSet<string>               _sheetNumberCache;
         [ThreadStatic] private static string                        _cacheDocKey;
         // P-12: view names, collected once per batch. NameExists ran a full
         // OfClass(View) collector and MakeUniqueViewName calls it up to 100
@@ -136,6 +141,7 @@ namespace StingTools.Core.Drawing
 
                 var s = new Dictionary<string, ElementId>(StringComparer.Ordinal);
                 var pkg = new Dictionary<string, int>(StringComparer.Ordinal);
+                var nums = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var sheet in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)).Cast<ViewSheet>())
                 {
                     var dtId = StingTools.Core.ParameterHelpers.GetString(sheet, DrawingTypeStamper.PARAM_DRAWING_TYPE_ID) ?? string.Empty;
@@ -147,9 +153,13 @@ namespace StingTools.Core.Drawing
                     if (!string.IsNullOrEmpty(dtId)) s[SheetKey(dtId, pkgId, shtCtx)] = sheet.Id;
                     if (pkg.TryGetValue(pkgId, out var n)) pkg[pkgId] = n + 1;
                     else pkg[pkgId] = 1;
+                    // Same pass feeds the sheet-number cache — no extra collector.
+                    try { if (!string.IsNullOrEmpty(sheet.SheetNumber)) nums.Add(sheet.SheetNumber); }
+                    catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
                 }
                 _existingSheetCache = s;
                 _packageSheetCount  = pkg;
+                _sheetNumberCache   = nums;
             }
             catch (Exception ex)
             {
@@ -164,6 +174,7 @@ namespace StingTools.Core.Drawing
             _categoryByName     = null;
             _existingSheetCache = null;
             _packageSheetCount  = null;
+            _sheetNumberCache   = null;
             _cacheDocKey        = null;
         }
 
@@ -1137,34 +1148,66 @@ namespace StingTools.Core.Drawing
         private static string EnsureUniqueSheetNumber(Document doc, string baseNumber, ElementId excludeId, ProduceResult result)
         {
             if (string.IsNullOrEmpty(baseNumber)) return baseNumber;
-            var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            try
-            {
-                foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)))
-                {
-                    if (el is ViewSheet vs && vs.Id != excludeId && !string.IsNullOrEmpty(vs.SheetNumber))
-                        existing.Add(vs.SheetNumber);
-                }
-            }
-            catch (Exception ex)
-            {
-                StingTools.Core.StingLog.Warn($"EnsureUniqueSheetNumber: {ex.Message}");
-                return baseNumber;
-            }
-            if (!existing.Contains(baseNumber)) return baseNumber;
 
-            for (char c = 'A'; c <= 'Z'; c++)
+            // GAP-L: reuse the per-batch sheet-number set when it is primed for
+            // this doc, so an M-sheet batch no longer re-collects every ViewSheet
+            // on each assignment (was O(M²)). The number chosen below is written
+            // back into the cache so a later sheet in the same batch sees it —
+            // matching the old per-call scan, which saw sheets numbered earlier
+            // in the same run. The just-created sheet (excludeId) carries only a
+            // default number that was never added to the cache, so excluding it
+            // is implicit. Falls back to a fresh scan when no batch cache is live.
+            bool useCache = _sheetNumberCache != null && CacheMatchesDoc(doc);
+            HashSet<string> existing;
+            if (useCache)
             {
-                var candidate = baseNumber + "-" + c;
-                if (!existing.Contains(candidate))
+                existing = _sheetNumberCache;
+            }
+            else
+            {
+                existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                try
                 {
-                    result?.Warnings.Add($"Sheet number '{baseNumber}' already exists; used '{candidate}'.");
-                    return candidate;
+                    foreach (var el in new FilteredElementCollector(doc).OfClass(typeof(ViewSheet)))
+                    {
+                        if (el is ViewSheet vs && vs.Id != excludeId && !string.IsNullOrEmpty(vs.SheetNumber))
+                            existing.Add(vs.SheetNumber);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingTools.Core.StingLog.Warn($"EnsureUniqueSheetNumber: {ex.Message}");
+                    return baseNumber;
                 }
             }
-            var fallback = baseNumber + "-" + Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
-            result?.Warnings.Add($"Sheet number '{baseNumber}' and all -A..-Z variants exist; used '{fallback}'.");
-            return fallback;
+
+            string chosen;
+            if (!existing.Contains(baseNumber))
+            {
+                chosen = baseNumber;
+            }
+            else
+            {
+                chosen = null;
+                for (char c = 'A'; c <= 'Z'; c++)
+                {
+                    var candidate = baseNumber + "-" + c;
+                    if (!existing.Contains(candidate))
+                    {
+                        result?.Warnings.Add($"Sheet number '{baseNumber}' already exists; used '{candidate}'.");
+                        chosen = candidate;
+                        break;
+                    }
+                }
+                if (chosen == null)
+                {
+                    chosen = baseNumber + "-" + Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant();
+                    result?.Warnings.Add($"Sheet number '{baseNumber}' and all -A..-Z variants exist; used '{chosen}'.");
+                }
+            }
+
+            if (useCache) _sheetNumberCache.Add(chosen);
+            return chosen;
         }
 
         private static readonly System.Text.RegularExpressions.Regex _seqWidthRegex


### PR DESCRIPTION
## Why this exists

PR **#473** (commit `632b6e0`) merged **into the `fix/drawings-production-p0` branch** at 09:11 on 07-21 — seven minutes *after* #449 had already squash-merged to `main`. Because its base was the feature branch, not `main`, its fixes were stranded there and never reached `main`. Verified: `BuildSpottedElementIndex` and `_sheetNumberCache` are both absent from `main`. This cherry-picks the two fixes that are genuinely new to `main`.

## What it lands

- **Spot-dimension idempotency (P2-1).** The C-4 idempotency fix guarded tags, grid/level dimensions and decorative instances, but the **spot** pass was uncovered — a pack with `spotElevationRules` / `spotCoordinateRules` re-run with `SkipSpots=false` stacked a duplicate `SpotDimension` per element on every run. `BuildSpottedElementIndex` mirrors the dimension guard: index elements already carrying a spot of that kind (`OST_SpotElevations` / `OST_SpotCoordinates`) by what each references, skip them, and record newly placed ones so a later rule can't double-spot in the same run. Fails open; `aux.Skipped` now folds into `stats.Skipped` so the skips surface.
- **O(M²) sheet-number scan (P2-2).** `EnsureUniqueSheetNumber` re-collected every `ViewSheet` on each assignment. Added a per-batch `_sheetNumberCache` primed in the same `ViewSheet` pass `PrimeBatchCaches` already runs (no extra collector), reset in `ResetBatchCaches`, and written back as each number is assigned so later sheets in the batch see it. Falls back to the original scan when no batch cache is live.

## The third #473 fix was already here

P2-3 (`ctx.Tag` / P-9 convergence) already landed on `main` via **#461**'s track A5. The cherry-pick's only conflict was a duplicate comment on identical code — resolved in favour of main's wording, so `DrawingProduceAndExportCommand.cs` is unchanged by this PR.

## Verification

Committed without `dotnet build` (no .NET/Revit toolchain — repo norm). Net diff is exactly the two fixes (AnnotationRunner +72; DrawingProducer +79/−18). Revit smoke tests, as #473 named: re-run annotation twice on one view (no duplicate spots), and a per-level batch of M sheets (unique numbering intact, no per-sheet full scan).

Once merged, the `fix/drawings-production-p0` branch has no unmerged work and is safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh

---
_Generated by [Claude Code](https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh)_