### PR TITLE
fix(drawings): production runtime fixes — dead buttons, engine, editor

### DIFF
--- a/StingTools/Commands/Drawing/BatchProduceCommands.cs
+++ b/StingTools/Commands/Drawing/BatchProduceCommands.cs
@@ -95,7 +95,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
 
                 // PERF-01: warm the per-document caches so every per-level
                 // / per-DrawingType Apply call hits the (template name →
@@ -161,7 +161,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
@@ -237,7 +237,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
 
                 // PERF-01: pre-warm view-template + pack caches before per-room loop.
                 DrawingTypePresentation.Prewarm(doc);
@@ -314,7 +314,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
@@ -425,7 +425,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
 
                 // PERF-01: pre-warm view-template + pack caches.
                 DrawingTypePresentation.Prewarm(doc);
@@ -539,7 +539,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
                 
                 var packs = ViewStylePackRegistry.GetLibrary(doc).Packs.Where(p => p.IsManaged).ToList();
                 if (packs.Count == 0)
@@ -597,7 +597,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
                 
                 var packages = DrawingPackageManager.GetPackages(doc);
                 if (packages.Count == 0) { TaskDialog.Show("STING", "No drawing packages found."); return Result.Succeeded; }
@@ -622,7 +622,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
                 
                 var packages = DrawingPackageManager.GetPackages(doc);
                 if (packages.Count == 0) { TaskDialog.Show("STING", "No drawing packages found."); return Result.Succeeded; }
@@ -652,7 +652,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document; if (doc == null) { message = "No active document"; return Result.Failed; }
                 
                 var packages = DrawingPackageManager.GetPackages(doc);
                 if (packages.Count == 0) { TaskDialog.Show("STING", "No drawing packages found."); return Result.Succeeded; }

--- a/StingTools/Commands/Drawing/BulkReStampDrawingTypeCommand.cs
+++ b/StingTools/Commands/Drawing/BulkReStampDrawingTypeCommand.cs
@@ -22,7 +22,7 @@ namespace StingTools.Commands.Drawing
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var uiDoc = commandData.Application?.ActiveUIDocument;
+            var uiDoc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument;
             var doc   = uiDoc?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
 

--- a/StingTools/Commands/Drawing/DrawingBrowserOrganizerCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingBrowserOrganizerCommand.cs
@@ -36,7 +36,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 // Enumerate all BrowserOrganization records; find the

--- a/StingTools/Commands/Drawing/DrawingDoctorCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingDoctorCommand.cs
@@ -31,7 +31,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 var sheets = new FilteredElementCollector(doc)

--- a/StingTools/Commands/Drawing/DrawingHealTitleBlocksCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingHealTitleBlocksCommand.cs
@@ -34,7 +34,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 // Collect every stamped sheet — even the ones drift detector

--- a/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingProduceAndExportCommand.cs
@@ -54,7 +54,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
                 // ── Scope dialog ────────────────────────────────────────────────

--- a/StingTools/Commands/Drawing/DrawingRenumberCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingRenumberCommand.cs
@@ -32,7 +32,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 var stamped = new FilteredElementCollector(doc)

--- a/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingSyncStylesCommand.cs
@@ -32,7 +32,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 // Phase 183 — pick up views affected by on-disk profile /
@@ -171,7 +171,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 var reports = DrawingDriftDetector.Scan(doc)

--- a/StingTools/Commands/Drawing/DrawingTypeEditorCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingTypeEditorCommand.cs
@@ -21,7 +21,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 var dlg = new DrawingTypeEditorDialog(doc);
                 // Phase 137 — Show() (modeless) instead of ShowDialog() (modal).
                 // A modal WPF window blocks Revit's ExternalEvent queue, so action

--- a/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
+++ b/StingTools/Commands/Drawing/DrawingTypesInspectCommand.cs
@@ -32,7 +32,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 var lib = DrawingTypeRegistry.GetLibrary(doc);
                 var reports = DrawingTypeValidator.ValidateAll(doc);
 
