### PR TITLE
docs: correct the symbol test plan against merged main

### DIFF
--- a/docs/SYMBOL_CACHE_TEST_PLAN.md
+++ b/docs/SYMBOL_CACHE_TEST_PLAN.md
@@ -1,6 +1,6 @@
 # W-1 / W-2 / W-3 — Revit test checklist
 
-**Branch**: `claude/iso-symbols-p0p1` · **PR**: #498
+**Merged**: PR #498 → `main` @ `c7b10d2c7`. Test from `main`, not a branch.
 **Purpose**: verify in Revit what unit tests structurally cannot reach — where files are written,
 when they are regenerated, and whether the P0 geometry repairs are actually visible.
 
@@ -18,11 +18,11 @@ prove the manifest *reports* correctly, not that the builder *acts* on it.
 Close Revit first; the DLL is locked while it runs.
 
 ```bash
-cd "C:/Dev/STINGTOOLS/.claude/worktrees/iso-annotation-symbols-88c820" && dotnet build StingTools/StingTools.csproj -c Release -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025" -t:Rebuild
+cd "C:/Dev/STINGTOOLS" && git checkout main && git pull && dotnet build StingTools/StingTools.csproj -c Release -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025" -t:Rebuild
 ```
 
 ```bash
-cp -r "C:/Dev/STINGTOOLS/.claude/worktrees/iso-annotation-symbols-88c820/StingTools/bin/Release/." "C:/Dev/STINGTOOLS/CompiledPlugin/"
+cp -r "C:/Dev/STINGTOOLS/StingTools/bin/Release/." "C:/Dev/STINGTOOLS/CompiledPlugin/"
 ```
 
 ✅ Build reports `0 Warning(s), 0 Error(s)` and `CompiledPlugin\StingTools.dll` timestamp is now.
@@ -113,14 +113,16 @@ SETUP → Symbols → **Rebuild**. Dialog offers *Stale only* / *Force all*.
 **The guard I could not test headlessly** (`ExistingProjectLibrary` takes a `Document`). It protects
 every library built before this change, so it matters most.
 
-1. Open a project that **already has** `<project>\_BIM_COORD\Families\Symbols\` with `.rfa` in it.
+1. Open a project that **already has** a populated symbol library. Either layout counts, and both
+   are probed (consolidated first): `<root>\_data\_BIM_COORD\Families\Symbols\` or the legacy
+   sibling `<project>\_BIM_COORD\Families\Symbols\`.
    If none exists, make one: temporarily rename `C:\ProgramData\STING\ContentLibrary`, build SLD
    into the project, then restore the name.
 2. Click **SLD**.
 
 | | Expect |
 |---|---|
-| ✅ | Log: `ResolveOutputRoot: using the project's existing symbol library at '<project>\_BIM_COORD\Families\Symbols'` |
+| ✅ | Log: `ResolveOutputRoot: using the project's existing symbol library at '<resolved path>'` — and the path it names is the layout the project actually uses |
 | ✅ | Families rebuild **in the project folder**, not in ProgramData |
 | ✅ | Because generator version moved 1 → 2, they genuinely rebuild rather than skip |
 | ❌ | Build goes to ProgramData while the project copies stay stale → the guard failed, and stale families will keep winning the read path. **Stop and report — this is the regression that matters.** |
