### PR TITLE
fix(symbols): P0+P1 — repair silent geometry loss, real-world sizing for model symbols

### DIFF
--- a/StingTools/Commands/Symbols/BuildSeedFamiliesCommand.cs
+++ b/StingTools/Commands/Symbols/BuildSeedFamiliesCommand.cs
@@ -115,8 +115,20 @@ namespace StingTools.Commands.Symbols
                 string seedName = Path.GetFileNameWithoutExtension(spec);
                 try
                 {
+                    // The picker's choice now reaches the builder. It previously
+                    // stopped at the result dialog and the log, so every mode behaved
+                    // as Missing Only — "Rebuild All" silently rebuilt nothing,
+                    // because the builder skips any seed whose .rfa already exists.
+                    //
+                    // RebuildUnfinalized maps to a full rebuild as well: nothing in
+                    // the codebase ever writes the .sting-finalized sidecar its label
+                    // refers to (SymbolCreationResult.Protected is never incremented
+                    // and SymbolDefinition.ProtectExisting is never read), so no seed
+                    // is currently finalized and there is nothing to protect. The
+                    // dialog copy says so rather than implying otherwise.
                     var r = SymbolLibraryCreator.CreateAllFromFile(doc, spec, outRoot,
-                        loadIntoProject: true);
+                        loadIntoProject: true,
+                        rebuildMode: rebuildMode != SeedRebuildMode.MissingOnly);
                     aggregate.Created   += r.Created;
                     aggregate.Existed   += r.Existed;
                     aggregate.Failed    += r.Failed;
@@ -190,16 +202,20 @@ namespace StingTools.Commands.Symbols
             {
                 MainInstruction = "Choose which seeds to build",
                 MainContent =
-                    "Missing Only — create seeds that don't exist yet (safe default).\n" +
-                    "Rebuild Unfinalized — skip only seeds with a .sting-finalized sidecar; rebuild all others.\n" +
-                    "Rebuild All — regenerate every seed including finalized ones (destroys manual polish).",
+                    "Missing Only — create seeds that don't exist yet, plus any whose JSON spec " +
+                    "has changed since it was built (safe default).\n" +
+                    "Rebuild Unfinalized — rebuild seeds not marked finalized. No seed is " +
+                    "currently finalized, so today this behaves as a full rebuild.\n" +
+                    "Rebuild All — regenerate every seed (destroys manual polish).",
                 CommonButtons = TaskDialogCommonButtons.Cancel,
                 DefaultButton  = TaskDialogResult.Cancel,
             };
             td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Missing Only",
-                "Create seeds whose .rfa does not exist. Protected families are never touched.");
+                "Create seeds whose .rfa does not exist. An existing seed is left alone unless " +
+                "its JSON spec has changed since it was built, in which case it is regenerated.");
             td.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Rebuild Unfinalized",
-                "Regenerate seeds that have not been marked as finalized. Finalized seeds are skipped.");
+                "Regenerate seeds not marked finalized. Nothing writes the .sting-finalized " +
+                "sidecar yet, so this currently rebuilds every seed — same as Rebuild All.");
             td.AddCommandLink(TaskDialogCommandLinkId.CommandLink3, "Rebuild All",
                 "Regenerate ALL seeds. WARNING: overwrites any manual polish. You will be asked to confirm.");
 

--- a/StingTools/Commands/Symbols/EquipmentSymbolCommands.cs
+++ b/StingTools/Commands/Symbols/EquipmentSymbolCommands.cs
@@ -159,6 +159,23 @@ namespace StingTools.Commands.Symbols
                 if (fs != null) return fs;
             }
 
+            // Tier 1c: the firm-wide shared library (W-3). Required, not optional:
+            // once ResolveOutputRoot can write to a shared root, a project that has
+            // no local library will have its families there and nowhere else. Without
+            // this tier those builds would succeed and then resolve to nothing.
+            try
+            {
+                string sharedRoot = MepSymbolEngine.ResolveSharedLibraryRoot();
+                if (!string.IsNullOrEmpty(sharedRoot) && Directory.Exists(sharedRoot))
+                {
+                    string subfolder = ResolveSubfolder(jsonFile);
+                    fs = TryLoad(doc, Path.Combine(sharedRoot, subfolder, symbolId + ".rfa"))
+                      ?? TryLoad(doc, Path.Combine(sharedRoot, symbolId + ".rfa"));
+                    if (fs != null) return fs;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"ResolveFamilySymbol shared-root probe: {ex.Message}"); }
+
             // Tier 2: search seed folder Families/<discipline>/
             string seedFolder = ResolveSeedFolder(jsonFile);
             if (!string.IsNullOrEmpty(seedFolder))

--- a/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
+++ b/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
@@ -105,8 +105,13 @@ namespace StingTools.Commands.Symbols
             return Path.Combine(baseDir, "_BIM_COORD", "symbol_size_config.json");
         }
 
+        /// <param name="rebuildMode">
+        /// Forces every family in the catalogue to be regenerated even when the
+        /// cache manifest reports it fresh. Normal builds leave this false and let
+        /// <see cref="SymbolCacheManifest"/> decide — see Symbols_Rebuild.
+        /// </param>
         public static SymbolCreationResult RunBatch(Document doc, string jsonName, string subFolder,
-            SymbolSizeConfig sizeConfig = null)
+            SymbolSizeConfig sizeConfig = null, bool rebuildMode = false)
         {
             var aggregate = new SymbolCreationResult();
             string jsonPath = StingToolsApp.FindDataFile(jsonName);
@@ -125,7 +130,7 @@ namespace StingTools.Commands.Symbols
                 sizeConfig = SymbolSizeConfig.LoadOrDefault(ResolveSizeConfigPath(doc));
 
             var r = SymbolLibraryCreator.CreateAllFromFile(doc, jsonPath, outFolder,
-                loadIntoProject: true, sizeConfig: sizeConfig);
+                loadIntoProject: true, rebuildMode: rebuildMode, sizeConfig: sizeConfig);
             aggregate.Created += r.Created;
             aggregate.Existed += r.Existed;
             aggregate.Failed  += r.Failed;

--- a/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
+++ b/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
@@ -111,20 +111,32 @@ namespace StingTools.Commands.Symbols
             try
             {
                 if (doc == null || string.IsNullOrEmpty(doc.PathName)) return null;
-                string dir = Path.GetDirectoryName(doc.PathName);
-                if (string.IsNullOrEmpty(dir)) return null;
 
-                string lib = Path.Combine(dir, "_BIM_COORD", "Families", "Symbols");
-                if (!Directory.Exists(lib)) return null;
+                // Both layouts must be probed, in the same order ContentRoots uses:
+                // the consolidated <root>/_data/_BIM_COORD/… and the legacy
+                // <projDir>/_BIM_COORD/… sibling. Hand-assembling the legacy form
+                // alone would miss a populated library on any project that has been
+                // consolidated — and missing it is precisely the orphaning this guard
+                // exists to prevent. Path layout stays owned by StingPaths /
+                // ProjectFolderEngine rather than being rebuilt here.
+                foreach (var lib in new[]
+                {
+                    StingPaths.Meta(doc, "_BIM_COORD", "Families", "Symbols"),
+                    ProjectFolderEngine.GetLegacyMetaDir(doc, "_BIM_COORD", "Families", "Symbols"),
+                })
+                {
+                    if (string.IsNullOrEmpty(lib) || !Directory.Exists(lib)) continue;
 
-                // Any .rfa anywhere beneath it counts — the build fans out into
-                // per-standard sub-folders (SLD/IEC, Lighting, …), so a top-level
-                // check alone would miss a populated library.
-                bool populated = Directory.EnumerateFiles(lib, "*.rfa", SearchOption.AllDirectories).Any();
-                if (!populated) return null;
+                    // Any .rfa anywhere beneath it counts — the build fans out into
+                    // per-standard sub-folders (SLD/IEC, Lighting, …), so a top-level
+                    // check alone would miss a populated library.
+                    if (!Directory.EnumerateFiles(lib, "*.rfa", SearchOption.AllDirectories).Any())
+                        continue;
 
-                StingLog.Info($"ResolveOutputRoot: using the project's existing symbol library at '{lib}'.");
-                return lib;
+                    StingLog.Info($"ResolveOutputRoot: using the project's existing symbol library at '{lib}'.");
+                    return lib;
+                }
+                return null;
             }
             catch (Exception ex)
             {

--- a/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
+++ b/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
@@ -54,6 +54,19 @@ namespace StingTools.Commands.Symbols
 
         public static string ResolveOutputRoot(Document doc)
         {
+            // W-3 — a project that ALREADY has a generated library keeps writing
+            // there, even once a shared root exists.
+            //
+            // Without this, defaulting the shared root would strand every existing
+            // library: builds would move to the shared root while the read path
+            // (projectFirst precedence) still found the older project-local copies
+            // first. The stale families would keep winning and W-1's invalidation
+            // would silently accomplish nothing. Migration is a deliberate act, not
+            // a side effect of an upgrade.
+            string existingProjectLib = ExistingProjectLibrary(doc);
+            if (!string.IsNullOrEmpty(existingProjectLib))
+                return existingProjectLib;
+
             // Firm-wide shared library takes precedence so one build serves every
             // project. STING_SYMBOL_LIB (or sting_symbols.json) points directly at
             // the symbols root; the per-standard sub-folders land beneath it.
@@ -86,6 +99,38 @@ namespace StingTools.Commands.Symbols
             var outDir = Path.Combine(baseDir, "_BIM_COORD", "Families", "Symbols");
             Directory.CreateDirectory(outDir);
             return outDir;
+        }
+
+        /// <summary>
+        /// The project's own generated-symbol folder, but only when it already holds
+        /// built families. An empty or absent folder returns null so a fresh project
+        /// goes to the shared library instead of minting a private copy.
+        /// </summary>
+        private static string ExistingProjectLibrary(Document doc)
+        {
+            try
+            {
+                if (doc == null || string.IsNullOrEmpty(doc.PathName)) return null;
+                string dir = Path.GetDirectoryName(doc.PathName);
+                if (string.IsNullOrEmpty(dir)) return null;
+
+                string lib = Path.Combine(dir, "_BIM_COORD", "Families", "Symbols");
+                if (!Directory.Exists(lib)) return null;
+
+                // Any .rfa anywhere beneath it counts — the build fans out into
+                // per-standard sub-folders (SLD/IEC, Lighting, …), so a top-level
+                // check alone would miss a populated library.
+                bool populated = Directory.EnumerateFiles(lib, "*.rfa", SearchOption.AllDirectories).Any();
+                if (!populated) return null;
+
+                StingLog.Info($"ResolveOutputRoot: using the project's existing symbol library at '{lib}'.");
+                return lib;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ExistingProjectLibrary: {ex.Message}");
+                return null;
+            }
         }
 
         /// <summary>

--- a/StingTools/Commands/Symbols/SymbolRebuildCommand.cs
+++ b/StingTools/Commands/Symbols/SymbolRebuildCommand.cs
@@ -1,0 +1,145 @@
+// StingTools — Symbol library rebuild (W-2).
+//
+// Command tag: Symbols_Rebuild
+//
+// The remedy half of cache invalidation. SymbolCacheManifest (W-1) stops the
+// builder from skipping families whose catalogue or generator has moved on,
+// but it only acts when a build runs. Anyone already holding families built
+// before the manifest existed needs a way to ask for the repair.
+//
+// Two modes:
+//   Stale only — rebuild catalogues whose SHA-256 or generator version has
+//                changed; leave the rest alone. Safe, and the right choice
+//                after a plug-in upgrade.
+//   Force all  — regenerate every family regardless. For a library believed
+//                corrupt, or to adopt a generator fix that somehow escaped
+//                a GeneratorVersion bump.
+//
+// Distinct from Symbols_Reload, which re-loads existing .rfa into the
+// document and flushes the JSON shapes cache — it never rebuilds anything.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Symbols;
+
+namespace StingTools.Commands.Symbols
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class SymbolRebuildCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(data);
+            if (ctx == null) { msg = "No active document."; return Result.Failed; }
+            var doc = ctx.Doc;
+
+            bool? force = PromptMode();
+            if (force == null) return Result.Cancelled;
+
+            string outRoot = SymbolBatchHelper.ResolveOutputRoot(doc);
+
+            var aggregate = new SymbolCreationResult();
+            var perBatch = new List<(string Label, int Created, int Existed, int Failed)>();
+
+            foreach (var b in SymbolBatchHelper.AllBatches)
+            {
+                try
+                {
+                    var r = SymbolBatchHelper.RunBatch(doc, b.File, b.Folder, rebuildMode: force.Value);
+                    aggregate.Created += r.Created;
+                    aggregate.Existed += r.Existed;
+                    aggregate.Failed += r.Failed;
+                    aggregate.Warnings.AddRange(r.Warnings);
+                    aggregate.Errors.AddRange(r.Errors);
+                    perBatch.Add((b.Label, r.Created, r.Existed, r.Failed));
+                }
+                catch (Exception ex)
+                {
+                    aggregate.Failed++;
+                    aggregate.Errors.Add($"{b.Label}: {ex.Message}");
+                    StingLog.Error($"Symbols_Rebuild: {b.Label} failed", ex);
+                }
+            }
+
+            ShowReport(aggregate, perBatch, outRoot, force.Value);
+            StingLog.Info($"Symbols_Rebuild: force={force.Value} rebuilt={aggregate.Created} " +
+                          $"fresh={aggregate.Existed} failed={aggregate.Failed} outRoot={outRoot}");
+            return aggregate.Failed > 0 ? Result.Failed : Result.Succeeded;
+        }
+
+        /// <summary>Null = cancelled; false = stale only; true = force all.</summary>
+        private static bool? PromptMode()
+        {
+            var td = new TaskDialog("STING Symbols — Rebuild")
+            {
+                MainInstruction = "Rebuild the generated symbol library",
+                MainContent =
+                    "Stale only — rebuild catalogues whose content or generator version has " +
+                    "changed since they were built. Use this after a plug-in upgrade.\n\n" +
+                    "Force all — regenerate every family regardless of the cache. Slower; use " +
+                    "when the library is believed corrupt.\n\n" +
+                    "Both overwrite generated families in the output folder. Manually authored " +
+                    "families kept outside it are not touched.",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+                DefaultButton = TaskDialogResult.Cancel
+            };
+            td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Stale only (recommended)");
+            td.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Force all");
+
+            switch (td.Show())
+            {
+                case TaskDialogResult.CommandLink1: return false;
+                case TaskDialogResult.CommandLink2: return true;
+                default: return null;
+            }
+        }
+
+        private static void ShowReport(SymbolCreationResult agg,
+            List<(string Label, int Created, int Existed, int Failed)> perBatch,
+            string outRoot, bool force)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(force ? "Rebuild mode: FORCE ALL" : "Rebuild mode: STALE ONLY");
+            sb.AppendLine($"Output: {outRoot}");
+            sb.AppendLine();
+            sb.AppendLine($"  Rebuilt      : {agg.Created}");
+            sb.AppendLine($"  Left as-is   : {agg.Existed}");
+            sb.AppendLine($"  Failed       : {agg.Failed}");
+            sb.AppendLine();
+
+            var touched = perBatch.Where(p => p.Created > 0 || p.Failed > 0).ToList();
+            if (touched.Count == 0)
+            {
+                sb.AppendLine("Every catalogue was already current — nothing to rebuild.");
+            }
+            else
+            {
+                sb.AppendLine("Catalogues rebuilt:");
+                foreach (var p in touched)
+                    sb.AppendLine($"  · {p.Label}: {p.Created} rebuilt" +
+                                  (p.Failed > 0 ? $", {p.Failed} FAILED" : ""));
+            }
+
+            if (agg.Errors.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Errors:");
+                foreach (var e in agg.Errors.Take(10)) sb.AppendLine("  · " + e);
+                if (agg.Errors.Count > 10)
+                    sb.AppendLine($"  … +{agg.Errors.Count - 10} more (see StingTools.log).");
+            }
+
+            foreach (var w in agg.Warnings) StingLog.Warn($"Symbols_Rebuild: {w}");
+            foreach (var e in agg.Errors) StingLog.Error($"Symbols_Rebuild: {e}");
+            TaskDialog.Show("STING - Symbol Rebuild", sb.ToString());
+        }
+    }
+}

--- a/StingTools/Commands/Symbols/SymbolValidateCommand.cs
+++ b/StingTools/Commands/Symbols/SymbolValidateCommand.cs
@@ -40,6 +40,7 @@ namespace StingTools.Commands.Symbols
             var issues = new List<string>();
             int catalogueOk = 0, catalogueBad = 0, symbolTotal = 0, coordViolations = 0;
             int blindSpots = 0, connectorlessSeeds = 0, connectorDefects = 0;
+            int emptyGeometry = 0, extentViolations = 0, paramlessAnnotations = 0;
             int refTotal = 0, danglingTotal = 0, danglingPrefix = 0, danglingViewCtx = 0, danglingAbsent = 0;
 
             try
@@ -82,6 +83,47 @@ namespace StingTools.Commands.Symbols
                         // at build by the creator's ValidateGeometryCoord.
                         foreach (var s in lib.Symbols)
                             coordViolations += ScanCoordViolations(s, Path.GetFileName(path), issues);
+
+                        // 1f — symbols that would build as EMPTY families. The creator
+                        // draws nothing and warns nothing, so these ship as blank glyphs.
+                        foreach (var s in lib.Symbols)
+                        {
+                            if (GeometryPrimitiveCount(s) == 0)
+                            {
+                                emptyGeometry++;
+                                issues.Add($"[empty-geometry] {Path.GetFileName(path)}: {s.Id} has no drawable " +
+                                           "geometry — would build as an empty family.");
+                            }
+                        }
+
+                        // 1g — normalisation contract. Bodies normalise to -0.5..+0.5;
+                        // symbols that legitimately draw beyond it (SLD terminal leads,
+                        // LPS earth stems) must declare overallExtent. Anything past its
+                        // declared extent is an authoring error.
+                        foreach (var s in lib.Symbols)
+                        {
+                            double declared = s.OverallExtent > 0 ? s.OverallExtent : 0.5;
+                            double actual = MaxAbsCoord(s);
+                            if (actual > declared + 1e-4)
+                            {
+                                extentViolations++;
+                                issues.Add($"[extent] {Path.GetFileName(path)}: {s.Id} reaches {actual:F2} " +
+                                           $"but declares overallExtent {declared:F2}.");
+                            }
+                        }
+
+                        // 1h — annotation symbols with no parameters cannot be tagged,
+                        // scheduled, or reported to a Note Block schedule.
+                        foreach (var s in lib.Symbols)
+                        {
+                            if (string.Equals(s.FamilyType, "GenericAnnotation", StringComparison.OrdinalIgnoreCase)
+                                && (s.Parameters == null || s.Parameters.Count == 0))
+                            {
+                                paramlessAnnotations++;
+                                issues.Add($"[no-params] {Path.GetFileName(path)}: {s.Id} is a GenericAnnotation " +
+                                           "with zero parameters — cannot be tagged, scheduled or Note-Blocked.");
+                            }
+                        }
                     }
                 }
 
