### PR TITLE
fix(drawings): converge sheet templates on the bottom-left slot convention (P-7)

### DIFF
--- a/StingTools/Docs/DrawingTypeSheetAdapter.cs
+++ b/StingTools/Docs/DrawingTypeSheetAdapter.cs
@@ -52,6 +52,13 @@ namespace StingTools.Docs
             {
                 foreach (var s in dt.Slots)
                 {
+                    // Straight copy: DrawingSlot and TemplateViewSlot both
+                    // anchor bottom-left. Before the P-7 convergence
+                    // TemplateViewSlot meant the slot CENTRE, so this copy
+                    // silently shifted every slot up and right by half its own
+                    // extent — the reason a profile placed through
+                    // "Create From Template" landed differently from the same
+                    // profile placed through DrawingProducer.
                     st.ViewportSlots.Add(new TemplateViewSlot
                     {
                         Label            = s.Label,

--- a/StingTools/Docs/SheetManagerEngineExt.cs
+++ b/StingTools/Docs/SheetManagerEngineExt.cs
@@ -23,8 +23,17 @@ namespace StingTools.Docs
     {
         [JsonProperty("viewType")] public string ViewType { get; set; }
         [JsonProperty("discipline")] public string Discipline { get; set; }
-        [JsonProperty("normX")] public double NormX { get; set; }  // 0.0 = left, 1.0 = right
-        [JsonProperty("normY")] public double NormY { get; set; }  // 0.0 = bottom, 1.0 = top
+        // CENTRE-anchored, unlike DrawingSlot and TemplateViewSlot which anchor
+        // bottom-left. The comments here used to claim "0.0 = left / 0.0 =
+        // bottom", which the code has never done: ApplyLayoutPreset denormalises
+        // with cx = zone.Min.X + NormX * zone.Width and SetBoxCenter's that
+        // straight onto the viewport, and every built-in preset below is
+        // authored around 0.5. Layout presets are a separate saved format that
+        // never exchanges slots with the other two, so the convention is left
+        // as-is and documented rather than converted; converging it is logged
+        // in ROADMAP.
+        [JsonProperty("normX")] public double NormX { get; set; }  // slot CENTRE, fraction of drawable width
+        [JsonProperty("normY")] public double NormY { get; set; }  // slot CENTRE, fraction of drawable height
         [JsonProperty("normW")] public double NormW { get; set; }  // fraction of drawable width
         [JsonProperty("normH")] public double NormH { get; set; }  // fraction of drawable height
         [JsonProperty("scale")] public int Scale { get; set; }

--- a/StingTools/Docs/SheetTemplateEngine.cs
+++ b/StingTools/Docs/SheetTemplateEngine.cs
@@ -38,15 +38,24 @@ namespace StingTools.Docs
 
     /// <summary>
     /// A slot within a sheet template defining where a view should be placed.
+    /// <para>
+    /// Coordinates are <b>bottom-left anchored</b> fractions of the drawable
+    /// zone, matching <see cref="StingTools.Core.Drawing.DrawingSlot"/> and the
+    /// shipped <c>STING_DRAWING_TYPES.json</c>: normX/normY locate the slot's
+    /// lower-left corner and normX+normW / normY+normH must stay within 1.0.
+    /// Templates written before library version 2.0 anchored on the slot
+    /// <i>centre</i>; <see cref="SheetTemplateEngine.LoadTemplateLibrary"/>
+    /// converts those on load.
+    /// </para>
     /// </summary>
     internal class TemplateViewSlot
     {
         [JsonProperty("label")] public string Label { get; set; }           // e.g. "Main Plan", "Section A"
         [JsonProperty("viewType")] public string ViewType { get; set; }     // FloorPlan, Section, Elevation, etc.
-        [JsonProperty("normX")] public double NormX { get; set; }
-        [JsonProperty("normY")] public double NormY { get; set; }
-        [JsonProperty("normW")] public double NormW { get; set; }
-        [JsonProperty("normH")] public double NormH { get; set; }
+        [JsonProperty("normX")] public double NormX { get; set; }           // 0.0 = left edge of drawable zone
+        [JsonProperty("normY")] public double NormY { get; set; }           // 0.0 = bottom edge of drawable zone
+        [JsonProperty("normW")] public double NormW { get; set; }           // fraction of drawable width
+        [JsonProperty("normH")] public double NormH { get; set; }           // fraction of drawable height
         [JsonProperty("preferredScale")] public int PreferredScale { get; set; }
         [JsonProperty("viewportTypeName")] public string ViewportTypeName { get; set; }
         [JsonProperty("required")] public bool Required { get; set; } = true;
@@ -57,7 +66,14 @@ namespace StingTools.Docs
     /// </summary>
     internal class SheetTemplateLibrary
     {
-        [JsonProperty("version")] public string Version { get; set; } = "1.0";
+        /// <summary>
+        /// Bumped to "2.0" when slot coordinates moved from centre-anchored to
+        /// bottom-left anchored. Anything older is converted on load by
+        /// <see cref="SheetTemplateEngine.MigrateSlotOrigin"/>.
+        /// </summary>
+        internal const string CurrentVersion = "2.0";
+
+        [JsonProperty("version")] public string Version { get; set; } = CurrentVersion;
         [JsonProperty("templates")] public List<SheetTemplate> Templates { get; set; } = new List<SheetTemplate>();
     }
 
@@ -132,7 +148,7 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "Main Plan", ViewType = "FloorPlan",
-                            NormX = 0.47, NormY = 0.52, NormW = 0.80, NormH = 0.82, PreferredScale = 50 }
+                            NormX = 0.07, NormY = 0.11, NormW = 0.80, NormH = 0.82, PreferredScale = 50 }
                     }
                 },
                 new SheetTemplate
@@ -145,11 +161,11 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "Main Plan", ViewType = "FloorPlan",
-                            NormX = 0.47, NormY = 0.65, NormW = 0.80, NormH = 0.55, PreferredScale = 100 },
+                            NormX = 0.07, NormY = 0.375, NormW = 0.80, NormH = 0.55, PreferredScale = 100 },
                         new TemplateViewSlot { Label = "Section A", ViewType = "Section",
-                            NormX = 0.27, NormY = 0.18, NormW = 0.38, NormH = 0.28, PreferredScale = 50 },
+                            NormX = 0.08, NormY = 0.04, NormW = 0.38, NormH = 0.28, PreferredScale = 50 },
                         new TemplateViewSlot { Label = "Section B", ViewType = "Section",
-                            NormX = 0.72, NormY = 0.18, NormW = 0.38, NormH = 0.28, PreferredScale = 50 }
+                            NormX = 0.53, NormY = 0.04, NormW = 0.38, NormH = 0.28, PreferredScale = 50 }
                     }
                 },
                 new SheetTemplate