@@ -284,7 +284,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 DrawingTypeRegistry.Reload(doc);
                 var lib = DrawingTypeRegistry.GetLibrary(doc);
                 TaskDialog.Show("STING — Drawing Types",

--- a/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
+++ b/StingTools/Commands/Drawing/GenerateFromScopeBoxesCommand.cs
@@ -31,7 +31,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 // PERF-01: warm view-template + pack caches once before the

--- a/StingTools/Commands/Drawing/ManagedTemplateCommands.cs
+++ b/StingTools/Commands/Drawing/ManagedTemplateCommands.cs
@@ -38,7 +38,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 // Pick a pack (only packs that are NOT already managed)
@@ -262,7 +262,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 var managedPacks = ViewStylePackRegistry.ListAll(doc)

--- a/StingTools/Commands/Drawing/PresentationStyleSetupCommand.cs
+++ b/StingTools/Commands/Drawing/PresentationStyleSetupCommand.cs
@@ -43,7 +43,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null)
                 {
                     TaskDialog.Show("STING — Presentation Setup", "No active document.");

--- a/StingTools/Commands/Drawing/TitleBlockMigrateCsvToRecipeCommand.cs
+++ b/StingTools/Commands/Drawing/TitleBlockMigrateCsvToRecipeCommand.cs
@@ -29,7 +29,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No document open."; return Result.Failed; }
 
                 string csvPath = LocateCsv(doc, "TITLE_BLOCK.csv");

--- a/StingTools/Commands/Drawing/TitleBlockParamMigrateCommand.cs
+++ b/StingTools/Commands/Drawing/TitleBlockParamMigrateCommand.cs
@@ -130,7 +130,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No active document."; return Result.Failed; }
 
                 // Collect PRJ_TB_* values from all title-block instances.
@@ -243,7 +243,7 @@ namespace StingTools.Commands.Drawing
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
                 if (doc == null) { msg = "No active document."; return Result.Failed; }
 
                 var tbValues   = TitleBlockParamMigrateHelper.CollectTbValues(doc);

--- a/StingTools/Commands/Drawing/TitleBlockRevisionSyncCommand.cs
+++ b/StingTools/Commands/Drawing/TitleBlockRevisionSyncCommand.cs
@@ -19,7 +19,7 @@ namespace StingTools.Commands.Drawing
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData.Application?.ActiveUIDocument?.Document;
+            var doc = (commandData?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)?.ActiveUIDocument?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
             var result = TitleBlockRevisionSyncer.SyncAll(doc);

--- a/StingTools/Commands/Drawing/TitleBlockSlotCommands.cs
+++ b/StingTools/Commands/Drawing/TitleBlockSlotCommands.cs
@@ -536,7 +536,57 @@ namespace StingTools.Commands.Drawing
         ///      or migrated layouts may still have them.
         ///
         /// JSON is the authoritative source.</summary>
+        // SLOT-5 — per-family slot-map memo. The reference-plane override pass
+        // below calls Document.EditFamily, which OPENS the family document; that
+        // ran once per sheet, uncached, so an M-sheet batch opened and closed the
+        // same title-block family M times. Cached by family name and dropped
+        // whenever the document changes or a batch starts, so an operator who
+        // nudges slots in the Family Editor still gets a fresh read on the next
+        // production run rather than a stale map for the session.
+        private static readonly object _slotMapLock = new object();
+        private static Dictionary<string, Dictionary<string, SlotBounds>> _slotMapCache;
+        private static string _slotMapDocKey;
+
+        /// <summary>Drop the cached slot maps. Called at batch boundaries by
+        /// DrawingProducer so a re-run re-reads the family.</summary>
+        public static void ClearSlotMapCache()
+        {
+            lock (_slotMapLock) { _slotMapCache = null; _slotMapDocKey = null; }
+        }
+
         public static Dictionary<string, SlotBounds> ReadSlotBoundsFromTitleBlock(Document doc, Element titleBlock)
+        {
+            var cacheKey = GetFamilyName(doc, titleBlock);
+            var docKey = doc?.PathName ?? "";
+            if (!string.IsNullOrEmpty(cacheKey))
+            {
+                lock (_slotMapLock)
+                {
+                    if (!string.Equals(_slotMapDocKey, docKey, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _slotMapCache = null;
+                        _slotMapDocKey = docKey;
+                    }
+                    if (_slotMapCache != null && _slotMapCache.TryGetValue(cacheKey, out var hit))
+                        return hit;
+                }
+            }
+
+            var computed = ReadSlotBoundsFromTitleBlockCore(doc, titleBlock);
+
+            if (!string.IsNullOrEmpty(cacheKey))
+            {
+                lock (_slotMapLock)
+                {
+                    if (_slotMapCache == null)
+                        _slotMapCache = new Dictionary<string, Dictionary<string, SlotBounds>>(StringComparer.OrdinalIgnoreCase);
+                    _slotMapCache[cacheKey] = computed;
+                }
+            }
+            return computed;
+        }
+
+        private static Dictionary<string, SlotBounds> ReadSlotBoundsFromTitleBlockCore(Document doc, Element titleBlock)
         {
             var result = new Dictionary<string, SlotBounds>(StringComparer.OrdinalIgnoreCase);
             var familyName = GetFamilyName(doc, titleBlock);

--- a/StingTools/Core/Drawing/AnnotationRunner.cs
+++ b/StingTools/Core/Drawing/AnnotationRunner.cs
@@ -245,7 +245,12 @@ namespace StingTools.Core.Drawing
                     if (catId == ElementId.InvalidElementId) continue;
                     long cv = catId.Value;
                     if (!doneCats.Add(cv)) continue;
-                    if (!Enum.IsDefined(typeof(BuiltInCategory), unchecked((int)cv))) continue; // skip custom categories
+                    // BuiltInCategory's underlying type is long (Revit 2024+), so
+                    // handing Enum.IsDefined an int threw "Enum underlying type
+                    // and the object must be same type" for EVERY rule — the
+                    // per-rule catch below swallowed it as a warning, so the
+                    // whole auto-tag pass silently placed nothing. Pass the long.
+                    if (!Enum.IsDefined(typeof(BuiltInCategory), cv)) continue; // skip custom categories
                     TagCategory(doc, view, pack, (BuiltInCategory)cv, rule.Category, stats, rule, taggedIndex.Value);
                 }
                 catch (Exception ex) { stats.Warnings.Add($"Tag rule '{rule.Category}': {ex.Message}"); }

--- a/StingTools/Core/Drawing/DrawingCropApplier.cs
+++ b/StingTools/Core/Drawing/DrawingCropApplier.cs
@@ -81,6 +81,7 @@ namespace StingTools.Core.Drawing
             if (contextScopeBox != null && contextScopeBox.Id != ElementId.InvalidElementId)
             {
                 SetScopeBox(view, contextScopeBox.Id, warnings);
+                ApplyCropVisibility(view, crop, warnings);
                 // Stamp the profile's declared kind so the drift detector still
                 // compares against the profile, not against this override.
                 try { DrawingTypeStamper.StampCrop(view, crop.Kind ?? string.Empty, crop.MarginMm); }
@@ -128,6 +129,10 @@ namespace StingTools.Core.Drawing
                         break;
                 }
 
+                // One place decides whether the crop frame is drawn — the three
+                // setters above no longer force it on.
+                ApplyCropVisibility(view, crop, warnings);
+
                 // Phase 183 — stamp crop kind + margin so the drift
                 // detector can spot bbox-derived crops that have fallen
                 // behind the profile. No-op when the params aren't bound.
@@ -154,6 +159,20 @@ namespace StingTools.Core.Drawing
             catch { return null; }
         }
 
+        /// <summary>
+        /// Apply the profile's crop-boundary visibility. Previously SetScopeBox,
+        /// SetTightBboxCrop and SetRoomBoundaryCrop each hardcoded
+        /// CropBoxVisible = true, so every produced drawing carried a visible
+        /// crop rectangle regardless of the profile. Now declared once, on
+        /// DrawingCropStrategy, and defaulted off.
+        /// </summary>
+        private static void ApplyCropVisibility(View view, DrawingCropStrategy crop, List<string> warnings)
+        {
+            if (view == null || crop == null) return;
+            try { view.CropBoxVisible = crop.CropBoxVisible; }
+            catch (Exception ex) { warnings.Add($"CropBoxVisible: {ex.Message}"); }
+        }
+
         private static void SetScopeBox(View view, ElementId scopeBoxId, List<string> warnings)
         {
             try
@@ -162,7 +181,6 @@ namespace StingTools.Core.Drawing
                 if (p == null || p.IsReadOnly) { warnings.Add("VIEWER_VOLUME_OF_INTEREST_CROP not writable."); return; }
                 p.Set(scopeBoxId);
                 view.CropBoxActive = true;
-                view.CropBoxVisible = true;
             }
             catch (Exception ex) { warnings.Add($"SetScopeBox: {ex.Message}"); }
         }