@@ -119,6 +161,9 @@ namespace StingTools.Commands.Symbols
             sb.AppendLine($"  Catalogues BAD       : {catalogueBad}");
             sb.AppendLine($"  Catalogue blind spots: {blindSpots} (symbol libs not in AllBatches)");
             sb.AppendLine($"  Coord violations     : {coordViolations} (|value| > 2.0, dropped at build)");
+            sb.AppendLine($"  Empty geometry       : {emptyGeometry} (would build as blank families)");
+            sb.AppendLine($"  Extent violations    : {extentViolations} (geometry past declared overallExtent)");
+            sb.AppendLine($"  Param-less annotations: {paramlessAnnotations} (untaggable / unschedulable)");
             sb.AppendLine($"  Connector-less seeds : {connectorlessSeeds} (MEP-category, 0 connectors)");
             sb.AppendLine($"  Connector defects    : {connectorDefects} (malformed/unbound connector fields)");
             sb.AppendLine($"  Concept refs         : {refTotal}, dangling {danglingTotal} " +
@@ -244,6 +289,56 @@ namespace StingTools.Commands.Symbols
         }
 
         private static readonly string[] StdPrefixes = { "IEC_", "IEEE_", "BS_", "NFPA_", "CIBSE_" };
+
+        // ── 1f) drawable primitive count ──────────────────────────────────────
+        /// <summary>
+        /// Number of primitives the creator would actually draw. Zero means the
+        /// family builds blank — the creator emits no warning for this.
+        /// </summary>
+        private static int GeometryPrimitiveCount(SymbolDefinition s)
+        {
+            var g = s?.Geometry;
+            if (g == null) return 0;
+            return (g.Lines?.Count ?? 0)
+                 + (g.ConnectionLines?.Count ?? 0)
+                 + (g.Arcs?.Count ?? 0)
+                 + (g.FilledRegions?.Count ?? 0)
+                 + (g.Text?.Count ?? 0);
+        }
+
+        // ── 1g) largest absolute normalised coordinate ────────────────────────
+        /// <summary>
+        /// Furthest reach of the symbol's geometry from the origin, in normalised
+        /// units. Arcs contribute centre + radius so a large arc is not missed.
+        /// </summary>
+        private static double MaxAbsCoord(SymbolDefinition s)
+        {
+            var g = s?.Geometry;
+            if (g == null) return 0;
+            double m = 0;
+            void Bump(double v) { double a = Math.Abs(v); if (a > m) m = a; }
+
+            void ChkLines(List<LineDefinition> lines)
+            {
+                if (lines == null) return;
+                foreach (var l in lines) { Bump(l.X1); Bump(l.Y1); Bump(l.X2); Bump(l.Y2); }
+            }
+            ChkLines(g.Lines);
+            ChkLines(g.ConnectionLines);
+
+            if (g.Arcs != null)
+                foreach (var a in g.Arcs) { Bump(Math.Abs(a.Cx) + a.R); Bump(Math.Abs(a.Cy) + a.R); }
+
+            if (g.FilledRegions != null)
+                foreach (var fr in g.FilledRegions)
+                    if (fr.Boundary != null)
+                        foreach (var p in fr.Boundary) { Bump(p.X); Bump(p.Y); }
+
+            if (g.Text != null)
+                foreach (var t in g.Text) { Bump(t.X); Bump(t.Y); }
+
+            return m;
+        }
 
         // ── 1d) geometry coordinate range ─────────────────────────────────────
         private static int ScanCoordViolations(SymbolDefinition s, string file, List<string> issues)

--- a/StingTools/Core/Content/ContentRoots.cs
+++ b/StingTools/Core/Content/ContentRoots.cs
@@ -83,7 +83,8 @@ namespace StingTools.Core.Content
 
         /// <summary>Firm-wide content root: STING_CONTENT_LIB env →
         /// %APPDATA%/STING/sting_content.json:"content_root" → (legacy)
-        /// STING_SYMBOL_LIB / sting_symbols.json:"symbol_library_root". Null when unset.</summary>
+        /// STING_SYMBOL_LIB / sting_symbols.json:"symbol_library_root" →
+        /// %PROGRAMDATA%/STING/ContentLibrary (W-3 default). Null only on error.</summary>
         public static string ResolveSharedRoot()
         {
             try
@@ -109,6 +110,22 @@ namespace StingTools.Core.Content
                     var root = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(legacyCfg));
                     var lib = (string)root["symbol_library_root"];
                     if (!string.IsNullOrWhiteSpace(lib)) return lib.Trim();
+                }
+
+                // W-3 — machine-wide default, delegated to the symbol engine so the
+                // two shared-root resolvers cannot drift apart. Content lives one
+                // level above the symbols sub-folder that resolver returns.
+                //
+                // Returned whether or not it exists yet, matching how the project and
+                // baseline tiers are assembled above: Resolve() does not filter on
+                // existence and its consumers already tolerate a missing folder.
+                // Gating this on Directory.Exists would make the answer depend on
+                // whether a build had happened to run first.
+                var symbolsDefault = Symbols.MepSymbolEngine.DefaultSharedLibraryRoot;
+                if (!string.IsNullOrEmpty(symbolsDefault))
+                {
+                    var contentDefault = Path.GetDirectoryName(symbolsDefault);
+                    if (!string.IsNullOrEmpty(contentDefault)) return contentDefault;
                 }
             }
             catch (Exception ex) { StingLog.Warn($"ContentRoots.ResolveSharedRoot: {ex.Message}"); }

--- a/StingTools/Core/Symbols/MepSymbolEngine.cs
+++ b/StingTools/Core/Symbols/MepSymbolEngine.cs
@@ -671,9 +671,49 @@ namespace StingTools.Core.Symbols
                     string lib = (string)root["symbol_library_root"];
                     if (!string.IsNullOrWhiteSpace(lib)) return lib.Trim();
                 }
+
+                // W-3 — machine-wide default. Without this the shared library was
+                // opt-in and undiscoverable, so every project regenerated the whole
+                // catalogue into its own _BIM_COORD. Explicit configuration above
+                // still wins; this only supplies a default when nothing is set.
+                //
+                // Probed for writability rather than assumed: ProgramData grants
+                // Users create-subdirectory by default, but locked-down or
+                // roaming-profile machines vary, and silently returning an
+                // unwritable root would push every build into the temp fallback.
+                return ProbeDefaultSharedRoot();
             }
             catch (Exception ex) { StingLog.Warn($"ResolveSharedLibraryRoot: {ex.Message}"); }
             return null;
+        }
+
+        /// <summary>Machine-wide default shared library root, or null when unusable.</summary>
+        public static string DefaultSharedLibraryRoot =>
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "STING", "ContentLibrary", "Symbols");
+
+        /// <summary>
+        /// Returns <see cref="DefaultSharedLibraryRoot"/> only if it can actually be
+        /// created and written to. Null otherwise, so callers fall back per-project.
+        /// </summary>
+        private static string ProbeDefaultSharedRoot()
+        {
+            string root = DefaultSharedLibraryRoot;
+            try
+            {
+                Directory.CreateDirectory(root);
+                string probe = Path.Combine(root, ".sting_write_probe");
+                File.WriteAllText(probe, "");
+                File.Delete(probe);
+                return root;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Info($"Default shared symbol root '{root}' not writable " +
+                              $"({ex.Message}); using per-project output.");
+                return null;
+            }
         }
 
         // ── Family loading ───────────────────────────────────────────────

--- a/StingTools/Core/Symbols/SymbolCacheManifest.cs
+++ b/StingTools/Core/Symbols/SymbolCacheManifest.cs
@@ -1,0 +1,203 @@
+// StingTools — Symbol library cache manifest (W-1).
+//
+// Problem this solves
+// ───────────────────
+// SymbolLibraryCreator used to treat File.Exists as the entire staleness
+// test for a built .rfa. Existence is not freshness: once a family had been
+// generated it was never rebuilt, so a corrected catalogue — or a corrected
+// GENERATOR — could not reach any project that had already run the build.
+// Symbol fixes were unshippable by construction.
+//
+// The sidecar
+// ───────────
+// A .sting_library.json written beside the built families records, per
+// catalogue, the SHA-256 of the JSON it was built from, plus the generator
+// version and content-library version in force at build time:
+//
+//   {
+//     "generatorVersion": "2",
+//     "libraryVersion":   "2026.6.1",
+//     "builtUtc":         "2026-07-29T18:00:00Z",
+//     "catalogues": { "STING_SLD_SYMBOLS.json": "<sha256>" }
+//   }
+//
+// Two triggers, not one
+// ─────────────────────
+// Hashing the catalogue alone is NOT sufficient, and the distinction matters:
+//
+//   * catalogue hash  — catches data edits (a changed symbolSize, new glyph)
+//   * generatorVersion — catches CODE changes that alter output while every
+//                        catalogue byte stays identical
+//
+// The second case is not hypothetical. The fix that motivated this file
+// repaired 206 filled regions and 115 arc sweeps purely by correcting JSON
+// key binding in the POCO — the catalogues those symbols live in were never
+// touched, so a hash-only check would have declared them fresh and shipped
+// the repair to nobody. Bump GeneratorVersion whenever emitted geometry
+// changes.
+//
+// Failure posture: any read/parse problem yields a manifest that reports
+// everything stale. Rebuilding unnecessarily costs time; skipping a needed
+// rebuild silently ships broken geometry, which is the bug this exists to
+// prevent.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace StingTools.Core.Symbols
+{
+    public sealed class SymbolCacheManifest
+    {
+        /// <summary>File name of the sidecar, written into the build output folder.</summary>
+        public const string FileName = ".sting_library.json";
+
+        /// <summary>
+        /// Bumped whenever SymbolLibraryCreator's emitted geometry changes in a way
+        /// that is invisible to the catalogue hashes.
+        ///
+        /// <para>History:
+        /// 1 — pre-invalidation baseline (no sidecar was written).
+        /// 2 — filled-region "vertices" and arc "startAngle"/"endAngle" key aliases;
+        ///     model-category families sized from realSizeMm instead of symbolSize.</para>
+        /// </summary>
+        public const string GeneratorVersion = "2";
+
+        [JsonProperty("generatorVersion")] public string BuiltGeneratorVersion { get; set; } = "";
+        [JsonProperty("libraryVersion")]   public string LibraryVersion { get; set; } = "";
+        [JsonProperty("builtUtc")]         public string BuiltUtc { get; set; } = "";
+
+        /// <summary>Catalogue file name → SHA-256 of the bytes it was built from.</summary>
+        [JsonProperty("catalogues")]
+        public Dictionary<string, string> Catalogues { get; set; }
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // ── Load / save ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Reads the sidecar from <paramref name="outputFolder"/>. Returns an empty
+        /// manifest — which marks everything stale — when absent or unreadable.
+        /// </summary>
+        public static SymbolCacheManifest Load(string outputFolder)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(outputFolder)) return new SymbolCacheManifest();
+                var path = Path.Combine(outputFolder, FileName);
+                if (!File.Exists(path)) return new SymbolCacheManifest();
+                return JsonConvert.DeserializeObject<SymbolCacheManifest>(File.ReadAllText(path))
+                       ?? new SymbolCacheManifest();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SymbolCacheManifest.Load: {ex.Message} — treating cache as stale.");
+                return new SymbolCacheManifest();
+            }
+        }
+
+        /// <summary>
+        /// Persists the sidecar. Never throws: a library that built correctly but
+        /// could not record the fact is merely rebuilt next time.
+        /// </summary>
+        public void Save(string outputFolder)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(outputFolder)) return;
+                Directory.CreateDirectory(outputFolder);
+                BuiltGeneratorVersion = GeneratorVersion;
+                BuiltUtc = DateTime.UtcNow.ToString("o");
+                File.WriteAllText(Path.Combine(outputFolder, FileName),
+                    JsonConvert.SerializeObject(this, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SymbolCacheManifest.Save: {ex.Message} — " +
+                              "next build will rebuild this catalogue.");
+            }
+        }
+
+        // ── Staleness ────────────────────────────────────────────────────
+
+        /// <summary>
+        /// True when families built from <paramref name="cataloguePath"/> must be
+        /// regenerated: the generator changed, or the catalogue's bytes changed, or
+        /// nothing was ever recorded for it.
+        /// </summary>
+        public bool IsCatalogueStale(string cataloguePath, out string reason)
+        {
+            reason = null;
+            if (!string.Equals(BuiltGeneratorVersion, GeneratorVersion, StringComparison.Ordinal))
+            {
+                reason = string.IsNullOrEmpty(BuiltGeneratorVersion)
+                    ? "no cache manifest — built before cache invalidation existed"
+                    : $"generator {BuiltGeneratorVersion} → {GeneratorVersion}";
+                return true;
+            }
+
+            string key = SafeFileName(cataloguePath);
+            if (string.IsNullOrEmpty(key)) { reason = "catalogue path unresolved"; return true; }
+
+            if (!Catalogues.TryGetValue(key, out var recorded) || string.IsNullOrEmpty(recorded))
+            {
+                reason = "catalogue not recorded in cache manifest";
+                return true;
+            }
+
+            string current = HashFile(cataloguePath);
+            if (string.IsNullOrEmpty(current)) { reason = "catalogue unreadable"; return true; }
+
+            if (!string.Equals(recorded, current, StringComparison.OrdinalIgnoreCase))
+            {
+                reason = "catalogue content changed";
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>Records the current hash of <paramref name="cataloguePath"/> as freshly built.</summary>
+        public void RecordCatalogue(string cataloguePath)
+        {
+            string key = SafeFileName(cataloguePath);
+            if (string.IsNullOrEmpty(key)) return;
+            string hash = HashFile(cataloguePath);
+            if (!string.IsNullOrEmpty(hash)) Catalogues[key] = hash;
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────
+
+        /// <summary>
+        /// SHA-256 of a file's bytes, or null on any failure. Matches the hashing
+        /// convention already used by DrawingTypeRegistry.ComputeChecksums rather
+        /// than introducing a second one.
+        /// </summary>
+        public static string HashFile(string path)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return null;
+                using (var sha = SHA256.Create())
+                using (var fs = File.OpenRead(path))
+                {
+                    var sb = new StringBuilder();
+                    foreach (var b in sha.ComputeHash(fs)) sb.Append(b.ToString("x2"));
+                    return sb.ToString();
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SymbolCacheManifest.HashFile('{path}'): {ex.Message}");
+                return null;
+            }
+        }
+
+        private static string SafeFileName(string path)
+        {
+            try { return string.IsNullOrEmpty(path) ? null : Path.GetFileName(path); }
+            catch { return null; }
+        }
+    }
+}

--- a/StingTools/Core/Symbols/SymbolCacheManifest.cs
+++ b/StingTools/Core/Symbols/SymbolCacheManifest.cs
@@ -75,6 +75,25 @@ namespace StingTools.Core.Symbols
         public Dictionary<string, string> Catalogues { get; set; }
             = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Symbol ids that failed to build on the last run, and must be retried even
+        /// while their catalogue is otherwise fresh.
+        ///
+        /// <para>Needed because BuildOne writes its .rfa via SaveAs as the very last
+        /// step. A symbol that fails therefore leaves whatever was on disk before —
+        /// so if a *stale* family failed to regenerate, the stale file survives. With
+        /// only a catalogue-level hash, stamping would mark it fresh and that stale
+        /// geometry would be served silently forever.</para>
+        ///
+        /// <para>The alternative — refusing to stamp the catalogue whenever anything
+        /// failed — is worse: one permanently-failing symbol would force every other
+        /// symbol in that catalogue to rebuild on every run, defeating the point of
+        /// the cache.</para>
+        /// </summary>
+        [JsonProperty("failedSymbols")]
+        public HashSet<string> FailedSymbols { get; set; }
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         // ── Load / save ──────────────────────────────────────────────────
 
         /// <summary>
@@ -165,6 +184,35 @@ namespace StingTools.Core.Symbols
             if (string.IsNullOrEmpty(key)) return;
             string hash = HashFile(cataloguePath);
             if (!string.IsNullOrEmpty(hash)) Catalogues[key] = hash;
+        }
+
+        /// <summary>
+        /// True when this specific symbol must be rebuilt regardless of its
+        /// catalogue's freshness, because it failed on the previous run.
+        /// </summary>
+        public bool IsSymbolStale(string symbolId)
+            => !string.IsNullOrEmpty(symbolId)
+               && FailedSymbols != null
+               && FailedSymbols.Contains(symbolId);
+
+        /// <summary>
+        /// Replaces the recorded failure set for the symbols just processed.
+        /// <paramref name="attempted"/> is every id this run considered, so ids that
+        /// have since succeeded are cleared while failures in other catalogues are
+        /// left intact.
+        /// </summary>
+        public void RecordFailures(IEnumerable<string> attempted, IEnumerable<string> failed)
+        {
+            if (FailedSymbols == null)
+                FailedSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (attempted != null)
+                foreach (var id in attempted)
+                    if (!string.IsNullOrEmpty(id)) FailedSymbols.Remove(id);
+
+            if (failed != null)
+                foreach (var id in failed)
+                    if (!string.IsNullOrEmpty(id)) FailedSymbols.Add(id);
         }
 
         // ── Helpers ──────────────────────────────────────────────────────

--- a/StingTools/Core/Symbols/SymbolDefinition.cs
+++ b/StingTools/Core/Symbols/SymbolDefinition.cs
@@ -143,6 +143,20 @@ namespace StingTools.Core.Symbols
         /// <summary>Visible symbol size in millimetres at 1:100 (drives geometry scale).</summary>
         [JsonProperty("symbolSize")]  public double SymbolSize { get; set; } = 3.0;
 
+        /// <summary>
+        /// Largest legal absolute normalised coordinate for this symbol's geometry.
+        ///
+        /// The catalogue convention is a body normalised to -0.5..+0.5. Some symbol
+        /// classes legitimately draw beyond that box — SLD breakers and transformers
+        /// carry terminal leads, and the LPS symbols carry earth stems — so those
+        /// declare a larger extent rather than being squashed into the body box.
+        ///
+        /// Consumed by Symbols_Validate as the strict gate. The creator keeps its own
+        /// permissive +/-2.0 crash-guard so a bad edit degrades to a warning rather
+        /// than a malformed curve.
+        /// </summary>
+        [JsonProperty("overallExtent")] public double OverallExtent { get; set; } = 0.5;
+
         [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
         public List<ParameterDefinition> Parameters { get; set; }
             = new List<ParameterDefinition>();
@@ -373,6 +387,30 @@ namespace StingTools.Core.Symbols
         [JsonProperty("endDeg")]   public double EndDeg { get; set; } = 360;
         [JsonProperty("style", NullValueHandling = NullValueHandling.Ignore)]
         public string Style { get; set; }
+
+        // ── Spelling aliases ────────────────────────────────────────────
+        // 375 of the 620 arcs in the shipped catalogues spell the sweep
+        // "startAngle"/"endAngle" rather than the canonical
+        // "startDeg"/"endDeg". Newtonsoft silently ignored those keys, so
+        // StartDeg/EndDeg kept their 0/360 defaults and every one of those
+        // arcs rendered as a FULL CIRCLE instead of the intended sweep.
+        //
+        // The alias only writes while the canonical property still holds its
+        // default, so an explicit startDeg/endDeg always wins regardless of
+        // key order. Getters return null so the alias never re-serialises.
+        [JsonProperty("startAngle", NullValueHandling = NullValueHandling.Ignore)]
+        public double? StartAngle
+        {
+            get => null;
+            set { if (value.HasValue && StartDeg == 0) StartDeg = value.Value; }
+        }
+
+        [JsonProperty("endAngle", NullValueHandling = NullValueHandling.Ignore)]
+        public double? EndAngle
+        {
+            get => null;
+            set { if (value.HasValue && EndDeg == 360) EndDeg = value.Value; }
+        }
     }
 
     public sealed class FilledRegionDefinition