@@ -162,13 +178,13 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "North", ViewType = "Elevation",
-                            NormX = 0.27, NormY = 0.73, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
+                            NormX = 0.07, NormY = 0.53, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
                         new TemplateViewSlot { Label = "East", ViewType = "Elevation",
-                            NormX = 0.72, NormY = 0.73, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
+                            NormX = 0.52, NormY = 0.53, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
                         new TemplateViewSlot { Label = "South", ViewType = "Elevation",
-                            NormX = 0.27, NormY = 0.27, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
+                            NormX = 0.07, NormY = 0.07, NormW = 0.40, NormH = 0.40, PreferredScale = 100 },
                         new TemplateViewSlot { Label = "West", ViewType = "Elevation",
-                            NormX = 0.72, NormY = 0.27, NormW = 0.40, NormH = 0.40, PreferredScale = 100 }
+                            NormX = 0.52, NormY = 0.07, NormW = 0.40, NormH = 0.40, PreferredScale = 100 }
                     }
                 },
                 new SheetTemplate
@@ -181,9 +197,9 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "MEP Plan", ViewType = "FloorPlan",
-                            NormX = 0.47, NormY = 0.55, NormW = 0.80, NormH = 0.72, PreferredScale = 50 },
+                            NormX = 0.07, NormY = 0.19, NormW = 0.80, NormH = 0.72, PreferredScale = 50 },
                         new TemplateViewSlot { Label = "Legend", ViewType = "Legend",
-                            NormX = 0.20, NormY = 0.10, NormW = 0.25, NormH = 0.14, PreferredScale = 1,
+                            NormX = 0.075, NormY = 0.03, NormW = 0.25, NormH = 0.14, PreferredScale = 1,
                             Required = false }
                     }
                 },