@@ -181,7 +199,6 @@ namespace StingTools.Core.Drawing
                 if (cropBox == null) return;
 
                 view.CropBoxActive  = true;
-                view.CropBoxVisible = true;
                 view.CropBox        = cropBox;
             }
             catch (Exception ex) { warnings.Add($"TightBbox: {ex.Message}"); }
@@ -337,7 +354,6 @@ namespace StingTools.Core.Drawing
                 if (cropBox == null) return;
 
                 view.CropBoxActive  = true;
-                view.CropBoxVisible = true;
                 view.CropBox        = cropBox;
             }
             catch (Exception ex) { warnings.Add($"RoomBoundary: {ex.Message}"); }

--- a/StingTools/Core/Drawing/DrawingProducer.cs
+++ b/StingTools/Core/Drawing/DrawingProducer.cs
@@ -75,6 +75,14 @@ namespace StingTools.Core.Drawing
         // assignment (was O(M²) across an M-sheet batch). Written back as each
         // number is assigned so later sheets in the same batch see it.
         [ThreadStatic] private static HashSet<string>               _sheetNumberCache;
+        // STACK-1: sheetId → the production context that claimed it during THIS
+        // batch. STING_SHEET_CONTEXT_TXT is what normally tells two per-level
+        // sheets apart; when it isn't bound, ReadSheetContext returns null for
+        // every sheet and the unstampable fallback below handed the SAME sheet to
+        // every level — so a 4-level run stacked all 4 plans on one sheet. The
+        // parameter may be unbindable, but within one run we always know which
+        // context we just used a sheet for, so claims are tracked here instead.
+        [ThreadStatic] private static Dictionary<long, string>      _sheetCtxClaims;
         [ThreadStatic] private static string                        _cacheDocKey;
         // P-12: view names, collected once per batch. NameExists ran a full
         // OfClass(View) collector and MakeUniqueViewName calls it up to 100
@@ -167,8 +175,28 @@ namespace StingTools.Core.Drawing
             }
         }
 
+        // ── STACK-1 helpers — per-batch sheet↔context claims ────────────────
+
+        /// <summary>True when this batch already used <paramref name="sheetId"/>
+        /// for a context other than <paramref name="ctx"/>. Claims only exist for
+        /// the current run, so this never blocks legitimate reuse across runs.</summary>
+        private static bool ClaimedByOtherContext(ElementId sheetId, string ctx)
+        {
+            if (sheetId == null || _sheetCtxClaims == null) return false;
+            return _sheetCtxClaims.TryGetValue(sheetId.Value, out var owner)
+                && !string.Equals(owner, ctx ?? "", StringComparison.Ordinal);
+        }
+
+        private static void ClaimSheetForContext(ElementId sheetId, string ctx)
+        {
+            if (sheetId == null) return;
+            if (_sheetCtxClaims == null) _sheetCtxClaims = new Dictionary<long, string>();
+            _sheetCtxClaims[sheetId.Value] = ctx ?? "";
+        }
+
         public static void ResetBatchCaches()
         {
+            _sheetCtxClaims     = null;   // STACK-1
             _existingViewCache  = null;
             _existingViewNames  = null;
             _categoryByName     = null;
@@ -176,6 +204,12 @@ namespace StingTools.Core.Drawing
             _packageSheetCount  = null;
             _sheetNumberCache   = null;
             _cacheDocKey        = null;
+            // SLOT-5: the title-block slot map memo lives with the slot utils,
+            // not here, but it has the same lifetime as a production batch —
+            // drop it on the same boundary so an operator who nudged slot
+            // reference planes in the Family Editor sees them on the next run.
+            try { StingTools.Commands.Drawing.TitleBlockSlotUtils.ClearSlotMapCache(); }
+            catch (Exception ex) { StingLog.Warn($"ClearSlotMapCache: {ex.Message}"); }
         }
 
         // GAP-L: a cache slot only matches the doc it was primed against.
@@ -640,13 +674,20 @@ namespace StingTools.Core.Drawing
                 // match: that reproduces the old stacking behaviour, but the
                 // alternative is minting a fresh duplicate sheet on every
                 // run. Surfaced as a warning so the fix is actionable.
-                var unstampable = candidates.FirstOrDefault(s => DrawingTypeStamper.ReadSheetContext(s) == null);
+                // STACK-1: never hand back a sheet this batch already claimed for a
+                // DIFFERENT context — that is what stacked every level onto one
+                // sheet. Falling through mints a fresh sheet for this context and
+                // records the claim below.
+                var unstampable = candidates.FirstOrDefault(s =>
+                    DrawingTypeStamper.ReadSheetContext(s) == null
+                    && !ClaimedByOtherContext(s.Id, sheetCtx));
                 if (unstampable != null)
                 {
                     result.Warnings.Add(
                         $"{DrawingTypeStamper.PARAM_SHEET_CONTEXT} is not bound in this project, so sheets cannot be " +
                         $"matched per level / scope box. Reusing sheet {unstampable.Id} for context '{sheetCtx}'. " +
                         "Run LoadSharedParams to bind it, then re-run production.");
+                    ClaimSheetForContext(unstampable.Id, sheetCtx);
                     result.SheetReused = true;
                     return unstampable.Id;
                 }
@@ -792,6 +833,7 @@ namespace StingTools.Core.Drawing
                 // Newly-created sheet should be discoverable next time.
                 if (_existingSheetCache != null)
                     _existingSheetCache[SheetKey(dt.Id, effectivePackage, sheetCtx)] = sheet.Id;
+                ClaimSheetForContext(sheet.Id, sheetCtx);   // STACK-1
             }
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
 

--- a/StingTools/Core/Drawing/DrawingType.cs
+++ b/StingTools/Core/Drawing/DrawingType.cs
@@ -519,6 +519,16 @@ namespace StingTools.Core.Drawing
         [JsonProperty("kind")]        public string Kind { get; set; } = "ScopeBoxOrBbox";
         [JsonProperty("scopeBoxName")] public string ScopeBoxName { get; set; }
         [JsonProperty("marginMm")]    public double MarginMm { get; set; } = 150.0;
