### PR TITLE
Fix viewer iframe auth handoff + downloads/handoff cleanup

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1921,6 +1921,35 @@ THREE.ColorManagement.enabled = false;
      Native WebView (mobile owns its own RealtimeClient). -->
 <script defer src="./signalr-shim.js"></script>
 
+<!-- Cross-origin auth bootstrap. When this viewer is embedded as an iframe
+     from a different origin (planscape-web's /projects/{id}/viewer route),
+     this origin's localStorage has never heard of that session — it starts
+     empty on every load. coordination-viewer.js, meeting-sync.js and
+     livekit-av.js each independently read planscape_token / planscape_tenant
+     / planscape_user from localStorage, so all three need it populated
+     before they run, not just whichever happens to read the URL itself.
+     Mirrors the existing ?api= convention already used for "share-links from
+     another origin" (see the apiBase resolution in coordination-viewer.js).
+     The token is stripped from the address bar immediately after reading —
+     same reasoning as the planscape.build handoff page: a JWT sitting in
+     iframe history is exposure with no upside once it's been consumed. -->
+<script>
+(function () {
+  try {
+    var p = new URLSearchParams(location.search);
+    var token = p.get('token'), tenant = p.get('tenant'), user = p.get('user');
+    if (token) localStorage.setItem('planscape_token', token);
+    if (tenant) localStorage.setItem('planscape_tenant', tenant);
+    if (user) localStorage.setItem('planscape_user', user);
+    if (token || tenant || user) {
+      p.delete('token'); p.delete('tenant'); p.delete('user');
+      var qs = p.toString();
+      history.replaceState(null, '', location.pathname + (qs ? '?' + qs : ''));
+    }
+  } catch (e) { console.warn('[viewer] auth bootstrap failed:', e); }
+})();
+</script>
+
 <!-- Coordination layer — panels, API, clash + issue management. -->
 <script defer src="./coordination-viewer.js"></script>
 

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1921,6 +1921,35 @@ THREE.ColorManagement.enabled = false;
      Native WebView (mobile owns its own RealtimeClient). -->
 <script defer src="./signalr-shim.js"></script>
 
+<!-- Cross-origin auth bootstrap. When this viewer is embedded as an iframe
+     from a different origin (planscape-web's /projects/{id}/viewer route),
+     this origin's localStorage has never heard of that session — it starts
+     empty on every load. coordination-viewer.js, meeting-sync.js and
+     livekit-av.js each independently read planscape_token / planscape_tenant
+     / planscape_user from localStorage, so all three need it populated
+     before they run, not just whichever happens to read the URL itself.
+     Mirrors the existing ?api= convention already used for "share-links from
+     another origin" (see the apiBase resolution in coordination-viewer.js).
+     The token is stripped from the address bar immediately after reading —
+     same reasoning as the planscape.build handoff page: a JWT sitting in
+     iframe history is exposure with no upside once it's been consumed. -->
+<script>
+(function () {
+  try {
+    var p = new URLSearchParams(location.search);
+    var token = p.get('token'), tenant = p.get('tenant'), user = p.get('user');
+    if (token) localStorage.setItem('planscape_token', token);
+    if (tenant) localStorage.setItem('planscape_tenant', tenant);
+    if (user) localStorage.setItem('planscape_user', user);
+    if (token || tenant || user) {
+      p.delete('token'); p.delete('tenant'); p.delete('user');
+      var qs = p.toString();
+      history.replaceState(null, '', location.pathname + (qs ? '?' + qs : ''));
+    }
+  } catch (e) { console.warn('[viewer] auth bootstrap failed:', e); }
+})();
+</script>
+
 <!-- Coordination layer — panels, API, clash + issue management. -->
 <script defer src="./coordination-viewer.js"></script>
 

--- a/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
@@ -130,6 +130,65 @@ public sealed partial class PlanscapeServerClient
         lock (_defaultUrlLock) { _cachedDefaultUrl = null; }
     }
 
+    /// <summary>Env var name to override the derived web-app (SPA) URL directly,
+    /// bypassing <see cref="FormatWebAppUrl"/>'s api.&lt;domain&gt;→app.&lt;domain&gt;
+    /// / same-origin-&lt;base&gt;/app/ derivation. Needed for deployments where the
+    /// API and the web app are independently-named hosts (e.g. two Render free-tier
+    /// services, <c>planscape-api-free.onrender.com</c> +
+    /// <c>planscape-web-free.onrender.com</c>) that fit neither convention.</summary>
+    public const string WebAppUrlEnvVar = "STING_PLANSCAPE_WEB_URL";
+
+    /// <summary>
+    /// Resolve an explicit web-app URL override, if one is configured: env var →
+    /// machine settings file (key <c>webAppUrl</c>). Returns null when neither is
+    /// set, meaning callers should fall back to <see cref="FormatWebAppUrl"/>'s
+    /// derivation from the API base.
+    /// </summary>
+    public static string? ResolveWebAppUrlOverride()
+    {
+        try
+        {
+            var env = Environment.GetEnvironmentVariable(WebAppUrlEnvVar);
+            if (!string.IsNullOrWhiteSpace(env)) return NormalizeServerUrl(env);
+        }
+        catch (Exception ex) { StingLog.Warn($"ResolveWebAppUrlOverride(env): {ex.Message}"); }
+
+        try
+        {
+            string path = MachineSettingsPath;
+            if (File.Exists(path))
+            {
+                var o = JObject.Parse(File.ReadAllText(path));
+                var url = o["webAppUrl"]?.Value<string>();
+                if (!string.IsNullOrWhiteSpace(url)) return NormalizeServerUrl(url);
+            }
+        }
+        catch (Exception ex) { StingLog.Warn($"ResolveWebAppUrlOverride(file): {ex.Message}"); }
+
+        return null;
+    }
+
+    /// <summary>Persist an explicit web-app URL override to the machine settings
+    /// file, alongside <c>serverUrl</c>. Pass null/blank to clear it (the "Open
+    /// Planscape" buttons then fall back to deriving the URL from the API base).</summary>
+    public static void SaveWebAppUrlOverride(string? webAppUrl)
+    {
+        try
+        {
+            string path = MachineSettingsPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var o = File.Exists(path)
+                ? JObject.Parse(File.ReadAllText(path))
+                : new JObject();
+            if (string.IsNullOrWhiteSpace(webAppUrl)) o.Remove("webAppUrl");
+            else o["webAppUrl"] = NormalizeServerUrl(webAppUrl);
+            o["updatedUtc"] = DateTime.UtcNow.ToString("o");
+            File.WriteAllText(path, o.ToString(Newtonsoft.Json.Formatting.Indented));
+            StingLog.Info($"Planscape: web-app URL override saved to machine settings ({webAppUrl}).");
+        }
+        catch (Exception ex) { StingLog.Warn($"SaveWebAppUrlOverride: {ex.Message}"); }
+    }
+
     /// <summary>
     /// Format the coordinator-SPA URL for a given API base. For a cloud host
     /// whose subdomain is <c>api.&lt;domain&gt;</c> the SPA lives at the sibling

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -111,6 +111,19 @@ public sealed partial class PlanscapeServerClient : IDisposable
         }
         if (string.IsNullOrWhiteSpace(baseUrl)) baseUrl = DefaultAppFallbackUrl;
 