@@ -136,11 +138,13 @@ Place these on a drafting view (SETUP → Symbols → **Place View**, or load th
 
 | Symbol | Was | Should now be |
 |---|---|---|
-| `BS_TX_2W` (SLD/BS) | two **full circles** | two **semicircles** (0→180° sweep) — a 2-winding transformer |
-| `IEEE_TX_2W` (SLD/IEEE) | full circles | semicircles |
-| `ELEC_C_POL` (Electrical) | full circle | 90→270° arc — polarised capacitor |
-| `EARTH_LPS_TERMINAL` (Earth) | **no solid fill** | solid filled region present |
-| `DRN_GREASE_TRAP` (DrainAbove) | no solid fill | solid filled region present |
+| `BS_TX_2W` (SLD/BS) | two **full circles** | two **semicircles** — spec declares 2 arcs, both 0→180° |
+| `IEEE_TX_2W` (SLD/IEEE) | two full circles | two semicircles — same 2 × 0→180° |
+| `ELEC_C_POL` (Electrical) | full circle | one 90→270° arc — polarised capacitor |
+| `EARTH_LPS_TERMINAL` (Earth) | **no solid fill** | 1 solid filled region |
+| `DRN_GREASE_TRAP` (DrainAbove) | no solid fill | 1 solid filled region |
+
+All five are GenericAnnotation, so they carry no `realSizeMm` — that is correct, not a defect.
 
 ❌ Full circles or missing fills means the alias fix didn't take — check the deployed DLL is current.
 
@@ -153,15 +157,28 @@ Place these on a drafting view (SETUP → Symbols → **Place View**, or load th
 | ✅ | SETUP → Symbols → **Validate** reports 880 symbols, 0 empty-geometry, 0 extent violations |
 | ✅ | 142 param-less annotations still reported — expected, that's P3 scope |
 | ✅ | **Reload** still works and is distinct from Rebuild (loads, never regenerates) |
-| ✅ | Place a socket (`ELEC_SOCKET_SINGLE`) — should now be ~86 mm, not 4 mm (P1) |
+| ✅ | Place `ELEC_SOCKET_SINGLE` — **85 mm**, not 4 mm (P1) |
+| ✅ | `ELEC_SOCKET_DOUBLE` **150 mm** · `ELEC_SWITCH_2G` **150 mm** · `HVAC_SAD_SQ` **595 mm** · `FP_MCP` **80 mm** |
+
+> These are the values after realignment to each symbol's authored `solid3D` footprint, which
+> superseded the standards-book estimates first committed. 85/150/595 are the numbers on `main`.
 
 ---
 
 ## Reporting back
 
 For each failing step: the step number, the log lines around it, and where files actually landed vs
-expected. Step 5 failing is the one that should stop a merge; Steps 1 and 6 failing are also
-blocking. Step 3's isolation check failing is a performance issue, not a correctness one.
+expected.
+
+This is already on `main`, so a failure is a fix-forward, not a merge veto. Severity order:
+
+- **Step 5** — highest. If the guard fails, existing project libraries are orphaned and stale
+  families keep winning the read path. It is also the newest code in the set: CI's path-discipline
+  gate forced it to be rewritten to resolve through `StingPaths.Meta`, so it has had the least
+  exposure of anything here.
+- **Steps 1 and 6** — a wrong output root, or geometry that did not actually repair, undermine the
+  whole point of the change.
+- **Step 3** — isolation failing means mass regeneration: slow, not wrong.
 
 If all seven pass, W-1/W-2/W-3 are verified and W-4 (converging the four resolvers) becomes safe to
 start — it changes three live lookup paths at once, so it needs this baseline proven first.


### PR DESCRIPTION
Doc-only. Corrects expectations in `docs/SYMBOL_CACHE_TEST_PLAN.md` that were
written before the review pass and no longer match `main` (#498).

- **Sizes**: `realSizeMm` was realigned to each symbol's authored `solid3D`
  footprint after the plan was drafted. Socket is **85 mm** not 86;
  `ELEC_SOCKET_DOUBLE` and `ELEC_SWITCH_2G` **150**; `HVAC_SAD_SQ` **595**;
  `FP_MCP` **80**. Values read from `main`, not restated from memory.
- **Step 5** covers both project layouts. CI's path-discipline gate forced
  `ExistingProjectLibrary` to resolve through `StingPaths.Meta`, which probes
  the consolidated `_data/_BIM_COORD` location as well as the legacy sibling.
- **Step 0** deploys from `main` rather than the merged worktree branch.
- **Step 6** gives exact arc/region counts so "2 semicircles" is
  distinguishable from "2 full circles" without guessing, and notes that those
  five symbols carrying no `realSizeMm` is correct.
- **Reporting** no longer references blocking a merge that already happened;
  reframed as fix-forward with a severity order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)