@@ -197,13 +213,13 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "Detail 1", ViewType = "Detail",
-                            NormX = 0.27, NormY = 0.73, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
+                            NormX = 0.07, NormY = 0.53, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
                         new TemplateViewSlot { Label = "Detail 2", ViewType = "Detail",
-                            NormX = 0.72, NormY = 0.73, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
+                            NormX = 0.52, NormY = 0.53, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
                         new TemplateViewSlot { Label = "Detail 3", ViewType = "Detail",
-                            NormX = 0.27, NormY = 0.27, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
+                            NormX = 0.07, NormY = 0.07, NormW = 0.40, NormH = 0.40, PreferredScale = 10 },
                         new TemplateViewSlot { Label = "Detail 4", ViewType = "Detail",
-                            NormX = 0.72, NormY = 0.27, NormW = 0.40, NormH = 0.40, PreferredScale = 10,
+                            NormX = 0.52, NormY = 0.07, NormW = 0.40, NormH = 0.40, PreferredScale = 10,
                             Required = false }
                     }
                 },
@@ -217,9 +233,9 @@ namespace StingTools.Docs
                     ViewportSlots = new List<TemplateViewSlot>
                     {
                         new TemplateViewSlot { Label = "3D View", ViewType = "ThreeD",
-                            NormX = 0.50, NormY = 0.55, NormW = 0.82, NormH = 0.72, PreferredScale = 100 },
+                            NormX = 0.09, NormY = 0.19, NormW = 0.82, NormH = 0.72, PreferredScale = 100 },
                         new TemplateViewSlot { Label = "Key Plan", ViewType = "FloorPlan",
-                            NormX = 0.82, NormY = 0.10, NormW = 0.20, NormH = 0.16, PreferredScale = 500,
+                            NormX = 0.72, NormY = 0.02, NormW = 0.20, NormH = 0.16, PreferredScale = 500,
                             Required = false }
                     }
                 }
@@ -291,9 +307,11 @@ namespace StingTools.Docs
                     catch (Exception ex2) { StingLog.Warn($"Locked by template: {ex2.Message}"); }
                 }
 