+        // An explicit override always wins — needed when the API and web app
+        // are independently-named hosts that fit neither of FormatWebAppUrl's
+        // two conventions (e.g. split Render free-tier services). See
+        // ResolveWebAppUrlOverride in the Settings partial.
+        var overrideUrl = ResolveWebAppUrlOverride();
+        if (!string.IsNullOrWhiteSpace(overrideUrl))
+        {
+            string url = overrideUrl!.TrimEnd('/') + "/";
+            if (!string.IsNullOrWhiteSpace(hash))
+                url += hash!.StartsWith("#") ? hash : "#" + hash;
+            return url;
+        }
+
         // FormatWebAppUrl maps a cloud api.<domain> host to the sibling
         // app.<domain> SPA root, and keeps the same-origin <base>/app/
         // convention for localhost / self-hosted stacks. See Settings partial.

--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -151,60 +151,22 @@ export const DOWNLOAD_CATALOG: Tool[] = [
           },
         ],
       },
-      {
-        version: "0.1.0-beta.2",
-        releasedAt: "2026-07-20",
-        notes:
-          "Adds sequence numbers to ArchiCAD tags so they match Revit's 8-segment format, and files processed IFCs into done/ and failed/ folders so you can see at a glance what is still outstanding. Sign in with an access token instead of a password — the only option if you signed up on planscape.build.",
-        artifacts: [
-          {
-            label: "win64",
-            platform: "Windows 64-bit",
-            objectKey: "sting-bridge/0.1.0-beta.2/StingBridge_0.1.0-beta.2_win64.zip",
-            sizeMb: 57,
-            sha256: "1b7eada10cff762e4c0a74503fbc7321301117766f6882a5d0da91aa15bc81ca",
-          },
-          {
-            label: "any",
-            platform: "Any OS (Python 3.11+)",
-            objectKey: "sting-bridge/0.1.0-beta.2/StingBridge_0.1.0-beta.2_any.zip",
-            sizeMb: 1,
-            sha256: "7353a062fdec8057942bb98c98320f79e3b1efecc91ac55f0aeaa931aaeb572c",
-          },
-        ],
-      },
-      {
-        version: "0.1.0-beta.1",
-        releasedAt: "2026-07-19",
-        notes:
-          "First public beta. The IFC drop-folder and single-file workflows are verified end-to-end; live ArchiCAD JSON-API sync ships but is still maturing — tell us how it goes.",
-        artifacts: [
-          {
-            label: "win64",
-            platform: "Windows 64-bit",
-            objectKey: "sting-bridge/0.1.0-beta.1/StingBridge_0.1.0-beta.1_win64.zip",
-            sizeMb: 51,
-            sha256: "976401ecce06c9c3231c1d92477c1fe3185ba167232ee3bf8ce4a857e0bc6d26",
-          },
-          {
-            label: "any",
-            platform: "Any OS (Python 3.11+)",
-            objectKey: "sting-bridge/0.1.0-beta.1/StingBridge_0.1.0-beta.1_any.zip",
-            sizeMb: 1,
-            sha256: "22f1ed6805f79e5fa2b64dc91a6b0a8c5a7475dd640dd68cbf48fc34ac425cc2",
-          },
-        ],
-      },
+      // 0.1.0-beta.1 and 0.1.0-beta.2 retired 2026-07-31 — superseded by
+      // beta.3, which fixes the re-processing/renumbering bug both of them
+      // had. Their R2 objects are untouched (in case a support case needs
+      // them); only the catalogue listing was pruned.
     ],
   },
   {
     id: "planscape-cloud",
     name: "Planscape cloud",
     tagline:
-      "Shared project workspace, document register and issue tracking, with the mobile site app.",
+      "Shared project workspace, meetings with live video and collaborative markup, document " +
+      "register and issue tracking, with a corporate coordination UI. Open it from your account page " +
+      "— there is nothing to download here.",
     kind: "cloud",
-    status: "in-development",
-    platform: "Web · iOS · Android",
+    status: "beta",
+    platform: "Web (mobile app in progress)",
     requiresProduct: null,
     versions: [],
   },

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -30,6 +30,25 @@ SITE_URL = "https://planscape.build"
 #                   Default: "Planscape <noreply@planscape.build>"
 # The auth Functions reuse the WAITLIST_DB D1 binding below — no new binding needed.
 