+
+        /// <summary>
+        /// Whether the crop BOUNDARY is drawn on the sheet. Every crop path
+        /// used to force this on, so production drawings shipped with a visible
+        /// crop rectangle around each viewport. Defaults to false — a produced
+        /// drawing should show its content, not its cropping frame. Set true
+        /// per drawing type when the boundary is wanted (coordination or
+        /// check prints, where the extent of the crop is the point).
+        /// </summary>
+        [JsonProperty("cropBoxVisible")] public bool CropBoxVisible { get; set; } = false;
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/StingTools/Core/Drawing/SheetPlacementBridge.cs
+++ b/StingTools/Core/Drawing/SheetPlacementBridge.cs
@@ -81,7 +81,7 @@ namespace StingTools.Core.Drawing
                 if (SlotOptsIntoFamilyGrid(slot))
                 {
                     var ctx = famCtx ?? BuildFamilySlotContext(doc, sheet, dt, result);
-                    var bounds = ResolveUnifiedSlotBounds(slot, ctx);
+                    var bounds = ResolveUnifiedSlotBounds(slot, ctx, result);
                     if (bounds?.Bbox != null)
                     {
                         // Slot bounds are in feet, origin at the title-block
@@ -182,14 +182,77 @@ namespace StingTools.Core.Drawing
             try
             {
                 if (!v.CropBoxActive) return; // can't measure intended footprint
-                var outline = v.Outline;
-                if (outline == null) return;
-                double curW = outline.Max.U - outline.Min.U;
-                double curH = outline.Max.V - outline.Min.V;
-                if (curW < 1e-9 || curH < 1e-9) return;
-                int curScale = v.Scale > 0 ? v.Scale : 100;
-                double fit = Math.Max(curW * curScale / sp.WidthFt,
-                                      curH * curScale / sp.HeightFt);
+
+                // View.Outline is PAPER-space and only recomputes on regeneration,
+                // so measuring it right after setting a crop in the same transaction
+                // read stale dimensions. Regenerating here fixed that but cost a
+                // full document regeneration per viewport — on a 20-type × 4-level
+                // batch that is 80+ regenerations inside one transaction, which
+                // reads as a hang. So measure MODEL-space geometry instead: both
+                // sources below are readable immediately, with no regeneration.
+                double modelW = 0, modelH = 0;
+
+                // 1. A scope box drives the crop — its own bounding box is the
+                //    intended extent, and it is independent of the view's
+                //    not-yet-regenerated crop.
+                //    PLAN VIEWS ONLY. get_BoundingBox(null) is model-space and
+                //    axis-aligned, so its X/Y are the view's horizontal axes only
+                //    for a plan. On a section or elevation the view's vertical axis
+                //    is model Z, so treating model Y as height would compute a
+                //    nonsense scale — those fall through to CropBox below, which is
+                //    expressed in the view's own frame and is correct for any type.
+                if (IsPlanFamily(v))
+                {
+                    try
+                    {
+                        var sbId = v.get_Parameter(BuiltInParameter.VIEWER_VOLUME_OF_INTEREST_CROP)?.AsElementId();
+                        if (sbId != null && sbId != ElementId.InvalidElementId)
+                        {
+                            var sbb = doc?.GetElement(sbId)?.get_BoundingBox(null);
+                            if (sbb != null)
+                            {
+                                modelW = Math.Abs(sbb.Max.X - sbb.Min.X);
+                                modelH = Math.Abs(sbb.Max.Y - sbb.Min.Y);
+                            }
+                        }
+                    }
+                    catch (Exception exS) { StingTools.Core.StingLog.Warn($"ApplyFitScale scope box: {exS.Message}"); }
+                }
+
+                // 2. Otherwise the crop box — which DrawingCropApplier just set
+                //    itself for TightBbox / RoomBoundary, so it is current.
+                if (modelW < 1e-9 || modelH < 1e-9)
+                {
+                    try
+                    {
+                        var cb = v.CropBox;
+                        if (cb != null)
+                        {
+                            modelW = Math.Abs(cb.Max.X - cb.Min.X);
+                            modelH = Math.Abs(cb.Max.Y - cb.Min.Y);
+                        }
+                    }
+                    catch (Exception exC) { StingTools.Core.StingLog.Warn($"ApplyFitScale crop box: {exC.Message}"); }
+                }
+
+                double fit;
+                if (modelW > 1e-9 && modelH > 1e-9)
+                {
+                    // Model feet ÷ paper feet = the scale that makes it fit.
+                    fit = Math.Max(modelW / sp.WidthFt, modelH / sp.HeightFt);
+                }
+                else
+                {
+                    // Last resort — the historic paper-space path.
+                    var outline = v.Outline;
+                    if (outline == null) return;
+                    double curW = outline.Max.U - outline.Min.U;
+                    double curH = outline.Max.V - outline.Min.V;
+                    if (curW < 1e-9 || curH < 1e-9) return;
+                    int curScale = v.Scale > 0 ? v.Scale : 100;
+                    fit = Math.Max(curW * curScale / sp.WidthFt,
+                                   curH * curScale / sp.HeightFt);
+                }
                 int fitScale = RoundUpToStandardScale(fit);
                 int target = sp.ScaleHint.HasValue ? Math.Max(fitScale, sp.ScaleHint.Value) : fitScale;
                 if (target > 0 && target != v.Scale)
@@ -200,6 +263,24 @@ namespace StingTools.Core.Drawing
             catch (Exception ex)
             {
                 StingTools.Core.StingLog.Warn($"SheetPlacementBridge.ApplyFitScale: {ex.Message}");
+            }
+        }
+
+        /// <summary>Plan-family views only — the ones whose paper axes are the
+        /// model's X/Y. Sections and elevations map paper-vertical to model Z, so
+        /// a model-space axis-aligned box cannot be read as width × height.</summary>
+        private static bool IsPlanFamily(View v)
+        {
+            if (v == null) return false;
+            switch (v.ViewType)
+            {
+                case ViewType.FloorPlan:
+                case ViewType.CeilingPlan:
+                case ViewType.AreaPlan:
+                case ViewType.EngineeringPlan:
+                    return true;
+                default:
+                    return false;
             }
         }
 
@@ -448,7 +529,8 @@ namespace StingTools.Core.Drawing
         /// PurposeTag (semantic, exact then alias chain) first, then SlotRef
         /// (exact family slot id). Returns null when neither resolves, letting
         /// the caller fall back to the norm* subdivision.</summary>
-        private static StingTools.Commands.Drawing.SlotBounds ResolveUnifiedSlotBounds(DrawingSlot slot, FamilySlotContext ctx)
+        private static StingTools.Commands.Drawing.SlotBounds ResolveUnifiedSlotBounds(
+            DrawingSlot slot, FamilySlotContext ctx, ProduceResult result = null)
         {
             if (slot == null || ctx?.Map == null || ctx.Map.Count == 0) return null;
 
@@ -464,6 +546,27 @@ namespace StingTools.Core.Drawing
             if (!string.IsNullOrWhiteSpace(slot.SlotRef)
                 && ctx.Map.TryGetValue(slot.SlotRef, out var byId) && byId?.Bbox != null)
                 return byId;
+
+            // SLOT-4: neither key resolved. The caller falls back to the norm*
+            // fractions, which usually LOOK plausible — so a mistyped purposeTag
+            // or a slotRef the family doesn't carry used to place the view in a
+            // silently different pocket with no clue why. Say so, and list what
+            // the family actually offers. Mirrors the existing SLOT-3 warning on
+            // view/slot TYPE mismatch, which was the only one of the pair present.
+            if (result != null)
+            {
+                var wanted = !string.IsNullOrWhiteSpace(slot.PurposeTag)
+                    ? $"purposeTag '{slot.PurposeTag}'"
+                    : $"slotRef '{slot.SlotRef}'";
+                var offered = string.Join(", ", ctx.Map.Values
+                    .Select(b => string.IsNullOrWhiteSpace(b?.PurposeTag) ? b?.Id : $"{b.Id}={b.PurposeTag}")
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .OrderBy(s => s));
+                result.Warnings.Add(
+                    $"Slot '{slot.Label}': {wanted} did not match the title-block family's slot grid — " +
+                    $"fell back to the normX/normY fractions, so the view may not land where the profile intends. " +
+                    $"Family offers: {offered}.");
+            }
 
             return null;
         }

--- a/StingTools/Data/STING_TITLE_BLOCKS.json
+++ b/StingTools/Data/STING_TITLE_BLOCKS.json
@@ -1068,7 +1068,7 @@
     },
     {
       "id": "STING_TB_A1_BIM_v2.0",
-      "extends": "A1_common_v2.0",
+      "extends": "A1_LAND_common_v2.0",
       "mode": "BIM",
       "description": "A1 landscape working sheet \u2014 full ISO 19650 BIM identity. Adds the 7-segment sheet ID strip, suitability chip + descriptive label, status band, revision-history register, federation status, LOIN/LOD, transmittal/CDE references, and the 4-eyes AUTHORISED BY signature row over the common base.",
       "saveAs": "Families/TitleBlocks/STING_TB_A1_BIM_v2.0.rfa",
@@ -1822,7 +1822,7 @@
     },
     {
       "id": "STING_TB_A1_NONBIM_v2.0",
-      "extends": "A1_common_v2.0",
+      "extends": "A1_LAND_common_v2.0",
       "mode": "NONBIM",
       "description": "A1 landscape working sheet \u2014 minimal non-BIM identity. Reuses the common identity-data + drawn/checked/approved block but skips the ISO-19650 sheet ID, suitability chip, and revision-history register. Sheet number is bound via PRJ_TB_SHEET_NR_TXT (the existing simple sheet identifier).",
       "saveAs": "Families/TitleBlocks/STING_TB_A1_NONBIM_v2.0.rfa",
@@ -4924,6 +4924,7 @@
       "id": "A1_LAND_common_v2.0",
       "abstract": true,
       "extends": "A1_common_v2.0",
+      "drawable": { "x": 10, "y": 115, "w": 821, "h": 474, "marginMm": 25 },
       "description": "A1 landscape working sheet (841 \u00d7 594 mm) \u2014 common base shared between BIM and NONBIM variants. Inherits the 40-param identity-data universe from A1_common_v2.0 and adds geometry sized for this paper. Five-column bottom strip (CLIENT/PROJECT/CONSULTANTS \u2014 NOTES/PROJECT-REF/DISCIPLINE/STAGE \u2014 DRAWING TITLE \u2014 DATES/AUTHORING \u2014 SHEET ID), strip height 110 mm, drawable zone 821 \u00d7 469 mm.",
       "templateRft": "Annotations/Titleblocks/A1 metric.rft",
       "category": "OST_TitleBlocks",

--- a/StingTools/UI/DrawingProductionConfigDialog.cs
+++ b/StingTools/UI/DrawingProductionConfigDialog.cs
@@ -161,6 +161,10 @@ namespace StingTools.UI
                 _typesTree.Items.Add(top);
             }
             stack.Children.Add(_typesTree);
+            stack.Children.Add(MakeCheckAllRow(
+                onAll:  () => SetAllTypesChecked(true),
+                onNone: () => SetAllTypesChecked(false),
+                label:  "drawing types"));
 
             stack.Children.Add(MakeHeading("Contexts to Include"));
             _contextsList = new ListBox { Height = 180, SelectionMode = SelectionMode.Multiple, Margin = new Thickness(0,0,0,8) };
@@ -170,6 +174,10 @@ namespace StingTools.UI
                 _contextsList.Items.Add(cb);
             }
             stack.Children.Add(_contextsList);
