### PR TITLE
fix(server): parse redis:// URLs before handing to StackExchange.Redis

### DIFF
--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -533,7 +533,10 @@ else
 builder.Services.AddSingleton<Planscape.Core.Interfaces.INotificationService, Planscape.Infrastructure.Services.NotificationService>();
 
 // ── Redis ──
-var redisConn = builder.Configuration["Redis:Connection"] ?? "localhost:6379";
+// Render (and most managed-Redis providers) inject connection strings as a
+// redis:// URL, which StackExchange.Redis's own parser does not understand —
+// see RedisConnectionStrings for the full failure mode this avoids.
+var redisConn = RedisConnectionStrings.Normalise(builder.Configuration["Redis:Connection"]);
 builder.Services.AddStackExchangeRedisCache(options =>
 {
     options.Configuration = redisConn;

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/RedisConnectionStrings.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/RedisConnectionStrings.cs
@@ -1,0 +1,71 @@
+namespace Planscape.Infrastructure.Data;
+
+/// <summary>
+/// Single place where a raw Redis connection string becomes something
+/// StackExchange.Redis can actually open.
+///
+/// WHY THIS EXISTS — same class of failure as <see cref="PgConnectionStrings"/>.
+/// Render (and most managed-Redis providers) hand out connection strings as a
+/// URL: <c>redis://[user:pass@]host:6379</c> or <c>rediss://...</c> for TLS.
+/// StackExchange.Redis's <c>ConfigurationOptions.Parse</c> does NOT understand
+/// this scheme — it expects its own comma-separated form
+/// (<c>host:port,password=...,ssl=true</c>). Handed a raw
+/// <c>redis://host:port</c> string, the parser mis-splits on the embedded
+/// colons and silently builds a broken endpoint, so the multiplexer never
+/// connects and every Redis-dependent feature (cache, SignalR backplane, the
+/// Redis-backed rate limiters) fails or times out — with no exception at
+/// startup, because <c>AbortOnConnectFail = false</c> is deliberately set to
+/// keep the app booting. <see cref="Normalise"/> converts URL form to
+/// StackExchange.Redis's native form and passes native form through
+/// untouched.
+/// </summary>
+public static class RedisConnectionStrings
+{
+    /// <summary>
+    /// Accepts either a <c>redis://</c> / <c>rediss://</c> URL or an already
+    /// StackExchange.Redis-native connection string, and always returns
+    /// native form (<c>host:port[,password=...][,user=...][,ssl=true]</c>).
+    /// </summary>
+    public static string Normalise(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return "localhost:6379";
+
+        raw = raw.Trim();
+
+        var isUrl = raw.StartsWith("redis://", StringComparison.OrdinalIgnoreCase)
+                 || raw.StartsWith("rediss://", StringComparison.OrdinalIgnoreCase);
+
+        if (!isUrl)
+            // Already native form — pass through untouched.
+            return raw;
+
+        if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Host))
+            // Malformed — return as-is so ConfigurationOptions.Parse throws
+            // its own descriptive error rather than us swallowing it here.
+            return raw;
+
+        var isTls = raw.StartsWith("rediss://", StringComparison.OrdinalIgnoreCase);
+        var port = uri.IsDefaultPort || uri.Port <= 0 ? 6379 : uri.Port;
+
+        var parts = new List<string> { $"{uri.Host}:{port}" };
+
+        // UserInfo is percent-encoded in a URL — passwords routinely contain
+        // characters that MUST be decoded before StackExchange.Redis sees them.
+        var userInfo = uri.UserInfo ?? string.Empty;
+        if (userInfo.Length > 0)
+        {
+            var split = userInfo.Split(':', 2);
+            var user = Uri.UnescapeDataString(split[0]);
+            if (!string.IsNullOrEmpty(user))
+                parts.Add($"user={user}");
+            if (split.Length == 2)
+                parts.Add($"password={Uri.UnescapeDataString(split[1])}");
+        }
+
+        if (isTls)
+            parts.Add("ssl=true");
+
+        return string.Join(',', parts);
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/RedisConnectionStringsTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/RedisConnectionStringsTests.cs
@@ -1,0 +1,88 @@
+using Planscape.Infrastructure.Data;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Guards the production failure RedisConnectionStrings exists to prevent:
+/// Render hands out redis:// URLs, but StackExchange.Redis's own parser
+/// expects its native comma-separated form and silently mis-parses a URL
+/// into a broken endpoint — no exception, just a multiplexer that never
+/// connects. See RedisConnectionStrings' doc comment for the full story.
+/// </summary>
+public class RedisConnectionStringsTests
+{
+    [Fact]
+    public void Normalise_ParsesRenderStyleUrl()
+    {
+        var opts = ConfigurationOptions.Parse(RedisConnectionStrings.Normalise(
+            "redis://red-abc123-a.frankfurt-redis.render.com:6379"));
+
+        Assert.Single(opts.EndPoints);
+        Assert.Contains("red-abc123-a.frankfurt-redis.render.com", opts.EndPoints[0].ToString());
+    }
+
+    [Fact]
+    public void Normalise_DefaultsPortWhenUrlOmitsIt()
+    {
+        var opts = ConfigurationOptions.Parse(RedisConnectionStrings.Normalise("redis://cache.example.com"));
+
+        Assert.Contains(":6379", opts.EndPoints[0].ToString());
+    }
+
+    [Fact]
+    public void Normalise_CarriesUserAndPassword()
+    {
+        var opts = ConfigurationOptions.Parse(RedisConnectionStrings.Normalise(
+            "redis://default:s3cret@cache.example.com:6379"));
+
+        Assert.Equal("default", opts.User);
+        Assert.Equal("s3cret", opts.Password);
+    }
+
+    [Fact]
+    public void Normalise_DecodesPercentEncodedPassword()
+    {
+        var opts = ConfigurationOptions.Parse(RedisConnectionStrings.Normalise(
+            "redis://default:p%40ss%3Aw%2Frd@cache.example.com:6379"));
+
+        Assert.Equal("p@ss:w/rd", opts.Password);
+    }
+
+    [Fact]
+    public void Normalise_EnablesSslForRedissScheme()
+    {
+        var opts = ConfigurationOptions.Parse(RedisConnectionStrings.Normalise(
+            "rediss://cache.example.com:6380"));
+
+        Assert.True(opts.Ssl);
+    }
+
+    [Fact]
+    public void Normalise_PassesNativeFormThrough()
+    {
+        var opts = ConfigurationOptions.Parse(
+            RedisConnectionStrings.Normalise("localhost:6379,password=dev"));
+
+        Assert.Contains("localhost:6379", opts.EndPoints[0].ToString());
+        Assert.Equal("dev", opts.Password);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Normalise_DefaultsToLocalhostWhenMissing(string? raw)
+        => Assert.Equal("localhost:6379", RedisConnectionStrings.Normalise(raw));
+
+    [Fact]
+    public void Normalise_ReturnsRawStringOnUnparseableUrl()
+    {
+        // Falls through unchanged rather than throwing, so ConfigurationOptions.Parse
+        // (called downstream in Program.cs, inside its own try/catch) produces the
+        // actual error — startup must never crash on a malformed Redis URL.
+        var result = RedisConnectionStrings.Normalise("redis://");
+        Assert.Equal("redis://", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Render (and most managed-Redis providers) inject `Redis__Connection` as a `redis://host:port` URL via the Key Value `fromService.connectionString` blueprint property.
- StackExchange.Redis's `ConfigurationOptions.Parse` does not understand that scheme — it expects its own native form (`host:port,password=...`). Handed a raw URL it mis-parses on the embedded colons and builds a broken endpoint. No exception at startup (`AbortOnConnectFail=false` is deliberate), just a multiplexer that never connects.
- Discovered live: on the new `render.free.yaml` deploy, this silently broke the Redis-backed `"auth"` sliding-window rate limiter (no fail-open handling there, unlike the rest of `AuthController`), turning every login attempt into an unhandled 500.
- Adds `RedisConnectionStrings.Normalise`, mirroring the existing `PgConnectionStrings` fix for the identical bug class on the Postgres side. Wired into the one place `Program.cs` reads `Redis:Connection`, so it covers the cache, SignalR backplane, and all Redis-backed rate limiters in one fix.
- Affects both `render.free.yaml` and the paid `render.yaml` — both wire Redis via the same `fromService` pattern, so this would have hit production the same way once its Redis is provisioned.

## Test plan
- [x] `dotnet build src/Planscape.API/Planscape.API.csproj -c Release` — 0 errors, only pre-existing baseline warnings
- [x] New `RedisConnectionStringsTests.cs` (10 cases: Render-style URL, default port, user/password, percent-decoding, `rediss://` → TLS, native-form passthrough, missing-string default, malformed-URL passthrough) — all passing
- [ ] Live-verify on `planscape-api-free` once merged: confirm `[STARTUP WARN] Redis unavailable` no longer appears and `/api/auth/login` returns normally instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)