+# Cloud handoff (functions/api/cloud/handoff.ts) — where "sign in" hands a
+# logged-in planscape.build user off to the coordinator app.
+#   CLOUD_APP_ORIGIN  Plain var, not actually secret (just a URL) — set as a
+#                     Pages secret only because this project deploys via
+#                     `wrangler pages deploy`, not git, so wrangler.toml [vars]
+#                     changes never reach it without a manual redeploy.
+#                     Falls back to https://app.planscape.build if unset.
+#                     CURRENT VALUE (set 2026-07-31, interim): the free-tier
+#                     Render web service directly —
+#                     https://planscape-web-free.onrender.com — because
+#                     app.planscape.build isn't wired up as a custom domain
+#                     yet. Swap it to https://app.planscape.build the moment
+#                     that domain resolves:
+#                       echo "https://app.planscape.build" | \
+#                         wrangler pages secret put CLOUD_APP_ORIGIN \
+#                         --project-name planscape-marketing
+#                     No redeploy required either way — Pages secrets are
+#                     runtime bindings.
+
 # D1 binding for the waitlist Function (functions/api/waitlist.ts)
 # Created via: wrangler d1 create planscape-waitlist
 [[d1_databases]]

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -37,13 +37,13 @@ SITE_URL = "https://planscape.build"
 #                     `wrangler pages deploy`, not git, so wrangler.toml [vars]
 #                     changes never reach it without a manual redeploy.
 #                     Falls back to https://app.planscape.build if unset.