+            stack.Children.Add(MakeCheckAllRow(
+                onAll:  () => SetAllContextsChecked(true),
+                onNone: () => SetAllContextsChecked(false),
+                label:  "levels / contexts"));
 
             stack.Children.Add(MakeHeading("Preset"));
             var presetRow = new DockPanel { LastChildFill = true, Margin = new Thickness(0,0,0,4) };
@@ -186,6 +194,58 @@ namespace StingTools.UI
             stack.Children.Add(presetRow);
 
             return stack;
+        }
+
+        // ── Select all / none ────────────────────────────────────────────────
+        // Both lists shipped with every box pre-ticked and no way to clear them,
+        // so producing one drawing type on one level meant unticking by hand.
+
+        private UIElement MakeCheckAllRow(Action onAll, Action onNone, string label)
+        {
+            var row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 8) };
+            row.Children.Add(MakeSmallLink("Select all", onAll, $"Tick every one of the {label} above"));
+            row.Children.Add(MakeSmallLink("Deselect all", onNone, $"Clear every one of the {label} above"));
+            return row;
+        }
+
+        private UIElement MakeSmallLink(string text, Action onClick, string tip)
+        {
+            var b = new Button
+            {
+                Content = text, Height = 22, MinWidth = 86, FontSize = 11,
+                Margin = new Thickness(0, 0, 6, 0), Padding = new Thickness(6, 0, 6, 0),
+                ToolTip = tip,
+            };
+            b.Click += (s, e) =>
+            {
+                try { onClick?.Invoke(); }
+                catch (Exception ex) { StingLog.Warn($"MakeSmallLink '{text}': {ex.Message}"); }
+            };
+            return b;
+        }
+
+        /// <summary>Tick / clear the checkbox in every top-level tree item's
+        /// header. ResolveSelectedTypes reads those same boxes, so this drives
+        /// the real selection rather than a parallel copy of it.</summary>
+        private void SetAllTypesChecked(bool value)
+        {
+            if (_typesTree == null) return;
+            foreach (var obj in _typesTree.Items)
+            {
+                if (!(obj is TreeViewItem tvi)) continue;
+                if (tvi.Header is StackPanel sp)
+                {
+                    foreach (var child in sp.Children)
+                        if (child is CheckBox cb) { cb.IsChecked = value; break; }
+                }
+            }
+        }
+
+        private void SetAllContextsChecked(bool value)
+        {
+            if (_contextsList == null) return;
+            foreach (var obj in _contextsList.Items)
+                if (obj is CheckBox cb) cb.IsChecked = value;
         }
 
         private FrameworkElement MakeTypeHeader(DrawingType dt)

