### PR TITLE
chore: ignore timestamped CompiledPlugin backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,12 +49,13 @@ build_output.txt
 # and gets COPIED here during build — the source is what we ship.
 CompiledPlugin/
 
-# Pre-redeploy backups of the above (CompiledPlugin.bak-<sha|label>/). Same
-# disposable build output, but `CompiledPlugin/` does not match them, so each
-# one shows up as ~18 MB of untracked DLL waiting to be committed by accident.
-# PR #501 covers the sibling `CompiledPlugin_backup_*` naming; this covers the
-# `.bak-` form the deploy steps actually produce.
+# Pre-redeploy backups of the above. Two naming conventions exist in the wild and
+# neither is matched by `CompiledPlugin/`, so each backup shows up as untracked
+# build output waiting to be committed by accident:
+#   CompiledPlugin.bak-<sha|label>/        — what the deploy steps produce
+#   CompiledPlugin_backup_YYYYMMDD_HHMMSS/ — what a manual pre-deploy copy produces
 CompiledPlugin.bak-*/
+CompiledPlugin_backup_*/
 
 # Claude Code session worktrees + local settings.
 .claude/worktrees/


### PR DESCRIPTION
One line. `.gitignore` already ignores `CompiledPlugin/`, but the timestamped
copies taken before a redeploy (`CompiledPlugin_backup_YYYYMMDD_HHMMSS`) do
not match that pattern, so each one surfaces as untracked noise. The current
example is **164 MB across 612 files**.

Checked before concluding they are disposable:

- **No secrets** — no `.pem`, `.lic`, `.key`, `.pfx`, `.env`, `*license*` or
  `*secret*` anywhere in the folder.
- **DLLs and `data/` are build output**, regenerated by any Release build, and
  already superseded (live `StingTools.dll` is six days newer).
- **The only non-reproducible content was 5 runtime logs**, and the live
  `CompiledPlugin/` has all of them — byte-identical for four, and *longer* for
  `20260724` (87,286 vs 71,754) — plus later days the backup predates.

Verified the pattern matches a folder of that exact name and that `git status`
no longer reports it.

Does not delete the existing folder; that is a local cleanup, separate from
stopping future ones appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)