-#                     CURRENT VALUE (set 2026-07-31, interim): the free-tier
-#                     Render web service directly —
-#                     https://planscape-web-free.onrender.com — because
-#                     app.planscape.build isn't wired up as a custom domain
-#                     yet. Swap it to https://app.planscape.build the moment
-#                     that domain resolves:
-#                       echo "https://app.planscape.build" | \
+#                     CURRENT VALUE (set 2026-07-31): https://app.planscape.build
+#                     — verified as a Render custom domain on planscape-web-free
+#                     and confirmed serving over HTTPS the same day. Briefly
+#                     pointed at the bare Render URL as an interim value while
+#                     the custom domain was being verified; no longer needed.
+#                     To change it later:
+#                       echo "<new origin>" | \
 #                         wrangler pages secret put CLOUD_APP_ORIGIN \
 #                         --project-name planscape-marketing
 #                     No redeploy required either way — Pages secrets are

--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { listModels, modelFileUrl, getSceneManifest, chunkFileUrl } from '@/lib/data';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, getToken } from '@/lib/api';
+import { useAuth } from '@/lib/auth';
 import type { ProjectModel, SceneManifest } from '@/lib/types';
 
 // useSearchParams needs the page rendered dynamically (no static prerender).
@@ -13,7 +14,7 @@ export const dynamic = 'force-dynamic';
 
 // The existing 3D viewer (Planscape/assets/viewer → API wwwroot). Override with
 // NEXT_PUBLIC_VIEWER_URL if it's hosted elsewhere.
-const VIEWER_URL = process.env.NEXT_PUBLIC_VIEWER_URL || `${API_BASE}/viewer.html`;
+const VIEWER_BASE_URL = process.env.NEXT_PUBLIC_VIEWER_URL || `${API_BASE}/viewer.html`;
 
 export default function ViewerPage() {
   const params = useParams<{ id: string }>();
@@ -25,6 +26,28 @@ export default function ViewerPage() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // The 3D viewer + meetings (camera, screen share, markup, chat) all live in
+  // a legacy static bundle served by the API (wwwroot/viewer.html), embedded
+  // here as a cross-origin iframe. That origin's localStorage starts empty on
+  // every load — it has never heard of this browser's planscape-web session —
+  // so coordination-viewer.js / meeting-sync.js / livekit-av.js (which each
+  // independently read 'planscape_token' etc. from localStorage) always saw
+  // nothing and bounced to their own login. Pass the current session through
+  // as URL params; viewer.html's own bootstrap script (added alongside this
+  // change) writes them into its origin's localStorage before those scripts
+  // run, then strips them from the address bar.
+  const { user: authUser } = useAuth();
+  const [viewerSrc, setViewerSrc] = useState<string | null>(null);
+  useEffect(() => {
+    const token = getToken();
+    if (!token) { setViewerSrc(VIEWER_BASE_URL); return; }
+    const u = new URL(VIEWER_BASE_URL);
+    u.searchParams.set('token', token);
+    if (authUser?.tenantId) u.searchParams.set('tenant', authUser.tenantId);
+    if (authUser?.email) u.searchParams.set('user', authUser.email);
+    setViewerSrc(u.toString());
+  }, [authUser]);
 
   // Federation (preferred): multi-discipline scene chunks.
   const [scene, setScene] = useState<SceneManifest | null>(null);
@@ -165,14 +188,16 @@ export default function ViewerPage() {
       )}
 
       <div className="overflow-hidden rounded-lg ring-1 ring-border" style={{ height: '70vh' }}>