--- a/StingTools/UI/DrawingTypeEditorDialog.cs
+++ b/StingTools/UI/DrawingTypeEditorDialog.cs
@@ -2931,8 +2931,18 @@ namespace StingTools.UI
             DockPanel.SetDock(right, Dock.Right);
             var btnClose = MakeBigBtn("Close", CardBg, false);
             var btnSave  = MakeBigBtn("Save",  AccentColor, true);
-            btnClose.Click += (s, e) => { DialogResult = false; };
-            btnSave.Click  += (s, e) => { if (SaveToProjectOverride()) { DialogResult = true; } };
+            // DialogResult may only be set on a window shown with ShowDialog().
+            // DrawingTypeEditorCommand launches this editor MODELESS (Show()) on
+            // purpose — a modal window blocks Revit's ExternalEvent queue, so the
+            // action buttons inside would never fire. Setting DialogResult here
+            // therefore threw InvalidOperationException and the window refused to
+            // close at all. Close() works in both modes.
+            btnClose.Click += (s, e) => { try { Close(); } catch (Exception ex) { StingLog.Warn($"Editor close: {ex.Message}"); } };
+            btnSave.Click  += (s, e) =>
+            {
+                if (!SaveToProjectOverride()) return;
+                try { Close(); } catch (Exception ex) { StingLog.Warn($"Editor close after save: {ex.Message}"); }
+            };
             right.Children.Add(btnClose);
             right.Children.Add(btnSave);
             row.Children.Add(right);