-                // Denormalise position
-                double cx = zone.Min.X + slot.NormX * zone.Width;
-                double cy = zone.Min.Y + slot.NormY * zone.Height;
+                // Denormalise position. Slots are bottom-left anchored (see
+                // TemplateViewSlot), and Viewport.Create takes a centre — so
+                // add half the extent, exactly as SheetPlacementBridge does.
+                double cx = zone.Min.X + (slot.NormX + slot.NormW / 2.0) * zone.Width;
+                double cy = zone.Min.Y + (slot.NormY + slot.NormH / 2.0) * zone.Height;
 
                 try
                 {
@@ -362,8 +380,10 @@ namespace StingTools.Docs
                     {
                         Label = view.Name,
                         ViewType = view.ViewType.ToString(),
-                        NormX = Math.Round((center.X - zone.Min.X) / zone.Width, 4),
-                        NormY = Math.Round((center.Y - zone.Min.Y) / zone.Height, 4),
+                        // Bottom-left anchored: GetBoxCenter is a centre, so
+                        // step back by half the viewport before normalising.
+                        NormX = Math.Round((center.X - vpW / 2.0 - zone.Min.X) / zone.Width, 4),
+                        NormY = Math.Round((center.Y - vpH / 2.0 - zone.Min.Y) / zone.Height, 4),
                         NormW = Math.Round(vpW / zone.Width, 4),
                         NormH = Math.Round(vpH / zone.Height, 4),
                         PreferredScale = view.Scale
@@ -405,13 +425,57 @@ namespace StingTools.Docs
             try
             {
                 string json = File.ReadAllText(path);
-                return JsonConvert.DeserializeObject<SheetTemplateLibrary>(json) ?? new SheetTemplateLibrary();
+                var lib = JsonConvert.DeserializeObject<SheetTemplateLibrary>(json);
+                if (lib == null) return new SheetTemplateLibrary();
+                MigrateSlotOrigin(lib);
+                return lib;
             }
             catch (Exception ex)
             {
                 StingLog.Warn($"Could not load sheet templates: {ex.Message}");
                 return new SheetTemplateLibrary();
             }
+        }
+
+        /// <summary>
+        /// Convert a pre-2.0 template library from centre-anchored slot
+        /// coordinates to bottom-left anchored ones.
+        /// <para>
+        /// Libraries written before this change stored normX/normY as the slot
+        /// CENTRE, while <see cref="StingTools.Core.Drawing.DrawingSlot"/> — and
+        /// therefore the shipped catalogue, the validator's
+        /// "extends beyond the drawable zone" check and
+        /// <c>SheetPlacementBridge</c> — have always meant the lower-left
+        /// corner. Converting is a subtraction of half the extent.
+        /// </para>
+        /// <para>
+        /// The migration is in-memory only: the converted library is persisted
+        /// the next time the caller saves, so simply opening a project never
+        /// rewrites the user's file. It is guarded by the version stamp rather
+        /// than by inspecting the numbers, because a centre-anchored slot and a
+        /// bottom-left one are not distinguishable by value — running it twice
+        /// would shift every slot down-left again.
+        /// </para>
+        /// </summary>
+        internal static void MigrateSlotOrigin(SheetTemplateLibrary lib)
+        {
+            if (lib == null) return;
+            if (string.Equals(lib.Version, SheetTemplateLibrary.CurrentVersion, StringComparison.Ordinal))
+                return;
+
+            int slots = 0;
+            foreach (var t in lib.Templates ?? new List<SheetTemplate>())
+            {
+                foreach (var s in t.ViewportSlots ?? new List<TemplateViewSlot>())
+                {
+                    s.NormX = Math.Round(s.NormX - s.NormW / 2.0, 4);
+                    s.NormY = Math.Round(s.NormY - s.NormH / 2.0, 4);
+                    slots++;
+                }
+            }
+            lib.Version = SheetTemplateLibrary.CurrentVersion;
+            StingLog.Info($"Sheet templates: migrated {slots} slot(s) from centre-anchored to " +
+                          $"bottom-left coordinates (library version -> {SheetTemplateLibrary.CurrentVersion}).");
         }
 
         internal static void SaveTemplateLibrary(Document doc, SheetTemplateLibrary library)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -170,6 +170,48 @@ forced through.
 | Rebar filter | Apply the `struct-pt-tendon` filter — post-tensioned rebar is overridden, not just framing and floors |
 | Filters | Run `AecFilters_Create` — 290 filters, and no "non-filterable category" errors |
 
+**P-7 — slot-convention convergence.** `DrawingSlot` has always been bottom-left
+anchored: `DrawingTypeValidator` rejects a slot whose `normX+normW` exceeds 1.0,
+`SheetPlacementBridge` denormalises with `(normX + normW/2)`, and
+`STING_DRAWING_TYPES.json` is authored to match. `SheetTemplateEngine`'s
+`TemplateViewSlot` meant the slot **centre** — `cx = zone.Min.X + normX * zone.Width` —
+and its six built-in templates were authored accordingly (0.47 / 0.72 / 0.5 against
+widths of 0.8). Read as bottom-left most of those run off the sheet (0.72 + 0.40 = 1.12);
+read as centre, `DrawingTypeSheetAdapter`'s straight copy of a `DrawingSlot` into a
+`TemplateViewSlot` shifted every slot up and right by half its own extent — which is why
+one profile placed through *Create From Template* landed differently from the same
+profile placed through `DrawingProducer`.
+
+- All 16 built-in slot coordinates re-authored bottom-left; every one now satisfies
+  `normX+normW ≤ 1` and `normY+normH ≤ 1`.
+- Placement adds half the extent, matching `SheetPlacementBridge` exactly; save steps
+  back from `GetBoxCenter` by half the viewport, so a saved template round-trips.
+- **User-saved libraries migrate on load.** `SheetTemplateLibrary.CurrentVersion` is
+  `"2.0"`; anything older is converted by `MigrateSlotOrigin`. Guarded by the version
+  stamp rather than by inspecting the numbers — a centre-anchored slot and a bottom-left
+  one are not distinguishable by value, so running it twice would shift everything
+  down-left again. In-memory only: the converted library persists on the next save, so
+  opening a project never silently rewrites the user's file.
+- A third convention exists and is now documented rather than converted:
+  `LayoutSlotPreset` (`SheetManagerEngineExt`) declared itself `"0.0 = left / 0.0 =
+  bottom"` while both its denormalise and its save treat the values as a centre, and all
+  its built-in presets are authored around 0.5. It is a separate saved format that never
+  exchanges slots with the other two. Comment corrected; converging it is in ROADMAP.
+
+`DrawingProducer` → `SheetPlacementBridge` → `DrawingSlot` and `DrawingTypeSheetAdapter`
+→ `TemplateViewSlot` now agree.
+
+**Needs a Revit smoke test** (human):
+
+| Area | Check |
+|---|---|
+| Built-in templates | `Create From Template` for each of the six built-ins — every viewport lands inside the title-block frame, none off-sheet |
+| Template round-trip | `Save Sheet Template` from a laid-out sheet, then create a new sheet from it — viewports land where they were saved |
+| Adapter parity | Produce one drawing type via `DrawingProducer` and the same type via `Create From Template` — viewports land in the same place |
+| Legacy migration | Open a project with a pre-existing `.sting_sheet_templates.json` (version 1.0) — the log reports the migrated slot count, and applying a saved template places viewports correctly |
+| Migration idempotency | Save a template after the migration, reopen, apply again — slots do not drift down-left on the second open |
+| Layout presets | Regression check: `Apply Layout Preset` for the built-in presets still centres viewports as before (unchanged by this PR) |
+
 #### Completed (cover title-block — ISO 19650 suitability in the revision schedule)
 
 The cover title-block family's revision history is a **native Revit Revision

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -218,9 +218,16 @@ not survive verification and are recorded here so they are not re-raised:
 the invert one wall thickness low. The geometry fix is understood, but the corrected value is an
 engineering number on a drainage deliverable and is not an autonomous call. Left unwired.
 
-**P-7 slot convention** — Phase 225, separate PR (`fix/drawings-p7-slots`): re-author
-`SheetTemplateEngine`'s built-in slots bottom-left to match the JSON convention, with a
-conversion for user-saved templates.
+**P-7 slot convention** — ✅ closed in Phase 225. `TemplateViewSlot` converged on the
+bottom-left convention: 16 built-in slots re-authored, placement and save maths aligned
+with `SheetPlacementBridge`, and pre-2.0 user libraries migrated on load by
+`MigrateSlotOrigin` (version-guarded, in-memory until the next save).
+
+**Still open — a third slot convention.** `LayoutSlotPreset` (`SheetManagerEngineExt`) is
+centre-anchored. Its comments claimed bottom-left and have been corrected, but the format
+itself was not converted: it is a separate saved preset format that never exchanges slots
+with `DrawingSlot` or `TemplateViewSlot`, so converging it means a second user-data
+migration for no current correctness gain. Worth doing when that area is next touched.
 Everything else in the review remains open, notably: D-1/P-2/P-10 token substitution and
 numbering; T-1/T-2/T-3 title-block resolution, silent fallback and `PRJ_TB_LOCK_BOOL`;
 C-4/A-6/A-7 annotation and match-line idempotency; A-3 legend in-place refresh; P-5/E-2 section


### PR DESCRIPTION
Closes P-7. Release build: **0 warnings, 0 errors**. **No Revit runtime verification** — the six checks a human needs to run are tabled in `docs/CHANGELOG.md` under Phase 225.

## The divergence

`Core.Drawing.DrawingSlot` has always been **bottom-left anchored**, and three independent things prove it:

- `DrawingTypeValidator` rejects a slot whose `normX + normW` exceeds 1.0 (DT-0xx "extends beyond the drawable zone").
- `SheetPlacementBridge` denormalises with `cx = zoneMinX + (slot.NormX + slot.NormW / 2.0) * zoneW`.
- `STING_DRAWING_TYPES.json` is authored to match — e.g. a spool `Plan` at `0.05, 0.55, 0.40, 0.40`.

`Docs.TemplateViewSlot` (`SheetTemplateEngine`) meant the slot **centre**: `cx = zone.Min.X + slot.NormX * zone.Width`. Its six built-in templates were authored accordingly — `0.47`, `0.72`, `0.5` against widths of `0.8`.

Two failure modes fall out of that:

1. **Read as bottom-left, most built-in slots run off the sheet.** `0.72 + 0.40 = 1.12`. In the 4-up elevation and detail templates that is two of four slots; across all six built-ins, most.
2. **`DrawingTypeSheetAdapter` copies `DrawingSlot` → `TemplateViewSlot` with no conversion.** So a bottom-left value was read as a centre, shifting every slot up and right by half its own extent. That is why one drawing type placed through *Create From Template* landed differently from the same type placed through `DrawingProducer`.

## What changed

`TemplateViewSlot` converges on bottom-left — the JSON convention, as instructed:

- **All 16 built-in slot coordinates re-authored** (subtract half the extent). Every one now satisfies `normX+normW ≤ 1` and `normY+normH ≤ 1`; asserted during the conversion.
- **Placement** adds half the extent, matching `SheetPlacementBridge` exactly.
- **`SaveSheetTemplate`** steps back from `GetBoxCenter` by half the viewport before normalising, so a saved template round-trips.
- **The adapter's copy is now correct as written**, and carries a comment saying what it used to do.

## Migration for user-saved templates

`SheetTemplateLibrary` gains `CurrentVersion = "2.0"`; `LoadTemplateLibrary` runs `MigrateSlotOrigin` on anything older.

Two deliberate properties:

- **Version-guarded, not value-guarded.** A centre-anchored slot and a bottom-left one are not distinguishable by their numbers, so there is no heuristic that can detect an already-migrated library. Running the conversion twice would shift every slot down-left again. The version stamp is the only safe guard.
- **In-memory only.** The converted library is persisted the next time the caller saves, so simply opening a project never rewrites the user's file on disk.

## A third convention — documented, not converted

`LayoutSlotPreset` (`SheetManagerEngineExt`) declared itself `// 0.0 = left, 1.0 = right` and `// 0.0 = bottom, 1.0 = top`. **The code has never done that**: `ApplyLayoutPreset` denormalises with `cx = zone.Min.X + slot.NormX * zone.Width` and `SetBoxCenter`s it directly, `SaveLayoutPreset` normalises from `GetBoxCenter`, and every built-in preset is authored around `0.5`. It is centre-anchored and internally consistent.

Only the comment is fixed. Layout presets are a separate saved format that never exchanges slots with `DrawingSlot` or `TemplateViewSlot`, so converting them would mean a second user-data migration for no current correctness gain. Logged in ROADMAP for whenever that area is next touched.

## Verified afterwards

`DrawingProducer` → `SheetPlacementBridge.ResolveSlot` → `DrawingSlot` (bottom-left) and `DrawingTypeSheetAdapter` → `TemplateViewSlot` (now bottom-left) agree. `DrawingTypeValidator`'s bounds and overlap checks were already written for bottom-left and are unchanged.