-        <iframe
-          ref={iframeRef}
-          src={VIEWER_URL}
-          title="3D model"
-          className="h-full w-full border-0"
-          onLoad={() => setReady(true)}
-          allow="fullscreen"
-        />
+        {viewerSrc && (
+          <iframe
+            ref={iframeRef}
+            src={viewerSrc}
+            title="3D model"
+            className="h-full w-full border-0"
+            onLoad={() => setReady(true)}
+            allow="fullscreen; camera; microphone; display-capture"
+          />
+        )}
       </div>
 
       {guid && <p className="mt-2 text-xs text-fg-subtle">Deep-linked to element {guid}.</p>}

--- a/planscape-web/lib/auth.tsx
+++ b/planscape-web/lib/auth.tsx
@@ -27,9 +27,16 @@ function decodeJwt(token: string): AuthUser | null {
     const json = atob(part.replace(/-/g, '+').replace(/_/g, '/'));
     const p = JSON.parse(json) as Record<string, string>;
     return {
+      // LiveKitTokenFactory/AuthController mint snake_case claims (tenant_id,
+      // display_name — see MeetingRoomController.cs / AuthController.cs), not
+      // the tenant/tenantId/tid/name/given_name this was actually checking
+      // for. tenantId in particular was silently always undefined — nothing
+      // downstream that read AuthUser.tenantId (this file's own callers, the
+      // viewer iframe bootstrap) ever had it, camouflaged because most of
+      // them degrade gracefully rather than error when it's missing.
       email: p.email || p.sub || p.unique_name || 'user',
-      name: p.name || p.given_name,
-      tenantId: p.tenant || p.tenantId || p.tid,
+      name: p.name || p.given_name || p.display_name,
+      tenantId: p.tenant_id || p.tenant || p.tenantId || p.tid,
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- **Viewer/meetings auth fix**: the embedded 3D viewer iframe (which hosts the LiveKit meeting/camera UI) never received the parent session's token, so it always bounced to its own legacy login and every meeting/camera control was unreachable. Fixed by passing token/tenant/user through as iframe URL params, bootstrapped into the iframe's own origin storage, plus fixing a snake_case JWT-claim mismatch in `decodeJwt()` that left `tenantId` silently undefined.
- Marketing site cleanup: pruned retired StingBridge download versions, un-stalled the Planscape Cloud listing (was hard-locked to "in development"), documented `CLOUD_APP_ORIGIN`/`PLANSCAPE_HANDOFF_SECRET`.

## Test plan
- [x] `dotnet test` — 493 passed / 0 failed / 9 skipped (unchanged)
- [x] `npm test` (planscape-web) — 69/69 passed (unchanged)
- [x] Verified live: rebuilt local docker API, signed in, opened a project viewer — full coordination UI renders with real data and zero console errors (previously bounced to legacy login within ~3s)
- [x] Confirmed the Meet menu (Start/Join/Copy-link) is reachable, which it was not before this fix
- [ ] PENDING-HUMAN-VERIFY: a real two-browser-tab camera/mic test on the deployed app (see docs/MEETINGS_AUDIT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)