--- a/StingTools/UI/ProjectAssetPicker.cs
+++ b/StingTools/UI/ProjectAssetPicker.cs
@@ -13,15 +13,22 @@ namespace StingTools.UI
 {
     internal static class ProjectAssetPicker
     {
-        // ── Title-block family symbols (FamilySymbol, OST_TitleBlocks) ──
+        // ── Title-block families (FamilySymbol, OST_TitleBlocks) ──
+        // Yields FAMILY names, not "Family : Type". DrawingType.TitleBlockFamily
+        // is matched by TitleBlockResolver.IsLoadedTitleBlock against
+        // FamilySymbol.FamilyName, so a "Family : Type" entry could never match:
+        // picking one wrote a value that fell through to "unknown vocabulary",
+        // and production then hunted for a family literally called
+        // "STING_TB_A1_BIM_v2.0 : A1". Query shape mirrors the resolver's own
+        // (OfClass over Cast) so the list and the matcher can't disagree.
         public static IEnumerable<string> TitleBlockFamilyTypes(Document doc)
         {
             if (doc == null) return System.Linq.Enumerable.Empty<string>();
             return new FilteredElementCollector(doc)
                 .OfCategory(BuiltInCategory.OST_TitleBlocks)
-                .WhereElementIsElementType()
+                .OfClass(typeof(FamilySymbol))
                 .Cast<FamilySymbol>()
-                .Select(fs => $"{fs.Family?.Name} : {fs.Name}")
+                .Select(fs => fs.FamilyName)
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .Distinct()
                 .OrderBy(s => s)

--- a/StingTools/UI/RevitVgEditor.cs
+++ b/StingTools/UI/RevitVgEditor.cs
@@ -717,7 +717,7 @@ namespace StingTools.UI
         {
             try
             {
-                bool ok = StingTools.UI.StingDockPanel.DispatchCommand("CreateObjectStyles");
+                bool ok = StingTools.UI.StingDockPanel.DispatchCommandSmart("CreateObjectStyles");
                 if (!ok)
                 {
                     MessageBox.Show(

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -4103,6 +4103,16 @@ namespace StingTools.UI
                     try { var r = BOQCostManagerPanel.PendingActionResolve; BOQCostManagerPanel.PendingActionResolve = null; r?.Invoke(); }
                     catch (Exception exR) { StingLog.Warn($"BOQ PendingActionResolve: {exR.Message}"); }
 
+                    // Same idea for the dock panel's own status line. Cmd_Click
+                    // sets "Running: <tag>…" when it raises the event, and nothing
+                    // ever cleared it — so a command that finished instantly (or
+                    // reported nothing) left the panel reading as permanently
+                    // in-flight. Resolve it here, at the one place every dispatch
+                    // converges. Only overwrites the label when it still shows
+                    // THIS tag, so a command that reported its own status wins.
+                    try { StingDockPanel.LastInstance?.ResolveRunningStatus(tag); }
+                    catch (Exception exS) { StingLog.Warn($"ResolveRunningStatus '{tag}': {exS.Message}"); }
+
                     // P0.1 — release the BOQ dispatch busy-guard so the Actions
                     // surface accepts the next click and the buttons un-grey. This
                     // is the universal reset point (fires on every command, not just

--- a/StingTools/UI/StingDockPanel.xaml.cs
+++ b/StingTools/UI/StingDockPanel.xaml.cs
@@ -185,6 +185,30 @@ namespace StingTools.UI
         }
 
         /// <summary>
+        /// Dispatch that works from a dialog shown DURING command execution.
+        ///
+        /// A modal dialog opened inside an IExternalCommand (the drawing-production
+        /// config dialog, and the VG / Object Styles editors it launches) is still
+        /// on the Revit API thread, and the ExternalEvent that is running that very
+        /// command cannot be re-raised — Raise() returns Denied, so every button in
+        /// those dialogs reported "open the dock panel first" and did nothing. Run
+        /// synchronously when we hold the API thread, and fall back to the async
+        /// queue when we don't (a modeless window with no command in flight).
+        /// </summary>
+        public static bool DispatchCommandSmart(string tag, string param1 = "", string param2 = "")
+        {
+            if (string.IsNullOrEmpty(tag)) return false;
+            var app = StingCommandHandler.CurrentApp;
+            if (app != null)
+            {
+                try { if (DispatchCommandSync(app, tag, param1, param2)) return true; }
+                catch (Exception ex)
+                { StingTools.Core.StingLog.Warn($"DispatchCommandSmart sync '{tag}': {ex.Message}"); }
+            }
+            return DispatchCommand(tag, param1, param2);
+        }
+
+        /// <summary>
         /// Deterministic synchronous dispatch for callers already on the Revit
         /// API thread (Hub ribbon commands). Bypasses ExternalEvent.Raise()
         /// entirely — runs the command immediately and returns false only when
@@ -2079,6 +2103,35 @@ namespace StingTools.UI
         }
 
         // ── Status bar helper ──────────────────────────────────────
+
+        /// <summary>
+        /// Clear the "Running: {tag}…" placeholder once that dispatch finishes.
+        /// Called from StingCommandHandler's execute finally-block. Deliberately
+        /// conservative: it only rewrites the label while it still shows THIS
+        /// tag, so a command that reported its own outcome keeps it.
+        /// </summary>
+        public void ResolveRunningStatus(string tag)
+        {
+            if (txtStatus == null || string.IsNullOrEmpty(tag)) return;
+            Action apply = () =>
+            {
+                try
+                {
+                    var cur = txtStatus.Text ?? "";
+                    if (!cur.StartsWith("Running: " + tag, StringComparison.OrdinalIgnoreCase)) return;
+                    // Must go through UpdateStatus, NOT txtStatus.Text directly:
+                    // UpdateStatus is also what releases FreezeTagSubTabs (any
+                    // message not starting "Running:" triggers UnfreezeTagSubTabs).
+                    // Writing Text here bypassed that, so a frozen Tag Studio would
+                    // have stayed frozen with the label claiming it had finished —
+                    // strictly worse than the sticky label this method fixes.
+                    UpdateStatus(tag + " — finished");
+                }
+                catch (Exception ex) { StingTools.Core.StingLog.Warn($"ResolveRunningStatus: {ex.Message}"); }
+            };
+            if (txtStatus.Dispatcher.CheckAccess()) apply();
+            else txtStatus.Dispatcher.BeginInvoke(apply);
+        }
 
         public void UpdateStatus(string message)
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,73 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 225 — drawings-production autonomous completion)
+
+Closes the drawings-production workstream on top of Phases 223/224. Every commit built
+clean against Revit 2025 (0 warnings, 0 errors). **Nothing below has been exercised
+inside Revit** — the smoke rows at the end of each section are the human's next action.
+
+**Runtime fixes — dead buttons, engine, editor.** Three commits that made
+drawing production actually run from the dock panel.
+
+- **`CurrentApp` fallback, 28 sites across 16 files.** `StingCommandHandler.RunCommand<T>`
+  calls `cmd.Execute(null, …)` by design and commands are expected to fall back to
+  `StingCommandHandler.CurrentApp` — a convention `TitleBlockFactoryCommands` documents
+  explicitly. 16 of the 17 `Commands/Drawing` files never did, so they read
+  `commandData?.Application?.ActiveUIDocument?.Document`, got null, and returned
+  "No active document" on their first line. Every drawing-production button was dead
+  from the panel; `DrawingTypeEditorCommand` built its editor with a null `Document`,
+  which is why the title-block dropdown came back blank. `BulkReStampDrawingTypeCommand`
+  and `TitleBlockRevisionSyncCommand` used non-null-safe `commandData.Application` and
+  threw `NullReferenceException` rather than failing quietly.
+- **Engine: six defects.** `AnnotationRunner` passed an `int` to `Enum.IsDefined` but
+  `BuiltInCategory`'s underlying type is `long` in Revit 2024+, so every tag rule threw
+  and the per-rule catch turned it into a warning — auto-tagging placed **nothing**.
+  A 4-level run stacked all four plans on one sheet because `STING_SHEET_CONTEXT_TXT`
+  was unbound and `ReadSheetContext` returned null for every sheet; sheet-context claims
+  are now tracked per batch. Fit-to-slot measured a stale paper-space `View.Outline`
+  (the crop it depends on is set earlier in the same transaction) and is now measured
+  from model-space geometry needing no regeneration — an earlier attempt regenerated
+  per viewport, costing 80+ full regenerations on a 20-type × 4-level batch and reading
+  as a hang. `A1_LAND_common_v2.0` declared no drawable of its own and inherited
+  `A1_common`'s, so its slot grid and drawable rect disagreed — given its own, the two
+  A1 landscape families now resolve 13 slots instead of 8. Every crop path forced
+  `CropBoxVisible = true`; now a declared `cropBoxVisible` defaulting off. A
+  `purposeTag`/`slotRef` matching nothing fell through to the `norm*` fractions in
+  silence and now warns, naming the slots the family offers. Title-block slot maps are
+  memoised — the reference-plane override pass calls `Document.EditFamily`, which was
+  opening the same family once per sheet.
+- **UI: editor close, in-dialog dispatch, select-all, picker.** The Drawing Type Editor
+  would not close — Close/Save set `DialogResult`, which may only be set on a window
+  shown with `ShowDialog()`, and the editor is modeless on purpose (a modal window
+  blocks Revit's `ExternalEvent` queue). Buttons inside dialogs opened *during* command
+  execution were dead: re-raising the same `ExternalEvent` from inside its own handler
+  is denied, so `DispatchCommandSmart` now runs synchronously when the API thread is
+  already held. The per-level config dialog shipped both lists fully ticked with no way
+  to clear them — added Select all / Deselect all. The title-block picker offered
+  "Family : Type" strings while `TitleBlockResolver.IsLoadedTitleBlock` matches bare
+  `FamilySymbol.FamilyName`, so any pick wrote a value that could never match. The
+  panel's "Running: <tag>…" label was set on dispatch and never cleared; resolved in the
+  handler's `finally` via `UpdateStatus` (not `txtStatus.Text` directly — `UpdateStatus`
+  is also what releases `FreezeTagSubTabs`, so a direct write would have left Tag Studio
+  frozen while claiming the command had finished).
+
+**Needs a Revit smoke test** (human):
+
+| Area | Check |
+|---|---|
+| Panel dispatch | Every Drawing button on the dock panel runs — spot-check Inspect, Doctor, Renumber, Editor; none returns "No active document" |
+| Drawing Type Editor | Opens with a populated title-block dropdown; both Close and Save dismiss the window |
+| In-dialog buttons | Per-level production config dialog: Select all / Deselect all drive both lists; RevitVgEditor → Object Styles opens |
+| Title-block picker | A family picked from the picker resolves during production (bare family name, not "Family : Type") |
+| Status label | After a command finishes, "Running: <tag>…" clears **and** Tag Studio sub-tabs unfreeze |
+| Auto-tagging | A DrawingType with autoTag rules places Room / Door / Window / Stair tags — previously placed nothing |
+| Per-level sheets | A 4-level run produces 4 sheets, not 1 stacked sheet. **Bind `STING_SHEET_CONTEXT_TXT` first (run LoadSharedParams once)** — without it the per-batch claim works within a run but sheet identity does not survive a session restart |
+| Fit-to-slot | Views scale from the cropped extent; a 20-type × 4-level batch completes without a hang |
+| A1 landscape | An A1 landscape title block resolves 13 slots (not 8); viewports land inside the frame |
+| Crop visibility | Produced drawings carry no visible crop rectangle unless `cropBoxVisible` is declared |
+| Slot miss | A typo'd `purposeTag` / `slotRef` warns and names the slots the family offers |
+
 #### Completed (cover title-block — ISO 19650 suitability in the revision schedule)
 
 The cover title-block family's revision history is a **native Revit Revision


### PR DESCRIPTION
Three commits that had never left their session, rebased onto latest `main` and built clean (Release, 0 warnings / 0 errors). Together they are what makes drawing production actually run from the dock panel.

## Scope

**1. `CurrentApp` fallback — 28 call sites, 16 files.** `StingCommandHandler.RunCommand<T>` calls `cmd.Execute(null, …)` by design; commands are expected to fall back to `StingCommandHandler.CurrentApp`, a convention `TitleBlockFactoryCommands` documents explicitly. 16 of the 17 `Commands/Drawing` files never did — they read `commandData?.Application?.ActiveUIDocument?.Document`, got null, and returned "No active document" on their first line, instantly and silently. **Every drawing-production button was dead from the panel.** `DrawingTypeEditorCommand` built its editor with a null `Document`, which is why the title-block dropdown came back blank. `BulkReStampDrawingTypeCommand` and `TitleBlockRevisionSyncCommand` used non-null-safe `commandData.Application`, so those threw `NullReferenceException` instead of failing quietly.

**2. Engine — six defects.**
- **Auto-tagging placed nothing.** `AnnotationRunner` passed an `int` to `Enum.IsDefined`, but `BuiltInCategory`'s underlying type is `long` in Revit 2024+, so every rule threw "Enum underlying type and the object must be same type" and the per-rule catch downgraded it to a warning. Rooms, Doors, Windows, Stairs, Railings, Furniture — all silently skipped.
- **A 4-level run stacked all 4 plans on one sheet.** `STING_SHEET_CONTEXT_TXT` is what tells per-level sheets apart; unbound, `ReadSheetContext` returns null for every sheet and the fallback handed the same sheet to every context. Within a run we always know which context we just used a sheet for, so claims are now tracked per batch.
- **Fit-to-slot measured a stale outline.** `View.Outline` is paper-space and only recomputes on regeneration, and the crop it depends on is set earlier in the *same* transaction — so the scale came from pre-crop dimensions. Now measured from model-space geometry needing no regeneration: the scope box's bbox (plan views only — model X/Y are the view's axes only for a plan) else the crop box.
- **A1 landscape** was the only paper size whose slot grid and drawable rect disagreed. `A1_LAND_common_v2.0` declared no drawable of its own so it inherited `A1_common`'s `{10,120,810,470}` while its slots were authored to `{10,115,821,474}`. Given its own drawable, the two A1 landscape families now resolve the same 13 slots as A0 instead of 8.
- **Crop frames shipped visible** — every crop path forced `CropBoxVisible = true`. Now a declared `cropBoxVisible` on `DrawingCropStrategy`, applied in one place, defaulting off.
- **A `purposeTag`/`slotRef` that matched nothing** fell through to the `norm*` fractions in silence. It now warns and names the slots the family offers — the missing half of the existing SLOT-3 warning.
- Also **memoises the title-block slot map**: the reference-plane override pass calls `Document.EditFamily`, which *opens* the family document, and that ran once per sheet. Cached by family name, dropped on document change and at every batch boundary so a Family Editor nudge is still picked up next run.

**3. UI — editor close, in-dialog dispatch, select-all, picker, status.**
- The Drawing Type Editor **would not close**. Close/Save set `DialogResult`, which may only be set on a window shown with `ShowDialog()` — and the editor is modeless on purpose (a modal window blocks Revit's `ExternalEvent` queue, so its own action buttons would never fire). The setter threw and the window stayed open. Both use `Close()` now.
- **Buttons inside dialogs opened during command execution were dead.** The production config dialog is modal and opens inside `ProduceViewsPerLevelCommand`, itself running in the `ExternalEvent` handler — re-raising that same event is denied, so every button reported "open the dock panel first". `DispatchCommandSmart` runs synchronously when we already hold the API thread and falls back to the async queue otherwise.
- The per-level config dialog **shipped both lists fully ticked with no way to clear them**. Added Select all / Deselect all.
- The **title-block picker offered "Family : Type"** strings while `TitleBlockResolver.IsLoadedTitleBlock` matches bare `FamilySymbol.FamilyName`, so picking any entry wrote a value that could never match.
- The panel's **"Running: <tag>…" label was never cleared**. Resolved in the handler's `finally`, routed through `UpdateStatus` rather than `txtStatus.Text` — `UpdateStatus` is also what releases `FreezeTagSubTabs`, so writing `Text` directly would have left Tag Studio frozen while claiming the command had finished.

## Two bugs caught in the course of this work

- **Per-viewport regeneration hang.** The first fix for the stale outline regenerated per viewport, which cost 80+ full regenerations on a 20-type × 4-level batch and read as a hang. Replaced with the model-space measurement above.
- **`txtStatus.Text` freeze.** Clearing the status label by writing `Text` directly would have left `FreezeTagSubTabs` engaged — Tag Studio permanently frozen while the panel claimed the command had finished.

## Smoke caveat

`STING_SHEET_CONTEXT_TXT` **must be bound** — run `LoadSharedParams` once — for the per-batch sheet identity to survive a session restart. Within a single run the per-batch claim is sufficient; across restarts the parameter is what re-identifies a sheet.

## Verification

`dotnet build StingTools/StingTools.csproj -c Release` → **0 warnings, 0 errors**. **No Revit runtime verification** — the eleven checks a human needs to run are tabled in `docs/CHANGELOG.md` under Phase 225.