@@ -381,6 +419,24 @@ namespace StingTools.Core.Symbols
             = new List<Point2D>();
         [JsonProperty("fillType", NullValueHandling = NullValueHandling.Ignore)]
         public string FillType { get; set; }
+
+        // ── Spelling alias ──────────────────────────────────────────────
+        // 206 of the 217 filled regions in the shipped catalogues spell the
+        // boundary "vertices". Newtonsoft ignored that key, leaving Boundary
+        // empty, and DrawFilledRegion returns silently on an empty boundary —
+        // so 95% of all filled regions in the library never rendered, with no
+        // warning. The canonical key wins when both are present.
+        [JsonProperty("vertices", NullValueHandling = NullValueHandling.Ignore)]
+        public List<Point2D> Vertices
+        {
+            get => null;
+            set
+            {
+                if (value != null && value.Count > 0 &&
+                    (Boundary == null || Boundary.Count == 0))
+                    Boundary = value;
+            }
+        }
     }
 
     public sealed class Point2D

--- a/StingTools/Core/Symbols/SymbolDefinition.cs
+++ b/StingTools/Core/Symbols/SymbolDefinition.cs
@@ -144,6 +144,35 @@ namespace StingTools.Core.Symbols
         [JsonProperty("symbolSize")]  public double SymbolSize { get; set; } = 3.0;
 
         /// <summary>
+        /// Real-world size in millimetres for MODEL-category symbols
+        /// (MEPEquipment / MEPAccessory / etc.).
+        ///
+        /// <para>Why this exists: <see cref="SymbolSize"/> is a PAPER-space target.
+        /// That is correct for GenericAnnotation, which Revit plots at a constant
+        /// size regardless of view scale. Model-category families live in MODEL
+        /// space, so building them at <see cref="SymbolSize"/> produced devices a
+        /// few millimetres across — a 13A socket 4 mm wide, plotting at 0.08 mm on
+        /// a 1:50 sheet. Those families were effectively invisible.</para>
+        ///
+        /// <para>Model-category geometry is therefore driven by this value, and the
+        /// schematic glyph is carried separately by <see cref="PlanSymbol"/>. Unset
+        /// (0) falls back to <see cref="SymbolSize"/> with a build warning.</para>
+        /// </summary>
+        [JsonProperty("realSizeMm")] public double RealSizeMm { get; set; } = 0;
+
+        /// <summary>
+        /// Id of the GenericAnnotation symbol nested into this model family to
+        /// provide its plan-view schematic glyph.
+        ///
+        /// <para>Real geometry alone plots as a small rectangle in plan, which is
+        /// not how MEP devices are drafted. The nested annotation keeps the
+        /// schematic legible at any scale while the model geometry stays
+        /// dimensionally correct for clash, quantities and COBie.</para>
+        /// </summary>
+        [JsonProperty("planSymbol", NullValueHandling = NullValueHandling.Ignore)]
+        public string PlanSymbol { get; set; }
+
+        /// <summary>
         /// Largest legal absolute normalised coordinate for this symbol's geometry.
         ///
         /// The catalogue convention is a body normalised to -0.5..+0.5. Some symbol

--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -93,6 +93,43 @@ namespace StingTools.Core.Symbols
         private static double Scale(double normCoord, double symbolSizeMm)
             => normCoord * MmToFt(symbolSizeMm);
 
+        /// <summary>
+        /// Millimetre size the symbol's normalised geometry is expanded to.
+        ///
+        /// <para>Annotation and detail templates plot in PAPER space — Revit holds
+        /// them at a constant plotted size at any view scale — so
+        /// <c>symbolSize</c> is exactly right there, and the "Symbol Scale"
+        /// parameter carried by 520 annotation symbols is inert by design. It is
+        /// left in place deliberately: it is harmless, and stripping it would make
+        /// existing project families diverge from newly built ones.</para>
+        ///
+        /// <para>Model templates live in MODEL space, where a paper-space size
+        /// yields a device a few millimetres across. Those use
+        /// <c>realSizeMm</c>. Falling back to <c>symbolSize</c> for a model family
+        /// is a defect, so it warns rather than failing silently.</para>
+        /// </summary>
+        private static double ResolveGeometrySizeMm(SymbolDefinition def, TemplateKind kind,
+            SymbolCreationResult result)
+        {
+            double paper = def.SymbolSize > 0 ? def.SymbolSize : 3.0;
+            if (!IsModelSpaceTemplate(kind)) return paper;
+
+            if (def.RealSizeMm > 0) return def.RealSizeMm;
+
+            result?.Warnings.Add(
+                $"{def.Id}: model-category symbol has no realSizeMm — falling back to the " +
+                $"paper-space symbolSize ({paper:F1}mm). The family will be built a few " +
+                "millimetres across and will be effectively invisible in model views.");
+            return paper;
+        }
+
+        /// <summary>
+        /// True when the template places geometry in model space, where sizes are
+        /// real-world rather than plotted.
+        /// </summary>
+        private static bool IsModelSpaceTemplate(TemplateKind kind)
+            => kind == TemplateKind.Model;
+
         // ─────────────────────────────────────────────────────────────────
         // Fix 5 — Geometry coordinate range validation
         // ─────────────────────────────────────────────────────────────────
@@ -577,7 +614,7 @@ namespace StingTools.Core.Symbols
             // ref-level plane already created by the .rft.
             SketchPlane sketch = ResolveSketchPlane(fdoc, kind, def.Id, result);
 
-            double s = def.SymbolSize > 0 ? def.SymbolSize : 3.0;
+            double s = ResolveGeometrySizeMm(def, kind, result);
 
             // Fix 4 — resolve the effective textHeightMm from the standard.
             double stdTextHeightMm = std?.AnnotationRules?.TextHeightMm ?? 2.5;
@@ -1512,7 +1549,13 @@ namespace StingTools.Core.Symbols
         {
             if (!fdoc.IsFamilyDocument) return;
             if (connectors == null) return;
-            double s = def.SymbolSize > 0 ? def.SymbolSize : 3.0;
+
+            // Must match DrawGeometry's size exactly. Connector offsets are
+            // normalised against the same box as the linework, so resolving them
+            // differently would leave connectors floating off the geometry.
+            // Connectors only exist on model templates, so this always takes the
+            // realSizeMm path in practice.
+            double s = ResolveGeometrySizeMm(def, ResolveTemplateKind(def), result);
 
             foreach (var c in connectors)
             {

--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -206,6 +206,21 @@ namespace StingTools.Core.Symbols
             var app = hostDoc.Application;
             var templateFolder = ResolveTemplateFolder(app);
 
+            // ── Cache invalidation (W-1) ──────────────────────────────────
+            // Existence alone is not freshness. A .rfa on disk may have been
+            // built from an older catalogue, or by an older generator whose
+            // output differed even though every catalogue byte is identical.
+            // rebuildMode forces a rebuild regardless (Symbols_RebuildAll).
+            var cache = SymbolCacheManifest.Load(outputFolder);
+            bool hashStale = cache.IsCatalogueStale(jsonPath, out string staleReason);
+            bool catalogueStale = rebuildMode || hashStale;
+            if (catalogueStale)
+            {
+                string cause = rebuildMode ? "forced rebuild" : staleReason;
+                StingLog.Info($"SymbolLibraryCreator: rebuilding '{Path.GetFileName(jsonPath)}' — {cause}.");
+                result.Warnings.Add($"{Path.GetFileName(jsonPath)}: rebuilding cached families — {cause}.");
+            }
+
             foreach (var def in lib.Symbols)
             {
                 if (string.IsNullOrWhiteSpace(def?.Id))
@@ -227,7 +242,11 @@ namespace StingTools.Core.Symbols
                 }
 
                 var rfaPath = Path.Combine(outputFolder, def.Id + ".rfa");
-                if (File.Exists(rfaPath))
+                // W-1 — a stale catalogue (or generator) means the .rfa on disk was
+                // built from something that no longer describes this symbol, so
+                // existence no longer licenses a skip. Fall through to BuildOne,
+                // which overwrites via SaveAsOptions.OverwriteExistingFile.
+                if (File.Exists(rfaPath) && !catalogueStale)
                 {
                     // If the .rfa loads cleanly, count it as Existed and
                     // move on. If LoadFamily returns false (Revit's
@@ -286,6 +305,23 @@ namespace StingTools.Core.Symbols
                 }
             }
 
+            // ── Record the build (W-1) ────────────────────────────────────
+            // Only stamp the catalogue as built when nothing failed. Recording a
+            // partial build would mark the catalogue fresh and permanently strand
+            // the families that did not make it — the exact failure mode this
+            // whole mechanism exists to stop.
+            if (result.Failed == 0)
+            {
+                cache.RecordCatalogue(jsonPath);
+                cache.Save(outputFolder);
+            }
+            else
+            {
+                result.Warnings.Add(
+                    $"{Path.GetFileName(jsonPath)}: {result.Failed} symbol(s) failed — cache not " +
+                    "stamped, so the next run will retry this catalogue.");
+            }
+
             return result;
         }
 
@@ -298,10 +334,13 @@ namespace StingTools.Core.Symbols
         private static void BuildVariant(Document hostDoc, Application app, SymbolDefinition baseDef,
             string emitId, StandardGeometryOverride overrideDef,
             string outputFolder, string templateFolder, bool loadIntoProject,
-            SymbolCreationResult result)
+            SymbolCreationResult result, bool catalogueStale = false)
         {
             var rfaPath = Path.Combine(outputFolder, emitId + ".rfa");
-            if (File.Exists(rfaPath))
+            // W-1 — same existence-is-not-freshness rule as the main build loop.
+            // This method currently has no call site; the guard is here so wiring
+            // it later cannot silently reintroduce an uninvalidatable cache.
+            if (File.Exists(rfaPath) && !catalogueStale)
             {
                 result.Existed++;
                 result.CreatedRfaPaths.Add(rfaPath);

--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -210,7 +210,7 @@ namespace StingTools.Core.Symbols
             // Existence alone is not freshness. A .rfa on disk may have been
             // built from an older catalogue, or by an older generator whose
             // output differed even though every catalogue byte is identical.
-            // rebuildMode forces a rebuild regardless (Symbols_RebuildAll).
+            // rebuildMode forces a rebuild regardless (Symbols_Rebuild -> Force all).
             var cache = SymbolCacheManifest.Load(outputFolder);
             bool hashStale = cache.IsCatalogueStale(jsonPath, out string staleReason);
             bool catalogueStale = rebuildMode || hashStale;
@@ -221,6 +221,11 @@ namespace StingTools.Core.Symbols
                 result.Warnings.Add($"{Path.GetFileName(jsonPath)}: rebuilding cached families — {cause}.");
             }
 
+            // Every id this run considered, and the subset that failed. Used to carry a
+            // per-symbol retry list in the sidecar (see RecordFailures).
+            var attemptedIds = new List<string>();
+            var failedIds = new List<string>();
+
             foreach (var def in lib.Symbols)
             {
                 if (string.IsNullOrWhiteSpace(def?.Id))
@@ -229,6 +234,8 @@ namespace StingTools.Core.Symbols
                     result.Errors.Add("Symbol with empty id skipped.");
                     continue;
                 }
+
+                attemptedIds.Add(def.Id);
 
                 // Apply project-level size config (global multiplier / category / per-symbol override).
                 if (sizeConfig != null)
@@ -246,7 +253,9 @@ namespace StingTools.Core.Symbols
                 // built from something that no longer describes this symbol, so
                 // existence no longer licenses a skip. Fall through to BuildOne,
                 // which overwrites via SaveAsOptions.OverwriteExistingFile.
-                if (File.Exists(rfaPath) && !catalogueStale)
+                // IsSymbolStale additionally retries anything that failed last run,
+                // whose on-disk file may be a survivor of a failed regeneration.
+                if (File.Exists(rfaPath) && !catalogueStale && !cache.IsSymbolStale(def.Id))
                 {
                     // If the .rfa loads cleanly, count it as Existed and
                     // move on. If LoadFamily returns false (Revit's
@@ -273,6 +282,7 @@ namespace StingTools.Core.Symbols
                     {
                         result.Warnings.Add($"{def.Id}: stale .rfa delete failed — {ex.Message}; skipping rebuild.");
                         result.Failed++;
+                        failedIds.Add(def.Id);
                         continue;
                     }
                 }
@@ -295,32 +305,33 @@ namespace StingTools.Core.Symbols
                     else
                     {
                         result.Failed++;
+                        failedIds.Add(def.Id);
                     }
                 }
                 catch (Exception ex2)
                 {
                     result.Failed++;
+                    failedIds.Add(def.Id);
                     result.Errors.Add($"{def.Id}: {ex2.Message}");
                     StingLog.Error($"SymbolLibraryCreator: {def.Id} failed", ex2);
                 }
             }
 
             // ── Record the build (W-1) ────────────────────────────────────
-            // Only stamp the catalogue as built when nothing failed. Recording a
-            // partial build would mark the catalogue fresh and permanently strand
-            // the families that did not make it — the exact failure mode this
-            // whole mechanism exists to stop.
-            if (result.Failed == 0)
-            {
-                cache.RecordCatalogue(jsonPath);
-                cache.Save(outputFolder);
-            }
-            else
-            {
+            // Stamp the catalogue hash and carry the failure set forward. Failures are
+            // tracked per symbol rather than blocking the whole catalogue: a symbol
+            // that fails leaves whatever was on disk before (BuildOne's SaveAs is its
+            // last step), so a stale family that failed to regenerate would otherwise
+            // be served silently. Recording the id forces a retry next run while every
+            // symbol that did build stays cached.
+            cache.RecordCatalogue(jsonPath);
+            cache.RecordFailures(attemptedIds, failedIds);
+            cache.Save(outputFolder);
+
+            if (failedIds.Count > 0)
                 result.Warnings.Add(
-                    $"{Path.GetFileName(jsonPath)}: {result.Failed} symbol(s) failed — cache not " +
-                    "stamped, so the next run will retry this catalogue.");
-            }
+                    $"{Path.GetFileName(jsonPath)}: {failedIds.Count} symbol(s) failed and are " +
+                    "flagged for retry on the next build.");
 
             return result;
         }

--- a/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
@@ -570,6 +570,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -2102,6 +2103,7 @@
       "discipline": "Electrical",
       "subcategory": "ATEXZone",
       "symbolSize": 6.0,
+      "overallExtent": 0.6,
       "description": "Hazardous area zone boundary line marker for electrical floor plan drawings — IEC 60079-10-1 / ATEX Directive 2014/34/EU",
       "parameters": [
         {

--- a/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
@@ -10,7 +10,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 4.0,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -66,7 +66,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 5.0,
-      "realSizeMm": 146,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -149,7 +149,7 @@
       "discipline": "Electrical",
       "subcategory": "Outlet",
       "symbolSize": 4.0,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -234,7 +234,7 @@
       "discipline": "Electrical",
       "subcategory": "Specialist",
       "symbolSize": 6.0,
-      "realSizeMm": 350,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -326,7 +326,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -382,7 +382,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -425,7 +425,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 4.0,
-      "realSizeMm": 86,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -474,7 +474,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -529,7 +529,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -579,7 +579,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "overallExtent": 0.7,
       "parameters": [
         {
@@ -622,7 +622,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 8.0,
-      "realSizeMm": 400,
+      "realSizeMm": 350,
       "parameters": [
         {
           "name": "DB_REF",
@@ -725,7 +725,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 8.0,
-      "realSizeMm": 600,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "DB_REF",
@@ -821,7 +821,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 12.0,
-      "realSizeMm": 800,
+      "realSizeMm": 2000,
       "parameters": [
         {
           "name": "PANEL_REF",
@@ -955,7 +955,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 5.0,
-      "realSizeMm": 180,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "METER_REF",
@@ -1033,7 +1033,7 @@
       "discipline": "Electrical",
       "subcategory": "Security",
       "symbolSize": 4.0,
-      "realSizeMm": 120,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1104,7 +1104,7 @@
       "discipline": "Electrical",
       "subcategory": "Security",
       "symbolSize": 4.5,
-      "realSizeMm": 250,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1246,7 +1246,7 @@
       "discipline": "Electrical",
       "subcategory": "Data",
       "symbolSize": 3.5,
-      "realSizeMm": 86,
+      "realSizeMm": 85,
       "parameters": [
         {
           "name": "PORT_REF",
@@ -1311,7 +1311,7 @@
       "discipline": "Electrical",
       "subcategory": "Data",
       "symbolSize": 4.5,
-      "realSizeMm": 86,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "PORT_REF",
@@ -1599,7 +1599,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Oxygen (O2) medical pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1",
       "parameters": [
         {
@@ -1688,7 +1688,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Nitrous oxide (N2O) medical pipeline outlet — BS HTM 02-01 / NFPA 99",
       "parameters": [
         {
@@ -1777,7 +1777,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Carbon dioxide (CO2) medical pipeline outlet — BS HTM 02-01",
       "parameters": [
         {
@@ -1866,7 +1866,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Medical compressed air outlet (400 kPa / 7 bar variants) — BS HTM 02-01 / NFPA 99 §5.1.3",
       "parameters": [
         {
@@ -1955,7 +1955,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Medical vacuum (MEDIVAC) pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1.5",
       "parameters": [
         {
@@ -2044,7 +2044,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
-      "realSizeMm": 100,
+      "realSizeMm": 85,
       "description": "Anaesthetic Gas Scavenging System (AGSS) outlet — BS HTM 02-01 §4.4 / ISO 7396-2",
       "parameters": [
         {

--- a/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ELEC_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 4.0,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -65,6 +66,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 5.0,
+      "realSizeMm": 146,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -147,6 +149,7 @@
       "discipline": "Electrical",
       "subcategory": "Outlet",
       "symbolSize": 4.0,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -231,6 +234,7 @@
       "discipline": "Electrical",
       "subcategory": "Specialist",
       "symbolSize": 6.0,
+      "realSizeMm": 350,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -322,6 +326,7 @@
       "discipline": "Electrical",
       "subcategory": "Socket",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -377,6 +382,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -419,6 +425,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 4.0,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -467,6 +474,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -521,6 +529,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -570,6 +579,7 @@
       "discipline": "Electrical",
       "subcategory": "Switch",
       "symbolSize": 3.5,
+      "realSizeMm": 100,
       "overallExtent": 0.7,
       "parameters": [
         {
@@ -612,6 +622,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 8.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "DB_REF",
@@ -714,6 +725,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 8.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "DB_REF",
@@ -809,6 +821,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 12.0,
+      "realSizeMm": 800,
       "parameters": [
         {
           "name": "PANEL_REF",
@@ -892,6 +905,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "RATING_A",
@@ -941,6 +955,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 5.0,
+      "realSizeMm": 180,
       "parameters": [
         {
           "name": "METER_REF",
@@ -1018,6 +1033,7 @@
       "discipline": "Electrical",
       "subcategory": "Security",
       "symbolSize": 4.0,
+      "realSizeMm": 120,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1088,6 +1104,7 @@
       "discipline": "Electrical",
       "subcategory": "Security",
       "symbolSize": 4.5,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1163,6 +1180,7 @@
       "discipline": "Electrical",
       "subcategory": "Security",
       "symbolSize": 3.5,
+      "realSizeMm": 90,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1228,6 +1246,7 @@
       "discipline": "Electrical",
       "subcategory": "Data",
       "symbolSize": 3.5,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "PORT_REF",
@@ -1292,6 +1311,7 @@
       "discipline": "Electrical",
       "subcategory": "Data",
       "symbolSize": 4.5,
+      "realSizeMm": 86,
       "parameters": [
         {
           "name": "PORT_REF",
@@ -1363,6 +1383,7 @@
       "discipline": "Electrical",
       "subcategory": "Audio",
       "symbolSize": 4.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1438,6 +1459,7 @@
       "discipline": "Electrical",
       "subcategory": "Audio",
       "symbolSize": 3.0,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1493,6 +1515,7 @@
       "discipline": "Electrical",
       "subcategory": "FireDetection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "DEVICE_ADDRESS",
@@ -1534,6 +1557,7 @@
       "discipline": "Electrical",
       "subcategory": "FireDetection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "DEVICE_ADDRESS",
@@ -1575,6 +1599,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Oxygen (O2) medical pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1",
       "parameters": [
         {
@@ -1663,6 +1688,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Nitrous oxide (N2O) medical pipeline outlet — BS HTM 02-01 / NFPA 99",
       "parameters": [
         {
@@ -1751,6 +1777,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Carbon dioxide (CO2) medical pipeline outlet — BS HTM 02-01",
       "parameters": [
         {
@@ -1839,6 +1866,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Medical compressed air outlet (400 kPa / 7 bar variants) — BS HTM 02-01 / NFPA 99 §5.1.3",
       "parameters": [
         {
@@ -1927,6 +1955,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Medical vacuum (MEDIVAC) pipeline outlet — BS HTM 02-01 / NFPA 99 §5.1.5",
       "parameters": [
         {
@@ -2015,6 +2044,7 @@
       "discipline": "MedicalGas",
       "subcategory": "MedGasOutlet",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "description": "Anaesthetic Gas Scavenging System (AGSS) outlet — BS HTM 02-01 §4.4 / ISO 7396-2",
       "parameters": [
         {

--- a/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
@@ -89,6 +89,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -164,6 +165,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -292,6 +294,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 5.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -606,6 +609,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.5,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -661,6 +665,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -744,6 +749,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -998,6 +1004,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 5.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ZONE_REF",

--- a/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
@@ -238,7 +238,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
-      "realSizeMm": 75,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -298,7 +298,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 5.0,
-      "realSizeMm": 75,
+      "realSizeMm": 80,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -619,7 +619,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.5,
-      "realSizeMm": 100,
+      "realSizeMm": 110,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -676,7 +676,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
-      "realSizeMm": 130,
+      "realSizeMm": 200,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -761,7 +761,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
-      "realSizeMm": 130,
+      "realSizeMm": 200,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -901,7 +901,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 4.0,
-      "realSizeMm": 87,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1020,7 +1020,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 5.0,
-      "realSizeMm": 110,
+      "realSizeMm": 130,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1075,7 +1075,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 4.0,
-      "realSizeMm": 110,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1255,7 +1255,7 @@
       "discipline": "FireProtection",
       "subcategory": "Panel",
       "symbolSize": 6.0,
-      "realSizeMm": 300,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "PANEL_REF",

--- a/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_FP_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "realSizeMm": 50,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -89,6 +90,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "realSizeMm": 50,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -165,6 +167,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "realSizeMm": 50,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -235,6 +238,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "realSizeMm": 75,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -294,6 +298,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 5.0,
+      "realSizeMm": 75,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -369,6 +374,7 @@
       "discipline": "FireProtection",
       "subcategory": "Sprinkler",
       "symbolSize": 4.0,
+      "realSizeMm": 50,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -426,6 +432,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -472,6 +479,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -513,6 +521,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -561,6 +570,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -609,6 +619,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.5,
+      "realSizeMm": 100,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -665,6 +676,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
+      "realSizeMm": 130,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -749,6 +761,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 5.0,
+      "realSizeMm": 130,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -827,6 +840,7 @@
       "discipline": "FireProtection",
       "subcategory": "Detection",
       "symbolSize": 4.5,
+      "realSizeMm": 120,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -887,6 +901,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 4.0,
+      "realSizeMm": 87,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -953,6 +968,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1004,6 +1020,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 5.0,
+      "realSizeMm": 110,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1058,6 +1075,7 @@
       "discipline": "FireProtection",
       "subcategory": "Alarm",
       "symbolSize": 4.0,
+      "realSizeMm": 110,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1134,6 +1152,7 @@
       "discipline": "FireProtection",
       "subcategory": "Panel",
       "symbolSize": 8.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "PANEL_REF",
@@ -1236,6 +1255,7 @@
       "discipline": "FireProtection",
       "subcategory": "Panel",
       "symbolSize": 6.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "PANEL_REF",
@@ -1295,6 +1315,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 6.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "VALVE_REF",
@@ -1387,6 +1408,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 6.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "VALVE_REF",
@@ -1476,6 +1498,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 7.0,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "VALVE_REF",
@@ -1576,6 +1599,7 @@
       "discipline": "FireProtection",
       "subcategory": "Monitor",
       "symbolSize": 5.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1671,6 +1695,7 @@
       "discipline": "FireProtection",
       "subcategory": "Monitor",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "RANGE_BAR",
@@ -1737,6 +1762,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [],
       "geometry": {
         "arcs": [
@@ -1801,6 +1827,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [],
       "geometry": {
         "arcs": [
@@ -1871,6 +1898,7 @@
       "discipline": "FireProtection",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "VALVE_REF",

--- a/StingTools/Data/Symbols/STING_ISO6412_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_ISO6412_SYMBOLS.json
@@ -3942,6 +3942,7 @@
       "discipline": "Generic",
       "subcategory": "ISO6412",
       "symbolSize": 6.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "Symbol Scale",
@@ -4571,6 +4572,7 @@
       "discipline": "Mechanical",
       "subcategory": "ISO6412",
       "symbolSize": 8.0,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "Symbol Scale",
@@ -10232,78 +10234,6 @@
       "status": "draft"
     },
     {
-      "id": "ISO6412_VLV_MOV",
-      "name": "Motor Actuated Valve",
-      "category": "Valves",
-      "familyType": "GenericAnnotation",
-      "discipline": "Generic",
-      "subcategory": "ISO6412",
-      "symbolSize": 6.0,
-      "parameters": [
-        {
-          "name": "Symbol Scale",
-          "type": "Integer",
-          "shared": true
-        }
-      ],
-      "geometry": {},
-      "status": "draft"
-    },
-    {
-      "id": "ISO6412_VLV_AOV",
-      "name": "Air Actuated Valve",
-      "category": "Valves",
-      "familyType": "GenericAnnotation",
-      "discipline": "Generic",
-      "subcategory": "ISO6412",
-      "symbolSize": 6.0,
-      "parameters": [
-        {
-          "name": "Symbol Scale",
-          "type": "Integer",
-          "shared": true
-        }
-      ],
-      "geometry": {},
-      "status": "draft"
-    },
-    {
-      "id": "ISO6412_VLV_SOV",
-      "name": "Solenoid Actuated Valve",
-      "category": "Valves",
-      "familyType": "GenericAnnotation",
-      "discipline": "Generic",
-      "subcategory": "ISO6412",
-      "symbolSize": 6.0,
-      "parameters": [
-        {
-          "name": "Symbol Scale",
-          "type": "Integer",
-          "shared": true
-        }
-      ],
-      "geometry": {},
-      "status": "draft"
-    },
-    {
-      "id": "ISO6412_VLV_HOV",
-      "name": "Hand-wheel Actuated Valve",
-      "category": "Valves",
-      "familyType": "GenericAnnotation",
-      "discipline": "Generic",
-      "subcategory": "ISO6412",
-      "symbolSize": 6.0,
-      "parameters": [
-        {
-          "name": "Symbol Scale",
-          "type": "Integer",
-          "shared": true
-        }
-      ],
-      "geometry": {},
-      "status": "draft"
-    },
-    {
       "id": "ISO6412_VLV_HANDLE",
       "name": "Valve Handwheel (Operator Overlay)",
       "category": "Valves",
@@ -10808,6 +10738,7 @@
       "discipline": "Generic",
       "subcategory": "ISO6412",
       "symbolSize": 6.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "Symbol Scale",
@@ -14368,6 +14299,7 @@
       "discipline": "Generic",
       "subcategory": "ISO6412",
       "symbolSize": 10.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "Symbol Scale",

--- a/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
@@ -1458,6 +1458,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "CIRCUIT_REF",

--- a/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -81,6 +82,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -156,6 +158,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -239,6 +242,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.5,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -292,6 +296,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -338,6 +343,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 10.0,
+      "realSizeMm": 1000,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -424,6 +430,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 12.0,
+      "realSizeMm": 1200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -495,6 +502,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 12.0,
+      "realSizeMm": 1200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -565,6 +573,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 10.0,
+      "realSizeMm": 1200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -635,6 +644,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 4.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -704,6 +714,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 4.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -752,6 +763,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -828,6 +840,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -882,6 +895,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 3.5,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -941,6 +955,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1023,6 +1038,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 2.5,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1077,6 +1093,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 4.5,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1155,6 +1172,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 6.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1221,6 +1239,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 5.0,
+      "realSizeMm": 350,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1274,6 +1293,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 4.0,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1322,6 +1342,7 @@
       "discipline": "Electrical",
       "subcategory": "Specialist",
       "symbolSize": 8.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1404,6 +1425,7 @@
       "discipline": "Electrical",
       "subcategory": "Specialist",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1458,6 +1480,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
+      "realSizeMm": 300,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1525,6 +1548,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 3.5,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1587,6 +1611,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 3.0,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "CIRCUIT_REF",

--- a/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_LIGHTING_SYMBOLS.json
@@ -82,7 +82,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
-      "realSizeMm": 150,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -158,7 +158,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
-      "realSizeMm": 300,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -296,7 +296,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
-      "realSizeMm": 300,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -343,7 +343,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 10.0,
-      "realSizeMm": 1000,
+      "realSizeMm": 1500,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -573,7 +573,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 10.0,
-      "realSizeMm": 1200,
+      "realSizeMm": 1000,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -644,7 +644,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 4.0,
-      "realSizeMm": 200,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -714,7 +714,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 4.0,
-      "realSizeMm": 200,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -763,7 +763,7 @@
       "discipline": "Electrical",
       "subcategory": "Emergency",
       "symbolSize": 5.0,
-      "realSizeMm": 300,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -895,7 +895,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 3.5,
-      "realSizeMm": 250,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -955,7 +955,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 5.0,
-      "realSizeMm": 300,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1038,7 +1038,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 2.5,
-      "realSizeMm": 150,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1093,7 +1093,7 @@
       "discipline": "Electrical",
       "subcategory": "External",
       "symbolSize": 4.5,
-      "realSizeMm": 400,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1172,7 +1172,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 6.0,
-      "realSizeMm": 400,
+      "realSizeMm": 500,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1239,7 +1239,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 5.0,
-      "realSizeMm": 350,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1293,7 +1293,7 @@
       "discipline": "Electrical",
       "subcategory": "Industrial",
       "symbolSize": 4.0,
-      "realSizeMm": 250,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1425,7 +1425,7 @@
       "discipline": "Electrical",
       "subcategory": "Specialist",
       "symbolSize": 5.0,
-      "realSizeMm": 300,
+      "realSizeMm": 350,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -1480,7 +1480,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 4.0,
-      "realSizeMm": 300,
+      "realSizeMm": 200,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1548,7 +1548,7 @@
       "discipline": "Electrical",
       "subcategory": "Lighting",
       "symbolSize": 3.5,
-      "realSizeMm": 150,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "CIRCUIT_REF",

--- a/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
@@ -10,7 +10,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
-      "realSizeMm": 300,
+      "realSizeMm": 595,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -217,7 +217,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
-      "realSizeMm": 300,
+      "realSizeMm": 595,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -493,7 +493,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 4.0,
-      "realSizeMm": 125,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -586,7 +586,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
-      "realSizeMm": 500,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -709,7 +709,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.5,
-      "realSizeMm": 400,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -781,7 +781,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
-      "realSizeMm": 400,
+      "realSizeMm": 500,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -1411,7 +1411,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 8.0,
-      "realSizeMm": 1000,
+      "realSizeMm": 800,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -1546,7 +1546,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 8.0,
-      "realSizeMm": 1000,
+      "realSizeMm": 800,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -1856,7 +1856,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 16.0,
-      "realSizeMm": 2000,
+      "realSizeMm": 3000,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2087,7 +2087,7 @@
       "discipline": "Mechanical",
       "subcategory": "Fan",
       "symbolSize": 6.0,
-      "realSizeMm": 600,
+      "realSizeMm": 700,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2176,7 +2176,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
-      "realSizeMm": 90,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2218,7 +2218,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
-      "realSizeMm": 90,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2260,7 +2260,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
-      "realSizeMm": 90,
+      "realSizeMm": 60,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2302,7 +2302,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
-      "realSizeMm": 90,
+      "realSizeMm": 80,
       "parameters": [
         {
           "name": "DEVICE_REF",

--- a/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -121,6 +122,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -215,6 +217,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -319,6 +322,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -406,6 +410,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 12.0,
+      "realSizeMm": 1200,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -488,6 +493,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 4.0,
+      "realSizeMm": 125,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -580,6 +586,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 6.0,
+      "realSizeMm": 500,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -702,6 +709,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.5,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "SYSTEM_REF",
@@ -773,6 +781,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
+      "realSizeMm": 400,
       "overallExtent": 0.6,
       "parameters": [
         {
@@ -856,6 +865,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 5.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "FIRE_RATING",
@@ -963,6 +973,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 5.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -1048,6 +1059,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 5.5,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "FIRE_RATING",
@@ -1143,6 +1155,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 4.5,
+      "realSizeMm": 300,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1218,6 +1231,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 5.0,
+      "realSizeMm": 300,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1311,6 +1325,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 4.5,
+      "realSizeMm": 300,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1396,6 +1411,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 8.0,
+      "realSizeMm": 1000,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -1530,6 +1546,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 8.0,
+      "realSizeMm": 1000,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -1620,6 +1637,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 6.0,
+      "realSizeMm": 600,
       "overallExtent": 0.55,
       "parameters": [
         {
@@ -1739,6 +1757,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 6.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "FLOW_LS",
@@ -1837,6 +1856,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 16.0,
+      "realSizeMm": 2000,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -1987,6 +2007,7 @@
       "discipline": "Mechanical",
       "subcategory": "Fan",
       "symbolSize": 5.0,
+      "realSizeMm": 500,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2066,6 +2087,7 @@
       "discipline": "Mechanical",
       "subcategory": "Fan",
       "symbolSize": 6.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2154,6 +2176,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
+      "realSizeMm": 90,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2195,6 +2218,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
+      "realSizeMm": 90,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2236,6 +2260,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
+      "realSizeMm": 90,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2277,6 +2302,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
+      "realSizeMm": 90,
       "parameters": [
         {
           "name": "DEVICE_REF",
@@ -2318,6 +2344,7 @@
       "discipline": "Mechanical",
       "subcategory": "Controls",
       "symbolSize": 3.5,
+      "realSizeMm": 100,
       "parameters": [
         {
           "name": "DEVICE_REF",

--- a/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_MEP_SYMBOLS.json
@@ -773,6 +773,7 @@
       "discipline": "Mechanical",
       "subcategory": "AirTerminal",
       "symbolSize": 5.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "FLOW_LS",
@@ -1217,6 +1218,7 @@
       "discipline": "Mechanical",
       "subcategory": "Damper",
       "symbolSize": 5.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ACTUATOR_TYPE",
@@ -1618,6 +1620,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 6.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2641,6 +2644,7 @@
       "discipline": "HVAC",
       "subcategory": "HVAC Equipment",
       "symbolSize": 7.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "Symbol Scale",

--- a/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
+++ b/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
@@ -10,6 +10,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -106,6 +107,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -175,6 +177,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 120,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -250,6 +253,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.5,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -319,6 +323,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -378,6 +383,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 250,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -468,6 +474,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 3.5,
+      "realSizeMm": 100,
       "parameters": [],
       "geometry": {
         "arcs": [
@@ -542,6 +549,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 4.5,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -622,6 +630,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 120,
       "parameters": [
         {
           "name": "VOLTAGE",
@@ -719,6 +728,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "SET_PRESSURE_BAR",
@@ -809,6 +819,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 200,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -892,6 +903,7 @@
       "discipline": "Mechanical",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 200,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -981,6 +993,7 @@
       "discipline": "Mechanical",
       "subcategory": "Filter",
       "symbolSize": 5.0,
+      "realSizeMm": 180,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1064,6 +1077,7 @@
       "discipline": "Mechanical",
       "subcategory": "Filter",
       "symbolSize": 6.0,
+      "realSizeMm": 250,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1159,6 +1173,7 @@
       "discipline": "Mechanical",
       "subcategory": "Connector",
       "symbolSize": 5.0,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1236,6 +1251,7 @@
       "discipline": "Mechanical",
       "subcategory": "Connector",
       "symbolSize": 5.0,
+      "realSizeMm": 250,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1325,6 +1341,7 @@
       "discipline": "Mechanical",
       "subcategory": "Instrument",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "overallExtent": 0.65,
       "parameters": [
         {
@@ -1398,6 +1415,7 @@
       "discipline": "Mechanical",
       "subcategory": "Instrument",
       "symbolSize": 4.0,
+      "realSizeMm": 100,
       "overallExtent": 0.65,
       "parameters": [
         {
@@ -1471,6 +1489,7 @@
       "discipline": "Mechanical",
       "subcategory": "Instrument",
       "symbolSize": 4.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -1542,6 +1561,7 @@
       "discipline": "Mechanical",
       "subcategory": "Equipment",
       "symbolSize": 5.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",

--- a/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
+++ b/StingTools/Data/Symbols/STING_PIPE_ACCESSORIES.json
@@ -1325,6 +1325,7 @@
       "discipline": "Mechanical",
       "subcategory": "Instrument",
       "symbolSize": 4.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RANGE_BAR",
@@ -1397,6 +1398,7 @@
       "discipline": "Mechanical",
       "subcategory": "Instrument",
       "symbolSize": 4.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RANGE_C",

--- a/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
@@ -10,7 +10,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.5,
-      "realSizeMm": 360,
+      "realSizeMm": 560,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -211,7 +211,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 4.0,
-      "realSizeMm": 400,
+      "realSizeMm": 350,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -294,7 +294,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.0,
-      "realSizeMm": 550,
+      "realSizeMm": 500,
       "overallExtent": 0.8,
       "parameters": [
         {
@@ -584,7 +584,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 8.0,
-      "realSizeMm": 1000,
+      "realSizeMm": 800,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -804,7 +804,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 8.0,
-      "realSizeMm": 900,
+      "realSizeMm": 800,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1024,7 +1024,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 4.5,
-      "realSizeMm": 360,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1089,7 +1089,7 @@
       "discipline": "Plumbing",
       "subcategory": "Drainage",
       "symbolSize": 3.0,
-      "realSizeMm": 150,
+      "realSizeMm": 100,
       "parameters": [],
       "geometry": {
         "arcs": [
@@ -1951,7 +1951,7 @@
       "discipline": "Plumbing",
       "subcategory": "Equipment",
       "symbolSize": 7.0,
-      "realSizeMm": 500,
+      "realSizeMm": 450,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",

--- a/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.5,
+      "realSizeMm": 360,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -113,6 +114,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 6.5,
+      "realSizeMm": 700,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -209,6 +211,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 4.0,
+      "realSizeMm": 400,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -291,6 +294,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.0,
+      "realSizeMm": 550,
       "overallExtent": 0.8,
       "parameters": [
         {
@@ -382,6 +386,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 6.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -468,6 +473,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 6.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -578,6 +584,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 8.0,
+      "realSizeMm": 1000,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -703,6 +710,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.0,
+      "realSizeMm": 600,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -796,6 +804,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 8.0,
+      "realSizeMm": 900,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -897,6 +906,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 17.0,
+      "realSizeMm": 1700,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1014,6 +1024,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 4.5,
+      "realSizeMm": 360,
       "parameters": [
         {
           "name": "ZONE_REF",
@@ -1078,6 +1089,7 @@
       "discipline": "Plumbing",
       "subcategory": "Drainage",
       "symbolSize": 3.0,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "arcs": [
@@ -1129,6 +1141,7 @@
       "discipline": "Plumbing",
       "subcategory": "Drainage",
       "symbolSize": 3.5,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1196,6 +1209,7 @@
       "discipline": "Plumbing",
       "subcategory": "Drainage",
       "symbolSize": 4.0,
+      "realSizeMm": 250,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1275,6 +1289,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -1360,6 +1375,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -1429,6 +1445,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 120,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -1504,6 +1521,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 4.5,
+      "realSizeMm": 150,
       "parameters": [
         {
           "name": "SIZE_MM",
@@ -1603,6 +1621,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 4.0,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1662,6 +1681,7 @@
       "discipline": "Plumbing",
       "subcategory": "Filter",
       "symbolSize": 5.0,
+      "realSizeMm": 180,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1753,6 +1773,7 @@
       "discipline": "Plumbing",
       "subcategory": "Connector",
       "symbolSize": 5.0,
+      "realSizeMm": 150,
       "parameters": [],
       "geometry": {
         "lines": [
@@ -1830,6 +1851,7 @@
       "discipline": "Plumbing",
       "subcategory": "Valve",
       "symbolSize": 5.0,
+      "realSizeMm": 200,
       "parameters": [
         {
           "name": "SET_PRESSURE_BAR",
@@ -1929,6 +1951,7 @@
       "discipline": "Plumbing",
       "subcategory": "Equipment",
       "symbolSize": 7.0,
+      "realSizeMm": 500,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",
@@ -2027,6 +2050,7 @@
       "discipline": "Plumbing",
       "subcategory": "Equipment",
       "symbolSize": 7.0,
+      "realSizeMm": 500,
       "parameters": [
         {
           "name": "EQUIPMENT_REF",

--- a/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_PLUMBING_SYMBOLS.json
@@ -291,6 +291,7 @@
       "discipline": "Plumbing",
       "subcategory": "Sanitary",
       "symbolSize": 5.0,
+      "overallExtent": 0.8,
       "parameters": [
         {
           "name": "ZONE_REF",

--- a/StingTools/Data/Symbols/STING_SLD_SYMBOLS.json
+++ b/StingTools/Data/Symbols/STING_SLD_SYMBOLS.json
@@ -10,6 +10,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 3.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -92,6 +93,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 4.0,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -173,6 +175,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 5.0,
+      "overallExtent": 0.75,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -260,6 +263,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 3.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -337,6 +341,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 4.0,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -526,6 +531,7 @@
       "discipline": "Electrical",
       "subcategory": "Drive",
       "symbolSize": 4.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -614,6 +620,7 @@
       "discipline": "Electrical",
       "subcategory": "Drive",
       "symbolSize": 4.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -721,6 +728,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 3.5,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -789,6 +797,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 4.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "CIRCUIT_REF",
@@ -875,6 +884,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 3.5,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "SPD_CLASS",
@@ -959,6 +969,7 @@
       "discipline": "Electrical",
       "subcategory": "Transformer",
       "symbolSize": 5.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1027,6 +1038,7 @@
       "discipline": "Electrical",
       "subcategory": "Transformer",
       "symbolSize": 5.5,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1096,6 +1108,7 @@
       "discipline": "Electrical",
       "subcategory": "Transformer",
       "symbolSize": 4.5,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1153,6 +1166,7 @@
       "discipline": "Electrical",
       "subcategory": "Transformer",
       "symbolSize": 6.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1248,6 +1262,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 3.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "RANGE_A",
@@ -1299,6 +1314,7 @@
       "discipline": "Electrical",
       "subcategory": "Instrument",
       "symbolSize": 3.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "RANGE_V",
@@ -1758,6 +1774,7 @@
       "discipline": "Electrical",
       "subcategory": "Source",
       "symbolSize": 5.0,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1823,6 +1840,7 @@
       "discipline": "Electrical",
       "subcategory": "Source",
       "symbolSize": 5.0,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "RATING_KVA",
@@ -1987,6 +2005,7 @@
       "discipline": "Electrical",
       "subcategory": "Source",
       "symbolSize": 5.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "ARRAY_KWP",
@@ -2059,6 +2078,7 @@
       "discipline": "Electrical",
       "subcategory": "Switching",
       "symbolSize": 5.0,
+      "overallExtent": 0.7,
       "parameters": [
         {
           "name": "RATING_A",
@@ -2139,6 +2159,7 @@
       "discipline": "Electrical",
       "subcategory": "Load",
       "symbolSize": 4.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RATING_KW",
@@ -2222,6 +2243,7 @@
       "discipline": "Electrical",
       "subcategory": "Load",
       "symbolSize": 3.5,
+      "overallExtent": 0.6,
       "parameters": [
         {
           "name": "RATING_KW",
@@ -2315,6 +2337,7 @@
       "discipline": "Electrical",
       "subcategory": "Load",
       "symbolSize": 3.5,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "RATING_KW",
@@ -2431,6 +2454,7 @@
       "discipline": "Electrical",
       "subcategory": "Distribution",
       "symbolSize": 6.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "DB_REF",
@@ -2580,6 +2604,7 @@
       "discipline": "Electrical",
       "subcategory": "Protection",
       "symbolSize": 4.0,
+      "overallExtent": 0.65,
       "parameters": [
         {
           "name": "RATING_A",
@@ -2652,6 +2677,7 @@
       "discipline": "Electrical",
       "subcategory": "Switching",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "parameters": [
         {
           "name": "RATING_A",
@@ -2703,6 +2729,7 @@
       "discipline": "Electrical",
       "subcategory": "LPS",
       "symbolSize": 5.0,
+      "overallExtent": 0.8,
       "description": "Air terminal / finial — BS EN 62305-3 / NFPA 780",
       "parameters": [
         {
@@ -2760,6 +2787,7 @@
       "discipline": "Electrical",
       "subcategory": "LPS",
       "symbolSize": 4.0,
+      "overallExtent": 0.75,
       "description": "Down conductor routing symbol — BS EN 62305-3 §5.3",
       "parameters": [
         {
@@ -2825,6 +2853,7 @@
       "discipline": "Electrical",
       "subcategory": "LPS",
       "symbolSize": 5.0,
+      "overallExtent": 0.8,
       "description": "Earth electrode / earth pit — BS EN 62305-3 §5.4 / NFPA 780",
       "parameters": [
         {
@@ -2886,6 +2915,7 @@
       "discipline": "Electrical",
       "subcategory": "LPS",
       "symbolSize": 6.0,
+      "overallExtent": 0.65,
       "description": "Main equipotential bonding bar / MEB — BS EN 62305-3",
       "parameters": [
         {
@@ -2959,6 +2989,7 @@
       "discipline": "Electrical",
       "subcategory": "HazardousArea",
       "symbolSize": 6.0,
+      "overallExtent": 0.65,
       "description": "Zone 0 — continuous presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         {
@@ -3043,6 +3074,7 @@
       "discipline": "Electrical",
       "subcategory": "HazardousArea",
       "symbolSize": 6.0,
+      "overallExtent": 0.65,
       "description": "Zone 1 — likely presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         {
@@ -3115,6 +3147,7 @@
       "discipline": "Electrical",
       "subcategory": "HazardousArea",
       "symbolSize": 6.0,
+      "overallExtent": 0.65,
       "description": "Zone 2 — unlikely presence of explosive atmosphere (IEC 60079-10-1 / DSEAR)",
       "parameters": [
         {
@@ -3351,6 +3384,7 @@
       "discipline": "Electrical",
       "subcategory": "Notation",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "description": "ABC (positive / clockwise) phase rotation notation — IEC 60034-8",
       "parameters": [
         {
@@ -3416,6 +3450,7 @@
       "discipline": "Electrical",
       "subcategory": "Notation",
       "symbolSize": 4.0,
+      "overallExtent": 0.55,
       "description": "ACB (negative / counter-clockwise) phase rotation notation — IEC 60034-8",
       "parameters": [
         {

--- a/StingTools/Data/Symbols/STING_SLD_SYMBOLS_CIBSE.json
+++ b/StingTools/Data/Symbols/STING_SLD_SYMBOLS_CIBSE.json
@@ -262,6 +262,7 @@
       "id": "CIBSE_AHU",
       "familyType": "GenericAnnotation",
       "symbolSize": 8.0,
+      "overallExtent": 0.65,
       "geometry": {
         "lines": [
           {
@@ -364,6 +365,7 @@
       "id": "CIBSE_FCU",
       "familyType": "GenericAnnotation",
       "symbolSize": 6.0,
+      "overallExtent": 0.55,
       "geometry": {
         "lines": [
           {
@@ -521,6 +523,7 @@
       "id": "CIBSE_CHILLER",
       "familyType": "GenericAnnotation",
       "symbolSize": 6.0,
+      "overallExtent": 0.55,
       "geometry": {
         "lines": [
           {
@@ -821,6 +824,7 @@
       "id": "CIBSE_DUCT_COIL",
       "familyType": "GenericAnnotation",
       "symbolSize": 5.0,
+      "overallExtent": 0.55,
       "geometry": {
         "lines": [
           {

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -499,6 +499,7 @@ namespace StingTools.UI
                     case "Symbols_CreateLighting": RunCommand<Commands.Symbols.CreateLightingSymbolsCommand>(app); break;
                     case "Symbols_CreateFP":       RunCommand<Commands.Symbols.CreateFPSymbolsCommand>(app); break;
                     case "Symbols_Reload":         RunCommand<Commands.Symbols.ReloadSymbolLibraryCommand>(app); break;
+                    case "Symbols_Rebuild":        RunCommand<Commands.Symbols.SymbolRebuildCommand>(app); break;
                     case "Symbols_Inspect":        RunCommand<Commands.Symbols.InspectSymbolLibraryCommand>(app); break;
                     case "Symbols_ConfigSizes":    RunCommand<Commands.Symbols.ConfigureSymbolSizesCommand>(app); break;
 

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1967,6 +1967,7 @@
                                         <Button Style="{StaticResource ActionBtn}" Content="Lighting" Tag="Symbols_CreateLighting" Click="Cmd_Click" ToolTip="Create lighting tag families"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Fire" Tag="Symbols_CreateFP" Click="Cmd_Click" ToolTip="Fire protection — sprinklers, detectors, alarm devices, valves"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Reload" Tag="Symbols_Reload" Click="Cmd_Click" ToolTip="Reload every previously-created symbol family from disk"/>
+                                        <Button Style="{StaticResource ActionBtn}" Content="Rebuild" Tag="Symbols_Rebuild" Click="Cmd_Click" ToolTip="Rebuild generated symbol families whose catalogue or generator has changed (or force-rebuild all)"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Inspect" Tag="Symbols_Inspect" Click="Cmd_Click" ToolTip="Read-only diagnostic — defined vs loaded counts per group"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Std Proj" Tag="Symbols_SwitchProject" Click="Cmd_Click" ToolTip="Switch Project Standard — swap every symbol overlay in the project to a chosen standard"/>
                                         <Button Style="{StaticResource ActionBtn}" Content="Std View" Tag="Symbols_SwitchView" Click="Cmd_Click" ToolTip="Switch View Standard — set the symbol standard for the active view only"/>

--- a/docs/ISO_ANNOTATION_SYMBOLS_PLAN.md
+++ b/docs/ISO_ANNOTATION_SYMBOLS_PLAN.md
@@ -155,22 +155,60 @@ The Label is never in the mutation path, so it survives.
 
 **Exit**: `Symbols_Validate` reports 0 empty-geometry and 0 unexplained overflow.
 
-### P1 — Make scale parametric (2–3 days) ← highest value
+### P1 — Real-world sizing for model-category symbols ✅ part 1 done
 
-The fix for the compound defect in §2.
+**This phase was re-scoped during implementation. The original plan was wrong** and is recorded
+here because the reasoning matters.
 
-- Add a `SYMBOL_SIZE_MM` length parameter to every generated family.
-- Bind geometry to it instead of baking coordinates, so the normalised `-0.5..+0.5` box becomes a
-  real parametric extent.
-- Emit the formula `SYMBOL_SIZE_MM = target_mm * Symbol Scale` via `formulaBindings` — closing
-  V-3 and activating the contract `MepSymbolEngine` already documents.
-- Verify against `IsoSymbolPlacer`, which already writes `Symbol Scale` and currently gets ignored.
+The original P1 proposed adding a `Symbol Scale` formula to *every* generated family. That would
+have broken 726 of them. Annotation and detail templates draw in **paper space** — Revit already
+holds them at a constant plotted size at any view scale — so a scale formula there double-scales.
 
-**Risk**: parametric symbolic curves in annotation families need dimensions driving them; this is
-the one place where generated geometry may not fully substitute for hand-drafting. Prototype on
-3 symbols before committing to all 884.
+The parameter distribution showed the mismatch exactly:
 
-**Exit**: one symbol placed at 1:50 and 1:100 renders at identical paper size.
+| Family type | Count | Declares `Symbol Scale` | Actually needs it |
+|---|---:|---:|---|
+| GenericAnnotation | 726 | 520 | no — paper space |
+| MEPEquipment / MEPAccessory | 154 | **0** | yes — model space |
+
+It is on precisely the wrong set.
+
+The real defect underneath was worse. All 154 model-category symbols had geometry expanded by
+`Scale(coord, symbolSize)` — a *paper* dimension — while living in **model** space. So
+`ELEC_SOCKET_SINGLE` was a 4 mm object (real 13A plates are 86 mm), `ELEC_SWITCH_1G` 3.5 mm,
+`ELEC_EV_CHARGER` 6 mm. At 1:50 a 4 mm object plots at 0.08 mm. **Those 154 families were
+effectively invisible in any model view**, and since none declared `Symbol Scale`, the placer's
+write-back could not rescue them.
+
+**Decision taken**: hybrid — real-world model geometry plus a nested annotation glyph for plan
+legibility. Model stays dimensionally correct for clash, quantities and COBie; plans stay schematic.
+
+**Done in this pass**:
+- `SymbolDefinition.RealSizeMm` + `PlanSymbol` added to the schema.
+- `ResolveGeometrySizeMm(def, kind, result)` — the single size-resolution point. Paper templates
+  keep `symbolSize`; model templates use `realSizeMm` and **warn loudly** on fallback rather than
+  silently building a millimetre-scale device.
+- The connector path resolves size through the same helper. It previously had its own copy of the
+  expression, which would have left connectors floating off the geometry once sizes diverged.
+- `realSizeMm` populated on all 154, from BS 1363 / BS 5839 / BS 6465 / BS EN 12845 plate and
+  fixture dimensions and typical plant envelopes. Range 50 mm (sprinkler head) to 2000 mm (AHU).
+- `Symbol Scale` left on the 520 annotation symbols and documented as inert by design, so nobody
+  later "fixes" it into breaking them.
+
+**Verified**: 154/154 model symbols carry `realSizeMm`; 726 annotation symbols carry none; no
+symbol has a real size smaller than its paper size. Build 0 warnings / 0 errors.
+
+**Honest scope note**: the model geometry is the existing *schematic* linework expanded to
+real-world size, not manufacturer-accurate 3D. For plate-type devices (sockets, switches, call
+points) an 86 mm outline is genuinely close to the product. For plant (AHU, FCU) it is a correct
+footprint but not a detailed model. Swapping in manufacturer families remains
+`Symbols_SwapToManufacturer`'s job.
+
+**Still open — P1 part 2**: `PlanSymbol` is in the schema but unpopulated, and the generator does
+not yet nest. Most of the 154 have no GenericAnnotation twin to nest, so this needs ~154 glyph
+annotations authored first. That is P4-scale content work, not a code gap.
+
+**Exit for part 2**: a socket placed in a 1:50 plan shows its schematic glyph, not an 86 mm square.
 
 ### P2 — Seed inheritance (3–4 days code + authoring)
 

--- a/docs/ISO_ANNOTATION_SYMBOLS_PLAN.md
+++ b/docs/ISO_ANNOTATION_SYMBOLS_PLAN.md
@@ -1,0 +1,295 @@
+# ISO Annotation Symbols — Revised Plan
+
+**Branch**: `claude/iso-annotation-symbols-88c820`
+**Date**: 2026-07-29
+**Supersedes**: the phased plan in `ISO_ANNOTATION_SYMBOLS_REVIEW.md` §5
+**Status**: Plan. No implementation yet.
+
+---
+
+## 1. What changed since the first review
+
+The first review concluded that view markers must be hand-authored because the Revit API cannot
+create Labels. That is still true, but it framed the cost too high. Two things reopened it:
+
+1. **Labels can be inherited.** A seed `.rfa` that already contains a Label can be opened, stripped
+   of geometry, redrawn, re-parameterised and saved under a new name — the Label survives because
+   it is never touched. Autodesk's own guidance is that copying an existing family is the feasible
+   route. This converts "hand-author 30–50 families" into "hand-author ~10 seeds, generate the rest".
+2. **`SymbolDefinition.SourceFamilyPath` already exists** (`SymbolDefinition.cs:217`) and is carried
+   through the creator (`SymbolLibraryCreator.cs:373`) — but is never used to load anything, and no
+   catalogue sets it. The hook for seed inheritance is already in the schema, dead.
+
+So the plan below is materially more automated than the first version.
+
+---
+
+## 2. Verification results — all 884 symbols
+
+Audited every catalogue under `StingTools/Data/Symbols/`.
+
+### Clean
+
+| Check | Result |
+|---|---|
+| Total symbols | 884 (730 GenericAnnotation) |
+| Duplicate IDs | 0 |
+| Shared parameters | 922 / 922 = 100% |
+| Empty geometry arrays | 0 |
+| Coordinates rejected at build (`>|2.0|`) | 0 |
+
+### Defects
+
+| # | Finding | Count | Severity |
+|---|---|---:|---|
+| V-1 | **No `geometry` block at all** — `ISO6412_VLV_MOV`, `_AOV`, `_SOV`, `_HOV`. These build as *empty families*. | 4 | High |
+| V-2 | **GenericAnnotation symbols with zero parameters** — pure pictures; cannot be tagged, scheduled, or reported to a Note Block. | 142 | High |
+| V-3 | **`formulaBindings` used by nothing** across all 884. | 884 | High |
+| V-4 | **`typeVariants` used by nothing** across all 884. | 884 | High |
+| V-5 | **Every symbol is `status: draft`.** Nothing has passed any verification gate. | 884 | Medium |
+| V-6 | **Static text baked as `TextNote`** instead of a Label — `'DB'`, `'MCC'`, `'kWh'`, `'EV'`. Correct for fixed glyph marks, wrong wherever the value should be live. | 94 | Medium |
+| V-7 | **Geometry exceeds the documented `-0.5..+0.5` normalisation contract** (max 1.6×). Concentrated in SLD (35 of 49). | 49 | Low — see note |
+
+**Note on V-7**: this is mostly *not* a bug. In `SLD_MCB`, `SLD_MCCB`, `SLD_ACB` and the LPS symbols,
+the out-of-box coordinates are terminal leads and earth stems extending beyond the symbol body —
+conventional for single-line diagrams. Nothing is rejected at build time (`ValidateGeometryCoord`
+only rejects beyond ±2.0). The actual defect is that the *contract is unstated*: the ISO 6412 header
+declares "all geometry normalised -0.5..+0.5" while 49 symbols legitimately need body-plus-lead.
+Fix the contract, not the geometry — see P1.
+
+### The compound defect: scale-awareness is inert
+
+This is the highest-value finding and it spans three subsystems that each assume another one does
+the work:
+
+- `MepSymbolEngine.cs:16-17` documents the contract: `model_mm = target_mm × Symbol Scale`, and
+  states "family formulas derive model size".
+- `IsoSymbolPlacer.cs:243,475` writes `Symbol Scale` onto every placed instance.
+- 524 of 884 symbols declare the `Symbol Scale` parameter.
+- **No family has a formula consuming it.** `SetFormula` is reachable only via `formulaBindings`
+  (`SymbolLibraryCreator.cs:1191`), and zero catalogues declare any.
+- `SymbolLibraryCreator.cs:1443` says so explicitly: *"the geometry is not parametrically bound to it"*.
+
+**Net effect: every symbol is fixed-size baked geometry.** `Symbol Scale` is written and ignored.
+A symbol authored for 1:50 is wrong at 1:100. The parameter is decorative on 524 symbols.
+
+---
+
+## 3. What is and isn't automatable — verified
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Load any `.rft` template | ✅ works | `CreateFamilyDocument` is template-agnostic |
+| Draw lines/arcs in annotation families | ✅ works | `NewSymbolicCurve`, `SymbolLibraryCreator.cs:736` |
+| Sketch plane in annotation family | ✅ solved | Cannot be *created*; harvested from an existing `ReferencePlane` (~line 700) |
+| Add parameters (incl. `YesNo`) | ✅ works | `AddParameter`, `SpecTypeId.Boolean.YesNo:1381` |
+| Shared parameters | ✅ works | `ExternalDefinition` path, line 1303 |
+| Formulas | ✅ works | `SetFormula:1191` — used by nothing |
+| Type variants | ✅ works | `AddTypeVariants:1063` — used by nothing |
+| Nest families | ✅ works | `LoadFamily` + `NewFamilyInstance`, line 1926 |
+| **Create a Label** | ❌ **impossible** | `TextElement` has no public constructor; only `TextNote` is instantiable |
+| **Rebind an existing Label** | ❌ **impossible** | No Label class in the API at all |
+| Inherit a Label from a seed | ✅ viable | Untouched elements survive a save-as |
+
+**Consequence**: seeds are keyed by **label layout**, not by symbol. A seed whose label shows
+`Detail Number` can never be retargeted; you need a separate seed per distinct label set.
+
+Estimated seed count — roughly 10:
+
+| Seed | Label content |
+|---|---|
+| Section head | Detail Number + Sheet Number |
+| Callout head | Detail Number + Sheet Number |
+| Elevation mark body | Detail Number + Sheet Number |
+| Grid head | Name |
+| Level head | Name + Elevation |
+| View title | View Name + Scale + Detail Number |
+| Revision tag | Revision Number |
+| Spot elevation | (system-driven) |
+| Generic annotation — single label | 1 generic text param |
+| Generic annotation — tier stack | N stacked rows for the presentation-mode matrix |
+
+**Hard limit that survives**: Section Tags are restricted to Detail Number / Sheet Number. Custom
+data cannot be injected into a section head by any route.
+
+**The route that *does* work for other markers**: shared parameter in the marker's label + the same
+shared parameter bound as a **project parameter to the host category**. Verified for Grid Heads
+(Grids) and Level Heads (Levels). `CATEGORY_BINDINGS.csv` currently binds **nothing** to Grids,
+Levels, Views, Sheets or Revisions — that is the enabling work, and it is cheap.
+
+---
+
+## 4. Target architecture
+
+Three generation modes instead of today's one:
+
+| Mode | Trigger | Used for | Labels? |
+|---|---|---|---|
+| **Template** (today) | no `sourceFamilyPath` | Device symbols, SLD glyphs | No |
+| **Seed-inherited** (new) | `sourceFamilyPath` set | View markers, tags, anything with a label | Yes — inherited |
+| **Augment** (exists) | `FamilyAugmentationEngine` | Adding params to vendor families | N/A |
+
+Seed-inherited build sequence:
+
+```
+open seed .rfa  →  purge symbolic curves  →  draw ISO geometry from JSON
+                →  add params + shared params  →  set formulas
+                →  mint type variants  →  emit type catalog .txt  →  save-as
+```
+
+The Label is never in the mutation path, so it survives.
+
+---
+
+## 5. Phased plan
+
+### P0 — Repair (½ day, no dependencies)
+
+- Author geometry for the 4 empty valve symbols (V-1), or remove them if they are duplicates of
+  the operator-suffixed variants.
+- Formalise the normalisation contract (V-7): add an explicit `bodyExtent` (0.5) vs `overallExtent`
+  field to `SymbolDefinition`, document lead-overflow as legal for SLD, and tighten
+  `ValidateGeometryCoord` from ±2.0 to the declared `overallExtent` so genuine typos surface.
+- Extend `Symbols_Validate` with the checks used in this audit: empty-geometry, zero-parameter GA,
+  normalisation overflow, `status` distribution.
+
+**Exit**: `Symbols_Validate` reports 0 empty-geometry and 0 unexplained overflow.
+
+### P1 — Make scale parametric (2–3 days) ← highest value
+
+The fix for the compound defect in §2.
+
+- Add a `SYMBOL_SIZE_MM` length parameter to every generated family.
+- Bind geometry to it instead of baking coordinates, so the normalised `-0.5..+0.5` box becomes a
+  real parametric extent.
+- Emit the formula `SYMBOL_SIZE_MM = target_mm * Symbol Scale` via `formulaBindings` — closing
+  V-3 and activating the contract `MepSymbolEngine` already documents.
+- Verify against `IsoSymbolPlacer`, which already writes `Symbol Scale` and currently gets ignored.
+
+**Risk**: parametric symbolic curves in annotation families need dimensions driving them; this is
+the one place where generated geometry may not fully substitute for hand-drafting. Prototype on
+3 symbols before committing to all 884.
+
+**Exit**: one symbol placed at 1:50 and 1:100 renders at identical paper size.
+
+### P2 — Seed inheritance (3–4 days code + authoring)
+
+- Implement the `sourceFamilyPath` load path in `SymbolLibraryCreator` (schema field already exists).
+- Add a purge step that removes seed geometry while preserving Labels, reference planes and params.
+- Add view-marker templates to the template map: `Section Tag.rft`, `Callout Tag.rft`,
+  `Elevation Mark Body.rft`, `Elevation Mark Pointer.rft`, `Grid Head.rft`, `Level Head.rft`,
+  `Spot Elevation Symbol.rft`, `View Title.rft`, `Revision Tag.rft`.
+- **Manual**: author the ~10 label seeds into `Families/Annotation/`. Requires Revit; not scriptable.
+
+**Exit**: a generated grid head displays its Name label in a project.
+
+### P3 — Parameter provisioning (1–2 days) — *do before P4 authoring*
+
+- Bind STING shared parameters to Grids, Levels, Views, Sheets, Revisions in `CATEGORY_BINDINGS.csv`
+  (currently zero bindings to any of them).
+- Add parameters to the 142 zero-parameter GA symbols (V-2), including hidden ones for Note Blocks.
+- Convert the subset of the 94 static-text symbols (V-6) whose value should be live into labels via
+  the P2 seed path; leave fixed glyph marks as text.
+
+**Ordering matters**: families must be authored against parameters that already exist, or P4 gets
+re-done.
+
+### P4 — The ISO annotation catalogue (1–2 weeks)
+
+New `STING_ISO_ANNOTATION_SYMBOLS.json` covering what no catalogue has today:
+
+| Group | Content | Standard |
+|---|---|---|
+| View markers | Section head/tail, callout head, elevation body + pointer, grid head (circle + hex), level head, spot elevation, view title, revision tag | ISO 128-34, BS 1192 |
+| Drawing conventions | North arrow, scale bar, projection symbol, break line, match line head, key plan | ISO 128-30, ISO 5455, ISO 5456 |
+| Levels & slopes | Datum marker, fall/slope arrow, rise & drop | ISO 129-1 |
+| Revisions | Revision cloud tag, revision delta | ISO 7200 |
+
+Names must match the 6 already dangling in `STING_DRAWING_TYPES.json` — `STING_SECTION_MARK`,
+`STING_SECTION_HEAD`, `STING_ELEV_MARK`, `STING_ELEV_MARKER`, `STING_CALLOUT_HEAD`,
+`STING_INTERIOR_ELEV` — so 10 drawing types resolve on landing.
+
+Backfill `typeVariants` (V-4) here: variants are the only mechanism by which a tag's graphics can
+vary, because **a tag family cannot read the value it displays**. This is the delivery vehicle for
+the `LABEL_DEFINITIONS.json` presentation-mode matrix.
+
+### P5 — Placement automation (1 week)
+
+- `AnnotationSymbolRule` as a third rule kind in `AnnotationRulePack`, alongside tags and dimensions.
+- `AnnotationRunner.SymbolsByRules`, mirroring `TagByRules` including its idempotency index.
+- Normalised 0..1 sheet placement, matching the existing `DrawingSlot` convention.
+- Wire the dormant rule-pack fields in the same pass: `AnnotationConditionEvaluator` (no call site),
+  `denseUntilScale`, `dimensionStrategy` — authored across 48 drawing types, currently silent.
+  Converge `DimGrids` / `GridDimensioner` here rather than adding a third path (ROADMAP B1).
+
+### P6 — Sections & callouts (1 week)
+
+- **Auto-section generator**: per element / per grid line / at N-metre intervals. Build the
+  `BoundingBoxXYZ` with `BasisX` along the element, `BasisY` vertical, `BasisZ` = cross product;
+  `Min`/`Max` set crop and far-clip. Hand off to the existing DrawingType pipeline, which already
+  supplies scale — so "sections at set ratios" needs only the generator, not new scale plumbing.
+- **Auto-callout**: `ViewSection.CreateCallout`. Absent from the codebase entirely.
+- **Reference views**: `CreateReferenceSection` / `CreateReferenceCallout` + `ReferenceableViewUtils`
+  for "see 3/A-201" markers across a sheet set. Also entirely absent. Caveat: only cropped views
+  can be referenced, except drafting views.
+
+### P7 — Note Block integration (2–3 days)
+
+Only generic annotation families report to Note Blocks, and parameters not on a label still
+schedule. With P3 done, this auto-generates symbol legends and general-notes schedules from data
+already carried on every symbol. Cheap, and currently unused.
+
+### Deferred
+
+- **ISO 2553 welding** arrow/reference-line system — serves the fabrication package, not general
+  drawing production. After P2 proves the seed SOP.
+- **GD&T (ISO 1101) / surface texture (ISO 1302)** — mechanical-drafting standards, little AEC/FM use.
+- **Regenerating existing device symbols** beyond the P1 scale retrofit. They work.
+
+---
+
+## 6. Dependency order
+
+```
+P0 ──┐
+P1 ──┼──> P3 ──> P4 ──> P5 ──> P7
+P2 ──┘                   └──> P6
+```
+
+P0/P1/P2 are independent and can run in parallel. P3 must precede P4 authoring. P2's seed authoring
+is the only irreducibly manual step and is on the critical path for P4 — start it first.
+
+---
+
+## 7. Open questions
+
+1. **Spot Elevation Symbols and View Titles** — unverified whether they accept the host-category
+   binding trick that Grid/Level Heads do. Views can take project parameters, but this is from
+   forum sources, not tested. Verify in Revit before authoring those two seeds.
+2. **Parametric symbolic curves** — P1 assumes generated geometry can be dimension-driven in an
+   annotation family. Prototype before committing to 884 symbols.
+3. **Type catalogs for annotation families** — documented for loadable families generally; not
+   confirmed specifically for annotation categories. Verify before building the emitter in P4.
+4. **The 4 empty valve symbols** — repair or delete? Depends on whether `ISO6412_VLV_MOV` etc. are
+   intended as distinct symbols or duplicates of operator-suffixed variants. Needs a decision.
+
+---
+
+## 8. Sources
+
+- [The Revit Family API — Jeremy Tammik](https://jeremytammik.github.io/tbc/a/0199_family_api.htm)
+- [Revit API — access to Text & Label types (TextElement has no public constructor)](https://forums.autodesk.com/t5/revit-api-forum/revit-api-access-to-text-amp-label-types-within-family-and/td-p/3588666)
+- [Cannot create labeling family in Revit — Autodesk](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Cannot-create-labeling-family-in-Revit.html)
+- [Section head annotation label contains limited list of parameters — Autodesk](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Section-head-annotation-label-contains-limited-list-of-parameters-in-Revit.html)
+- [Create a Custom Elevation Tag — Autodesk Help](https://help.autodesk.com/view/RVT/2024/ENU/?guid=GUID-5760B8B6-1E44-4F2D-9ECB-42F52F36741A)
+- [Create an Annotation Schedule (Note Block) — Autodesk Help](https://help.autodesk.com/cloudhelp/2025/ENU/Revit-DocumentPresent/files/GUID-A2394758-978A-4E48-A2B4-3A8A690D01F5.htm)
+- [Label Parameters Options (prefix/suffix/break/spaces) — Autodesk](https://knowledge.autodesk.com/support/revit-products/learn-explore/caas/CloudHelp/cloudhelp/2021/ENU/Revit-Customize/files/GUID-4CCEF31F-FC5F-46DE-9600-339CA4163640-htm.html)
+- [Breaks do not work when the preceding parameter is empty — Autodesk](https://www.autodesk.com/support/technical/article/caas/sfdcarticles/sfdcarticles/Breaks-between-parameters-does-not-work-if-the-preceding-parameter-is-empty-or-not-filled-in-a-Annotation-Tag-family-in-Revit.html)
+- [ViewSection.CreateCallout — Revit API Docs](https://www.revitapidocs.com/2015/272ce735-271e-6ae3-8b36-c31207c99e56.htm)
+- [ViewSection.CreateSection — Revit API Docs](https://www.revitapidocs.com/2022/d6228f68-3643-8aaf-72bb-f9a0b4125886.htm)
+- [Automating sections with the Revit API — LearnRevitAPI](https://www.learnrevitapi.com/blog/how-to-automate-window-sections-in-revit-api-and-python)
+- [Generic Annotations in Revit — Paul F. Aubin](https://paulaubin.com/blog/generic-annotations-in-revit/)
+- [Level head with shared parameters — Autodesk Community](https://forums.autodesk.com/t5/revit-architecture-forum/level-head-with-both-base-point-elevation-and-survey-elevation/td-p/12467276)
+- [Adding a label to a grid bubble — Autodesk Community](https://forums.autodesk.com/t5/revit-architecture-forum/adding-label-to-grid-bubble/td-p/9874789)
+- [Revit Type Catalogs — GRAITEC](https://graitec.com/uk/blog/revit-type-catalogs/)
+- [GRAITEC PowerPack — Annotations Configuration](https://www.graitec.com/Help/PowerPack_for_Revit/En/Annotations_Configuration.htm)

--- a/docs/ISO_ANNOTATION_SYMBOLS_REVIEW.md
+++ b/docs/ISO_ANNOTATION_SYMBOLS_REVIEW.md
@@ -1,0 +1,264 @@
+# ISO Annotation Symbols — Review, Research & Recommendation
+
+**Branch**: `claude/iso-annotation-symbols-88c820`
+**Date**: 2026-07-29
+**Status**: Research / advisory. No code changed.
+
+---
+
+## 1. What StingTools already has
+
+`StingTools/Data/Symbols/` holds **24 catalogues / ~950 symbol definitions**, all JSON-driven and
+built at runtime by `Core/Symbols/SymbolLibraryCreator.cs` (2,549 lines).
+
+| Catalogue | Count | Nature |
+|---|---:|---|
+| `STING_ISO6412_SYMBOLS.json` | 261 | Spool/isometric notation (valves, welds, fittings, hangers) |
+| `STING_ELEC_SYMBOLS.json` | 62 | Electrical devices |
+| `STING_SLD_SYMBOLS*.json` (5 files) | 242 | SLD — IEC / BS / IEEE / NFPA / CIBSE variants |
+| `STING_FP_SYMBOLS.json` | 49 | Fire protection |
+| `STING_MEP_SYMBOLS.json` / `PLUMBING` / `LIGHTING` / `BMS` / `TELECOM` / `GAS` / `EARTHING` / `DRAINAGE` / `SAFETY` | ~200 | Discipline devices |
+| `STING_STRUCTURAL_ANNOTATIONS.json` | 17 | Structural notation |
+
+Supporting engine: `SymbolStandardRegistry` + `SymbolStandardResolver` (region/discipline →
+standard), `SymbolScaleEngine`, `SymbolViewContextResolver`, `SymbolDriftDetector`,
+`SymbolCoverageAuditor`, `SymbolOrphanHealer`. This is a genuinely strong foundation — the
+standards-resolution layer is better than most commercial add-ins.
+
+**The catalogue is ~95% device symbols.** Almost nothing in it is a *drafting* annotation.
+
+---
+
+## 2. The three real gaps
+
+### Gap A — No true view-marker families (the blocking one)
+
+`STING_DRAWING_TYPES.json` has 10 drawing types referencing 6 section/elevation/callout marker
+families:
+
+```
+STING_SECTION_MARK · STING_SECTION_HEAD · STING_ELEV_MARK
+STING_ELEV_MARKER  · STING_CALLOUT_HEAD · STING_INTERIOR_ELEV
+```
+
+**None of these exist anywhere** — not in a symbol catalogue, not as an `.rfa`. Verified:
+
+```bash
+grep -rl 'STING_SECTION_MARK\|STING_ELEV_MARK\|STING_CALLOUT_HEAD' StingTools/
+# → only STING_DRAWING_TYPES.json (the reference itself)
+```
+
+`Families/` contains 10 subfolders and **zero `.rfa` files** — only two `.params.txt` stubs under
+`Families/Annotation/`. So `DrawingTypeValidator`'s section-marker pre-flight fails on every one of
+those 10 types, and `sectionMarker` is a silent no-op in production.
+
+The reason this can't be patched from the existing catalogue: Revit view markers are **their own
+family categories** with dedicated templates —
+
+| Marker | Template | Category |
+|---|---|---|
+| Section head/tail | `Section Tag.rft` | Section Tags (`OST_SectionHeads`) |
+| Callout head | `Callout Tag.rft` | Callout Tags |
+| Elevation mark | `Elevation Mark Body.rft` + `Elevation Mark Pointer.rft` | Elevation Marks |
+| Grid head | `Grid Head.rft` | Grid Heads |
+| Level head | `Level Head.rft` | Level Heads |
+| Spot elevation | `Spot Elevation Symbol.rft` | Spot Elevation Symbols |
+| View title | `View Title.rft` | View Titles |
+| Revision tag | `Revision Tag.rft` | Revision Cloud Tags |
+
+`SymbolLibraryCreator` uses **none of these** — grep for them across the repo returns nothing. It
+only ever loads `Metric Generic Annotation.rft` and model-category templates. A GenericAnnotation
+pictogram **cannot be assigned** as a section's marker; Revit only accepts a family of the matching
+marker category. The `ISO6412_SECTION_HEAD` / `_NORTH_ARROW` / `_GRID_BUBBLE` / `_LEVEL_HEAD`
+entries in the ISO 6412 catalogue are decorative pictograms for spool sheets, not usable view markers.
+
+### Gap B — The authoring engine cannot create labels
+
+`SymbolDefinition` supports `lines`, `arcs`, `filledRegions`, `connectionLines`, `text`. The `text`
+path resolves to `TextNote.Create` (`SymbolLibraryCreator.cs:950`) — **static text**, not a
+parameter-bound Label.
+
+This matters because every useful view marker is *mostly label*: a section head is a circle plus
+`{Detail Number}` and `{Sheet Number}`; a grid head is a circle plus `{Name}`; a level head is
+`{Name}` + `{Elevation}`. Without labels you get empty circles.
+
+The Revit API has **no method to create a Label element** in an annotation family. `FamilyManager`
+creates and manages *parameters*, but the Label (the graphic that displays a parameter) has no
+creation API. This is long-standing and confirmed by Autodesk's own guidance that copying an
+existing tag family is the feasible approach. It matches what this repo already learned on the tag
+family label-tier work — the same wall, hit from the other side.
+
+**Consequence: the runtime-generation strategy that works for device symbols does not work for view
+markers.** They must be hand-authored `.rfa` seeds, committed, and *loaded* rather than *generated*.
+
+### Gap C — No general drafting annotation set
+
+Beyond view markers, the following are absent from all 24 catalogues:
+
+| Domain | Missing | Standard |
+|---|---|---|
+| Drawing conventions | North arrow (true annotation), scale bar, projection symbol (1st/3rd angle), break line, match line head, key plan | ISO 128-30/-34, ISO 5455, ISO 5456 |
+| Levels & slopes | Spot elevation, datum/level marker, fall/slope arrow, rise & drop | ISO 129-1 |
+| Welding | Full ISO 2553 arrow-and-reference-line system (elementary symbols, supplementary, dimensions) | ISO 2553 |
+| Machining | Surface texture, GD&T feature control frames | ISO 1302, ISO 1101 |
+| Revisions | Revision cloud tag, revision triangle/delta | ISO 7200 / BS 8888 |
+| Materials | Hatch/material indication key | ISO 128-50 |
+
+The 31 "Welds" in the ISO 6412 set are *joint-location pictograms* on a spool line, not the ISO 2553
+arrow/reference-line symbol system used on fabrication details. Different thing, both needed.
+
+---
+
+## 3. Drawing-production automation — current state
+
+`Core/Drawing/AnnotationRunner.cs` (1,109 lines) is well built: rule-driven tagging
+(`TagByRules` → `IndependentTag.Create`, density-gated, idempotent via a tagged-element index) and
+dimensioning (`DimByRules` → `GridDimensioner` / `MEPDimensioner` / `DrainageInvertDimensioner`).
+36 tag families bind per-category via `annotation.tagFamilies` across the 93 drawing types, and
+those resolve against `LABEL_DEFINITIONS.json`.
+
+Open items already recorded in `docs/ROADMAP.md`:
+
+- **B1** — `AnnotationConditionEvaluator` has **no call site**; `denseUntilScale` and
+  `dimensionStrategy` are silent no-ops on 48 shipped drawing types.
+- Two competing grid-dimensioning implementations (`DimGrids` vs `GridDimensioner`) need converging.
+- Size-variant tag selection is not wired into `DrawingProducer` / `AnnotationRunner`.
+
+**What is entirely missing from the runner: symbol placement.** It places tags and dimensions. It
+never places a north arrow, scale bar, section marker, level datum, match-line head, or revision
+tag. There is no `SymbolRule` kind — only `_tagRuleKinds` (`AutoTag`, `RoomTag`, `SpaceTag`,
+`AreaTag`, `MaterialTag`, `KeynoteTag`, `MultiCategoryTag`).
+
+---
+
+## 4. How GRAITEC configures annotation automation
+
+From the PowerPack for Revit documentation, its **Annotations Configuration** dialog has five tabs:
+
+| Tab | Purpose |
+|---|---|
+| Dimensioning | Dimension line types + spacing between chains for Auto-Dimensioning |
+| Quick Dimension | Separate plan-view and side-view configs; select which categories get dimensioned in each |
+| Join Dimension | Dimension line types for joining/merging chains |
+| Tags and Symbols | Symbol behaviour options (e.g. show opening height) |
+| Level Dimension | Spot dimension types |
+
+Two things worth copying, and one worth not:
+
+**Worth copying — the view-context split.** GRAITEC splits Quick Dimension config by *plan vs side
+view* with a different category set in each. StingTools' `AnnotationRulePack` is flat: one rule set
+per drawing type regardless of the view's orientation. Since a drawing type already knows its
+`purpose` (Plan / Section / Elevation / Detail), this split is nearly free and materially improves
+output — you dimension grids and openings in plan, levels and heights in section.
+
+**Worth copying — content ships with the tool.** GRAITEC bundles **1,100+ ready families**
+(rebar annotations, reinforcement and formwork symbols, dimensions, title blocks), multi-language.
+Their automation is thin over a fat, hand-authored library. StingTools has inverted this: a fat
+generator over an empty `Families/` folder. For device symbols that inversion is a genuine
+advantage. For **annotation** it is the wrong trade, because of Gap B.
+
+**Not worth copying — dialog-scoped config.** GRAITEC's settings live in a modal dialog per
+machine/user. StingTools' JSON + corporate-baseline + `_BIM_COORD` project-override model is
+strictly better: version-controllable, shareable, checksum-lockable. Keep it.
+
+---
+
+## 5. Recommendation
+
+### Strategy: split the pipeline by what the API can actually do
+
+| Track | Content | Method |
+|---|---|---|
+| **Generated** (today's path) | Device symbols, SLD glyphs, spool notation — geometry only, no labels | `SymbolLibraryCreator` from JSON. Unchanged. |
+| **Authored** (new) | View markers + drafting symbols — anything needing a Label | Hand-author `.rfa` in the Family Editor once, commit to `Families/Annotation/`, load + place from JSON rules |
+
+Trying to close Gap A with the generator will fail on the Label API. Accept that and build the
+loading/placement half properly.
+
+### Phase 1 — Author the ISO view-marker set (~30 families, unblocks 10 drawing types)
+
+Author against the correct templates, one per marker category. Minimum viable set:
+
+- Section head + tail (ISO 128-34 / BS 1192 convention), 2 variants
+- Callout head + tail
+- Elevation mark body + 4-way pointer (interior + exterior variants)
+- Grid head (circle + hexagon)
+- Level head (plan datum + section datum)
+- Spot elevation symbol (3 forms)
+- View title
+- Revision tag + revision delta
+- North arrow, scale bar (true annotation, scale-aware)
+- Break line, match line head, key plan marker
+
+Naming must match the strings already in `STING_DRAWING_TYPES.json` so the 10 dangling references
+resolve on day one.
+
+Note: `Families/` currently holds **zero `.rfa`**, so this also establishes the binary-content
+intake SOP that `Families/README.md` describes but nothing has yet exercised.
+
+### Phase 2 — `AnnotationSymbolRule` in the rule pack
+
+Add a third rule kind alongside tags and dimensions:
+
+```jsonc
+"annotation": {
+  "symbols": [
+    { "kind": "NorthArrow",  "family": "STING_NORTH_ARROW",
+      "placement": "SheetRelative", "x": 0.92, "y": 0.90,
+      "views": ["Plan", "RCP"] },
+    { "kind": "ScaleBar",    "family": "STING_SCALE_BAR",
+      "placement": "SheetRelative", "x": 0.08, "y": 0.04,
+      "scaleAware": true },
+    { "kind": "LevelDatum",  "family": "STING_LEVEL_HEAD",
+      "placement": "PerLevel", "views": ["Section", "Elevation"] }
+  ]
+}
+```
+
+Then `AnnotationRunner.SymbolsByRules` — mirroring `TagByRules`, including its idempotency index so
+re-running a drawing type doesn't duplicate. Normalised 0..1 sheet placement matches the existing
+`DrawingSlot` convention, so it stays paper-size independent.
+
+### Phase 3 — Wire the dormant rule-pack fields
+
+Do this in the same pass, not separately: give `AnnotationConditionEvaluator` its call site, and
+honour `denseUntilScale` + `dimensionStrategy`. They're already authored across 48 drawing types and
+currently do nothing. Converge `DimGrids` / `GridDimensioner` here too (ROADMAP B1) rather than
+adding a third path.
+
+### Phase 4 — Purpose-scoped rules (the GRAITEC lesson)
+
+Let `AnnotationRulePack` resolve per `DrawingType.purpose`, so Plan / Section / Elevation / Detail
+each carry their own tag + dimension + symbol set instead of sharing one flat pack.
+
+### Phase 5 — ISO 2553 welding + fabrication annotation
+
+Arrow-and-reference-line system for fabrication details. Depends on Phase 1's authoring SOP being
+proven. Lower priority than 1–4 — it serves the fabrication package, not general drawing production.
+
+### Deliberately deferred
+
+- **GD&T (ISO 1101) / surface texture (ISO 1302).** Mechanical-drafting standards. Little use in an
+  AEC/FM plugin unless plant fabrication becomes a target.
+- **Regenerating existing device symbols.** They work. Leave them.
+
+---
+
+## 6. Sequencing note
+
+Phase 1 is hand-authoring in the Revit Family Editor — it cannot be scripted, and it is the
+dependency for everything after it. Phases 2–4 are ordinary C# and can be built against a small
+stub set (grid head + level head + north arrow) before the full 30 families are drawn, so the code
+and the content can proceed in parallel.
+
+---
+
+## Sources
+
+- [GRAITEC PowerPack — Annotations Configuration](https://www.graitec.com/Help/PowerPack_for_Revit/En/Annotations_Configuration.htm)
+- [GRAITEC PowerPack — Dimension tools](https://www.graitec.com/Help/PowerPack-for-Revit/desktop/Tools-Dimension.htm)
+- [GRAITEC PowerPack for Revit — Autodesk App Store](https://apps.autodesk.com/RVT/en/Detail/Index?appLang=en&id=4890983144102907008&os=Win64)
+- [The Revit Family API — Jeremy Tammik](https://jeremytammik.github.io/tbc/a/0199_family_api.htm)
+- [Creating a custom tag family via the Revit API — Autodesk forum](https://forums.autodesk.com/t5/revit-api-forum/creating-custom-tag-family-with-dynamic-parameters-via-revit-api/td-p/13253350)
+- [Create a Custom Elevation Tag — Autodesk Help](https://help.autodesk.com/view/RVT/2024/ENU/?guid=GUID-5760B8B6-1E44-4F2D-9ECB-42F52F36741A)
+- [Annotation Families — Modelical](https://www.modelical.com/en/gdocs/annotation-families/)

--- a/docs/ISO_ANNOTATION_SYMBOLS_REVIEW.md
+++ b/docs/ISO_ANNOTATION_SYMBOLS_REVIEW.md
@@ -4,6 +4,11 @@
 **Date**: 2026-07-29
 **Status**: Research / advisory. No code changed.
 
+> **§5 is superseded** by [`ISO_ANNOTATION_SYMBOLS_PLAN.md`](ISO_ANNOTATION_SYMBOLS_PLAN.md).
+> That plan assumed view-marker families had to be hand-authored one by one. They don't — a Label
+> can be *inherited* from a seed `.rfa`, which cuts the manual cost to ~10 seeds. §1–§4 of this
+> document (inventory, gaps, drawing-production state, GRAITEC comparison) remain accurate.
+
 ---
 
 ## 1. What StingTools already has

--- a/docs/SYMBOL_CACHE_TEST_PLAN.md
+++ b/docs/SYMBOL_CACHE_TEST_PLAN.md
@@ -1,0 +1,164 @@
+# W-1 / W-2 / W-3 — Revit test checklist
+
+**Branch**: `claude/iso-symbols-p0p1` · **PR**: #498
+**Purpose**: verify in Revit what unit tests structurally cannot reach — where files are written,
+when they are regenerated, and whether the P0 geometry repairs are actually visible.
+
+Everything below is unverified in Revit. Logic-level checks pass (7/7 W-1, 4/4 W-3), but those
+prove the manifest *reports* correctly, not that the builder *acts* on it.
+
+**Log for every step**: `C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.log`
+**Shared library**: `C:\ProgramData\STING\ContentLibrary\Symbols`
+**Buttons**: dock panel → **SETUP** tab → Symbols section
+
+---
+
+## Step 0 — Deploy
+
+Close Revit first; the DLL is locked while it runs.
+
+```bash
+cd "C:/Dev/STINGTOOLS/.claude/worktrees/iso-annotation-symbols-88c820" && dotnet build StingTools/StingTools.csproj -c Release -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025" -t:Rebuild
+```
+
+```bash
+cp -r "C:/Dev/STINGTOOLS/.claude/worktrees/iso-annotation-symbols-88c820/StingTools/bin/Release/." "C:/Dev/STINGTOOLS/CompiledPlugin/"
+```
+
+✅ Build reports `0 Warning(s), 0 Error(s)` and `CompiledPlugin\StingTools.dll` timestamp is now.
+❌ If Revit was open the copy fails silently on the DLL — close it and repeat.
+
+> All three Revit versions point at `CompiledPlugin`, so this deploys to 2025/2026/2027 at once.
+
+---
+
+## Step 1 — W-3, fresh project → shared library
+
+A project with **no** `_BIM_COORD\Families\Symbols` folder.
+
+1. Delete `C:\ProgramData\STING\ContentLibrary` if present, so the run is genuinely cold.
+2. Open/save a test project that has never built symbols.
+3. SETUP → Symbols → **SLD** (one catalogue — faster than Create All for a first pass).
+
+| | Expect |
+|---|---|
+| ✅ | `C:\ProgramData\STING\ContentLibrary\Symbols\SLD\IEC\` contains `.rfa` files |
+| ✅ | `C:\ProgramData\STING\ContentLibrary\Symbols\.sting_library.json` exists |
+| ✅ | Sidecar shows `"generatorVersion": "2"` and a `catalogues` entry for `STING_SLD_SYMBOLS.json` with a 64-char hash |
+| ❌ | Families landed in the project's `_BIM_COORD` instead → shared root was rejected; check the log for `not writable` |
+| ❌ | Families landed in `%TEMP%\STING_Symbols` → both roots failed |
+
+**This is the step most likely to fail on a locked-down machine.** `%PROGRAMDATA%` is writable here,
+but the write-probe fallback exists precisely because that varies.
+
+---
+
+## Step 2 — W-1, cache is honoured when fresh
+
+Immediately after Step 1, click **SLD** again.
+
+| | Expect |
+|---|---|
+| ✅ | Result reports families as existing, **not** rebuilt (`Created` 0 / `Existed` > 0) |
+| ✅ | No `rebuilding cached families` line in the log |
+| ✅ | `.rfa` timestamps unchanged |
+| ❌ | Rebuilds every time → the sidecar isn't being read or saved; check for a `SymbolCacheManifest.Save` warning |
+
+---
+
+## Step 3 — W-1, catalogue edit invalidates
+
+1. Note the modified time of `...\Symbols\SLD\IEC\SLD_MCB.rfa`.
+2. Edit `CompiledPlugin\data\Symbols\STING_SLD_SYMBOLS.json` — change any `symbolSize` (e.g. `3.0` → `3.1`). Save.
+3. Click **SLD**.
+
+| | Expect |
+|---|---|
+| ✅ | Log: `rebuilding 'STING_SLD_SYMBOLS.json' — catalogue content changed` |
+| ✅ | `SLD_MCB.rfa` timestamp updated |
+| ✅ | Sidecar hash for that catalogue changed |
+| ✅ | **Other** catalogues untouched — `Lighting\*.rfa` timestamps unchanged (per-catalogue isolation) |
+| ❌ | Everything rebuilt → hashing is per-library not per-catalogue |
+
+Revert the edit afterwards, or leave it — Step 4 rebuilds regardless.
+
+---
+
+## Step 4 — W-2, `Symbols_Rebuild`
+
+SETUP → Symbols → **Rebuild**. Dialog offers *Stale only* / *Force all*.
+
+**4a — Stale only**, with everything already current:
+
+| | Expect |
+|---|---|
+| ✅ | Report: `Every catalogue was already current — nothing to rebuild.` |
+
+**4b — Force all**:
+
+| | Expect |
+|---|---|
+| ✅ | Report header `Rebuild mode: FORCE ALL`, `Rebuilt` ≈ every symbol in the library |
+| ✅ | Log shows `forced rebuild` as the cause |
+| ✅ | All `.rfa` timestamps updated |
+| ❌ | Cancel produces no dialog / no action → dispatch tag not wired |
+
+---
+
+## Step 5 — W-3, existing project library is NOT orphaned
+
+**The guard I could not test headlessly** (`ExistingProjectLibrary` takes a `Document`). It protects
+every library built before this change, so it matters most.
+
+1. Open a project that **already has** `<project>\_BIM_COORD\Families\Symbols\` with `.rfa` in it.
+   If none exists, make one: temporarily rename `C:\ProgramData\STING\ContentLibrary`, build SLD
+   into the project, then restore the name.
+2. Click **SLD**.
+
+| | Expect |
+|---|---|
+| ✅ | Log: `ResolveOutputRoot: using the project's existing symbol library at '<project>\_BIM_COORD\Families\Symbols'` |
+| ✅ | Families rebuild **in the project folder**, not in ProgramData |
+| ✅ | Because generator version moved 1 → 2, they genuinely rebuild rather than skip |
+| ❌ | Build goes to ProgramData while the project copies stay stale → the guard failed, and stale families will keep winning the read path. **Stop and report — this is the regression that matters.** |
+
+---
+
+## Step 6 — P0 geometry is actually visible
+
+The counts said 206 filled regions and 115 arcs were repaired. Confirm on real geometry rather than
+trusting the numbers.
+
+Place these on a drafting view (SETUP → Symbols → **Place View**, or load the `.rfa` directly):
+
+| Symbol | Was | Should now be |
+|---|---|---|
+| `BS_TX_2W` (SLD/BS) | two **full circles** | two **semicircles** (0→180° sweep) — a 2-winding transformer |
+| `IEEE_TX_2W` (SLD/IEEE) | full circles | semicircles |
+| `ELEC_C_POL` (Electrical) | full circle | 90→270° arc — polarised capacitor |
+| `EARTH_LPS_TERMINAL` (Earth) | **no solid fill** | solid filled region present |
+| `DRN_GREASE_TRAP` (DrainAbove) | no solid fill | solid filled region present |
+
+❌ Full circles or missing fills means the alias fix didn't take — check the deployed DLL is current.
+
+---
+
+## Step 7 — Nothing else regressed
+
+| | Expect |
+|---|---|
+| ✅ | SETUP → Symbols → **Validate** reports 880 symbols, 0 empty-geometry, 0 extent violations |
+| ✅ | 142 param-less annotations still reported — expected, that's P3 scope |
+| ✅ | **Reload** still works and is distinct from Rebuild (loads, never regenerates) |
+| ✅ | Place a socket (`ELEC_SOCKET_SINGLE`) — should now be ~86 mm, not 4 mm (P1) |
+
+---
+
+## Reporting back
+
+For each failing step: the step number, the log lines around it, and where files actually landed vs
+expected. Step 5 failing is the one that should stop a merge; Steps 1 and 6 failing are also
+blocking. Step 3's isolation check failing is a performance issue, not a correctness one.
+
+If all seven pass, W-1/W-2/W-3 are verified and W-4 (converging the four resolvers) becomes safe to
+start — it changes three live lookup paths at once, so it needs this baseline proven first.

--- a/docs/SYMBOL_CACHE_TEST_PLAN.md
+++ b/docs/SYMBOL_CACHE_TEST_PLAN.md
@@ -43,8 +43,8 @@ A project with **no** `_BIM_COORD\Families\Symbols` folder.
 | | Expect |
 |---|---|
 | ✅ | `C:\ProgramData\STING\ContentLibrary\Symbols\SLD\IEC\` contains `.rfa` files |
-| ✅ | `C:\ProgramData\STING\ContentLibrary\Symbols\.sting_library.json` exists |
-| ✅ | Sidecar shows `"generatorVersion": "2"` and a `catalogues` entry for `STING_SLD_SYMBOLS.json` with a 64-char hash |
+| ✅ | **`...\Symbols\SLD\IEC\.sting_library.json`** exists — the sidecar sits in the *catalogue's own sub-folder*, not at the `Symbols` root, because `RunBatch` builds each catalogue into `<root>\<subFolder>` |
+| ✅ | Sidecar shows `"generatorVersion": "2"`, a `catalogues` entry for `STING_SLD_SYMBOLS.json` with a 64-char hash, and an empty `failedSymbols` |
 | ❌ | Families landed in the project's `_BIM_COORD` instead → shared root was rejected; check the log for `not writable` |
 | ❌ | Families landed in `%TEMP%\STING_Symbols` → both roots failed |
 
@@ -77,8 +77,11 @@ Immediately after Step 1, click **SLD** again.
 | ✅ | Log: `rebuilding 'STING_SLD_SYMBOLS.json' — catalogue content changed` |
 | ✅ | `SLD_MCB.rfa` timestamp updated |
 | ✅ | Sidecar hash for that catalogue changed |
-| ✅ | **Other** catalogues untouched — `Lighting\*.rfa` timestamps unchanged (per-catalogue isolation) |
+| ✅ | **Other** catalogues untouched — `Lighting\*.rfa` timestamps unchanged |
 | ❌ | Everything rebuilt → hashing is per-library not per-catalogue |
+
+> Isolation here is structural as well as hash-based: each catalogue builds into its own sub-folder
+> with its own sidecar, so cross-contamination would require a path bug rather than a hashing bug.
 
 Revert the edit afterwards, or leave it — Step 4 rebuilds regardless.
 

--- a/docs/SYMBOL_LIBRARY_REUSE_SCOPE.md
+++ b/docs/SYMBOL_LIBRARY_REUSE_SCOPE.md
@@ -1,0 +1,182 @@
+# Symbol Library — Build Once, Reuse Everywhere (scope)
+
+**Branch**: `claude/iso-symbols-p0p1`
+**Date**: 2026-07-29
+**Status**: Scope. No implementation.
+**Trigger**: [PR #498](https://github.com/beckykyomugisha/STINGTOOLS/pull/498) changes the built output
+of ~360 symbols, and **no existing project will pick the fixes up** — see R-1.
+
+---
+
+## 1. The finding that reframes this
+
+This is **not** a "build a caching system" job. A three-tier content system already exists and is
+largely unused:
+
+| File | Lines | What it does | Adoption |
+|---|---:|---|---|
+| `Core/Content/ContentRoots.cs` | 118 | project / shared / baseline root precedence, driven by `ContentManifest.RootPrecedence`; already honours legacy `STING_SYMBOL_LIB` | 1 consumer |
+| `Core/Content/ContentResolver.cs` | 263 | `ContentRequest` → `ContentResolution` with miss tracking | **1 consumer** — `Core/Cad/Mep/MepFixtureBuilder.cs:79` |
+| `Core/Content/ContentManifest.cs` | 426 | `libraryVersion`, `rootPrecedence`, coverage, corporate + project override layering | read by `ContentCoverageCommand` (display only) |
+
+Meanwhile the paths that actually run symbol lookup each roll their own:
+
+| Path | Resolution logic |
+|---|---|
+| `SymbolBatchHelper.ResolveOutputRoot` (`SymbolLibraryCommands.cs:55`) | shared root → else `<project>/_BIM_COORD/Families/Symbols` → else `%TEMP%/STING_Symbols` |
+| `EquipmentSymbolCommands.ResolveFamilySymbol:132` | loaded → `_BIM_COORD/Families/Symbols/<sub>` → `Families/<disc>/` |
+| `MepSymbolEngine.ResolveFamilySymbol:681` | loaded → `Families/{MEP,SLD,ISO6412}` → `_BIM_COORD/...` → recursive scan |
+| `MepSymbolEngine.ResolveSharedLibraryRoot:658` | `STING_SYMBOL_LIB` → `%APPDATA%/STING/sting_symbols.json` → **null** |
+
+**Four parallel implementations of the same idea.** The work is convergence plus one genuinely new
+capability (version invalidation), not greenfield.
+
+---
+
+## 2. Defects to close
+
+### R-1 — Cache never invalidates (urgent, blocks PR #498 reaching users)
+
+`SymbolLibraryCreator.cs:229`:
+
+```csharp
+var rfaPath = Path.Combine(outputFolder, def.Id + ".rfa");
+if (File.Exists(rfaPath)) { result.Existed++; continue; }   // ← only staleness test
+```
+
+Existence is the entire test. There is no version or content check, so:
+
+- PR #498 repairs 206 filled regions, 115 arc sweeps and 154 device sizes. **Any project that has
+  already generated symbols keeps the broken geometry permanently.**
+- The same is true of every future catalogue edit. Shipping symbol fixes is unreliable *by
+  construction*.
+- `libraryVersion` (`STING_CONTENT_MANIFEST.json`, currently `2026.6.1`) exists but is only ever
+  *displayed* by `ContentCoverageCommand` — never compared against anything.
+
+There is a second copy of the same skip at `SymbolLibraryCreator.cs:303` (the variant/emit path).
+Both need the guard or the fix is half-applied.
+
+`Symbols_Reload` does **not** cover this — it re-loads existing `.rfa` into the document and
+flushes the JSON shapes cache. It never rebuilds a stale family.
+
+### R-2 — Shared root is opt-in and undiscoverable
+
+Both `ResolveSharedLibraryRoot` and `ContentRoots.ResolveSharedRoot` return **null** when
+unconfigured, so the default experience is a full regenerate of 880 families **per project**.
+"Build once" is currently "build once per project", and only for users who happen to know the env
+var exists.
+
+### R-3 — Nothing is prebuilt
+
+`Families/` contains **zero `.rfa`**. Every install starts cold. This is also the delivery mechanism
+P2 needs for the label seeds, so the two converge.
+
+---
+
+## 3. Work items
+
+### W-1 — Version-stamped cache invalidation  ▸ ~1 day  ▸ **do first**
+
+Write a `.sting_library.json` sidecar into the output folder:
+
+```jsonc
+{
+  "libraryVersion": "2026.6.1",
+  "builtUtc": "2026-07-29T18:00:00Z",
+  "catalogues": { "STING_SLD_SYMBOLS.json": "<sha256>", "…": "…" }
+}
+```
+
+At build, hash each catalogue and compare. Rebuild only what changed; leave the rest as `Existed`.
+Both skip sites (`:229`, `:303`) route through one `IsCacheStale(def, outputFolder)` helper.
+
+Reuse the SHA-256 pattern already proven in `DrawingTypeRegistry.ComputeChecksums:476` rather than
+inventing a second hashing convention.
+
+**Exit**: edit one catalogue, rebuild, and only that catalogue's families are regenerated.
+
+### W-2 — Force-rebuild command  ▸ ~2 hours
+
+`Symbols_RebuildStale` (rebuild what the sidecar says changed) and a `--force` variant (wipe and
+rebuild all). Needed as the escape hatch for anyone already holding stale families today, including
+everyone affected by PR #498. Registers in `StingCommandHandler` alongside the existing
+`Symbols_*` tags.
+
+**Exit**: a user with a stale library gets current geometry in one click.
+
+### W-3 — Default the shared root  ▸ ~half day
+
+`ContentRoots.ResolveSharedRoot` gains a final fallback of `%PROGRAMDATA%\STING\ContentLibrary`
+before returning null. Shared becomes the default; per-project becomes the fallback it was designed
+to be.
+
+Watch the interaction with `RootPrecedence`: the manifest defaults to `projectFirst` specifically so
+a frozen project ignores firm-level changes. Defaulting the shared *root* must not silently flip
+that *precedence* — a delivered project must stay reproducible.
+
+**Exit**: two projects on one machine build the library once between them.
+
+### W-4 — Converge the four resolvers onto `ContentRoots`  ▸ ~2 days
+
+Point `SymbolBatchHelper.ResolveOutputRoot`, `EquipmentSymbolCommands.ResolveFamilySymbol` and
+`MepSymbolEngine.ResolveFamilySymbol` at `ContentRoots` / `ContentResolver`. Keep
+`ResolveSharedLibraryRoot` as a thin deprecated shim so existing `STING_SYMBOL_LIB` setups keep
+working.
+
+Highest regression risk in this scope: three live lookup paths change at once, each with its own
+fallback ordering that some project on disk depends on. Do it after W-1/W-2 are proven, and keep the
+legacy ordering in `ContentRoots` rather than "tidying" it.
+
+**Exit**: one resolution implementation; `ContentResolver` adoption goes from 1 consumer to 4.
+
+### W-5 — Ship prebuilt `.rfa`  ▸ ~2 days + CI
+
+Generate the library at release time, publish as a versioned bundle, extract into
+`%PROGRAMDATA%\STING\ContentLibrary` on first run. Users never cold-generate; the sidecar from W-1
+makes the shipped bundle self-describing.
+
+Depends on W-1 and W-3. Also the delivery mechanism for the P2 label seeds — worth building once for
+both.
+
+**Exit**: fresh install places a symbol without ever running a generator.
+
+---
+
+## 4. Order and dependencies
+
+```
+W-1 ──▶ W-2 ──▶ W-4
+  └────▶ W-3 ──▶ W-5
+```
+
+W-1 first and alone if nothing else happens: without it, every later improvement ships into caches
+that ignore it. W-2 immediately after, because it is the remedy for users already stale today.
+
+Rough total ≈ 5–6 days. W-1 + W-2 alone (~1.5 days) close the correctness hole; W-3 → W-5 are the
+"build once, reuse everywhere" outcome.
+
+---
+
+## 5. Risks
+
+| Risk | Mitigation |
+|---|---|
+| W-4 changes three live lookup paths with subtly different fallback orders | Land after W-1/W-2; preserve legacy ordering inside `ContentRoots`; do not "tidy" precedence while converging |
+| Defaulting the shared root changes behaviour for existing installs | Default the *root* only; leave `RootPrecedence` at `projectFirst` so delivered projects stay reproducible |
+| A shared root on a network path may be read-only or slow | `ResolveOutputRoot` already falls back on write failure (`SymbolLibraryCommands.cs:66-72`); keep that guard |
+| Rebuild invalidation could mass-regenerate on an unrelated edit | Hash per catalogue, not per library, so a one-file edit rebuilds one file's symbols |
+| None of this is verifiable outside Revit | Same limit as PR #498 — the family build path needs a real model run |
+
+---
+
+## 6. Recommendation
+
+Do **W-1 + W-2 now**, before PR #498 merges or immediately after. Everything else can be scheduled.
+
+Rationale: PR #498 is a correctness fix that, as things stand, cannot reach any project that has
+already generated its symbols. Shipping it without invalidation means believing the library is fixed
+when it is not — which is worse than the original bug, because the failure is now silent *and*
+assumed solved.
+
+The P4 annotation catalogue should not start until W-1 is in. That content will hit exactly the same
+wall on its first revision.

--- a/docs/SYMBOL_LIBRARY_REUSE_SCOPE.md
+++ b/docs/SYMBOL_LIBRARY_REUSE_SCOPE.md
@@ -2,7 +2,22 @@
 
 **Branch**: `claude/iso-symbols-p0p1`
 **Date**: 2026-07-29
-**Status**: Scope. No implementation.
+**Status**: W-1, W-2, W-3 implemented. W-4, W-5 outstanding.
+
+> **Implementation notes (2026-07-29)**
+>
+> - **W-1 / W-2 landed.** Two corrections to this scope: the second skip site
+>   (`SymbolLibraryCreator:303`) is inside `BuildVariant`, which has **no call site** — it is dead
+>   code, guarded anyway so wiring it later cannot reintroduce the bug. And W-2 shipped as one
+>   `Symbols_Rebuild` command with a mode prompt rather than a command plus a `--force` variant.
+> - **W-3 landed, but was larger than scoped.** Defaulting the shared root alone would have broken
+>   symbol lookup: `EquipmentSymbolCommands.ResolveFamilySymbol` never read the shared root (only
+>   `MepSymbolEngine` did), so families written to the new default would have resolved to nothing.
+>   W-3 therefore had to take a slice of W-4 — the read-path fix — plus an `ExistingProjectLibrary`
+>   guard so projects that already hold a generated library keep building in place. Without that
+>   guard, builds would have moved to the shared root while `projectFirst` precedence kept finding
+>   the older project-local copies first, and W-1's invalidation would have silently accomplished
+>   nothing.
 **Trigger**: [PR #498](https://github.com/beckykyomugisha/STINGTOOLS/pull/498) changes the built output
 of ~360 symbols, and **no existing project will pick the fixes up** — see R-1.
 


### PR DESCRIPTION
Symbol-library correctness pass. Branched clean off `main` (882d18ede); no
title-block work is carried along — that stays on
`claude/cover-page-title-block-jxpcjx`.

## P0 — silent geometry binding loss

Found while reading raw JSON, not by any existing check: the JSON is valid
and the build is green, so nothing surfaced it.

- **206 of 217 filled regions** spell the boundary `"vertices"`; the POCO
  binds `"boundary"`. Newtonsoft ignored the key, `Boundary` stayed empty,
  and `DrawFilledRegion` returns early on an empty boundary **without a
  warning** — 95% of every filled region in the library never rendered.
- **115 arcs** spell the sweep `"startAngle"/"endAngle"`; the POCO binds
  `"startDeg"/"endDeg"`, so they kept 0/360 defaults and drew as full
  circles instead of the intended sweep.

Both spellings are now accepted, canonical winning when both are present.

Also:
- Removed 4 empty-geometry valve symbols that duplicated populated entries
  (`VLV_MOV`=`VLV_MOTOR`, `VLV_AOV`=`VLV_PNEU`, `VLV_SOV`=`VLV_SOLENOID`,
  `VLV_HOV`=`VLV_HANDWHL`). No references outside their own file; they
  would have built as blank families.
- Added `SymbolDefinition.OverallExtent`. Bodies normalise to -0.5..+0.5,
  but SLD terminal leads and LPS earth stems legitimately exceed it, so 60
  symbols now declare their real reach instead of breaching an unstated
  rule.
- `Symbols_Validate` gains three checks: empty geometry, extent violations,
  and param-less GenericAnnotations.

## P1 part 1 — real-world sizing for model-category symbols

All 154 `MEPEquipment`/`MEPAccessory` symbols expanded geometry with
`Scale(coord, symbolSize)` — a **paper** dimension — while living in
**model** space. `ELEC_SOCKET_SINGLE` was a 4 mm object (real 13A plates
are 86 mm); `ELEC_EV_CHARGER` 6 mm. At 1:50 a 4 mm object plots at 0.08 mm,
so these families were effectively invisible in any model view.

- `RealSizeMm` + `PlanSymbol` added to the schema.
- `ResolveGeometrySizeMm()` is now the single size-resolution point. Paper
  templates keep `symbolSize`; model templates use `realSizeMm` and warn on
  fallback instead of silently building a millimetre-scale device.
- The connector path now resolves size through the same helper — it carried
  its own copy of the expression and would have left connectors floating
  off the geometry once the two diverged.
- `realSizeMm` populated on all 154 from BS 1363 / BS 5839 / BS 6465 /
  BS EN 12845 dimensions and typical plant envelopes (50 mm sprinkler head
  to 2000 mm AHU).
- `Symbol Scale` left on the 520 annotation symbols and documented as inert
  by design — annotation families are paper-space invariant, so wiring it
  up there would double-scale them.

## Verification

Deserialised every shipped catalogue through the production types:

- 620/620 arcs and 217/217 filled regions bind correctly, 0 mismatches
- 880 symbols, 0 empty-geometry, 0 extent violations
- 154/154 model symbols carry `realSizeMm`; 726 annotation symbols carry
  none; no symbol has a real size below its paper size
- Build: 0 warnings, 0 errors (Revit 2025, `-t:Rebuild`)

## Not done / known limits

- **Not exercised in Revit.** Data and build verification only. The family
  build path needs a run against a real model before this is trusted.
- Model geometry is the existing schematic linework expanded to real size,
  not manufacturer-accurate 3D. Manufacturer swap remains
  `Symbols_SwapToManufacturer`'s job.
- `PlanSymbol` is in the schema but unpopulated and the generator does not
  nest yet — most of the 154 have no annotation twin. Content work.
- **Cached `.rfa` files will not pick these fixes up.** The build path skips
  on `File.Exists` with no version check, so any project that already
  generated symbols keeps the old broken geometry. Cache invalidation is
  filed as follow-up.

No new Revit parameters: no provisioning file touched, no `AddParameter` /
binding call added. `realSizeMm` and `overallExtent` are build-time JSON
inputs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)