### PR TITLE
Document sync (Companion + planscape:// protocol), projects grid, tenant invite, Deliverables fix

### DIFF
--- a/Planscape.Companion/AutoStart.cs
+++ b/Planscape.Companion/AutoStart.cs
@@ -1,0 +1,108 @@
+using Microsoft.Win32;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// Start-on-login registration.
+///
+/// <b>HKEY_CURRENT_USER only.</b> Same rule, same reasoning as
+/// <c>PlanscapeProtocol.EnsureRegistered</c>: <c>HKCU\…\Run</c> needs no
+/// elevation and is scoped to the signed-in user. Writing an HKLM Run entry
+/// would start this process for every account on the machine, which is both a
+/// machine-wide change made unattended and wrong on its own terms — sync is
+/// per-user, against per-user credentials, into a per-user folder.
+///
+/// The design says explicitly that a machine-wide Windows Service is out of
+/// scope; this is the per-user tray app it asks for instead.
+/// </summary>
+internal static class AutoStart
+{
+    private const string RunKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string ValueName = "PlanscapeCompanion";
+
+    public static string? CurrentCommand()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKey);
+            return key?.GetValue(ValueName) as string;
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"autostart read failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    public static string ExePath()
+    {
+        // MainModule is the apphost .exe. Environment.ProcessPath is the same
+        // thing without the extra P/Invoke, and is null only for a self-hosted
+        // runtime this app never runs under.
+        var path = Environment.ProcessPath;
+        return string.IsNullOrEmpty(path)
+            ? System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName ?? ""
+            : path;
+    }
+
+    private static string CommandFor(string exe) => $"\"{exe}\"";
+
+    /// <summary>
+    /// Register, or repair a registration pointing at a path that has moved.
+    /// Idempotent — returns false with a reason when nothing changed, including
+    /// the common "already correct" case.
+    ///
+    /// Re-checked on every start for the same reason the protocol handler is:
+    /// the deployment folder moves, and an autostart entry pointing at a deleted
+    /// exe fails silently at login, which is the worst possible time to fail.
+    /// </summary>
+    public static bool Install(out string detail)
+    {
+        var exe = ExePath();
+        if (string.IsNullOrWhiteSpace(exe) || !File.Exists(exe))
+        {
+            detail = $"cannot resolve own path ({exe})";
+            return false;
+        }
+
+        var want = CommandFor(exe);
+        if (string.Equals(CurrentCommand(), want, StringComparison.OrdinalIgnoreCase))
+        {
+            detail = "already registered";
+            return false;
+        }
+
+        try
+        {
+            using var key = Registry.CurrentUser.CreateSubKey(RunKey);
+            if (key == null) { detail = "could not open HKCU Run key"; return false; }
+            key.SetValue(ValueName, want);
+            detail = want;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            detail = ex.Message;
+            return false;
+        }
+    }
+
+    /// <summary>Remove the entry. Never called automatically — stopping an app
+    /// from starting is a decision a user makes, not one an app makes for them.</summary>
+    public static bool Uninstall(out string detail)
+    {
+        detail = "";
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKey, writable: true);
+            if (key?.GetValue(ValueName) == null) { detail = "was not registered"; return false; }
+            key.DeleteValue(ValueName, throwOnMissingValue: false);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            detail = ex.Message;
+            return false;
+        }
+    }
+}

--- a/Planscape.Companion/CompanionIpc.cs
+++ b/Planscape.Companion/CompanionIpc.cs
@@ -18,16 +18,24 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
 {
     private readonly Func<SyncStatus> _status;
     private readonly Func<string?, Task<string>> _syncNow;
+    private readonly Func<string, string, Task<string>>? _syncHistory;
     private readonly CancellationTokenSource _cts = new();
     private Task? _loop;
 
     /// <param name="status">Reads the live status — called per request, never cached.</param>
     /// <param name="syncNow">Triggers a sync; null projectId means every linked project.
     /// Returns a human-readable outcome for the caller to show.</param>
-    public CompanionIpcServer(Func<SyncStatus> status, Func<string?, Task<string>> syncNow)
+    /// <param name="syncHistory">Slice E — pulls the full version history of ONE
+    /// document. Optional so a host that does not offer it refuses the command
+    /// rather than accepting and doing nothing.</param>
+    public CompanionIpcServer(
+        Func<SyncStatus> status,
+        Func<string?, Task<string>> syncNow,
+        Func<string, string, Task<string>>? syncHistory = null)
     {
         _status = status;
         _syncNow = syncNow;
+        _syncHistory = syncHistory;
     }
 
     public void Start()
@@ -123,6 +131,8 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
                     consecutiveFailures = s.ConsecutiveFailures,
                     linkedProjects = s.LinkedProjects,
                     filesLastSync = s.FilesLastSync,
+                    checkedOutCount = s.CheckedOutCount,
+                    checkedOut = s.CheckedOut,
                 });
             }
 
@@ -137,6 +147,25 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
                 {
                     try { CompanionLog.Info(await _syncNow(projectId)); }
                     catch (Exception ex) { CompanionLog.Error("sync-now failed", ex); }
+                });
+                return JsonConvert.SerializeObject(new { ok = true, started = true });
+            }
+
+            case CompanionIpc.CmdHistory:
+            {
+                var projectId = req["projectId"]?.Value<string>();
+                var documentId = req["documentId"]?.Value<string>();
+                if (_syncHistory == null)
+                    return JsonConvert.SerializeObject(new { ok = false, error = "history download is not available" });
+                if (string.IsNullOrWhiteSpace(projectId) || string.IsNullOrWhiteSpace(documentId))
+                    return JsonConvert.SerializeObject(new { ok = false, error = "projectId and documentId are required" });
+
+                // Fire-and-forget like sync-now, for the same reason: a document
+                // with twenty versions is a long download and the caller is a UI.
+                _ = Task.Run(async () =>
+                {
+                    try { CompanionLog.Info(await _syncHistory(projectId!, documentId!)); }
+                    catch (Exception ex) { CompanionLog.Error("sync-history failed", ex); }
                 });
                 return JsonConvert.SerializeObject(new { ok = true, started = true });
             }

--- a/Planscape.Companion/CompanionIpc.cs
+++ b/Planscape.Companion/CompanionIpc.cs
@@ -1,0 +1,229 @@
+using System.IO.Pipes;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// The local surface BCC talks to. Named pipe, one JSON line per request, one
+/// per response.
+///
+/// <para><b>Why a pipe and not the file-drop StingLink.exe uses.</b> That
+/// precedent was reasoned about a specific asymmetry: StingLink is short-lived
+/// and its receiver (Revit) had no listener, so a pipe's only job would have been
+/// handing work to an <c>IIdlingJob</c> that already existed. Neither half holds
+/// here — the Companion is long-lived and can host an accept loop, and BCC is
+/// asking a question rather than dropping a job.</para>
+///
+/// <para>The deciding factor is the failure mode. With a file drop, "the
+/// Companion isn't running" and "the Companion is busy" look identical at the
+/// moment the user clicks Sync now; distinguishing them means writing, polling
+/// and then guessing how stale is too stale. A pipe connect that fails in 200 ms
+/// answers it exactly.</para>
+///
+/// <para><b>Why not loopback HTTP.</b> <c>HttpListener</c> on a fixed port needs a
+/// URL ACL, which is machine-wide state and an elevation prompt. Kestrel avoids
+/// that but drags ASP.NET Core hosting into a tray app to serve two verbs, and an
+/// open TCP port is reachable by any local process — including a browser tab — so
+/// it would need its own bearer token. A pipe is ACL'd to the creating user by
+/// Windows, with no port and no firewall prompt.</para>
+/// </summary>
+internal static class CompanionIpc
+{
+    /// <summary>
+    /// Fixed name — no user suffix. Windows scopes a default-ACL pipe to the
+    /// creating user already, and a predictable name is what lets BCC connect
+    /// without a discovery file to keep in sync.
+    /// </summary>
+    public const string PipeName = "planscape-companion";
+
+    /// <summary>
+    /// How long a client waits before calling it "not running". Deliberately
+    /// short: this runs on a UI click, and the answer is almost always instant or
+    /// never.
+    /// </summary>
+    public const int ConnectTimeoutMs = 500;
+}
+
+/// <summary>
+/// Serves <see cref="CompanionIpc"/>. One connection at a time, handled and
+/// closed — BCC asks a question every few seconds at most, so a connection pool
+/// would be machinery with no load to justify it.
+/// </summary>
+internal sealed class CompanionIpcServer : IAsyncDisposable
+{
+    private readonly Func<SyncStatus> _status;
+    private readonly Func<string?, Task<string>> _syncNow;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _loop;
+
+    /// <param name="status">Reads the live status — called per request, never cached.</param>
+    /// <param name="syncNow">Triggers a sync; null projectId means every linked project.
+    /// Returns a human-readable outcome for the caller to show.</param>
+    public CompanionIpcServer(Func<SyncStatus> status, Func<string?, Task<string>> syncNow)
+    {
+        _status = status;
+        _syncNow = syncNow;
+    }
+
+    public void Start()
+    {
+        _loop = Task.Run(() => AcceptLoopAsync(_cts.Token));
+        CompanionLog.Info($"IPC listening on \\\\.\\pipe\\{CompanionIpc.PipeName}");
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                // A fresh server stream per connection. Reusing one across
+                // connections is possible but the disconnect/reconnect state
+                // machine is fiddly and buys nothing at this call rate.
+                using var pipe = new NamedPipeServerStream(
+                    CompanionIpc.PipeName,
+                    PipeDirection.InOut,
+                    maxNumberOfServerInstances: 1,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous);
+
+                await pipe.WaitForConnectionAsync(ct);
+                await HandleAsync(pipe, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return; // shutting down
+            }
+            catch (Exception ex)
+            {
+                // One bad client must not end the accept loop — that would take
+                // the whole IPC surface down until the next login.
+                CompanionLog.Warn($"IPC connection failed: {ex.Message}");
+                try { await Task.Delay(250, ct); } catch { return; }
+            }
+        }
+    }
+
+    private async Task HandleAsync(NamedPipeServerStream pipe, CancellationToken ct)
+    {
+        // Not `using` on the reader/writer: disposing them would close the pipe
+        // the caller still owns and disposes itself.
+        var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
+        var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+
+        var line = await reader.ReadLineAsync(ct);
+        if (string.IsNullOrWhiteSpace(line)) return;
+
+        string response;
+        try
+        {
+            response = Dispatch(await ParseAsync(line));
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"IPC request failed: {ex.Message}");
+            response = JsonConvert.SerializeObject(new { ok = false, error = ex.Message });
+        }
+        await writer.WriteLineAsync(response);
+
+        async Task<JObject> ParseAsync(string raw) => await Task.FromResult(JObject.Parse(raw));
+    }
+
+    private string Dispatch(JObject req)
+    {
+        var cmd = req["cmd"]?.Value<string>()?.ToLowerInvariant();
+        switch (cmd)
+        {
+            case "ping":
+                // Deliberately cheap and side-effect free: this is how BCC asks
+                // "are you there" without provoking any work.
+                return JsonConvert.SerializeObject(new
+                {
+                    ok = true,
+                    pid = Environment.ProcessId,
+                    version = typeof(CompanionIpcServer).Assembly.GetName().Version?.ToString(),
+                });
+
+            case "status":
+            {
+                var s = _status();
+                return JsonConvert.SerializeObject(new
+                {
+                    ok = true,
+                    state = s.State.ToString(),
+                    summary = s.Summary(),
+                    lastSuccessUtc = s.LastSuccessUtc,
+                    lastError = s.LastError,
+                    lastErrorUtc = s.LastErrorUtc,
+                    consecutiveFailures = s.ConsecutiveFailures,
+                    linkedProjects = s.LinkedProjects,
+                    filesLastSync = s.FilesLastSync,
+                });
+            }
+
+            case "sync-now":
+            {
+                var projectId = req["projectId"]?.Value<string>();
+                // Fire-and-forget with the result reported through status. A sync
+                // can take minutes; holding the pipe open would block BCC's UI
+                // thread on a file download, which is exactly the freeze this
+                // whole out-of-process design exists to avoid.
+                _ = Task.Run(async () =>
+                {
+                    try { CompanionLog.Info(await _syncNow(projectId)); }
+                    catch (Exception ex) { CompanionLog.Error("sync-now failed", ex); }
+                });
+                return JsonConvert.SerializeObject(new { ok = true, started = true });
+            }
+
+            default:
+                return JsonConvert.SerializeObject(new { ok = false, error = $"unknown command '{cmd}'" });
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        // A pipe blocked in WaitForConnectionAsync only unblocks when the token
+        // fires; give it a moment, but never hang shutdown on it.
+        if (_loop != null)
+        {
+            try { await _loop.WaitAsync(TimeSpan.FromSeconds(2)); }
+            catch (Exception) { /* shutting down anyway */ }
+        }
+        _cts.Dispose();
+    }
+}
+
+/// <summary>
+/// Client side. Lives here rather than in StingTools so the request and response
+/// shapes cannot drift apart — when BCC integration lands (Slice D) it links this
+/// file in, the same way StingLink.exe shares PlanscapeProtocol.cs.
+/// </summary>
+internal static class CompanionIpcClient
+{
+    /// <summary>
+    /// Send one command. Returns null when the Companion is not running, which is
+    /// a normal answer and not an error — a user may simply not have started it.
+    /// </summary>
+    public static async Task<JObject?> SendAsync(object request, CancellationToken ct = default)
+    {
+        try
+        {
+            using var pipe = new NamedPipeClientStream(".", CompanionIpc.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await pipe.ConnectAsync(CompanionIpc.ConnectTimeoutMs, ct);
+
+            var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+            var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
+
+            await writer.WriteLineAsync(JsonConvert.SerializeObject(request));
+            var line = await reader.ReadLineAsync(ct);
+            return string.IsNullOrWhiteSpace(line) ? null : JObject.Parse(line);
+        }
+        catch (TimeoutException) { return null; }   // not running
+        catch (IOException) { return null; }        // died mid-request
+        catch (OperationCanceledException) { return null; }
+    }
+}

--- a/Planscape.Companion/CompanionIpc.cs
+++ b/Planscape.Companion/CompanionIpc.cs
@@ -5,46 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Planscape.Companion;
 
-/// <summary>
-/// The local surface BCC talks to. Named pipe, one JSON line per request, one
-/// per response.
-///
-/// <para><b>Why a pipe and not the file-drop StingLink.exe uses.</b> That
-/// precedent was reasoned about a specific asymmetry: StingLink is short-lived
-/// and its receiver (Revit) had no listener, so a pipe's only job would have been
-/// handing work to an <c>IIdlingJob</c> that already existed. Neither half holds
-/// here — the Companion is long-lived and can host an accept loop, and BCC is
-/// asking a question rather than dropping a job.</para>
-///
-/// <para>The deciding factor is the failure mode. With a file drop, "the
-/// Companion isn't running" and "the Companion is busy" look identical at the
-/// moment the user clicks Sync now; distinguishing them means writing, polling
-/// and then guessing how stale is too stale. A pipe connect that fails in 200 ms
-/// answers it exactly.</para>
-///
-/// <para><b>Why not loopback HTTP.</b> <c>HttpListener</c> on a fixed port needs a
-/// URL ACL, which is machine-wide state and an elevation prompt. Kestrel avoids
-/// that but drags ASP.NET Core hosting into a tray app to serve two verbs, and an
-/// open TCP port is reachable by any local process — including a browser tab — so
-/// it would need its own bearer token. A pipe is ACL'd to the creating user by
-/// Windows, with no port and no firewall prompt.</para>
-/// </summary>
-internal static class CompanionIpc
-{
-    /// <summary>
-    /// Fixed name — no user suffix. Windows scopes a default-ACL pipe to the
-    /// creating user already, and a predictable name is what lets BCC connect
-    /// without a discovery file to keep in sync.
-    /// </summary>
-    public const string PipeName = "planscape-companion";
-
-    /// <summary>
-    /// How long a client waits before calling it "not running". Deliberately
-    /// short: this runs on a UI click, and the answer is almost always instant or
-    /// never.
-    /// </summary>
-    public const int ConnectTimeoutMs = 500;
-}
+// The wire contract (pipe name, timeouts, command names) and the CLIENT live in
+// CompanionIpcContract.cs, which is compiled into StingTools too so the two sides
+// cannot drift. This file is the SERVER, which only the Companion ever runs.
 
 /// <summary>
 /// Serves <see cref="CompanionIpc"/>. One connection at a time, handled and
@@ -136,7 +99,7 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
         var cmd = req["cmd"]?.Value<string>()?.ToLowerInvariant();
         switch (cmd)
         {
-            case "ping":
+            case CompanionIpc.CmdPing:
                 // Deliberately cheap and side-effect free: this is how BCC asks
                 // "are you there" without provoking any work.
                 return JsonConvert.SerializeObject(new
@@ -146,7 +109,7 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
                     version = typeof(CompanionIpcServer).Assembly.GetName().Version?.ToString(),
                 });
 
-            case "status":
+            case CompanionIpc.CmdStatus:
             {
                 var s = _status();
                 return JsonConvert.SerializeObject(new
@@ -163,7 +126,7 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
                 });
             }
 
-            case "sync-now":
+            case CompanionIpc.CmdSyncNow:
             {
                 var projectId = req["projectId"]?.Value<string>();
                 // Fire-and-forget with the result reported through status. A sync
@@ -194,36 +157,5 @@ internal sealed class CompanionIpcServer : IAsyncDisposable
             catch (Exception) { /* shutting down anyway */ }
         }
         _cts.Dispose();
-    }
-}
-
-/// <summary>
-/// Client side. Lives here rather than in StingTools so the request and response
-/// shapes cannot drift apart — when BCC integration lands (Slice D) it links this
-/// file in, the same way StingLink.exe shares PlanscapeProtocol.cs.
-/// </summary>
-internal static class CompanionIpcClient
-{
-    /// <summary>
-    /// Send one command. Returns null when the Companion is not running, which is
-    /// a normal answer and not an error — a user may simply not have started it.
-    /// </summary>
-    public static async Task<JObject?> SendAsync(object request, CancellationToken ct = default)
-    {
-        try
-        {
-            using var pipe = new NamedPipeClientStream(".", CompanionIpc.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
-            await pipe.ConnectAsync(CompanionIpc.ConnectTimeoutMs, ct);
-
-            var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
-            var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
-
-            await writer.WriteLineAsync(JsonConvert.SerializeObject(request));
-            var line = await reader.ReadLineAsync(ct);
-            return string.IsNullOrWhiteSpace(line) ? null : JObject.Parse(line);
-        }
-        catch (TimeoutException) { return null; }   // not running
-        catch (IOException) { return null; }        // died mid-request
-        catch (OperationCanceledException) { return null; }
     }
 }

--- a/Planscape.Companion/CompanionIpcContract.cs
+++ b/Planscape.Companion/CompanionIpcContract.cs
@@ -1,0 +1,262 @@
+// EVERY using is explicit, including the ones ImplicitUsings would supply.
+// This file is compiled into two projects with different settings — the
+// Companion enables ImplicitUsings, StingTools does not — so relying on them
+// builds on one side and fails on the other. (It did, exactly once.)
+//
+// Same reason for the #nullable directive: the Companion enables nullable
+// reference types project-wide, StingTools disables them, and the `string?`
+// annotations below are CS8632 warnings in a disabled context. Turning the
+// context on for this one file keeps StingTools' 0-warning baseline intact
+// without either project having to change its own setting.
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// The Companion↔BCC wire contract, and the client half of it.
+///
+/// <para><b>This file is compiled into BOTH assemblies</b> — the Companion (which
+/// serves it) and StingTools (which calls it), via a <c>&lt;Compile Include&gt;</c>
+/// in <c>StingTools.csproj</c>. Same trick <c>StingLink.exe</c> uses to share
+/// <c>PlanscapeProtocol.cs</c>, and for the same reason: a request shape defined
+/// twice is a request shape that will eventually disagree with itself, silently,
+/// in a direction neither side logs.</para>
+///
+/// <para>So it must stay free of Revit, WPF, WinForms and anything else the other
+/// side cannot load. Only <c>System.IO.Pipes</c> and Newtonsoft. If a build error
+/// points here, that rule is what broke — move the offending code into
+/// <c>CompanionIpc.cs</c> (Companion-only) rather than adding a reference.</para>
+///
+/// Transport rationale is in the plan §1a: a named pipe, because the failure mode
+/// that matters is telling "not running" apart from "busy" at the instant a user
+/// clicks Sync now, and a pipe connect answers that in a bounded time where a file
+/// drop needs a staleness heuristic.
+/// </summary>
+internal static class CompanionIpc
+{
+    /// <summary>
+    /// Fixed name — no user suffix. Windows scopes a default-ACL pipe to the
+    /// creating user already, and a predictable name is what lets BCC connect
+    /// without a discovery file that could itself go stale.
+    /// </summary>
+    public const string PipeName = "planscape-companion";
+
+    /// <summary>
+    /// How long a client waits before calling it "not running". Deliberately
+    /// short: this runs on a UI click, the answer is almost always instant or
+    /// never, and a Revit UI thread must not be held while we find out.
+    /// </summary>
+    public const int ConnectTimeoutMs = 500;
+
+    public const string CmdPing = "ping";
+    public const string CmdStatus = "status";
+    public const string CmdSyncNow = "sync-now";
+}
+
+/// <summary>
+/// Where the Companion keeps things, and how a project code becomes a folder.
+///
+/// Shared because BCC needs the same answers to badge a document row with its
+/// local state, and a second implementation of "which folder is this project in"
+/// would drift the first time someone changed the override rules.
+/// </summary>
+internal static class CompanionPaths
+{
+    /// <summary>
+    /// <c>%APPDATA%\StingTools</c> — the same directory
+    /// <c>PlanscapeServerClient.MachineSettingsPath</c> already uses, so support
+    /// asks for one folder rather than two.
+    /// </summary>
+    public static string SettingsDir => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "StingTools");
+
+    /// <summary>A separate file from the plugin's: two processes writing one file race.</summary>
+    public static string SettingsPath => Path.Combine(SettingsDir, "planscape_sync.json");
+
+    /// <summary>
+    /// <c>%USERPROFILE%\Planscape</c>. Deliberately not under %APPDATA% — an
+    /// Author has to find these files from Explorer and from Revit's own
+    /// file-open dialog, and a path nobody navigates to by habit is a path they
+    /// copy files out of.
+    /// </summary>
+    public static string DefaultRoot => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Planscape");
+
+    /// <summary>
+    /// A project code is user-supplied and travels into a path. Strip what
+    /// Windows refuses plus the traversal characters, so a project coded
+    /// <c>..\..\Windows</c> cannot write outside the sync root.
+    /// </summary>
+    public static string SanitiseFolderName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "project";
+        var cleaned = new string(name!
+            .Where(c => (!Path.GetInvalidFileNameChars().Contains(c) && c != '.') || char.IsLetterOrDigit(c))
+            .ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(cleaned) ? "project" : cleaned;
+    }
+
+    /// <summary>
+    /// The sync folder for a project code, read straight from the settings file:
+    /// per-project override → global root → default. Returns null when the file
+    /// is missing or the project is not linked on this machine, which is the
+    /// normal case for a project nobody has asked to sync.
+    /// </summary>
+    public static string? ResolveProjectFolder(string? projectCode)
+    {
+        if (string.IsNullOrWhiteSpace(projectCode)) return null;
+        try
+        {
+            if (!File.Exists(SettingsPath)) return null;
+            var o = JObject.Parse(File.ReadAllText(SettingsPath));
+
+            var match = o["projects"] as JArray;
+            JObject? project = null;
+            foreach (var p in match ?? new JArray())
+            {
+                if (string.Equals(p?["projectCode"]?.Value<string>(), projectCode,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    project = p as JObject;
+                    break;
+                }
+            }
+            if (project == null) return null;
+
+            var over = project["folderOverride"]?.Value<string>();
+            if (!string.IsNullOrWhiteSpace(over)) return over;
+
+            var root = o["rootFolder"]?.Value<string>();
+            if (string.IsNullOrWhiteSpace(root)) root = DefaultRoot;
+            return Path.Combine(root!, SanitiseFolderName(projectCode));
+        }
+        catch (Exception)
+        {
+            // A settings file mid-write, or one a newer build reshaped. Reading it
+            // is a convenience for a badge; failing to is not worth surfacing.
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// A parsed <c>status</c> reply. Mirrors the Companion's own <c>SyncStatus</c>
+/// (plan §1c) — the two are kept in step by this file being shared.
+///
+/// <see cref="Running"/> false means the pipe did not answer, which is a real and
+/// expected answer rather than an error: the user may simply not have started the
+/// Companion. Everything else on the object is meaningless in that case.
+/// </summary>
+internal sealed class CompanionStatus
+{
+    public bool Running { get; set; }
+
+    /// <summary>Idle | Syncing | Offline | Error. Empty when not running.</summary>
+    public string State { get; set; } = "";
+
+    /// <summary>One line already formatted for a tooltip or status bar.</summary>
+    public string Summary { get; set; } = "";
+
+    public DateTime? LastSuccessUtc { get; set; }
+    public string? LastError { get; set; }
+    public DateTime? LastErrorUtc { get; set; }
+    public int ConsecutiveFailures { get; set; }
+    public int LinkedProjects { get; set; }
+    public int FilesLastSync { get; set; }
+
+    /// <summary>Not running — the one state BCC must render as information, not failure.</summary>
+    public static CompanionStatus NotRunning() => new()
+    {
+        Running = false,
+        State = "",
+        Summary = "Planscape Companion is not running",
+    };
+
+    /// <summary>True when a human needs to do something. Offline deliberately does NOT count.</summary>
+    public bool NeedsAttention =>
+        Running && string.Equals(State, "Error", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Client side of <see cref="CompanionIpc"/>. Used by BCC; also used by the
+/// Companion's own CLI so both exercise the same path.
+/// </summary>
+internal static class CompanionIpcClient
+{
+    /// <summary>
+    /// Send one command and read one reply. Returns null when the Companion is
+    /// not running — a normal answer, not an exception, because "the user hasn't
+    /// started it" is the single most likely outcome and must not surface as a
+    /// stack trace inside Revit.
+    /// </summary>
+    public static async Task<JObject?> SendAsync(object request, CancellationToken ct = default)
+    {
+        try
+        {
+            using var pipe = new NamedPipeClientStream(
+                ".", CompanionIpc.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await pipe.ConnectAsync(CompanionIpc.ConnectTimeoutMs, ct);
+
+            var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+            var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
+
+            await writer.WriteLineAsync(JsonConvert.SerializeObject(request));
+            var line = await reader.ReadLineAsync(ct);
+            return string.IsNullOrWhiteSpace(line) ? null : JObject.Parse(line);
+        }
+        catch (TimeoutException) { return null; }              // not running
+        catch (IOException) { return null; }                    // died mid-request
+        catch (UnauthorizedAccessException) { return null; }    // another user's pipe
+        catch (OperationCanceledException) { return null; }
+        catch (JsonReaderException) { return null; }            // garbage on the wire
+    }
+
+    /// <summary>Is the Companion up? Cheap and side-effect free.</summary>
+    public static async Task<bool> IsRunningAsync(CancellationToken ct = default)
+        => (await SendAsync(new { cmd = CompanionIpc.CmdPing }, ct))?["ok"]?.Value<bool>() == true;
+
+    /// <summary>Read the live status. Never throws; never returns null.</summary>
+    public static async Task<CompanionStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        var reply = await SendAsync(new { cmd = CompanionIpc.CmdStatus }, ct);
+        if (reply == null || reply["ok"]?.Value<bool>() != true) return CompanionStatus.NotRunning();
+
+        return new CompanionStatus
+        {
+            Running = true,
+            State = reply["state"]?.Value<string>() ?? "",
+            Summary = reply["summary"]?.Value<string>() ?? "",
+            LastSuccessUtc = reply["lastSuccessUtc"]?.Value<DateTime?>(),
+            LastError = reply["lastError"]?.Value<string>(),
+            LastErrorUtc = reply["lastErrorUtc"]?.Value<DateTime?>(),
+            ConsecutiveFailures = reply["consecutiveFailures"]?.Value<int>() ?? 0,
+            LinkedProjects = reply["linkedProjects"]?.Value<int>() ?? 0,
+            FilesLastSync = reply["filesLastSync"]?.Value<int>() ?? 0,
+        };
+    }
+
+    /// <summary>
+    /// Ask for a sync. <paramref name="projectId"/> null = every linked project.
+    ///
+    /// Returns false only when the Companion is not running. A true means the
+    /// sync was STARTED, not finished — the Companion answers immediately and
+    /// works in the background, because holding the pipe open for a multi-minute
+    /// download would block the caller's UI thread, which is the freeze this
+    /// whole out-of-process design exists to avoid.
+    /// </summary>
+    public static async Task<bool> SyncNowAsync(string? projectId = null, CancellationToken ct = default)
+    {
+        var reply = await SendAsync(new { cmd = CompanionIpc.CmdSyncNow, projectId }, ct);
+        return reply?["ok"]?.Value<bool>() == true;
+    }
+}

--- a/Planscape.Companion/CompanionIpcContract.cs
+++ b/Planscape.Companion/CompanionIpcContract.cs
@@ -61,6 +61,7 @@ internal static class CompanionIpc
     public const string CmdPing = "ping";
     public const string CmdStatus = "status";
     public const string CmdSyncNow = "sync-now";
+    public const string CmdHistory = "sync-history";
 }
 
 /// <summary>
@@ -174,6 +175,13 @@ internal sealed class CompanionStatus
     public int LinkedProjects { get; set; }
     public int FilesLastSync { get; set; }
 
+    /// <summary>WIP working copies on this machine (Slice E). Drives the tray count
+    /// and BCC's read of it.</summary>
+    public int CheckedOutCount { get; set; }
+
+    /// <summary>The file names behind <see cref="CheckedOutCount"/>, capped by the server side.</summary>
+    public List<string> CheckedOut { get; set; } = new();
+
     /// <summary>Not running — the one state BCC must render as information, not failure.</summary>
     public static CompanionStatus NotRunning() => new()
     {
@@ -242,6 +250,8 @@ internal static class CompanionIpcClient
             ConsecutiveFailures = reply["consecutiveFailures"]?.Value<int>() ?? 0,
             LinkedProjects = reply["linkedProjects"]?.Value<int>() ?? 0,
             FilesLastSync = reply["filesLastSync"]?.Value<int>() ?? 0,
+            CheckedOutCount = reply["checkedOutCount"]?.Value<int>() ?? 0,
+            CheckedOut = reply["checkedOut"]?.ToObject<List<string>>() ?? new List<string>(),
         };
     }
 
@@ -257,6 +267,19 @@ internal static class CompanionIpcClient
     public static async Task<bool> SyncNowAsync(string? projectId = null, CancellationToken ct = default)
     {
         var reply = await SendAsync(new { cmd = CompanionIpc.CmdSyncNow, projectId }, ct);
+        return reply?["ok"]?.Value<bool>() == true;
+    }
+
+    /// <summary>
+    /// Slice E — pull the FULL version history of one document, deliberately.
+    /// Never a default: history is opt-in per document so it cannot silently grow
+    /// on every machine. Returns false only when the Companion is not running.
+    /// </summary>
+    public static async Task<bool> DownloadHistoryAsync(
+        string projectId, string documentId, CancellationToken ct = default)
+    {
+        var reply = await SendAsync(
+            new { cmd = CompanionIpc.CmdHistory, projectId, documentId }, ct);
         return reply?["ok"]?.Value<bool>() == true;
     }
 }

--- a/Planscape.Companion/CompanionLog.cs
+++ b/Planscape.Companion/CompanionLog.cs
@@ -1,0 +1,65 @@
+using System.Text;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// The Companion's only diagnostic surface.
+///
+/// A tray app has no console and, by design (see the plan's §1c), does not
+/// toast. When something goes wrong the log IS the evidence, so it is written
+/// eagerly rather than buffered — a crash must not take the last few lines with
+/// it, and those are exactly the lines that explain the crash.
+///
+/// Also mirrored to stdout when a console is attached, which is what makes
+/// <c>--diagnose</c> usable from a terminal.
+/// </summary>
+internal static class CompanionLog
+{
+    private static readonly object Gate = new();
+    private static bool _echoToConsole;
+
+    /// <summary>%APPDATA%\StingTools\companion.log — beside the settings file
+    /// StingTools already writes, so support asks for one folder, not two.</summary>
+    public static string Path => System.IO.Path.Combine(CompanionSettings.SettingsDir, "companion.log");
+
+    /// <summary>Turned on by --diagnose so a terminal run shows its work.</summary>
+    public static void EchoToConsole() => _echoToConsole = true;
+
+    public static void Info(string message) => Write("INFO ", message);
+    public static void Warn(string message) => Write("WARN ", message);
+
+    public static void Error(string message, Exception? ex = null) =>
+        Write("ERROR", ex == null ? message : $"{message} — {ex.GetType().Name}: {ex.Message}");
+
+    private static void Write(string level, string message)
+    {
+        var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{level}] {message}";
+        if (_echoToConsole)
+        {
+            try { Console.WriteLine(line); } catch { /* no console attached */ }
+        }
+        lock (Gate)
+        {
+            try
+            {
+                Directory.CreateDirectory(CompanionSettings.SettingsDir);
+                // Roll at 2 MB. A sync loop that fails every 30 s for a fortnight
+                // would otherwise quietly fill a user's disk — the exact kind of
+                // background misbehaviour nobody notices until it matters.
+                var path = Path;
+                if (File.Exists(path) && new FileInfo(path).Length > 2 * 1024 * 1024)
+                {
+                    var old = path + ".1";
+                    File.Delete(old);
+                    File.Move(path, old);
+                }
+                File.AppendAllText(path, line + Environment.NewLine, Encoding.UTF8);
+            }
+            catch
+            {
+                // Logging must never be the thing that breaks the app. If the log
+                // cannot be written there is nowhere left to report that fact.
+            }
+        }
+    }
+}

--- a/Planscape.Companion/CompanionService.cs
+++ b/Planscape.Companion/CompanionService.cs
@@ -179,13 +179,11 @@ internal sealed class CompanionService : IDisposable
         try
         {
             SetState(SyncState.Syncing);
-            // Slice C wires the download-and-place engine in here. Until then a
-            // triggered sync proves the whole path around it — trigger, gate,
-            // status transitions — and downloads nothing.
-            await Task.Yield();
-            var outcome = "sync engine lands in Slice C";
+            var engine = new SyncEngine(_api, _settings);
+            var outcome = await engine.SyncProjectAsync(project, trigger, ct);
 
             _settings.Save();  // persist the advanced high-water mark
+            Status.FilesLastSync = outcome.Downloaded;
             Status.LastSuccessUtc = DateTime.UtcNow;
             Status.ConsecutiveFailures = 0;
             SetState(SyncState.Idle);

--- a/Planscape.Companion/CompanionService.cs
+++ b/Planscape.Companion/CompanionService.cs
@@ -1,0 +1,265 @@
+namespace Planscape.Companion;
+
+/// <summary>Why a sync ran. Logging only — every trigger runs the same code.</summary>
+internal enum SyncTrigger
+{
+    /// <summary>A DocumentChanged push arrived.</summary>
+    Push,
+
+    /// <summary>The hub (re)connected; sweeping up what was missed while offline.</summary>
+    Reconnect,
+
+    /// <summary>A project was just linked on this machine — `since` is unset.</summary>
+    InitialLink,
+
+    /// <summary>Someone pressed Sync now, in BCC or the tray.</summary>
+    Manual,
+}
+
+
+/// <summary>
+/// The Companion's brain: owns the API client, the hub connection, the IPC
+/// server and the status record, and is the single place a sync is triggered
+/// from — whichever of the four triggers fired.
+///
+/// Separate from the tray so that <c>--diagnose</c> can run exactly the same
+/// logic with no window, which is what makes the thing testable at all.
+/// </summary>
+internal sealed class CompanionService : IDisposable
+{
+    private readonly CompanionSettings _settings;
+    private readonly SemaphoreSlim _syncGate = new(1, 1);
+    private readonly CancellationTokenSource _cts = new();
+    private PlanscapeApiClient? _api;
+    private SyncHubClient? _hub;
+    private CompanionIpcServer? _ipc;
+
+    public SyncStatus Status { get; }
+
+    /// <summary>Raised whenever the status changes so the tray can repaint.</summary>
+    public event Action? StatusChanged;
+
+    public CompanionService(CompanionSettings settings)
+    {
+        _settings = settings;
+        Status = SyncStatus.Load();
+        Status.LinkedProjects = settings.Projects.Count;
+    }
+
+    private bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(_settings.ServerUrl) && !string.IsNullOrWhiteSpace(_settings.AccessToken);
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    /// <summary>Start the IPC surface and the hub connection. Returns immediately.</summary>
+    public void Start()
+    {
+        // IPC first, and unconditionally. An unconfigured Companion is exactly
+        // the one BCC most needs to be able to interrogate — "it's running but it
+        // has no token" is a far more useful answer than silence.
+        _ipc = new CompanionIpcServer(() => Status, SyncNowAsync);
+        _ipc.Start();
+
+        if (!IsConfigured)
+        {
+            CompanionLog.Warn("no server URL or access token configured — idle until set");
+            SetState(SyncState.Error, "not configured — set a server and access token");
+            return;
+        }
+
+        _ = Task.Run(() => ConnectLoopAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Keep trying to establish the initial connection. SignalR's automatic
+    /// reconnect only covers a connection that once succeeded — a Companion that
+    /// starts at login before the VPN is up would otherwise sit dead forever.
+    /// </summary>
+    private async Task ConnectLoopAsync(CancellationToken ct)
+    {
+        var attempt = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                _api ??= new PlanscapeApiClient(_settings.ServerUrl!, _settings.AccessToken!);
+                _hub = new SyncHubClient(
+                    _settings.ServerUrl!,
+                    _api.GetAccessTokenAsync,
+                    onDocumentChanged: projectId => SyncOneAsync(projectId, SyncTrigger.Push, ct),
+                    onConnected: () => SyncAllAsync(SyncTrigger.Reconnect, ct),
+                    onConnectionStateChanged: connected =>
+                    {
+                        if (!connected && Status.State != SyncState.Error) SetState(SyncState.Offline);
+                        else if (connected && Status.State == SyncState.Offline) SetState(SyncState.Idle);
+                    });
+
+                await _hub.StartAsync(_settings.Projects.Select(p => p.ProjectId), ct);
+                return; // connected; SignalR's own reconnect takes it from here
+            }
+            catch (CompanionAuthException ex)
+            {
+                // A rejected token is NOT offline. It will never fix itself, so it
+                // is the state that shouts (see SyncStatus).
+                SetState(SyncState.Error, ex.Message);
+                CompanionLog.Error("authentication failed — stopping connection attempts", ex);
+                return;
+            }
+            catch (Exception ex)
+            {
+                attempt++;
+                SetState(SyncState.Offline);
+                var delay = TimeSpan.FromSeconds(Math.Min(60, Math.Pow(2, Math.Min(attempt, 6))));
+                CompanionLog.Warn($"connect attempt {attempt} failed ({ex.Message}); retrying in {delay.TotalSeconds:0}s");
+                try { await Task.Delay(delay, ct); } catch { return; }
+            }
+        }
+    }
+
+    // ── Triggers — all four land on SyncProjectAsync ──────────────────────────
+
+    /// <summary>Manual "Sync now" (tray or BCC over IPC). Null = every linked project.</summary>
+    public async Task<string> SyncNowAsync(string? projectId)
+    {
+        var outcome = projectId == null
+            ? await SyncAllAsync(SyncTrigger.Manual, _cts.Token)
+            : await SyncOneAsync(projectId, SyncTrigger.Manual, _cts.Token);
+        return outcome;
+    }
+
+    /// <summary>Link a project and immediately pull everything visible.</summary>
+    public async Task<string> LinkAndSyncAsync(string projectId, string projectCode, CancellationToken ct = default)
+    {
+        if (_settings.Find(projectId) == null)
+            _settings.Projects.Add(new LinkedProject { ProjectId = projectId, ProjectCode = projectCode });
+        _settings.Save();
+        Status.LinkedProjects = _settings.Projects.Count;
+
+        if (_hub != null) await _hub.JoinAsync(projectId);
+        return await SyncOneAsync(projectId, SyncTrigger.InitialLink, ct);
+    }
+
+    private async Task<string> SyncAllAsync(SyncTrigger trigger, CancellationToken ct)
+    {
+        var results = new List<string>();
+        foreach (var project in _settings.Projects.ToList())
+        {
+            // The per-project auto/manual toggle gates only the AUTOMATIC
+            // triggers. A user who explicitly pressed Sync now has overridden it
+            // by definition, and refusing them would be obtuse.
+            if (!project.AutoSync && trigger is SyncTrigger.Push or SyncTrigger.Reconnect)
+            {
+                CompanionLog.Info($"skipping {project.ProjectCode} — auto-sync is off");
+                continue;
+            }
+            results.Add(await SyncProjectAsync(project, trigger, ct));
+        }
+        return results.Count == 0 ? "nothing to sync" : string.Join("; ", results);
+    }
+
+    private async Task<string> SyncOneAsync(string projectId, SyncTrigger trigger, CancellationToken ct)
+    {
+        var project = _settings.Find(projectId);
+        if (project == null) return $"project {projectId} is not linked on this machine";
+        if (!project.AutoSync && trigger is SyncTrigger.Push or SyncTrigger.Reconnect)
+            return $"{project.ProjectCode}: auto-sync is off";
+        return await SyncProjectAsync(project, trigger, ct);
+    }
+
+    /// <summary>
+    /// The one place a sync actually happens. Serialised by a semaphore: two
+    /// passes writing the same folder would race on the supersede-then-replace
+    /// sequence and could leave a document with no live copy at all.
+    /// </summary>
+    private async Task<string> SyncProjectAsync(LinkedProject project, SyncTrigger trigger, CancellationToken ct)
+    {
+        if (_api == null) return "not connected";
+
+        await _syncGate.WaitAsync(ct);
+        try
+        {
+            SetState(SyncState.Syncing);
+            // Slice C wires the download-and-place engine in here. Until then a
+            // triggered sync proves the whole path around it — trigger, gate,
+            // status transitions — and downloads nothing.
+            await Task.Yield();
+            var outcome = "sync engine lands in Slice C";
+
+            _settings.Save();  // persist the advanced high-water mark
+            Status.LastSuccessUtc = DateTime.UtcNow;
+            Status.ConsecutiveFailures = 0;
+            SetState(SyncState.Idle);
+            return $"{project.ProjectCode}: {outcome}";
+        }
+        catch (CompanionAuthException ex)
+        {
+            Status.ConsecutiveFailures++;
+            SetState(SyncState.Error, ex.Message);
+            return $"{project.ProjectCode}: {ex.Message}";
+        }
+        catch (OperationCanceledException)
+        {
+            return $"{project.ProjectCode}: cancelled";
+        }
+        catch (HttpRequestException ex)
+        {
+            // Offline, not broken — quiet, and it will retry itself.
+            Status.ConsecutiveFailures++;
+            SetState(SyncState.Offline);
+            CompanionLog.Warn($"{project.ProjectCode}: {ex.Message}");
+            return $"{project.ProjectCode}: offline";
+        }
+        catch (Exception ex)
+        {
+            // Everything else — an unwritable folder, a full disk — needs a human.
+            Status.ConsecutiveFailures++;
+            SetState(SyncState.Error, ex.Message);
+            CompanionLog.Error($"{project.ProjectCode}: sync failed", ex);
+            return $"{project.ProjectCode}: {ex.Message}";
+        }
+        finally
+        {
+            _syncGate.Release();
+        }
+    }
+
+    /// <summary>One-shot for <c>--diagnose</c>: sync every linked project once.</summary>
+    public async Task<bool> RunOnceAsync(CancellationToken ct)
+    {
+        if (!IsConfigured) return false;
+        _api = new PlanscapeApiClient(_settings.ServerUrl!, _settings.AccessToken!);
+        var result = await SyncAllAsync(SyncTrigger.Manual, ct);
+        Console.WriteLine(result);
+        return Status.State != SyncState.Error;
+    }
+
+    // ── Status ────────────────────────────────────────────────────────────────
+
+    private void SetState(SyncState state, string? error = null)
+    {
+        Status.State = state;
+        if (state == SyncState.Error && error != null)
+        {
+            Status.LastError = error;
+            Status.LastErrorUtc = DateTime.UtcNow;
+        }
+        else if (state == SyncState.Idle)
+        {
+            // A success clears the sticky error — otherwise the tray keeps
+            // reporting a problem that fixed itself hours ago.
+            Status.LastError = null;
+        }
+        Status.Save();
+        StatusChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { _ipc?.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(2)); } catch { }
+        try { _hub?.DisposeAsync().AsTask().Wait(TimeSpan.FromSeconds(2)); } catch { }
+        _api?.Dispose();
+        _cts.Dispose();
+        _syncGate.Dispose();
+    }
+}

--- a/Planscape.Companion/CompanionService.cs
+++ b/Planscape.Companion/CompanionService.cs
@@ -86,7 +86,8 @@ internal sealed class CompanionService : IDisposable
                 _hub = new SyncHubClient(
                     _settings.ServerUrl!,
                     _api.GetAccessTokenAsync,
-                    onDocumentChanged: projectId => SyncOneAsync(projectId, SyncTrigger.Push, ct),
+                    onDocumentChanged: (projectId, autoSync) =>
+                        SyncOneAsync(projectId, SyncTrigger.Push, ct, serverAutoSync: autoSync),
                     onConnected: () => SyncAllAsync(SyncTrigger.Reconnect, ct),
                     onConnectionStateChanged: connected =>
                     {
@@ -157,10 +158,26 @@ internal sealed class CompanionService : IDisposable
         return results.Count == 0 ? "nothing to sync" : string.Join("; ", results);
     }
 
-    private async Task<string> SyncOneAsync(string projectId, SyncTrigger trigger, CancellationToken ct)
+    /// <param name="serverAutoSync">
+    /// The project's flag as the SERVER just reported it, when the caller has it
+    /// (a push carries it). Overrides the cached copy, because the cache can be
+    /// one sync behind and the push is by definition current.
+    /// </param>
+    private async Task<string> SyncOneAsync(string projectId, SyncTrigger trigger, CancellationToken ct,
+        bool? serverAutoSync = null)
     {
         var project = _settings.Find(projectId);
         if (project == null) return $"project {projectId} is not linked on this machine";
+
+        if (serverAutoSync.HasValue && project.AutoSync != serverAutoSync.Value)
+        {
+            // Keep the cache honest even when we are about to skip: the tray and
+            // BCC read it, and showing "auto-sync on" while silently not syncing
+            // would be worse than either behaviour on its own.
+            project.AutoSync = serverAutoSync.Value;
+            _settings.Save();
+        }
+
         if (!project.AutoSync && trigger is SyncTrigger.Push or SyncTrigger.Reconnect)
             return $"{project.ProjectCode}: auto-sync is off";
         return await SyncProjectAsync(project, trigger, ct);

--- a/Planscape.Companion/CompanionService.cs
+++ b/Planscape.Companion/CompanionService.cs
@@ -57,8 +57,12 @@ internal sealed class CompanionService : IDisposable
         // IPC first, and unconditionally. An unconfigured Companion is exactly
         // the one BCC most needs to be able to interrogate — "it's running but it
         // has no token" is a far more useful answer than silence.
-        _ipc = new CompanionIpcServer(() => Status, SyncNowAsync);
+        _ipc = new CompanionIpcServer(() => Status, SyncNowAsync, DownloadHistoryAsync);
         _ipc.Start();
+        // Count before the first sync as well: the files are already on disk from
+        // previous sessions, and a tray that reads 0 until the first sync of the
+        // day would be wrong for as long as the user is offline.
+        RefreshCheckedOut();
 
         if (!IsConfigured)
         {
@@ -202,6 +206,7 @@ internal sealed class CompanionService : IDisposable
             _settings.Save();  // persist the advanced high-water mark
             Status.FilesLastSync = outcome.Downloaded;
             Status.LastSuccessUtc = DateTime.UtcNow;
+            RefreshCheckedOut();
             Status.ConsecutiveFailures = 0;
             SetState(SyncState.Idle);
             return $"{project.ProjectCode}: {outcome}";
@@ -246,6 +251,68 @@ internal sealed class CompanionService : IDisposable
         var result = await SyncAllAsync(SyncTrigger.Manual, ct);
         Console.WriteLine(result);
         return Status.State != SyncState.Error;
+    }
+
+    /// <summary>
+    /// Slice E — full revision history for ONE document, on explicit request.
+    /// Never called by any automatic trigger.
+    /// </summary>
+    public async Task<string> DownloadHistoryAsync(string projectId, string documentId)
+    {
+        var project = _settings.Find(projectId);
+        if (project == null) return $"project {projectId} is not linked on this machine";
+        if (!Guid.TryParse(documentId, out var docGuid)) return $"'{documentId}' is not a document id";
+        if (_api == null)
+        {
+            // History is a deliberate user action, so it is worth connecting for
+            // even when the background loop has not managed to yet.
+            if (!IsConfigured) return "not configured — set a server and access token";
+            _api = new PlanscapeApiClient(_settings.ServerUrl!, _settings.AccessToken!);
+        }
+
+        await _syncGate.WaitAsync(_cts.Token);
+        try
+        {
+            SetState(SyncState.Syncing);
+            var engine = new SyncEngine(_api, _settings);
+            var result = await engine.DownloadHistoryAsync(project, docGuid, _cts.Token);
+            SetState(SyncState.Idle);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            SetState(SyncState.Error, ex.Message);
+            return $"history download failed: {ex.Message}";
+        }
+        finally
+        {
+            _syncGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Recount the WIP working copies on disk across every linked project.
+    /// Cheap (a directory enumeration per project) and always truthful, because
+    /// it reads the same filesystem the user is looking at.
+    /// </summary>
+    private void RefreshCheckedOut()
+    {
+        try
+        {
+            var all = new List<string>();
+            foreach (var project in _settings.Projects.ToList())
+                foreach (var name in SyncEngine.WorkingCopiesIn(_settings.FolderFor(project)))
+                    all.Add($"{project.ProjectCode}/{name}");
+
+            Status.CheckedOutCount = all.Count;
+            // Capped: the tray shows a short list, and a status file carrying
+            // thousands of names would be written on every state change.
+            Status.CheckedOut = all.Take(50).ToList();
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"checked-out refresh: {ex.Message}");
+        }
     }
 
     // ── Status ────────────────────────────────────────────────────────────────

--- a/Planscape.Companion/CompanionSettings.cs
+++ b/Planscape.Companion/CompanionSettings.cs
@@ -79,10 +79,11 @@ internal sealed class CompanionSettings
 
     // ── Location ──────────────────────────────────────────────────────────────
 
-    public static string SettingsDir => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "StingTools");
+    // Delegated to CompanionPaths so BCC, which needs the same answers to badge a
+    // document row, cannot end up with a second copy of these rules.
+    public static string SettingsDir => CompanionPaths.SettingsDir;
 
-    public static string SettingsPath => Path.Combine(SettingsDir, "planscape_sync.json");
+    public static string SettingsPath => CompanionPaths.SettingsPath;
 
     /// <summary>
     /// The default sync root: <c>%USERPROFILE%\Planscape</c>.
@@ -91,8 +92,7 @@ internal sealed class CompanionSettings
     /// Explorer and from Revit's own file-open dialog; a path nobody can navigate
     /// to by habit is a path they will copy files out of.
     /// </summary>
-    public static string DefaultRoot => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Planscape");
+    public static string DefaultRoot => CompanionPaths.DefaultRoot;
 
     /// <summary>Resolved sync folder for a project: override → global root → default.</summary>
     public string FolderFor(LinkedProject project)
@@ -107,14 +107,7 @@ internal sealed class CompanionSettings
     /// Windows refuses plus the traversal characters, so a project coded
     /// <c>..\..\Windows</c> cannot write outside the sync root.
     /// </summary>
-    public static string SanitiseFolderName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name)) return "project";
-        var cleaned = new string(name
-            .Where(c => !Path.GetInvalidFileNameChars().Contains(c) && c != '.' || char.IsLetterOrDigit(c))
-            .ToArray()).Trim();
-        return string.IsNullOrWhiteSpace(cleaned) ? "project" : cleaned;
-    }
+    public static string SanitiseFolderName(string name) => CompanionPaths.SanitiseFolderName(name);
 
     // ── Load / save ───────────────────────────────────────────────────────────
 

--- a/Planscape.Companion/CompanionSettings.cs
+++ b/Planscape.Companion/CompanionSettings.cs
@@ -1,0 +1,178 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// One project this machine syncs.
+///
+/// Explicit camelCase <see cref="JsonPropertyAttribute"/> names throughout: the
+/// top-level keys are written by hand and are camelCase, and without these the
+/// nested objects would serialise PascalCase, leaving one file with two
+/// conventions. It is a file people open and edit by hand — consistency is the
+/// whole point of following the existing settings-file pattern.
+/// </summary>
+internal sealed class LinkedProject
+{
+    [JsonProperty("projectId")]
+    public string ProjectId { get; set; } = "";
+
+    /// <summary>Used for the folder name — <c>%USERPROFILE%\Planscape\{ProjectCode}\</c>.</summary>
+    [JsonProperty("projectCode")]
+    public string ProjectCode { get; set; } = "";
+
+    /// <summary>
+    /// The per-project auto/manual toggle from the design, on by default. Off
+    /// means the project stays linked but nothing happens until someone triggers
+    /// a sync — the toggle gates only whether the PUSH is allowed to fire, never
+    /// which code path runs.
+    /// </summary>
+    [JsonProperty("autoSync")]
+    public bool AutoSync { get; set; } = true;
+
+    /// <summary>Per-project folder override. Null = the default convention.</summary>
+    [JsonProperty("folderOverride")]
+    public string? FolderOverride { get; set; }
+
+    /// <summary>
+    /// High-water mark for the delta query. Always a value the SERVER gave us
+    /// (<c>serverTimeUtc</c>), never this machine's clock — a laptop running fast
+    /// would otherwise ask for changes since an instant that has not happened and
+    /// silently sync nothing for as long as the skew lasts.
+    /// </summary>
+    [JsonProperty("lastSyncUtc")]
+    public DateTime? LastSyncUtc { get; set; }
+}
+
+/// <summary>
+/// Per-machine Companion settings.
+///
+/// Deliberately the same shape, directory and library as
+/// <c>PlanscapeServerClient.MachineSettingsPath</c>
+/// (<c>%APPDATA%\StingTools\planscape_server.json</c>): read-merge-write over a
+/// <see cref="JObject"/> so an unknown key written by a newer build survives an
+/// older one. A different settings mechanism for the same product would be a
+/// second thing to find, back up and support.
+///
+/// A SEPARATE FILE from the plugin's, though. Two processes writing one file
+/// race, and the plugin's file is the server URL that the Companion only ever
+/// reads.
+/// </summary>
+internal sealed class CompanionSettings
+{
+    public string? ServerUrl { get; set; }
+
+    /// <summary>
+    /// A personal access token (see /settings/tokens in the web app), exchanged
+    /// for a JWT at <c>POST /api/auth/token/exchange</c>.
+    ///
+    /// A PAT rather than a stored password: it is scoped to one user, revocable
+    /// from the web app without a password change, and expires on its own. The
+    /// same choice StingBridge made, for the same reasons.
+    /// </summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>Global root override. Null = <c>%USERPROFILE%\Planscape</c>.</summary>
+    public string? RootFolder { get; set; }
+
+    public List<LinkedProject> Projects { get; set; } = new();
+
+    // ── Location ──────────────────────────────────────────────────────────────
+
+    public static string SettingsDir => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "StingTools");
+
+    public static string SettingsPath => Path.Combine(SettingsDir, "planscape_sync.json");
+
+    /// <summary>
+    /// The default sync root: <c>%USERPROFILE%\Planscape</c>.
+    ///
+    /// Deliberately NOT under %APPDATA%. An Author has to find these files from
+    /// Explorer and from Revit's own file-open dialog; a path nobody can navigate
+    /// to by habit is a path they will copy files out of.
+    /// </summary>
+    public static string DefaultRoot => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Planscape");
+
+    /// <summary>Resolved sync folder for a project: override → global root → default.</summary>
+    public string FolderFor(LinkedProject project)
+    {
+        if (!string.IsNullOrWhiteSpace(project.FolderOverride)) return project.FolderOverride!;
+        var root = string.IsNullOrWhiteSpace(RootFolder) ? DefaultRoot : RootFolder!;
+        return Path.Combine(root, SanitiseFolderName(project.ProjectCode));
+    }
+
+    /// <summary>
+    /// A project code is user-supplied and travels into a path. Strip what
+    /// Windows refuses plus the traversal characters, so a project coded
+    /// <c>..\..\Windows</c> cannot write outside the sync root.
+    /// </summary>
+    public static string SanitiseFolderName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "project";
+        var cleaned = new string(name
+            .Where(c => !Path.GetInvalidFileNameChars().Contains(c) && c != '.' || char.IsLetterOrDigit(c))
+            .ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(cleaned) ? "project" : cleaned;
+    }
+
+    // ── Load / save ───────────────────────────────────────────────────────────
+
+    public static CompanionSettings Load()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return new CompanionSettings();
+            var o = JObject.Parse(File.ReadAllText(SettingsPath));
+            return new CompanionSettings
+            {
+                ServerUrl = o["serverUrl"]?.Value<string>(),
+                AccessToken = o["accessToken"]?.Value<string>(),
+                RootFolder = o["rootFolder"]?.Value<string>(),
+                Projects = o["projects"]?.ToObject<List<LinkedProject>>() ?? new List<LinkedProject>(),
+            };
+        }
+        catch (Exception ex)
+        {
+            // A corrupt settings file must not stop the app from starting — it
+            // would take the tray icon with it and leave no way to fix anything.
+            CompanionLog.Error($"settings unreadable, starting with defaults ({SettingsPath})", ex);
+            return new CompanionSettings();
+        }
+    }
+
+    /// <summary>
+    /// Merge-and-write, preserving unknown keys — the same read-modify-write
+    /// discipline PlanscapeServerClient.SaveDefaultServerUrl uses.
+    /// </summary>
+    public void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDir);
+            var o = File.Exists(SettingsPath)
+                ? JObject.Parse(File.ReadAllText(SettingsPath))
+                : new JObject();
+
+            if (ServerUrl != null) o["serverUrl"] = ServerUrl;
+            if (AccessToken != null) o["accessToken"] = AccessToken;
+            o["rootFolder"] = RootFolder;
+            o["projects"] = JArray.FromObject(Projects);
+            o["updatedUtc"] = DateTime.UtcNow.ToString("o");
+
+            // Write via a temp file + replace: a power cut mid-write would
+            // otherwise leave a half-written JSON file, and the catch in Load()
+            // would silently discard every linked project.
+            var tmp = SettingsPath + ".tmp";
+            File.WriteAllText(tmp, o.ToString(Formatting.Indented));
+            File.Move(tmp, SettingsPath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Error("could not save settings", ex);
+        }
+    }
+
+    public LinkedProject? Find(string projectId) =>
+        Projects.FirstOrDefault(p => string.Equals(p.ProjectId, projectId, StringComparison.OrdinalIgnoreCase));
+}

--- a/Planscape.Companion/CompanionTray.cs
+++ b/Planscape.Companion/CompanionTray.cs
@@ -22,12 +22,19 @@ internal sealed class CompanionTray : IDisposable
     private readonly CompanionService _service;
     private readonly NotifyIcon _icon;
     private readonly Dictionary<SyncState, Icon> _icons = new();
+    private ToolStripMenuItem _checkedOutItem = null!;
 
     public CompanionTray(CompanionService service)
     {
         _service = service;
 
         var menu = new ContextMenuStrip();
+        // Click-to-expand: the count on the tooltip, the names one click away.
+        // Rebuilt each time it opens so it never shows a stale list.
+        _checkedOutItem = new ToolStripMenuItem("Checked out") { Enabled = false };
+        menu.Opening += (_, _) => RebuildCheckedOutMenu();
+        menu.Items.Add(_checkedOutItem);
+        menu.Items.Add(new ToolStripSeparator());
         menu.Items.Add("Sync now", null, (_, _) => _ = SyncNowAsync());
         menu.Items.Add("Open sync folder", null, (_, _) => OpenFolder());
         menu.Items.Add(new ToolStripSeparator());
@@ -74,6 +81,67 @@ internal sealed class CompanionTray : IDisposable
         }
     }
 
+    /// <summary>
+    /// Slice E — "N checked out", expanding to the file names.
+    ///
+    /// Status only, no editing: the design is explicit that the tray is not a
+    /// second UI surface to maintain. Clicking a name opens the containing folder
+    /// with the file selected, which is the one thing a user actually wants from
+    /// here and costs no UI of our own.
+    /// </summary>
+    private void RebuildCheckedOutMenu()
+    {
+        try
+        {
+            var st = _service.Status;
+            _checkedOutItem.DropDownItems.Clear();
+            _checkedOutItem.Text = st.CheckedOutCount == 0
+                ? "No working copies"
+                : $"{st.CheckedOutCount} checked out";
+            _checkedOutItem.Enabled = st.CheckedOutCount > 0;
+            if (st.CheckedOutCount == 0) return;
+
+            var settings = CompanionSettings.Load();
+            foreach (var entry in st.CheckedOut)
+            {
+                // Entries are "PROJECTCODE/filename" — see RefreshCheckedOut.
+                var slash = entry.IndexOf('/');
+                var code = slash > 0 ? entry.Substring(0, slash) : null;
+                var name = slash > 0 ? entry.Substring(slash + 1) : entry;
+
+                var item = new ToolStripMenuItem(entry);
+                item.Click += (_, _) => RevealInExplorer(settings, code, name);
+                _checkedOutItem.DropDownItems.Add(item);
+            }
+
+            if (st.CheckedOutCount > st.CheckedOut.Count)
+                _checkedOutItem.DropDownItems.Add(new ToolStripMenuItem(
+                    $"… and {st.CheckedOutCount - st.CheckedOut.Count} more") { Enabled = false });
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"checked-out menu: {ex.Message}");
+        }
+    }
+
+    private static void RevealInExplorer(CompanionSettings settings, string? projectCode, string fileName)
+    {
+        try
+        {
+            var folder = CompanionPaths.ResolveProjectFolder(projectCode);
+            if (string.IsNullOrEmpty(folder)) return;
+            var path = Path.Combine(folder, fileName);
+            // /select, puts the file itself under the cursor rather than dumping
+            // the user in a folder to hunt through.
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("explorer.exe")
+            {
+                Arguments = File.Exists(path) ? $"/select,\"{path}\"" : $"\"{folder}\"",
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception ex) { CompanionLog.Warn($"reveal '{fileName}': {ex.Message}"); }
+    }
+
     private async Task SyncNowAsync()
     {
         try
@@ -113,8 +181,19 @@ internal sealed class CompanionTray : IDisposable
     }
 
     /// <summary>
-    /// State → colour. Offline is grey, not red: it is expected and self-healing,
-    /// and colouring it as a fault is what makes users stop reading the icon.
+    /// State → glyph. Slice E.
+    ///
+    /// <para><b>Shape as well as colour.</b> At 16×16 in a crowded notification
+    /// area, colour alone is a weak signal, and for a colour-blind user it is no
+    /// signal at all — so each state also differs in form: a filled disc when
+    /// idle, a ring while syncing, a hollow outline when offline, and a disc with
+    /// a bar through it on error.</para>
+    ///
+    /// <para><b>Offline is grey and quiet</b>, not red. It is expected and
+    /// self-healing, and painting it as a fault is exactly what makes a user stop
+    /// reading the icon — at which point the red one means nothing either
+    /// (plan §1c). Only Error is red, and Error is the only state that has an
+    /// accompanying message naming what a human has to fix.</para>
     /// </summary>
     private Icon IconFor(SyncState state)
     {
@@ -122,10 +201,10 @@ internal sealed class CompanionTray : IDisposable
 
         var colour = state switch
         {
-            SyncState.Idle => Color.FromArgb(0x2E, 0x7D, 0x32),    // green — synced
-            SyncState.Syncing => Color.FromArgb(0x15, 0x65, 0xC0), // blue — working
-            SyncState.Offline => Color.FromArgb(0x9E, 0x9E, 0x9E), // grey — quiet
-            SyncState.Error => Color.FromArgb(0xC6, 0x28, 0x28),   // red — needs a human
+            SyncState.Idle    => Color.FromArgb(0x2E, 0x7D, 0x32),   // green — synced
+            SyncState.Syncing => Color.FromArgb(0x15, 0x65, 0xC0),   // blue  — working
+            SyncState.Offline => Color.FromArgb(0x9E, 0x9E, 0x9E),   // grey  — quiet
+            SyncState.Error   => Color.FromArgb(0xC6, 0x28, 0x28),   // red   — needs a human
             _ => Color.Gray,
         };
 
@@ -135,7 +214,34 @@ internal sealed class CompanionTray : IDisposable
             g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
             g.Clear(Color.Transparent);
             using var brush = new SolidBrush(colour);
-            g.FillEllipse(brush, 2, 2, 12, 12);
+            using var pen = new Pen(colour, 2f);
+
+            switch (state)
+            {
+                case SyncState.Offline:
+                    // Hollow: "nothing is flowing" reads at a glance.
+                    g.DrawEllipse(pen, 3, 3, 10, 10);
+                    break;
+
+                case SyncState.Syncing:
+                    // Ring with a gap — a progress arc, not a full stop.
+                    g.DrawArc(pen, 3, 3, 10, 10, 45, 270);
+                    break;
+
+                case SyncState.Error:
+                    // Disc with a bar. Distinct in silhouette from every other
+                    // state even in a monochrome or high-contrast theme.
+                    g.FillEllipse(brush, 2, 2, 12, 12);
+                    using (var bar = new SolidBrush(Color.White))
+                        g.FillRectangle(bar, 7, 4, 2, 6);
+                    using (var dot = new SolidBrush(Color.White))
+                        g.FillRectangle(dot, 7, 11, 2, 2);
+                    break;
+
+                default: // Idle
+                    g.FillEllipse(brush, 2, 2, 12, 12);
+                    break;
+            }
         }
         var icon = Icon.FromHandle(bmp.GetHicon());
         _icons[state] = icon;

--- a/Planscape.Companion/CompanionTray.cs
+++ b/Planscape.Companion/CompanionTray.cs
@@ -1,0 +1,152 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// The tray icon. Deliberately minimal this pass: an icon whose state reflects
+/// <see cref="SyncStatus"/>, a tooltip, and three menu items.
+///
+/// The design's richer tray surface — a checked-out count, click-to-expand into a
+/// document list — is a later slice. What is here is the part that carries the
+/// error-visibility decision (plan §1c): <b>Offline is quiet, Error is not.</b>
+/// No toasts, from anywhere, ever: the most common failure is a closed laptop,
+/// and an app that notifies about that gets muted, taking the real errors with it.
+///
+/// The icon is drawn in code rather than shipped as a .ico — three coloured dots
+/// is not worth a binary asset in the repo, and drawing it keeps the state→colour
+/// mapping in one readable place.
+/// </summary>
+internal sealed class CompanionTray : IDisposable
+{
+    private readonly CompanionService _service;
+    private readonly NotifyIcon _icon;
+    private readonly Dictionary<SyncState, Icon> _icons = new();
+
+    public CompanionTray(CompanionService service)
+    {
+        _service = service;
+
+        var menu = new ContextMenuStrip();
+        menu.Items.Add("Sync now", null, (_, _) => _ = SyncNowAsync());
+        menu.Items.Add("Open sync folder", null, (_, _) => OpenFolder());
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add("View log", null, (_, _) => OpenLog());
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add("Exit", null, (_, _) => Application.Exit());
+
+        _icon = new NotifyIcon
+        {
+            Icon = IconFor(service.Status.State),
+            Text = service.Status.Summary(),
+            Visible = true,
+            ContextMenuStrip = menu,
+        };
+        _icon.DoubleClick += (_, _) => OpenFolder();
+
+        _service.StatusChanged += OnStatusChanged;
+    }
+
+    private void OnStatusChanged()
+    {
+        // Raised from the sync loop, which is not the UI thread. Touching
+        // NotifyIcon from there throws intermittently rather than reliably —
+        // the worst kind of bug to leave in a background app.
+        if (_icon.ContextMenuStrip is { } menu && menu.InvokeRequired)
+        {
+            menu.BeginInvoke(new Action(Repaint));
+            return;
+        }
+        Repaint();
+    }
+
+    private void Repaint()
+    {
+        try
+        {
+            _icon.Icon = IconFor(_service.Status.State);
+            // NotifyIcon.Text throws above 63 characters; Summary() is built to fit.
+            _icon.Text = _service.Status.Summary();
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"tray repaint failed: {ex.Message}");
+        }
+    }
+
+    private async Task SyncNowAsync()
+    {
+        try
+        {
+            var result = await _service.SyncNowAsync(null);
+            CompanionLog.Info($"tray sync-now: {result}");
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Error("tray sync-now failed", ex);
+        }
+    }
+
+    private void OpenFolder()
+    {
+        try
+        {
+            var settings = CompanionSettings.Load();
+            var root = string.IsNullOrWhiteSpace(settings.RootFolder)
+                ? CompanionSettings.DefaultRoot
+                : settings.RootFolder!;
+            Directory.CreateDirectory(root);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(root) { UseShellExecute = true });
+        }
+        catch (Exception ex) { CompanionLog.Warn($"could not open the sync folder: {ex.Message}"); }
+    }
+
+    private void OpenLog()
+    {
+        try
+        {
+            if (File.Exists(CompanionLog.Path))
+                System.Diagnostics.Process.Start(
+                    new System.Diagnostics.ProcessStartInfo(CompanionLog.Path) { UseShellExecute = true });
+        }
+        catch (Exception ex) { CompanionLog.Warn($"could not open the log: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// State → colour. Offline is grey, not red: it is expected and self-healing,
+    /// and colouring it as a fault is what makes users stop reading the icon.
+    /// </summary>
+    private Icon IconFor(SyncState state)
+    {
+        if (_icons.TryGetValue(state, out var cached)) return cached;
+
+        var colour = state switch
+        {
+            SyncState.Idle => Color.FromArgb(0x2E, 0x7D, 0x32),    // green — synced
+            SyncState.Syncing => Color.FromArgb(0x15, 0x65, 0xC0), // blue — working
+            SyncState.Offline => Color.FromArgb(0x9E, 0x9E, 0x9E), // grey — quiet
+            SyncState.Error => Color.FromArgb(0xC6, 0x28, 0x28),   // red — needs a human
+            _ => Color.Gray,
+        };
+
+        using var bmp = new Bitmap(16, 16);
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            g.Clear(Color.Transparent);
+            using var brush = new SolidBrush(colour);
+            g.FillEllipse(brush, 2, 2, 12, 12);
+        }
+        var icon = Icon.FromHandle(bmp.GetHicon());
+        _icons[state] = icon;
+        return icon;
+    }
+
+    public void Dispose()
+    {
+        _service.StatusChanged -= OnStatusChanged;
+        _icon.Visible = false;
+        _icon.Dispose();
+        foreach (var icon in _icons.Values) icon.Dispose();
+    }
+}

--- a/Planscape.Companion/Planscape.Companion.csproj
+++ b/Planscape.Companion/Planscape.Companion.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Planscape Companion — the always-running half of document sync.
+
+    A SIBLING of StingTools.LinkHandler, never a modification of it. StingLink.exe
+    is short-lived by design (it drops a URL and exits); this stays running for
+    the whole login session because sync has to work when Revit is closed. The
+    approved design says to keep them as two small single-purpose processes rather
+    than retrofitting one into the other, and that is what this is.
+
+    WinExe so no console window flashes at login. UseWindowsForms is for exactly
+    one type — NotifyIcon. There is no form, no designer, and no WinForms message
+    loop beyond the one the tray icon needs.
+  -->
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>Planscape.Companion</AssemblyName>
+    <RootNamespace>Planscape.Companion</RootNamespace>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Version>0.1.0</Version>
+    <Company>Planscape</Company>
+    <Product>Planscape Companion</Product>
+    <!-- A background tray app must never take the whole session down because a
+         socket blipped. Unobserved task exceptions are logged, not fatal. -->
+    <TieredPGO>true</TieredPGO>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.11" />
+    <!-- Newtonsoft rather than System.Text.Json purely for consistency: the
+         settings file this reads and writes lives beside, and follows the shape
+         of, PlanscapeServerClient's machine settings, which is Newtonsoft. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/Planscape.Companion/PlanscapeApiClient.cs
+++ b/Planscape.Companion/PlanscapeApiClient.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Planscape.Companion;
+
+/// <summary>Raised when the server rejected our credentials — an Error, not an Offline.</summary>
+internal sealed class CompanionAuthException : Exception
+{
+    public CompanionAuthException(string message) : base(message) { }
+}
+
+/// <summary>One document as the delta feed describes it.</summary>
+internal sealed class RemoteDocument
+{
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = "";
+    public string? DocumentType { get; set; }
+    public string CdeStatus { get; set; } = "";
+    public string? SuitabilityCode { get; set; }
+    public string? Revision { get; set; }
+    public string? Discipline { get; set; }
+    public long FileSizeBytes { get; set; }
+    public string? ContentHash { get; set; }
+    public string? ScanStatus { get; set; }
+    public DateTime ChangedAt { get; set; }
+}
+
+internal sealed class ChangedSincePage
+{
+    public List<RemoteDocument> Items { get; set; } = new();
+    public bool HasMore { get; set; }
+    public DateTime ServerTimeUtc { get; set; }
+}
+
+/// <summary>
+/// The Companion's REST client. Small on purpose — it needs three calls: exchange
+/// a token, read a delta, download a file.
+/// </summary>
+internal sealed class PlanscapeApiClient : IDisposable
+{
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromMinutes(5) };
+    private readonly string _baseUrl;
+    private readonly string _personalAccessToken;
+    private string? _jwt;
+    private DateTime _jwtObtainedUtc;
+
+    /// <summary>
+    /// Re-exchange the PAT well before the JWT's own expiry rather than waiting
+    /// for a 401. A background process that only discovers expiry by failing
+    /// turns every token rollover into a visible sync failure.
+    /// </summary>
+    private static readonly TimeSpan JwtRefreshAfter = TimeSpan.FromMinutes(30);
+
+    public PlanscapeApiClient(string baseUrl, string personalAccessToken)
+    {
+        _baseUrl = baseUrl.TrimEnd('/');
+        _personalAccessToken = personalAccessToken;
+    }
+
+    /// <summary>The JWT, exchanged from the PAT and cached. Thread-confined to the sync loop.</summary>
+    private async Task<string> TokenAsync(CancellationToken ct)
+    {
+        if (_jwt != null && DateTime.UtcNow - _jwtObtainedUtc < JwtRefreshAfter) return _jwt;
+
+        var body = new StringContent(
+            JsonConvert.SerializeObject(new { token = _personalAccessToken }),
+            Encoding.UTF8, "application/json");
+
+        using var res = await _http.PostAsync($"{_baseUrl}/api/auth/token/exchange", body, ct);
+        if (res.StatusCode == HttpStatusCode.Unauthorized)
+            throw new CompanionAuthException(
+                "Planscape rejected the access token. Create a new one in the web app under Settings → Access tokens.");
+        res.EnsureSuccessStatusCode();
+
+        var json = JObject.Parse(await res.Content.ReadAsStringAsync(ct));
+        var jwt = json["accessToken"]?.Value<string>()
+            ?? throw new CompanionAuthException("token exchange returned no accessToken");
+
+        _jwt = jwt;
+        _jwtObtainedUtc = DateTime.UtcNow;
+        CompanionLog.Info("access token exchanged");
+        return jwt;
+    }
+
+    /// <summary>A JWT for the SignalR client, which does its own connecting.</summary>
+    public Task<string> GetAccessTokenAsync(CancellationToken ct = default) => TokenAsync(ct);
+
+    private async Task<HttpRequestMessage> AuthorisedAsync(HttpMethod method, string url, CancellationToken ct)
+    {
+        var req = new HttpRequestMessage(method, url);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await TokenAsync(ct));
+        return req;
+    }
+
+    /// <summary>
+    /// One page of the delta feed. <paramref name="since"/> null = everything
+    /// currently visible (the initial-link case).
+    /// </summary>
+    public async Task<ChangedSincePage> ChangedSinceAsync(
+        string projectId, DateTime? since, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/projects/{projectId}/documents/changed-since";
+        if (since.HasValue)
+            url += "?since=" + Uri.EscapeDataString(
+                DateTime.SpecifyKind(since.Value, DateTimeKind.Utc).ToString("O"));
+
+        using var req = await AuthorisedAsync(HttpMethod.Get, url, ct);
+        using var res = await _http.SendAsync(req, ct);
+
+        if (res.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // The cached JWT went stale sooner than expected (a server restart
+            // rotating its signing key does this). Drop it and let the next pass
+            // re-exchange rather than reporting a permanent auth failure.
+            _jwt = null;
+            throw new CompanionAuthException("session expired; will re-authenticate");
+        }
+        if (res.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden)
+            throw new InvalidOperationException(
+                $"project {projectId} is not visible to this account — unlink it or check the token's user.");
+        res.EnsureSuccessStatusCode();
+
+        var json = JObject.Parse(await res.Content.ReadAsStringAsync(ct));
+        return new ChangedSincePage
+        {
+            Items = json["items"]?.ToObject<List<RemoteDocument>>() ?? new List<RemoteDocument>(),
+            HasMore = json["hasMore"]?.Value<bool>() ?? false,
+            ServerTimeUtc = json["serverTimeUtc"]?.Value<DateTime>() ?? DateTime.UtcNow,
+        };
+    }
+
+    /// <summary>
+    /// Stream a document's bytes to <paramref name="destination"/>.
+    ///
+    /// Streamed, not buffered: a 100 MB drawing set held in memory on a laptop
+    /// that is also running Revit is a real cost for no benefit.
+    /// </summary>
+    public async Task DownloadAsync(string projectId, Guid documentId, string destination, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/projects/{projectId}/documents/{documentId}/download";
+        using var req = await AuthorisedAsync(HttpMethod.Get, url, ct);
+        using var res = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (res.StatusCode == HttpStatusCode.Locked)
+            throw new InvalidOperationException("document is still awaiting an antivirus scan");
+        res.EnsureSuccessStatusCode();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        await using (var src = await res.Content.ReadAsStreamAsync(ct))
+        await using (var dst = File.Create(destination))
+            await src.CopyToAsync(dst, ct);
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/Planscape.Companion/PlanscapeApiClient.cs
+++ b/Planscape.Companion/PlanscapeApiClient.cs
@@ -33,6 +33,13 @@ internal sealed class ChangedSincePage
     public List<RemoteDocument> Items { get; set; } = new();
     public bool HasMore { get; set; }
     public DateTime ServerTimeUtc { get; set; }
+
+    /// <summary>
+    /// The project's server-side "Auto-sync this project" flag, echoed on every
+    /// delta. Defaults true when an older server omits it — the design says the
+    /// toggle is on by default, so an absent field must mean on, never off.
+    /// </summary>
+    public bool AutoSyncEnabled { get; set; } = true;
 }
 
 /// <summary>
@@ -129,6 +136,7 @@ internal sealed class PlanscapeApiClient : IDisposable
             Items = json["items"]?.ToObject<List<RemoteDocument>>() ?? new List<RemoteDocument>(),
             HasMore = json["hasMore"]?.Value<bool>() ?? false,
             ServerTimeUtc = json["serverTimeUtc"]?.Value<DateTime>() ?? DateTime.UtcNow,
+            AutoSyncEnabled = json["autoSyncEnabled"]?.Value<bool>() ?? true,
         };
     }
 

--- a/Planscape.Companion/PlanscapeApiClient.cs
+++ b/Planscape.Companion/PlanscapeApiClient.cs
@@ -140,6 +140,65 @@ internal sealed class PlanscapeApiClient : IDisposable
         };
     }
 
+    /// <summary>One historical upload of a document.</summary>
+    public sealed class RemoteVersion
+    {
+        public int VersionNumber { get; set; }
+        public long FileSizeBytes { get; set; }
+        public string? ContentHash { get; set; }
+        public string? UploadedBy { get; set; }
+        public DateTime? UploadedAt { get; set; }
+        public string? ChangeDescription { get; set; }
+    }
+
+    /// <summary>
+    /// Every stored upload of a document, newest first.
+    ///
+    /// Note this reads DocumentVERSIONS, not DocumentRevisions. The two are
+    /// different things in this schema: a revision is a metadata snapshot minted
+    /// at a CDE transition (and several can share one file), whereas a version is
+    /// a distinct set of bytes that was actually uploaded. "Download full
+    /// history" means the files, so versions is the right list — and it is also
+    /// the only one of the two with a per-item download route.
+    /// </summary>
+    public async Task<List<RemoteVersion>> ListVersionsAsync(
+        string projectId, Guid documentId, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/projects/{projectId}/documents/{documentId}/versions";
+        using var req = await AuthorisedAsync(HttpMethod.Get, url, ct);
+        using var res = await _http.SendAsync(req, ct);
+        if (res.StatusCode == HttpStatusCode.Unauthorized) { _jwt = null; throw new CompanionAuthException("session expired; will re-authenticate"); }
+        res.EnsureSuccessStatusCode();
+        return JArray.Parse(await res.Content.ReadAsStringAsync(ct)).ToObject<List<RemoteVersion>>()
+               ?? new List<RemoteVersion>();
+    }
+
+    /// <summary>Download one historical version's bytes.</summary>
+    public async Task DownloadVersionAsync(
+        string projectId, Guid documentId, int versionNumber, string destination, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/projects/{projectId}/documents/{documentId}/versions/{versionNumber}/download";
+        using var req = await AuthorisedAsync(HttpMethod.Get, url, ct);
+        using var res = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+        res.EnsureSuccessStatusCode();
+
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        await using var src = await res.Content.ReadAsStreamAsync(ct);
+        await using var dst = File.Create(destination);
+        await src.CopyToAsync(dst, ct);
+    }
+
+    /// <summary>Metadata for one document (used to name a history folder).</summary>
+    public async Task<RemoteDocument?> GetDocumentAsync(
+        string projectId, Guid documentId, CancellationToken ct = default)
+    {
+        // The delta feed is the only listing endpoint the Companion is wired to,
+        // and asking for "everything visible" then filtering avoids adding a
+        // dependency on a second response shape for one field.
+        var page = await ChangedSinceAsync(projectId, null, ct);
+        return page.Items.FirstOrDefault(d => d.Id == documentId);
+    }
+
     /// <summary>
     /// Stream a document's bytes to <paramref name="destination"/>.
     ///

--- a/Planscape.Companion/Program.cs
+++ b/Planscape.Companion/Program.cs
@@ -1,0 +1,230 @@
+using System.Diagnostics;
+using System.Threading;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// Planscape Companion — entry point and host.
+///
+/// Modes:
+///   (no args)             tray app; the normal start-on-login path
+///   --diagnose            headless one-shot: connect, sync every linked
+///                         project once, print what happened, exit
+///   --install-autostart   HKCU Run registration (user scope, no elevation)
+///   --uninstall-autostart remove it
+///   --status              print the persisted status and exit
+///   --link &lt;projectId&gt; &lt;code&gt;   link a project on this machine
+///   --set-server &lt;url&gt; · --set-token &lt;pat&gt;
+///
+/// <para><c>--diagnose</c> exists because a tray app is otherwise unprovable: it
+/// has no console, no window and no exit code worth reading. It is how this was
+/// verified during development and it doubles as the first thing to ask a user to
+/// run when sync "isn't working".</para>
+/// </summary>
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        // A background process must not take the session down over an unobserved
+        // exception on a socket continuation.
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            CompanionLog.Error("unobserved task exception", e.Exception);
+            e.SetObserved();
+        };
+
+        var mode = args.Length > 0 ? args[0].ToLowerInvariant() : "";
+        try
+        {
+            return mode switch
+            {
+                "--install-autostart" => InstallAutostart(),
+                "--uninstall-autostart" => UninstallAutostart(),
+                "--status" => PrintStatus(),
+                "--diagnose" => Diagnose().GetAwaiter().GetResult(),
+                "--set-server" => SetServer(args),
+                "--set-token" => SetToken(args),
+                "--link" => LinkProject(args),
+                "--help" or "-h" or "/?" => Help(),
+                "" => RunTray(),
+                _ => Help($"unknown option '{args[0]}'"),
+            };
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Error($"fatal in mode '{mode}'", ex);
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    // ── Modes ─────────────────────────────────────────────────────────────────
+
+    private static int Help(string? problem = null)
+    {
+        if (problem != null) Console.Error.WriteLine(problem);
+        Console.WriteLine("""
+            Planscape Companion — syncs cloud documents to this machine.
+
+              (no arguments)          run in the system tray
+              --diagnose              connect + sync once, print the result, exit
+              --status                print the last recorded status
+              --set-server <url>      e.g. http://localhost:5000
+              --set-token <pat>       a personal access token from the web app
+              --link <projectId> <code>   sync a project into <root>\<code>\
+              --install-autostart     start at login (current user only)
+              --uninstall-autostart   stop starting at login
+
+            Settings:  %APPDATA%\StingTools\planscape_sync.json
+            Log:       %APPDATA%\StingTools\companion.log
+            """);
+        return problem == null ? 0 : 2;
+    }
+
+    private static int InstallAutostart()
+    {
+        var changed = AutoStart.Install(out var detail);
+        Console.WriteLine(changed ? $"Autostart registered: {detail}" : $"No change: {detail}");
+        CompanionLog.Info($"autostart install — {(changed ? detail : "no change: " + detail)}");
+        return 0;
+    }
+
+    private static int UninstallAutostart()
+    {
+        var changed = AutoStart.Uninstall(out var detail);
+        Console.WriteLine(changed ? "Autostart removed." : $"No change: {detail}");
+        return 0;
+    }
+
+    private static int PrintStatus()
+    {
+        var s = SyncStatus.Load();
+        Console.WriteLine($"State                : {s.State}");
+        Console.WriteLine($"Summary              : {s.Summary()}");
+        Console.WriteLine($"Last success (UTC)   : {s.LastSuccessUtc?.ToString("O") ?? "never"}");
+        Console.WriteLine($"Last error           : {s.LastError ?? "none"}");
+        Console.WriteLine($"Consecutive failures : {s.ConsecutiveFailures}");
+        Console.WriteLine($"Linked projects      : {s.LinkedProjects}");
+        Console.WriteLine($"Settings             : {CompanionSettings.SettingsPath}");
+        Console.WriteLine($"Log                  : {CompanionLog.Path}");
+        return 0;
+    }
+
+    private static int SetServer(string[] args)
+    {
+        if (args.Length < 2) return Help("--set-server needs a URL");
+        var settings = CompanionSettings.Load();
+        settings.ServerUrl = args[1].TrimEnd('/');
+        settings.Save();
+        Console.WriteLine($"Server set to {settings.ServerUrl}");
+        return 0;
+    }
+
+    private static int SetToken(string[] args)
+    {
+        if (args.Length < 2) return Help("--set-token needs a personal access token");
+        var settings = CompanionSettings.Load();
+        settings.AccessToken = args[1];
+        settings.Save();
+        // Never echo the token — this writes to a console that may be logged.
+        Console.WriteLine("Access token saved.");
+        return 0;
+    }
+
+    private static int LinkProject(string[] args)
+    {
+        if (args.Length < 3) return Help("--link needs a project id and a project code");
+        var settings = CompanionSettings.Load();
+        var existing = settings.Find(args[1]);
+        if (existing != null)
+        {
+            existing.ProjectCode = args[2];
+            // Clearing the mark makes the next sync an initial one, which is what
+            // re-linking should mean.
+            existing.LastSyncUtc = null;
+        }
+        else
+        {
+            settings.Projects.Add(new LinkedProject { ProjectId = args[1], ProjectCode = args[2] });
+        }
+        settings.Save();
+        var project = settings.Find(args[1])!;
+        Console.WriteLine($"Linked {args[2]} → {settings.FolderFor(project)}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Headless one-shot. Connects, syncs every linked project once, reports, exits.
+    /// Everything the tray does, minus the tray.
+    /// </summary>
+    private static async Task<int> Diagnose()
+    {
+        CompanionLog.EchoToConsole();
+        CompanionLog.Info("--diagnose starting");
+
+        var settings = CompanionSettings.Load();
+        Console.WriteLine($"Settings : {CompanionSettings.SettingsPath}");
+        Console.WriteLine($"Log      : {CompanionLog.Path}");
+        Console.WriteLine($"Server   : {settings.ServerUrl ?? "(not set — use --set-server)"}");
+        Console.WriteLine($"Token    : {(string.IsNullOrEmpty(settings.AccessToken) ? "(not set — use --set-token)" : "set")}");
+        Console.WriteLine($"Root     : {(string.IsNullOrWhiteSpace(settings.RootFolder) ? CompanionSettings.DefaultRoot : settings.RootFolder)}");
+        Console.WriteLine($"Projects : {settings.Projects.Count}");
+        foreach (var p in settings.Projects)
+            Console.WriteLine($"   • {p.ProjectCode} ({p.ProjectId}) auto={p.AutoSync} last={p.LastSyncUtc?.ToString("O") ?? "never"} → {settings.FolderFor(p)}");
+
+        if (string.IsNullOrWhiteSpace(settings.ServerUrl) || string.IsNullOrWhiteSpace(settings.AccessToken))
+        {
+            Console.WriteLine();
+            Console.WriteLine("No server or token configured — nothing to sync. Set both and re-run.");
+            CompanionLog.Info("--diagnose finished (not configured)");
+            return 0;
+        }
+
+        using var service = new CompanionService(settings);
+        var ok = await service.RunOnceAsync(CancellationToken.None);
+        Console.WriteLine();
+        Console.WriteLine(service.Status.Summary());
+        CompanionLog.Info("--diagnose finished");
+        return ok ? 0 : 1;
+    }
+
+    /// <summary>
+    /// The normal path: a tray icon and a background service, until the user
+    /// exits or logs out.
+    /// </summary>
+    private static int RunTray()
+    {
+        // One Companion per user session. A second instance would open a second
+        // pipe (failing), fight the first over the settings file, and download
+        // everything twice.
+        using var single = new Mutex(true, @"Local\PlanscapeCompanion", out var isFirst);
+        if (!isFirst)
+        {
+            CompanionLog.Info("another Companion is already running in this session; exiting");
+            return 0;
+        }
+
+        // REPAIR an existing autostart entry whose path has gone stale (the
+        // deployment folder moves, and a Run entry pointing at a deleted exe
+        // fails silently at login, which is the worst time to fail).
+        //
+        // It deliberately does NOT register itself when no entry exists. Adding
+        // yourself to a user's startup because they ran you once is a change to
+        // their machine that they did not ask for. Opting in is explicit —
+        // `--install-autostart`, which is what the StingTools first-run hook
+        // will call once Slice D lands.
+        if (AutoStart.CurrentCommand() != null && AutoStart.Install(out var autoDetail))
+            CompanionLog.Info($"autostart entry repaired → {autoDetail}");
+
+        var settings = CompanionSettings.Load();
+        using var service = new CompanionService(settings);
+        using var tray = new CompanionTray(service);
+
+        service.Start();
+        CompanionLog.Info($"tray started (pid {Environment.ProcessId})");
+        System.Windows.Forms.Application.Run();
+        CompanionLog.Info("tray exiting");
+        return 0;
+    }
+}

--- a/Planscape.Companion/Program.cs
+++ b/Planscape.Companion/Program.cs
@@ -47,6 +47,7 @@ internal static class Program
                 "--set-server" => SetServer(args),
                 "--set-token" => SetToken(args),
                 "--link" => LinkProject(args),
+                "--history" => History(args).GetAwaiter().GetResult(),
                 "--help" or "-h" or "/?" => Help(),
                 "" => RunTray(),
                 _ => Help($"unknown option '{args[0]}'"),
@@ -75,6 +76,9 @@ internal static class Program
               --set-server <url>      e.g. http://localhost:5000
               --set-token <pat>       a personal access token from the web app
               --link <projectId> <code>   sync a project into <root>\<code>\
+              --history <projectId> <documentId>
+                                      download EVERY stored version of one
+                                      document (opt-in, never automatic)
               --install-autostart     start at login (current user only)
               --uninstall-autostart   stop starting at login
 
@@ -125,6 +129,37 @@ internal static class Program
         Console.WriteLine($"linked projects : {st.LinkedProjects}");
         Console.WriteLine($"last success    : {st.LastSuccessUtc?.ToString("O") ?? "never"}");
         Console.WriteLine($"last error      : {st.LastError ?? "none"}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Slice E — full version history for one document, on demand.
+    ///
+    /// A CLI entry point as well as the BCC one because this is precisely the
+    /// action a coordinator asks for over the phone ("can you get me every
+    /// revision of that drawing"), and because it makes the feature testable
+    /// without Revit.
+    /// </summary>
+    private static async Task<int> History(string[] args)
+    {
+        if (args.Length < 3) return Help("--history needs a project id and a document id");
+        CompanionLog.EchoToConsole();
+
+        // Prefer a RUNNING Companion: it holds the connection and serialises
+        // against any sync already in flight. Fall back to doing it in-process so
+        // the command still works on a machine where the tray is not up.
+        if (await CompanionIpcClient.IsRunningAsync())
+        {
+            var ok = await CompanionIpcClient.DownloadHistoryAsync(args[1], args[2]);
+            Console.WriteLine(ok
+                ? "Requested — the running Companion is downloading it. See the log."
+                : "The Companion refused the request; see the log.");
+            return ok ? 0 : 1;
+        }
+
+        var settings = CompanionSettings.Load();
+        using var service = new CompanionService(settings);
+        Console.WriteLine(await service.DownloadHistoryAsync(args[1], args[2]));
         return 0;
     }
 

--- a/Planscape.Companion/Program.cs
+++ b/Planscape.Companion/Program.cs
@@ -173,6 +173,11 @@ internal static class Program
         foreach (var p in settings.Projects)
             Console.WriteLine($"   • {p.ProjectCode} ({p.ProjectId}) auto={p.AutoSync} last={p.LastSyncUtc?.ToString("O") ?? "never"} → {settings.FolderFor(p)}");
 
+        // The offline half is still worth exercising with no server configured:
+        // it proves the settings round-trip and the superseded purge on real files.
+        foreach (var p in settings.Projects)
+            SyncEngine.PurgeExpiredSuperseded(settings.FolderFor(p));
+
         if (string.IsNullOrWhiteSpace(settings.ServerUrl) || string.IsNullOrWhiteSpace(settings.AccessToken))
         {
             Console.WriteLine();

--- a/Planscape.Companion/Program.cs
+++ b/Planscape.Companion/Program.cs
@@ -42,6 +42,7 @@ internal static class Program
                 "--install-autostart" => InstallAutostart(),
                 "--uninstall-autostart" => UninstallAutostart(),
                 "--status" => PrintStatus(),
+                "--ping" => Ping().GetAwaiter().GetResult(),
                 "--diagnose" => Diagnose().GetAwaiter().GetResult(),
                 "--set-server" => SetServer(args),
                 "--set-token" => SetToken(args),
@@ -69,7 +70,8 @@ internal static class Program
 
               (no arguments)          run in the system tray
               --diagnose              connect + sync once, print the result, exit
-              --status                print the last recorded status
+              --status                print the last recorded status (from disk)
+              --ping                  ask a RUNNING Companion over the pipe
               --set-server <url>      e.g. http://localhost:5000
               --set-token <pat>       a personal access token from the web app
               --link <projectId> <code>   sync a project into <root>\<code>\
@@ -94,6 +96,35 @@ internal static class Program
     {
         var changed = AutoStart.Uninstall(out var detail);
         Console.WriteLine(changed ? "Autostart removed." : $"No change: {detail}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Talk to a running Companion over the pipe, using the SAME
+    /// <see cref="CompanionIpcClient"/> that StingTools/BCC uses — the file is
+    /// compiled into both. That makes this the headless proof of the plugin-side
+    /// client, and the first thing to run when BCC says sync is not available.
+    /// </summary>
+    private static async Task<int> Ping()
+    {
+        var running = await CompanionIpcClient.IsRunningAsync();
+        Console.WriteLine(@"pipe            : \\.\pipe\" + CompanionIpc.PipeName);
+        Console.WriteLine($"running         : {running}");
+        if (!running)
+        {
+            Console.WriteLine();
+            Console.WriteLine("No Companion answered. That is a normal answer, not an error —");
+            Console.WriteLine("start it with no arguments, or check it is not running as another user.");
+            return 1;
+        }
+
+        var st = await CompanionIpcClient.GetStatusAsync();
+        Console.WriteLine($"state           : {st.State}");
+        Console.WriteLine($"summary         : {st.Summary}");
+        Console.WriteLine($"needs attention : {st.NeedsAttention}");
+        Console.WriteLine($"linked projects : {st.LinkedProjects}");
+        Console.WriteLine($"last success    : {st.LastSuccessUtc?.ToString("O") ?? "never"}");
+        Console.WriteLine($"last error      : {st.LastError ?? "none"}");
         return 0;
     }
 

--- a/Planscape.Companion/SyncEngine.cs
+++ b/Planscape.Companion/SyncEngine.cs
@@ -1,0 +1,303 @@
+using System.Security.Cryptography;
+
+namespace Planscape.Companion;
+
+internal sealed record SyncOutcome(int Downloaded, int Skipped, int Superseded, int Failed)
+{
+    public override string ToString() =>
+        $"{Downloaded} downloaded, {Skipped} unchanged, {Superseded} superseded, {Failed} failed";
+}
+
+/// <summary>
+/// The download-and-place engine. <b>One code path, four triggers</b> — push,
+/// reconnect delta, initial link and manual all call
+/// <see cref="SyncProjectAsync"/>; only the <see cref="SyncTrigger"/> in the log
+/// line differs.
+///
+/// <para><b>There is no OS-level locking here, deliberately.</b> No
+/// <c>FileShare.None</c>, no lock files, nothing that treats the local
+/// filesystem as the record of who owns an edit. The CDE state machine on the
+/// server is that record. This is the specific mechanism that fails in Autodesk
+/// Desktop Connector — files stranded "checked out" after the local app closes,
+/// needing a manual unlock — and the design says in as many words not to
+/// reproduce it.</para>
+///
+/// <para>Non-WIP copies do get the <b>read-only file attribute</b>. That is a
+/// hint, not a lock: any user can clear it, nothing here fights them for it, and
+/// it is never consulted to decide anything. It exists so an Author who opens a
+/// PUBLISHED reference copy in Word is told, by Word, that this is not the file
+/// to edit.</para>
+/// </summary>
+internal sealed class SyncEngine
+{
+    private readonly PlanscapeApiClient _api;
+    private readonly CompanionSettings _settings;
+
+    /// <summary>
+    /// How long a superseded copy is kept. From the design: long enough that
+    /// someone who had the file open on Friday still finds it on Monday, short
+    /// enough that it cleans itself up without anyone managing it.
+    /// </summary>
+    public static readonly TimeSpan SupersededRetention = TimeSpan.FromDays(7);
+
+    private const string SupersededMarker = " (superseded ";
+
+    public SyncEngine(PlanscapeApiClient api, CompanionSettings settings)
+    {
+        _api = api;
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Sync one project. Pages through the delta until the server says there is
+    /// no more, then advances the project's high-water mark.
+    /// </summary>
+    public async Task<SyncOutcome> SyncProjectAsync(
+        LinkedProject project, SyncTrigger trigger, CancellationToken ct = default)
+    {
+        var folder = _settings.FolderFor(project);
+        Directory.CreateDirectory(folder);
+
+        // InitialLink means "everything currently visible", so `since` is
+        // deliberately dropped even if a stamp exists from a previous linking.
+        var since = trigger == SyncTrigger.InitialLink ? null : project.LastSyncUtc;
+        CompanionLog.Info(
+            $"sync {project.ProjectCode} ({trigger}) since={since?.ToString("O") ?? "(everything)"} → {folder}");
+
+        int downloaded = 0, skipped = 0, superseded = 0, failed = 0;
+        DateTime? newHighWater = null;
+
+        while (true)
+        {
+            var page = await _api.ChangedSinceAsync(project.ProjectId, since, ct);
+
+            foreach (var doc in page.Items)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    var result = await PlaceAsync(project, folder, doc, ct);
+                    if (result == PlaceResult.Downloaded) downloaded++;
+                    else if (result == PlaceResult.DownloadedOverSuperseded) { downloaded++; superseded++; }
+                    else skipped++;
+                }
+                catch (CompanionAuthException) { throw; }   // an auth failure ends the pass, not one file
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    // One bad document must not abandon the rest of the project.
+                    failed++;
+                    CompanionLog.Error($"could not sync '{doc.FileName}'", ex);
+                }
+            }
+
+            // The server's clock, never ours — see LinkedProject.LastSyncUtc.
+            newHighWater = page.ServerTimeUtc;
+
+            if (!page.HasMore) break;
+
+            // A full page means more is waiting. Continue from the last item's
+            // change time rather than the server clock, or the tail beyond this
+            // page is skipped.
+            var last = page.Items.LastOrDefault();
+            if (last == null) break;
+            since = last.ChangedAt;
+        }
+
+        superseded += PurgeExpiredSuperseded(folder);
+
+        // Only advance the mark once the pass finished. Advancing on a partial
+        // pass would mean a failure permanently skips whatever it failed on.
+        if (failed == 0 && newHighWater.HasValue)
+            project.LastSyncUtc = newHighWater;
+        else if (failed > 0)
+            CompanionLog.Warn(
+                $"{project.ProjectCode}: {failed} file(s) failed — not advancing the sync mark so they are retried");
+
+        var outcome = new SyncOutcome(downloaded, skipped, superseded, failed);
+        CompanionLog.Info($"sync {project.ProjectCode} done — {outcome}");
+        return outcome;
+    }
+
+    private enum PlaceResult { Downloaded, DownloadedOverSuperseded, Unchanged }
+
+    private async Task<PlaceResult> PlaceAsync(
+        LinkedProject project, string folder, RemoteDocument doc, CancellationToken ct)
+    {
+        // An unscanned or infected file is refused by the download endpoint (423).
+        // Skipping here keeps that out of the failure count, where it would look
+        // like a bug rather than the scanner simply not having run yet.
+        if (!string.IsNullOrEmpty(doc.ScanStatus)
+            && doc.ScanStatus is not ("CLEAN" or "SKIPPED"))
+        {
+            CompanionLog.Info($"skipping '{doc.FileName}' — scan status {doc.ScanStatus}");
+            return PlaceResult.Unchanged;
+        }
+
+        var target = Path.Combine(folder, SafeFileName(doc.FileName));
+
+        // Content-addressed skip. Comparing the server's hash against the bytes on
+        // disk means no local index to drift or corrupt: if the file already IS
+        // the file, there is nothing to do, whatever the timestamps say.
+        if (File.Exists(target) && !string.IsNullOrEmpty(doc.ContentHash)
+            && string.Equals(Sha256Of(target), doc.ContentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            ApplyReadOnlyHint(target, doc.CdeStatus);
+            return PlaceResult.Unchanged;
+        }
+
+        var supersededExisting = false;
+        if (File.Exists(target))
+        {
+            // The safety net. Something external (Acrobat, Word) may have this
+            // open; renaming rather than overwriting means their handle stays
+            // valid and the file does not vanish underneath them.
+            supersededExisting = SupersedeExisting(target);
+        }
+
+        // Download to a temp name in the same folder, then move into place, so a
+        // half-downloaded file is never visible under the real name — and so the
+        // move is same-volume and atomic.
+        var temp = target + ".part";
+        try
+        {
+            await _api.DownloadAsync(project.ProjectId, doc.Id, temp, ct);
+            ClearReadOnly(target);
+            File.Move(temp, target, overwrite: true);
+        }
+        finally
+        {
+            try { if (File.Exists(temp)) File.Delete(temp); } catch { /* best effort */ }
+        }
+
+        ApplyReadOnlyHint(target, doc.CdeStatus);
+        return supersededExisting ? PlaceResult.DownloadedOverSuperseded : PlaceResult.Downloaded;
+    }
+
+    /// <summary>
+    /// Rename the outgoing copy to <c>{Name} (superseded {yyyy-MM-dd}).{ext}</c>.
+    /// Returns false when there was nothing to rename or the rename failed — a
+    /// failure here must not stop the new revision from landing.
+    /// </summary>
+    private static bool SupersedeExisting(string target)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(target)!;
+            var stem = Path.GetFileNameWithoutExtension(target);
+            var ext = Path.GetExtension(target);
+            var stamped = $"{stem}{SupersededMarker}{DateTime.Now:yyyy-MM-dd}){ext}";
+            var dest = Path.Combine(dir, stamped);
+
+            // Two revisions superseded on the same day would collide on the name.
+            var n = 2;
+            while (File.Exists(dest))
+                dest = Path.Combine(dir, $"{stem}{SupersededMarker}{DateTime.Now:yyyy-MM-dd} #{n++}){ext}");
+
+            ClearReadOnly(target);
+            File.Move(target, dest);
+            CompanionLog.Info($"superseded → {Path.GetFileName(dest)}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Most likely cause: the file is genuinely locked by another process.
+            // Log it and let the caller overwrite — losing the safety net for one
+            // file is better than refusing to deliver the current revision.
+            CompanionLog.Warn($"could not rename the superseded copy of '{Path.GetFileName(target)}': {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Delete superseded copies older than <see cref="SupersededRetention"/>.
+    /// Called on every sync pass and at startup — an age check, not a scheduler,
+    /// which is all the design asks for.
+    /// </summary>
+    public static int PurgeExpiredSuperseded(string folder)
+    {
+        var purged = 0;
+        try
+        {
+            if (!Directory.Exists(folder)) return 0;
+            var cutoff = DateTime.UtcNow - SupersededRetention;
+            foreach (var file in Directory.EnumerateFiles(folder, "*" + SupersededMarker.TrimEnd() + "*"))
+            {
+                try
+                {
+                    // Match on the marker, never on age alone — a user's own file
+                    // that happens to be old must never be touched by this.
+                    if (!Path.GetFileName(file).Contains(SupersededMarker, StringComparison.Ordinal)) continue;
+                    if (File.GetLastWriteTimeUtc(file) >= cutoff) continue;
+                    ClearReadOnly(file);
+                    File.Delete(file);
+                    purged++;
+                    CompanionLog.Info($"purged expired superseded copy {Path.GetFileName(file)}");
+                }
+                catch (Exception ex)
+                {
+                    CompanionLog.Warn($"could not purge '{Path.GetFileName(file)}': {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"purge scan failed in {folder}: {ex.Message}");
+        }
+        return purged;
+    }
+
+    /// <summary>
+    /// Mark non-WIP copies read-only. A HINT — see the class remarks. WIP copies
+    /// are left writable because a WIP document checked out to this Author is the
+    /// working copy they are meant to edit.
+    /// </summary>
+    private static void ApplyReadOnlyHint(string path, string cdeStatus)
+    {
+        try
+        {
+            var isWorkingCopy = string.Equals(cdeStatus, "WIP", StringComparison.OrdinalIgnoreCase);
+            var attrs = File.GetAttributes(path);
+            File.SetAttributes(path, isWorkingCopy
+                ? attrs & ~FileAttributes.ReadOnly
+                : attrs | FileAttributes.ReadOnly);
+        }
+        catch (Exception ex)
+        {
+            // Cosmetic. Never fail a sync over an attribute.
+            CompanionLog.Warn($"could not set the read-only hint on '{Path.GetFileName(path)}': {ex.Message}");
+        }
+    }
+
+    private static void ClearReadOnly(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return;
+            var attrs = File.GetAttributes(path);
+            if (attrs.HasFlag(FileAttributes.ReadOnly))
+                File.SetAttributes(path, attrs & ~FileAttributes.ReadOnly);
+        }
+        catch (Exception) { /* the move/delete will report the real problem */ }
+    }
+
+    /// <summary>
+    /// A server-supplied file name lands in a local path, so strip separators and
+    /// invalid characters. Without this a document named <c>..\..\evil.exe</c>
+    /// writes outside the project folder.
+    /// </summary>
+    public static string SafeFileName(string fileName)
+    {
+        var name = Path.GetFileName(fileName ?? "");
+        if (string.IsNullOrWhiteSpace(name)) return "document";
+        foreach (var c in Path.GetInvalidFileNameChars()) name = name.Replace(c, '_');
+        return name;
+    }
+
+    public static string Sha256Of(string path)
+    {
+        using var sha = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
+    }
+}

--- a/Planscape.Companion/SyncEngine.cs
+++ b/Planscape.Companion/SyncEngine.cs
@@ -141,6 +141,69 @@ internal sealed class SyncEngine
         return outcome;
     }
 
+    /// <summary>
+    /// Slice E — pull EVERY stored version of one document into a
+    /// <c>_history\{document}\</c> subfolder.
+    ///
+    /// <para><b>Never automatic.</b> The design is explicit that full history is
+    /// an action a user takes deliberately per document, never a default that
+    /// silently grows on every machine — a drawing with forty revisions would
+    /// otherwise multiply a project folder by forty for nobody's benefit.</para>
+    ///
+    /// <para>History files are written read-only and are NOT superseded-renamed
+    /// or purged: they are already history, so there is nothing to protect them
+    /// from, and a user who asked for them should not find them expiring after a
+    /// week like a superseded copy does.</para>
+    /// </summary>
+    public async Task<string> DownloadHistoryAsync(
+        LinkedProject project, Guid documentId, CancellationToken ct = default)
+    {
+        var doc = await _api.GetDocumentAsync(project.ProjectId, documentId, ct);
+        if (doc == null)
+            return $"document {documentId} is not visible in {project.ProjectCode}";
+
+        var versions = await _api.ListVersionsAsync(project.ProjectId, documentId, ct);
+        if (versions.Count == 0)
+            return $"'{doc.FileName}' has no stored version history";
+
+        var stem = Path.GetFileNameWithoutExtension(SafeFileName(doc.FileName));
+        var ext = Path.GetExtension(SafeFileName(doc.FileName));
+        var folder = Path.Combine(_settings.FolderFor(project), "_history", SafeFileName(stem));
+        Directory.CreateDirectory(folder);
+
+        int written = 0, skipped = 0;
+        foreach (var v in versions.OrderBy(v => v.VersionNumber))
+        {
+            ct.ThrowIfCancellationRequested();
+            var target = Path.Combine(folder, $"{stem} v{v.VersionNumber:D3}{ext}");
+
+            // Content-addressed skip, same as the main path: asking for history
+            // twice must not re-download what is already correct on disk.
+            if (File.Exists(target) && !string.IsNullOrEmpty(v.ContentHash)
+                && string.Equals(Sha256Of(target), v.ContentHash, StringComparison.OrdinalIgnoreCase))
+            {
+                skipped++;
+                continue;
+            }
+
+            try
+            {
+                ClearReadOnly(target);
+                await _api.DownloadVersionAsync(project.ProjectId, documentId, v.VersionNumber, target, ct);
+                // Read-only because a historical file is by definition not the one
+                // to edit. A hint, like everywhere else — not a lock.
+                ApplyReadOnlyHint(target, cdeStatus: "ARCHIVE");
+                written++;
+            }
+            catch (Exception ex)
+            {
+                CompanionLog.Warn($"history v{v.VersionNumber} of '{doc.FileName}': {ex.Message}");
+            }
+        }
+
+        return $"'{doc.FileName}': {written} version(s) downloaded, {skipped} already present → {folder}";
+    }
+
     private enum PlaceResult { Downloaded, DownloadedOverSuperseded, Unchanged }
 
     private async Task<PlaceResult> PlaceAsync(
@@ -229,6 +292,50 @@ internal sealed class SyncEngine
             CompanionLog.Warn($"could not rename the superseded copy of '{Path.GetFileName(target)}': {ex.Message}");
             return false;
         }
+    }
+
+    /// <summary>
+    /// Slice E — the WIP working copies sitting on this machine for one project.
+    ///
+    /// <para>Derived from the file system rather than tracked in state: a working
+    /// copy is exactly a synced file that is NOT read-only, because that is the
+    /// distinction the sync engine writes (WIP stays writable, everything else
+    /// gets the read-only hint). Reading it back off disk means the count cannot
+    /// drift from reality, and it survives a Companion restart with no
+    /// bookkeeping.</para>
+    ///
+    /// <para><b>Naming caveat, stated because the tray says "checked out":</b> this
+    /// schema has no per-user checkout owner on a document, so this is really
+    /// "WIP documents visible to this account and synced here". With the ACL
+    /// narrowing currently inert (plan §4b) that is a wider set than "checked out
+    /// to me" would be. See the plan.</para>
+    /// </summary>
+    public static List<string> WorkingCopiesIn(string folder)
+    {
+        var found = new List<string>();
+        try
+        {
+            if (!Directory.Exists(folder)) return found;
+            foreach (var file in Directory.EnumerateFiles(folder))
+            {
+                var name = Path.GetFileName(file);
+                // History and superseded copies are never working copies, whatever
+                // their attributes say.
+                if (name.Contains(SupersededMarker, StringComparison.Ordinal)) continue;
+                if (name.EndsWith(".part", StringComparison.OrdinalIgnoreCase)) continue;
+                try
+                {
+                    if ((File.GetAttributes(file) & FileAttributes.ReadOnly) == 0) found.Add(name);
+                }
+                catch (Exception) { /* vanished mid-scan */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"working-copy scan failed in {folder}: {ex.Message}");
+        }
+        found.Sort(StringComparer.OrdinalIgnoreCase);
+        return found;
     }
 
     /// <summary>

--- a/Planscape.Companion/SyncEngine.cs
+++ b/Planscape.Companion/SyncEngine.cs
@@ -67,9 +67,31 @@ internal sealed class SyncEngine
         int downloaded = 0, skipped = 0, superseded = 0, failed = 0;
         DateTime? newHighWater = null;
 
+        var firstPage = true;
         while (true)
         {
             var page = await _api.ChangedSinceAsync(project.ProjectId, since, ct);
+
+            if (firstPage)
+            {
+                firstPage = false;
+                // Refresh the cached per-project toggle from the server, which is
+                // authoritative. Doing it here rather than only on a push means a
+                // Companion that was offline while someone turned auto-sync OFF
+                // honours it on the very first reconnect, instead of doing one
+                // more unwanted sync and only then noticing.
+                if (project.AutoSync != page.AutoSyncEnabled)
+                {
+                    project.AutoSync = page.AutoSyncEnabled;
+                    CompanionLog.Info(
+                        $"{project.ProjectCode}: auto-sync is now {(page.AutoSyncEnabled ? "on" : "off")} (from the server)");
+                }
+                if (!page.AutoSyncEnabled && trigger is SyncTrigger.Push or SyncTrigger.Reconnect)
+                {
+                    CompanionLog.Info($"{project.ProjectCode}: auto-sync off — stopping this {trigger} pass");
+                    return new SyncOutcome(0, 0, 0, 0);
+                }
+            }
 
             foreach (var doc in page.Items)
             {

--- a/Planscape.Companion/SyncHubClient.cs
+++ b/Planscape.Companion/SyncHubClient.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.SignalR.Client;
-using Newtonsoft.Json.Linq;
 
 namespace Planscape.Companion;
 
@@ -64,10 +63,15 @@ internal sealed class SyncHubClient : IAsyncDisposable
             .WithAutomaticReconnect(new BoundedBackoff())
             .Build();
 
-        _connection.On<JObject>("DocumentChanged", async payload =>
+        // A CONCRETE type, not a JObject. SignalR's default hub protocol is
+        // System.Text.Json, which cannot materialise a Newtonsoft JObject - the
+        // handler silently never fires, the connection stays up and healthy, and
+        // the only symptom is that pushes do nothing. This was found exactly that
+        // way: the server logged the push, the client logged nothing at all.
+        _connection.On<DocumentChangedPayload>("DocumentChanged", async payload =>
         {
-            var projectId = payload["projectId"]?.Value<string>();
-            var kind = payload["kind"]?.Value<string>() ?? "change";
+            var projectId = payload?.ProjectId;
+            var kind = payload?.Kind ?? "change";
             if (string.IsNullOrEmpty(projectId)) return;
             CompanionLog.Info($"push: {kind} on project {projectId}");
             try { await _onDocumentChanged(projectId); }
@@ -159,4 +163,18 @@ internal sealed class SyncHubClient : IAsyncDisposable
                 ? Ladder[ctx.PreviousRetryCount]
                 : TimeSpan.FromSeconds(60);
     }
+}
+
+/// <summary>
+/// Wire shape of <c>DocumentChanged</c> - mirrors <c>DocumentSyncHub.Payload</c>.
+/// Property names bind case-insensitively under SignalR's JSON protocol, so the
+/// server's camelCase maps onto these directly.
+/// </summary>
+internal sealed class DocumentChangedPayload
+{
+    public string? ProjectId { get; set; }
+    public string? DocumentId { get; set; }
+    public string? Kind { get; set; }
+    public string? CdeStatus { get; set; }
+    public DateTime? ChangedAtUtc { get; set; }
 }

--- a/Planscape.Companion/SyncHubClient.cs
+++ b/Planscape.Companion/SyncHubClient.cs
@@ -1,0 +1,162 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Newtonsoft.Json.Linq;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// The push half of the client: a SignalR connection to
+/// <c>/hubs/document-sync</c>.
+///
+/// Two behaviours carry the design's "push, with polling only as the reconnect
+/// fallback" rule:
+///
+/// <list type="number">
+/// <item>A <c>DocumentChanged</c> event triggers the same sync routine every
+/// other trigger uses. The event is a nudge, not data — it carries no file
+/// content, and the Companion answers it by calling <c>changed-since</c>, which
+/// re-applies the caller's ACL server-side.</item>
+/// <item><b>On every (re)connect, sync immediately.</b> This is the whole point
+/// of the fallback: while the connection was down, pushes were missed, and
+/// nothing will ever resend them. Reconnecting without a delta sweep leaves the
+/// machine quietly stale until the next unrelated change happens to fire.</item>
+/// </list>
+/// </summary>
+internal sealed class SyncHubClient : IAsyncDisposable
+{
+    private readonly string _baseUrl;
+    private readonly Func<CancellationToken, Task<string>> _tokenFactory;
+    private readonly Func<string, Task> _onDocumentChanged;
+    private readonly Func<Task> _onConnected;
+    private readonly Action<bool> _onConnectionStateChanged;
+    private HubConnection? _connection;
+
+    public SyncHubClient(
+        string baseUrl,
+        Func<CancellationToken, Task<string>> tokenFactory,
+        Func<string, Task> onDocumentChanged,
+        Func<Task> onConnected,
+        Action<bool> onConnectionStateChanged)
+    {
+        _baseUrl = baseUrl.TrimEnd('/');
+        _tokenFactory = tokenFactory;
+        _onDocumentChanged = onDocumentChanged;
+        _onConnected = onConnected;
+        _onConnectionStateChanged = onConnectionStateChanged;
+    }
+
+    public bool IsConnected => _connection?.State == HubConnectionState.Connected;
+
+    public async Task StartAsync(IEnumerable<string> projectIds, CancellationToken ct)
+    {
+        _connection = new HubConnectionBuilder()
+            .WithUrl($"{_baseUrl}/hubs/document-sync", options =>
+            {
+                // Re-read per connection attempt so a reconnect after a long
+                // offline stretch picks up a freshly exchanged JWT rather than
+                // replaying an expired one forever.
+                options.AccessTokenProvider = async () => await _tokenFactory(CancellationToken.None);
+            })
+            // Explicit ladder rather than WithAutomaticReconnect()'s default
+            // (0s, 2s, 10s, 30s, then GIVE UP). A closed laptop is offline for
+            // hours; a client that stops trying after 30 seconds is a client that
+            // never syncs again until the user restarts it. `null` at the end of
+            // the delegate would mean stop, so this one never returns null.
+            .WithAutomaticReconnect(new BoundedBackoff())
+            .Build();
+
+        _connection.On<JObject>("DocumentChanged", async payload =>
+        {
+            var projectId = payload["projectId"]?.Value<string>();
+            var kind = payload["kind"]?.Value<string>() ?? "change";
+            if (string.IsNullOrEmpty(projectId)) return;
+            CompanionLog.Info($"push: {kind} on project {projectId}");
+            try { await _onDocumentChanged(projectId); }
+            catch (Exception ex) { CompanionLog.Error("push-triggered sync failed", ex); }
+        });
+
+        _connection.Reconnecting += _ =>
+        {
+            _onConnectionStateChanged(false);
+            CompanionLog.Warn("hub connection lost; reconnecting");
+            return Task.CompletedTask;
+        };
+
+        _connection.Reconnected += async _ =>
+        {
+            CompanionLog.Info("hub reconnected; running catch-up delta");
+            _onConnectionStateChanged(true);
+            await RejoinAsync(projectIds);
+            // The reconnect fallback. Without this the missed pushes are simply lost.
+            await _onConnected();
+        };
+
+        _connection.Closed += async error =>
+        {
+            _onConnectionStateChanged(false);
+            CompanionLog.Warn($"hub closed: {error?.Message ?? "no error"}");
+            await Task.CompletedTask;
+        };
+
+        await _connection.StartAsync(ct);
+        _onConnectionStateChanged(true);
+        CompanionLog.Info($"hub connected to {_baseUrl}/hubs/document-sync");
+        await RejoinAsync(projectIds);
+        await _onConnected();
+    }
+
+    /// <summary>
+    /// Group membership does NOT survive a reconnect — SignalR gives the client a
+    /// new connection id and the server's groups are keyed on it. Re-joining is
+    /// mandatory, and forgetting it is the classic silent SignalR bug: everything
+    /// looks connected and no events ever arrive.
+    /// </summary>
+    private async Task RejoinAsync(IEnumerable<string> projectIds)
+    {
+        if (_connection == null) return;
+        foreach (var id in projectIds)
+        {
+            try
+            {
+                await _connection.InvokeAsync("JoinProject", id);
+                CompanionLog.Info($"joined project group {id}");
+            }
+            catch (Exception ex)
+            {
+                CompanionLog.Warn($"could not join project {id}: {ex.Message}");
+            }
+        }
+    }
+
+    public async Task JoinAsync(string projectId)
+    {
+        if (_connection?.State == HubConnectionState.Connected)
+            await _connection.InvokeAsync("JoinProject", projectId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection != null) await _connection.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Backoff that never gives up: 0s, 2s, 5s, 10s, 30s, then every 60s forever.
+    /// A laptop shut for the weekend must find its way back on Monday without
+    /// anyone restarting anything.
+    /// </summary>
+    private sealed class BoundedBackoff : IRetryPolicy
+    {
+        private static readonly TimeSpan[] Ladder =
+        {
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(30),
+        };
+
+        public TimeSpan? NextRetryDelay(RetryContext ctx) =>
+            ctx.PreviousRetryCount < Ladder.Length
+                ? Ladder[ctx.PreviousRetryCount]
+                : TimeSpan.FromSeconds(60);
+    }
+}

--- a/Planscape.Companion/SyncHubClient.cs
+++ b/Planscape.Companion/SyncHubClient.cs
@@ -24,7 +24,7 @@ internal sealed class SyncHubClient : IAsyncDisposable
 {
     private readonly string _baseUrl;
     private readonly Func<CancellationToken, Task<string>> _tokenFactory;
-    private readonly Func<string, Task> _onDocumentChanged;
+    private readonly Func<string, bool, Task> _onDocumentChanged;
     private readonly Func<Task> _onConnected;
     private readonly Action<bool> _onConnectionStateChanged;
     private HubConnection? _connection;
@@ -32,7 +32,7 @@ internal sealed class SyncHubClient : IAsyncDisposable
     public SyncHubClient(
         string baseUrl,
         Func<CancellationToken, Task<string>> tokenFactory,
-        Func<string, Task> onDocumentChanged,
+        Func<string, bool, Task> onDocumentChanged,
         Func<Task> onConnected,
         Action<bool> onConnectionStateChanged)
     {
@@ -73,8 +73,9 @@ internal sealed class SyncHubClient : IAsyncDisposable
             var projectId = payload?.ProjectId;
             var kind = payload?.Kind ?? "change";
             if (string.IsNullOrEmpty(projectId)) return;
-            CompanionLog.Info($"push: {kind} on project {projectId}");
-            try { await _onDocumentChanged(projectId); }
+            var autoSync = payload?.AutoSyncEnabled ?? true;
+            CompanionLog.Info($"push: {kind} on project {projectId} (auto-sync {(autoSync ? "on" : "off")})");
+            try { await _onDocumentChanged(projectId, autoSync); }
             catch (Exception ex) { CompanionLog.Error("push-triggered sync failed", ex); }
         });
 
@@ -176,5 +177,17 @@ internal sealed class DocumentChangedPayload
     public string? DocumentId { get; set; }
     public string? Kind { get; set; }
     public string? CdeStatus { get; set; }
+
+    /// <summary>
+    /// The project's "Auto-sync this project" flag as the server sees it, sent
+    /// with the notification so the Companion can decide whether it may act
+    /// without first calling the API to ask.
+    ///
+    /// Nullable, and a null is treated as TRUE by the caller: an older server
+    /// that does not send the field must not be read as "auto-sync off", which
+    /// would silently stop syncing for everyone on that deployment.
+    /// </summary>
+    public bool? AutoSyncEnabled { get; set; }
+
     public DateTime? ChangedAtUtc { get; set; }
 }

--- a/Planscape.Companion/SyncStatus.cs
+++ b/Planscape.Companion/SyncStatus.cs
@@ -40,6 +40,20 @@ internal sealed class SyncStatus
     public int LinkedProjects { get; set; }
     public int FilesLastSync { get; set; }
 
+    /// <summary>
+    /// Slice E — WIP working copies on this machine, across every linked project.
+    /// Recomputed from disk after each sync pass (see SyncEngine.WorkingCopiesIn),
+    /// so it cannot drift from what is actually there.
+    /// </summary>
+    public int CheckedOutCount { get; set; }
+
+    /// <summary>
+    /// The file names behind <see cref="CheckedOutCount"/>, for the tray's
+    /// click-to-expand list. Capped when stored — the tray shows a short list,
+    /// not a file manager.
+    /// </summary>
+    public List<string> CheckedOut { get; set; } = new();
+
     /// <summary>Set when the app starts, so a stale status file is recognisable.</summary>
     public DateTime StartedUtc { get; set; } = DateTime.UtcNow;
 
@@ -94,16 +108,28 @@ internal sealed class SyncStatus
 
     /// <summary>One line for the tray tooltip. Kept under the 63-character limit
     /// Windows silently truncates NotifyIcon.Text at.</summary>
-    public string Summary() => State switch
+    public string Summary()
     {
-        SyncState.Syncing => "Planscape — syncing…",
-        SyncState.Idle => LastSuccessUtc.HasValue
-            ? $"Planscape — synced {LastSuccessUtc.Value.ToLocalTime():HH:mm}"
-            : "Planscape — connected",
-        SyncState.Offline => "Planscape — offline, will retry",
-        SyncState.Error => $"Planscape — {Truncate(LastError ?? "sync failed", 40)}",
-        _ => "Planscape",
-    };
+        // The checked-out count is the at-a-glance number the design asks the
+        // tray to carry, so it rides on every non-error state. It is deliberately
+        // dropped from the Error text: when something needs fixing, the failure
+        // is the message, and a count competing with it costs the one line
+        // Windows gives a tooltip.
+        var checkedOut = CheckedOutCount > 0 ? $" · {CheckedOutCount} checked out" : "";
+        return State switch
+        {
+            SyncState.Syncing => "Planscape — syncing…" + checkedOut,
+            SyncState.Idle => (LastSuccessUtc.HasValue
+                ? $"Planscape — synced {LastSuccessUtc.Value.ToLocalTime():HH:mm}"
+                : "Planscape — connected") + checkedOut,
+            // Offline says "will retry" on purpose: it is expected and
+            // self-healing, and the wording is what stops a user treating a
+            // closed laptop as a fault (plan §1c).
+            SyncState.Offline => "Planscape — offline, will retry" + checkedOut,
+            SyncState.Error => $"Planscape — {Truncate(LastError ?? "sync failed", 40)}",
+            _ => "Planscape",
+        };
+    }
 
     private static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "…";
 }

--- a/Planscape.Companion/SyncStatus.cs
+++ b/Planscape.Companion/SyncStatus.cs
@@ -1,0 +1,109 @@
+using Newtonsoft.Json;
+
+namespace Planscape.Companion;
+
+/// <summary>
+/// What the Companion is doing, and whether anyone needs to care.
+///
+/// The distinction that carries the whole error-visibility decision (plan §1c):
+/// <b>Offline is not an error.</b> A closed laptop, a dropped VPN and a
+/// restarting server all produce a failed sync, all resolve themselves on
+/// reconnect, and all happen constantly. Treating them as errors — a red icon, a
+/// toast — trains the user to ignore the indicator, and then a genuinely broken
+/// sync goes unnoticed too.
+///
+/// So only <see cref="SyncState.Error"/> (auth rejected, folder unwritable, disk
+/// full) changes the tray icon. Offline is a quiet, muted state.
+/// </summary>
+internal enum SyncState
+{
+    /// <summary>Connected, nothing to do.</summary>
+    Idle,
+
+    /// <summary>A sync pass is running right now.</summary>
+    Syncing,
+
+    /// <summary>Cannot reach the server. Expected, self-healing, quiet.</summary>
+    Offline,
+
+    /// <summary>Something a human has to fix. This is the one that shouts.</summary>
+    Error,
+}
+
+internal sealed class SyncStatus
+{
+    public SyncState State { get; set; } = SyncState.Offline;
+    public DateTime? LastSuccessUtc { get; set; }
+    public string? LastError { get; set; }
+    public DateTime? LastErrorUtc { get; set; }
+    public int ConsecutiveFailures { get; set; }
+    public int LinkedProjects { get; set; }
+    public int FilesLastSync { get; set; }
+
+    /// <summary>Set when the app starts, so a stale status file is recognisable.</summary>
+    public DateTime StartedUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Separate from the settings file: this is written on every state
+    /// change, that one is written rarely. One file for both would mean a
+    /// high-frequency writer racing the record of which projects are linked.</summary>
+    public static string StatusPath => Path.Combine(CompanionSettings.SettingsDir, "companion_status.json");
+
+    /// <summary>
+    /// Persisted so a failure at 17:00 is still visible at 09:00 the next day,
+    /// even though the Companion restarted at login in between. An error a user
+    /// never saw is an error that never got fixed.
+    /// </summary>
+    public void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(CompanionSettings.SettingsDir);
+            var tmp = StatusPath + ".tmp";
+            File.WriteAllText(tmp, JsonConvert.SerializeObject(this, Formatting.Indented));
+            File.Move(tmp, StatusPath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"could not save status: {ex.Message}");
+        }
+    }
+
+    public static SyncStatus Load()
+    {
+        try
+        {
+            if (File.Exists(StatusPath))
+            {
+                var loaded = JsonConvert.DeserializeObject<SyncStatus>(File.ReadAllText(StatusPath));
+                if (loaded != null)
+                {
+                    // The previous run's live state is meaningless now; its
+                    // FAILURE record is not, so that part carries over.
+                    loaded.State = SyncState.Offline;
+                    loaded.StartedUtc = DateTime.UtcNow;
+                    return loaded;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            CompanionLog.Warn($"could not read status: {ex.Message}");
+        }
+        return new SyncStatus();
+    }
+
+    /// <summary>One line for the tray tooltip. Kept under the 63-character limit
+    /// Windows silently truncates NotifyIcon.Text at.</summary>
+    public string Summary() => State switch
+    {
+        SyncState.Syncing => "Planscape — syncing…",
+        SyncState.Idle => LastSuccessUtc.HasValue
+            ? $"Planscape — synced {LastSuccessUtc.Value.ToLocalTime():HH:mm}"
+            : "Planscape — connected",
+        SyncState.Offline => "Planscape — offline, will retry",
+        SyncState.Error => $"Planscape — {Truncate(LastError ?? "sync failed", 40)}",
+        _ => "Planscape",
+    };
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..(max - 1)] + "…";
+}

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
@@ -114,8 +114,12 @@ public class DocumentRevisionsController : ControllerBase
         // After the commit, for the same reason as the CDE transition path: a
         // Companion answers a push by re-reading, and a push sent first races it.
         if (_syncHub != null)
+        {
+            var autoSync = await _db.Projects.Where(p => p.Id == projectId)
+                .Select(p => p.DocumentSyncAutoEnabled).FirstOrDefaultAsync(ct);
             await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
-                DocumentSyncHub.Payload(projectId, documentId, "revision", doc.CdeStatus));
+                DocumentSyncHub.Payload(projectId, documentId, "revision", doc.CdeStatus, autoSync));
+        }
 
         return CreatedAtAction(nameof(List), new { projectId, documentId },
             new { rev.Id, rev.Revision, rev.CdeStateAtRevision, rev.CreatedAt });

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Planscape.API.Authorization;
 using Planscape.API.Services;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.SignalR;
 
 namespace Planscape.API.Controllers;
 
@@ -29,10 +31,14 @@ public class DocumentRevisionsController : ControllerBase
     private readonly PlanscapeDbContext _db;
     private readonly ITenantContext _tenant;
     private readonly IAuditService _audit;
+    // Optional — a null just means no Companion is told and the change is picked
+    // up by the next reconnect delta instead.
+    private readonly IHubContext<DocumentSyncHub>? _syncHub;
 
-    public DocumentRevisionsController(PlanscapeDbContext db, ITenantContext tenant, IAuditService audit)
+    public DocumentRevisionsController(PlanscapeDbContext db, ITenantContext tenant, IAuditService audit,
+        IHubContext<DocumentSyncHub>? syncHub = null)
     {
-        _db = db; _tenant = tenant; _audit = audit;
+        _db = db; _tenant = tenant; _audit = audit; _syncHub = syncHub;
     }
 
     /// <summary>List revisions for a document, newest first.</summary>
@@ -89,14 +95,27 @@ public class DocumentRevisionsController : ControllerBase
 
         // Bump the document's revision label if the caller asked for a new one.
         if (!string.IsNullOrWhiteSpace(req.Revision) && req.Revision != doc.Revision)
-        {
             doc.Revision = req.Revision!;
-            doc.UpdatedAt = DateTime.UtcNow;
-        }
+
+        // UpdatedAt moves for EVERY minted revision, not only a relabelled one.
+        //
+        // Document sync's delta query keys on UpdatedAt. Previously a manual
+        // revision that reused the existing label left UpdatedAt untouched, so a
+        // Companion would receive the push below, call changed-since, get an empty
+        // result and do nothing — the push and the delta disagreeing about whether
+        // anything happened. That silent inconsistency is worse than the timestamp
+        // being slightly more eager: minting a revision IS a change to the record.
+        doc.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(ct);
         await _audit.LogAsync("CREATE", "DocumentRevision", rev.Id.ToString(),
             System.Text.Json.JsonSerializer.Serialize(new { rev.Revision, rev.Source }));
+
+        // After the commit, for the same reason as the CDE transition path: a
+        // Companion answers a push by re-reading, and a push sent first races it.
+        if (_syncHub != null)
+            await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
+                DocumentSyncHub.Payload(projectId, documentId, "revision", doc.CdeStatus));
 
         return CreatedAtAction(nameof(List), new { projectId, documentId },
             new { rev.Id, rev.Revision, rev.CdeStateAtRevision, rev.CreatedAt });

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -933,8 +933,10 @@ public class DocumentsController : ControllerBase
         // read and return the pre-transition row.
         if (_syncHub != null)
         {
+            var autoSync = await _db.Projects.Where(p => p.Id == projectId)
+                .Select(p => p.DocumentSyncAutoEnabled).FirstOrDefaultAsync();
             await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
-                DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus));
+                DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus, autoSync));
             _logger.LogInformation("DocumentSync push sent for {DocumentId} on {ProjectId}", doc.Id, projectId);
         }
         else
@@ -1020,10 +1022,17 @@ public class DocumentsController : ControllerBase
             })
             .ToListAsync();
 
+        // The project's auto-sync flag rides along on every delta so a Companion
+        // that reconnects after an offline stretch learns the current setting in
+        // the same call it uses to catch up, rather than needing a second one.
+        var autoSyncEnabled = await _db.Projects.Where(p => p.Id == projectId)
+            .Select(p => p.DocumentSyncAutoEnabled).FirstOrDefaultAsync();
+
         return Ok(new
         {
             items = docs,
             count = docs.Count,
+            autoSyncEnabled,
             // True when the page was filled exactly — the caller should immediately
             // re-query with since = the last item's changedAt rather than assume it
             // has caught up. Without this a project with more than `limit` changes

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -80,6 +80,10 @@ public class DocumentsController : ControllerBase
     private readonly IHubContext<NotificationHub> _hub;
     private readonly IPushNotificationService _push;
     private readonly Planscape.Infrastructure.Services.OutboundWebhookDispatcher? _webhooks;
+    // Document sync push. Optional so every existing construction site (and the
+    // test factory) keeps working without knowing about it; a null just means no
+    // Companion gets told, which degrades to the reconnect-delta path.
+    private readonly IHubContext<DocumentSyncHub>? _syncHub;
 
     // Max file size: 100 MB
     private const long MaxFileSize = 100 * 1024 * 1024;
@@ -94,7 +98,8 @@ public class DocumentsController : ControllerBase
         IAuditService audit,
         IHubContext<NotificationHub> hub,
         IPushNotificationService push,
-        Planscape.Infrastructure.Services.OutboundWebhookDispatcher? webhooks = null)
+        Planscape.Infrastructure.Services.OutboundWebhookDispatcher? webhooks = null,
+        IHubContext<DocumentSyncHub>? syncHub = null)
     {
         _db = db;
         _storage = storage!;
@@ -105,6 +110,7 @@ public class DocumentsController : ControllerBase
         _hub = hub;
         _push = push;
         _webhooks = webhooks;
+        _syncHub = syncHub;
     }
 
     /// <summary>
@@ -921,7 +927,102 @@ public class DocumentsController : ControllerBase
             transitionedAt = doc.UpdatedAt
         });
 
+        // Document sync — tell every Companion on this project that something
+        // moved. Deliberately after SaveChangesAsync: a Companion answers this by
+        // calling changed-since, and a push sent before the commit would race the
+        // read and return the pre-transition row.
+        if (_syncHub != null)
+            await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
+                DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus));
+
         return Ok(doc);
+    }
+
+    /// <summary>
+    /// Delta feed for the Planscape Companion's local-disk sync — the reconnect
+    /// fallback and the initial-link path from
+    /// <c>docs/superpowers/specs/2026-07-31-document-sync-design.md</c>.
+    ///
+    /// <para><paramref name="since"/> omitted means "everything currently
+    /// visible", which is the initial-sync case. Supplied, it means "what changed
+    /// after this instant" — a delta, never a full re-scan.</para>
+    ///
+    /// <para>Three properties this endpoint must keep, because sync is a
+    /// long-lived background copy of whatever it returns:</para>
+    /// <list type="number">
+    /// <item><b>Never wider than the documents list.</b> The same
+    /// <see cref="ProjectMemberAcl"/> narrowing runs here. A caller whose
+    /// <c>AllowedCdeStates</c> excludes PUBLISHED must not receive published
+    /// documents on disk when they cannot see them in the UI.</item>
+    /// <item><b>Latest revision only.</b> Metadata for the current state of each
+    /// document, not its history — full history is a deliberate per-document
+    /// action, never something that silently grows on every machine.</item>
+    /// <item><b>Ordered by change time, and it returns the server's clock.</b> The
+    /// caller stores <c>serverTimeUtc</c> as its next <c>since</c> rather than its
+    /// own clock, so a machine whose clock runs fast cannot skip documents by
+    /// asking for changes since an instant that has not happened yet.</item>
+    /// </list>
+    /// </summary>
+    [HttpGet("changed-since")]
+    public async Task<ActionResult> ChangedSince(Guid projectId, [FromQuery] DateTime? since = null,
+        [FromQuery] int limit = 500)
+    {
+        var tenantId = GetTenantId();
+        // Captured BEFORE the query so a document written while this request is in
+        // flight is caught by the NEXT call rather than falling in the gap between
+        // the query and the timestamp the caller stores.
+        var serverTimeUtc = DateTime.UtcNow;
+
+        limit = Math.Clamp(limit, 1, 2000);
+
+        var query = _db.Documents
+            .Where(d => d.ProjectId == projectId && d.Project!.TenantId == tenantId);
+
+        if (since.HasValue)
+        {
+            // Model-bound DateTimes arrive as Unspecified/Local depending on the
+            // format; normalising to UTC keeps the comparison honest against
+            // UpdatedAt/UploadedAt, which are always UTC.
+            var sinceUtc = since.Value.Kind == DateTimeKind.Utc
+                ? since.Value
+                : since.Value.ToUniversalTime();
+            query = query.Where(d => (d.UpdatedAt ?? d.UploadedAt) > sinceUtc);
+        }
+
+        var acl = await ProjectMemberAcl.ResolveAsync(_db, projectId, User);
+        query = ProjectMemberAcl.ApplyTo(query, acl);
+
+        var docs = await query
+            .OrderBy(d => d.UpdatedAt ?? d.UploadedAt)
+            .Take(limit)
+            .Select(d => new
+            {
+                d.Id,
+                d.FileName,
+                d.DocumentType,
+                d.CdeStatus,
+                d.SuitabilityCode,
+                d.Revision,
+                d.Discipline,
+                d.FileSizeBytes,
+                d.ContentHash,
+                d.ScanStatus,
+                changedAt = d.UpdatedAt ?? d.UploadedAt,
+            })
+            .ToListAsync();
+
+        return Ok(new
+        {
+            items = docs,
+            count = docs.Count,
+            // True when the page was filled exactly — the caller should immediately
+            // re-query with since = the last item's changedAt rather than assume it
+            // has caught up. Without this a project with more than `limit` changes
+            // since the last sync would silently lose the tail.
+            hasMore = docs.Count == limit,
+            serverTimeUtc,
+            since,
+        });
     }
 
     [HttpGet("{docId}/history")]

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -932,8 +932,17 @@ public class DocumentsController : ControllerBase
         // calling changed-since, and a push sent before the commit would race the
         // read and return the pre-transition row.
         if (_syncHub != null)
+        {
             await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
                 DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus));
+            _logger.LogInformation("DocumentSync push sent for {DocumentId} on {ProjectId}", doc.Id, projectId);
+        }
+        else
+        {
+            // Not fatal - the Companion catches up on its next reconnect delta -
+            // but it means the push path is silently dead, which is worth knowing.
+            _logger.LogWarning("DocumentSync hub context unavailable; no push sent for {DocumentId}", doc.Id);
+        }
 
         return Ok(doc);
     }

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
@@ -40,7 +40,7 @@ public class ProjectsController : ControllerBase
                 p.CompliancePercent, p.RagStatus, p.TotalElements, p.TaggedElements,
                 p.LastSyncAt, p.CreatedAt,
                 p.Latitude, p.Longitude, p.City, p.Country,
-                p.CoverImageUrl, p.IsPinned,
+                p.CoverImageUrl, p.IsPinned, p.DocumentSyncAutoEnabled,
                 MemberCount = _db.ProjectMembers
                     .Count(m => m.ProjectId == p.Id && m.IsActive),
                 // The projects grid shows an open-issue count per row. Without
@@ -94,7 +94,8 @@ public class ProjectsController : ControllerBase
         return Ok(new
         {
             project.Id, project.Name, project.Code, project.Description, project.Phase,
-            project.Status, project.TagSeparator, project.SeqNumPad,
+            project.Status, project.DocumentSyncAutoEnabled,
+            project.TagSeparator, project.SeqNumPad,
             project.TagPrefix, project.TagSuffix, project.ConfigJson,
             project.CompliancePercent, project.ContainerCompliancePercent,
             project.RagStatus, project.TotalElements, project.TaggedElements,
@@ -210,6 +211,8 @@ public class ProjectsController : ControllerBase
         if (req.TagPrefix != null) project.TagPrefix = req.TagPrefix;
         if (req.TagSuffix != null) project.TagSuffix = req.TagSuffix;
         if (req.ConfigJson != null) project.ConfigJson = req.ConfigJson;
+        if (req.DocumentSyncAutoEnabled.HasValue)
+            project.DocumentSyncAutoEnabled = req.DocumentSyncAutoEnabled.Value;
 
         await _db.SaveChangesAsync();
         return Ok(project);
@@ -348,4 +351,7 @@ public record CreateProjectRequest(string Name, string? Code, string? Descriptio
 public record UpdateProjectRequest(
     string? Name, string? Description, string? Phase, ProjectStatus? Status,
     string? TagSeparator, int? SeqNumPad, string? TagPrefix, string? TagSuffix,
-    string? ConfigJson);
+    string? ConfigJson,
+    // Document sync — "Auto-sync this project". Nullable so an existing caller
+    // that omits it leaves the flag alone, same as every other field here.
+    bool? DocumentSyncAutoEnabled = null);

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
@@ -42,7 +42,13 @@ public class ProjectsController : ControllerBase
                 p.Latitude, p.Longitude, p.City, p.Country,
                 p.CoverImageUrl, p.IsPinned,
                 MemberCount = _db.ProjectMembers
-                    .Count(m => m.ProjectId == p.Id && m.IsActive)
+                    .Count(m => m.ProjectId == p.Id && m.IsActive),
+                // The projects grid shows an open-issue count per row. Without
+                // it here the web app would have to call {id}/dashboard once per
+                // project — an N+1 for a single integer. Same predicate the
+                // dashboard's OpenIssues uses, so the two agree.
+                OpenIssueCount = _db.Issues
+                    .Count(i => i.ProjectId == p.Id && i.Status != "CLOSED")
             })
             .OrderByDescending(p => p.IsPinned)
             .ThenByDescending(p => p.LastSyncAt)

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1886,6 +1886,9 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"Country\" text",
         "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"CoverImageUrl\" text",
         "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"IsPinned\" boolean NOT NULL DEFAULT false",
+        // Document sync — per-project auto/manual toggle (design §Flexibility).
+        // Default true so existing projects keep the on-by-default behaviour.
+        "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"DocumentSyncAutoEnabled\" boolean NOT NULL DEFAULT true",
         // N2 — LiveKit Egress meeting recordings (table not covered by the discovered
         // EF migration set; idempotent CREATE so the running dev/container DB gets it).
         "CREATE TABLE IF NOT EXISTS \"MeetingRecordings\" (" +

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1489,6 +1489,9 @@ app.MapHub<Planscape.Infrastructure.SignalR.FederatedModelHub>("/hubs/model");
 app.MapHub<Planscape.Infrastructure.SignalR.PlatformEventHub>("/hubs/events");
 app.MapHub<Planscape.Infrastructure.SignalR.MeetingHub>("/hubs/meeting");
 app.MapHub<Planscape.Infrastructure.SignalR.TwinHub>("/hubs/twin");
+// Document sync — push half of the Planscape Companion's local-disk sync.
+// See docs/superpowers/specs/2026-07-31-document-sync-design.md.
+app.MapHub<Planscape.Infrastructure.SignalR.DocumentSyncHub>("/hubs/document-sync");
 
 // ── Database schema + seed ──
 {

--- a/Planscape.Server/src/Planscape.Core/Entities/Project.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Project.cs
@@ -62,6 +62,20 @@ public class Project : ITenantScoped
     public string? CoverImageUrl { get; set; }
     public bool IsPinned { get; set; } = false;
 
+    /// <summary>
+    /// Document sync — "Auto-sync this project" (design §Flexibility). On by
+    /// default, one toggle per PROJECT rather than per document (too fine-grained
+    /// to manage day to day) and not per member (the design calls it a project
+    /// setting, so one coordinator turning it off turns it off for the project's
+    /// machines, not just their own).
+    ///
+    /// Off does NOT unlink anything: a Planscape Companion still knows the
+    /// project and still syncs on an explicit "Sync now". The flag gates only
+    /// whether the automatic triggers — the SignalR push and the reconnect delta —
+    /// are allowed to fire on their own.
+    /// </summary>
+    public bool DocumentSyncAutoEnabled { get; set; } = true;
+
     // Compliance metrics (cached)
     public double CompliancePercent { get; set; }
     public double ContainerCompliancePercent { get; set; }

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.SignalR;
+
+/// <summary>
+/// Document sync — the push half of the local-disk sync pipeline described in
+/// <c>docs/superpowers/specs/2026-07-31-document-sync-design.md</c>.
+///
+/// Tells every Planscape Companion connected for a project that a document
+/// changed, the moment a coordinator transitions its CDE state or mints a new
+/// revision. Polling exists only as the reconnect fallback
+/// (<c>GET /api/projects/{id}/documents/changed-since</c>) — this hub is the
+/// normal path.
+///
+/// <para><b>Why a separate hub rather than reusing NotificationHub.</b> That hub
+/// already carries a <c>DocumentUpdated</c> event, but scoped to
+/// <c>project-{id}-cde-{state}</c> groups a web client joins per CDE state it is
+/// looking at. A Companion does not have a "state it is looking at" — it wants
+/// everything the user is allowed to see, for the whole session, across the
+/// project. Bending the existing groups to that shape would make a UI-driven
+/// subscription model serve a background daemon, and both would get worse.</para>
+///
+/// <para><b>The payload is deliberately a notification, not the data.</b> It says
+/// "something about document X changed" and nothing about file contents or
+/// permissions. The Companion answers by calling <c>changed-since</c>, which
+/// re-runs the caller's own ACL server-side. That way a push can never be the
+/// thing that widens what a client sees — the hub group is scoped per project,
+/// but per-user CDE/discipline/suitability narrowing lives in one place
+/// (<c>ProjectMemberAcl</c>) and stays there.</para>
+///
+/// Client usage (Planscape.Companion):
+///   conn.On&lt;object&gt;("DocumentChanged", _ =&gt; queue.RequestSync(projectId));
+///   await conn.InvokeAsync("JoinProject", projectId);
+/// </summary>
+[Authorize]
+public class DocumentSyncHub : Hub
+{
+    private const string AuthKey = "docsync_projects";
+    private readonly PlanscapeDbContext _db;
+
+    public DocumentSyncHub(PlanscapeDbContext db) => _db = db;
+
+    internal static string Group(Guid projectId) => $"docsync:{projectId}";
+
+    /// <summary>
+    /// Projects this connection passed the tenant check for. Cached per-connection
+    /// so a reconnect storm doesn't become a DB hit per message — same reasoning
+    /// as <see cref="MeetingHub"/>'s authorised-session set.
+    /// </summary>
+    private HashSet<Guid> Authorized =>
+        Context.Items.TryGetValue(AuthKey, out var v) && v is HashSet<Guid> set
+            ? set
+            : (HashSet<Guid>)(Context.Items[AuthKey] = new HashSet<Guid>());
+
+    /// <summary>
+    /// Subscribe to a project's document changes.
+    ///
+    /// Gated by <see cref="HubTenantGuard.OwnsProjectAsync"/> for the reason that
+    /// guard exists: a hub connection has no HttpContext, so the DbContext tenant
+    /// query filter resolves to an empty TenantId and cannot be relied on. Without
+    /// the explicit claims check, any authenticated user could join another firm's
+    /// project group by guessing a GUID and receive its document traffic.
+    ///
+    /// Returns silently on refusal rather than throwing — a hub exception
+    /// surfaces to the client as an opaque transport error, and there is nothing
+    /// the caller can usefully do about "that project is not yours". The caller
+    /// simply receives no events.
+    /// </summary>
+    public async Task JoinProject(string projectId)
+    {
+        if (!Guid.TryParse(projectId, out var pid)) return;
+        if (!await HubTenantGuard.OwnsProjectAsync(Context.User, _db, pid)) return;
+
+        Authorized.Add(pid);
+        await Groups.AddToGroupAsync(Context.ConnectionId, Group(pid));
+    }
+
+    /// <summary>
+    /// Unsubscribe. Deliberately NOT tenant-gated: leaving a group you are not in
+    /// is a no-op, and refusing to let someone leave is not a security property.
+    /// </summary>
+    public async Task LeaveProject(string projectId)
+    {
+        if (!Guid.TryParse(projectId, out var pid)) return;
+        Authorized.Remove(pid);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, Group(pid));
+    }
+
+    /// <summary>
+    /// Liveness probe for the Companion's reconnect logic. Returns the server's
+    /// UTC clock so a client can detect meaningful drift before it uses its own
+    /// clock to build a <c>changed-since</c> query — a Companion whose clock runs
+    /// fast would otherwise ask for changes "since" a future instant and silently
+    /// receive nothing.
+    /// </summary>
+    public Task<DateTime> ServerTimeUtc() => Task.FromResult(DateTime.UtcNow);
+
+    /// <summary>
+    /// Server-side push. Called from the controllers at the two points a document
+    /// actually changes: a CDE transition (<c>DocumentsController</c>) and a minted
+    /// revision (<c>DocumentRevisionsController</c>).
+    ///
+    /// Static + <see cref="IHubContext{THub}"/> because the caller is a controller,
+    /// not a hub connection — the same shape as
+    /// <see cref="MeetingHub.NotifyRoomChanged"/>.
+    /// </summary>
+    public static Task NotifyDocumentChanged(
+        IHubContext<DocumentSyncHub> hub, Guid projectId, object payload)
+        => hub.Clients.Group(Group(projectId)).SendAsync("DocumentChanged", payload);
+
+    /// <summary>
+    /// The <c>DocumentChanged</c> payload. A notification, not the document — see
+    /// the class remarks. <paramref name="kind"/> is <c>cde_transition</c> or
+    /// <c>revision</c>; the Companion treats both identically today and the field
+    /// exists so a log line can say which happened.
+    /// </summary>
+    public static object Payload(Guid projectId, Guid documentId, string kind, string? cdeStatus = null)
+        => new
+        {
+            projectId,
+            documentId,
+            kind,
+            cdeStatus,
+            changedAtUtc = DateTime.UtcNow,
+        };
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
@@ -137,13 +137,21 @@ public class DocumentSyncHub : Hub
     /// <c>revision</c>; the Companion treats both identically today and the field
     /// exists so a log line can say which happened.
     /// </summary>
-    public static object Payload(Guid projectId, Guid documentId, string kind, string? cdeStatus = null)
+    /// <param name="autoSyncEnabled">
+    /// The project's "Auto-sync this project" flag, sent WITH the notification
+    /// rather than looked up separately. A Companion has to decide whether it is
+    /// allowed to act the moment it hears about a change, and making it call the
+    /// API to find out would mean querying in order to learn whether it may query.
+    /// </param>
+    public static object Payload(Guid projectId, Guid documentId, string kind,
+        string? cdeStatus = null, bool autoSyncEnabled = true)
         => new
         {
             projectId,
             documentId,
             kind,
             cdeStatus,
+            autoSyncEnabled,
             changedAtUtc = DateTime.UtcNow,
         };
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/DocumentSyncHub.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using Planscape.Infrastructure.Data;
 
 namespace Planscape.Infrastructure.SignalR;
@@ -39,8 +40,13 @@ public class DocumentSyncHub : Hub
 {
     private const string AuthKey = "docsync_projects";
     private readonly PlanscapeDbContext _db;
+    private readonly ILogger<DocumentSyncHub>? _logger;
 
-    public DocumentSyncHub(PlanscapeDbContext db) => _db = db;
+    public DocumentSyncHub(PlanscapeDbContext db, ILogger<DocumentSyncHub>? logger = null)
+    {
+        _db = db;
+        _logger = logger;
+    }
 
     internal static string Group(Guid projectId) => $"docsync:{projectId}";
 
@@ -70,11 +76,26 @@ public class DocumentSyncHub : Hub
     /// </summary>
     public async Task JoinProject(string projectId)
     {
-        if (!Guid.TryParse(projectId, out var pid)) return;
-        if (!await HubTenantGuard.OwnsProjectAsync(Context.User, _db, pid)) return;
+        if (!Guid.TryParse(projectId, out var pid))
+        {
+            _logger?.LogWarning("DocumentSync join refused - unparseable project id {ProjectId}", projectId);
+            return;
+        }
+        if (!await HubTenantGuard.OwnsProjectAsync(Context.User, _db, pid))
+        {
+            // Logged because the refusal is SILENT to the client by design: the
+            // caller sees a successful InvokeAsync and then simply never receives
+            // an event. Without this line the only symptom is "sync does nothing",
+            // with nothing anywhere saying why.
+            _logger?.LogWarning(
+                "DocumentSync join refused - connection tenant {Tenant} does not own project {ProjectId}",
+                HubTenantGuard.TenantIdOf(Context.User), pid);
+            return;
+        }
 
         Authorized.Add(pid);
         await Groups.AddToGroupAsync(Context.ConnectionId, Group(pid));
+        _logger?.LogInformation("DocumentSync joined {Group} (connection {Conn})", Group(pid), Context.ConnectionId);
     }
 
     /// <summary>

--- a/Planscape.Server/tests/Planscape.Tests/DocumentChangedSinceTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/DocumentChangedSinceTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Document sync — the delta query
+/// (<c>GET /api/projects/{id}/documents/changed-since</c>).
+///
+/// This is the reconnect fallback and the initial-link path. It is the only
+/// server surface that decides what ends up written to an Author's local disk,
+/// which is why the tests below care most about two things:
+///
+///   • it is never WIDER than the documents list a user can already see, and
+///   • the timestamp contract actually works, because a Companion chains one
+///     call's <c>serverTimeUtc</c> into the next call's <c>since</c> forever.
+///     A subtle error there does not fail loudly — it silently stops syncing.
+/// </summary>
+public class DocumentChangedSinceTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public DocumentChangedSinceTests(PlanscapeWebApplicationFactory factory) => _factory = factory;
+
+    private const string Base = "/api/projects/66666666-6666-6666-6666-666666666666/documents";
+
+    // ── Initial sync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task No_since_returns_everything_currently_visible()
+    {
+        // The initial-link case from the spec: "since unset ⇒ everything
+        // currently visible", not an empty delta.
+        SeedDocument("CS-INITIAL-A.pdf", DateTime.UtcNow.AddDays(-30));
+        SeedDocument("CS-INITIAL-B.pdf", DateTime.UtcNow.AddMinutes(-1));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var names = await FileNamesAsync(client, $"{Base}/changed-since");
+
+        Assert.Contains("CS-INITIAL-A.pdf", names);
+        Assert.Contains("CS-INITIAL-B.pdf", names);
+    }
+
+    // ── Delta semantics ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Since_excludes_documents_that_have_not_changed()
+    {
+        var old = SeedDocument("CS-OLD.pdf", DateTime.UtcNow.AddHours(-2));
+        var cutoff = DateTime.UtcNow.AddHours(-1);
+        SeedDocument("CS-NEW.pdf", DateTime.UtcNow.AddMinutes(-5));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var names = await FileNamesAsync(client, $"{Base}/changed-since?since={Iso(cutoff)}");
+
+        Assert.Contains("CS-NEW.pdf", names);
+        Assert.DoesNotContain("CS-OLD.pdf", names);
+        Assert.NotEqual(Guid.Empty, old.Id);
+    }
+
+    [Fact]
+    public async Task Since_uses_UpdatedAt_in_preference_to_UploadedAt()
+    {
+        // A document uploaded long ago but transitioned five minutes ago IS a
+        // change the Companion must pull. Keying on UploadedAt alone would mean a
+        // CDE transition never reaches a disk that was already in sync — the
+        // single most likely way this endpoint could be quietly wrong.
+        SeedDocument("CS-TRANSITIONED.pdf",
+            uploadedAt: DateTime.UtcNow.AddDays(-10),
+            updatedAt: DateTime.UtcNow.AddMinutes(-5));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var names = await FileNamesAsync(client,
+            $"{Base}/changed-since?since={Iso(DateTime.UtcNow.AddHours(-1))}");
+
+        Assert.Contains("CS-TRANSITIONED.pdf", names);
+    }
+
+    [Fact]
+    public async Task Results_are_ordered_oldest_change_first()
+    {
+        // The Companion pages by taking the last item's changedAt as the next
+        // `since`. That only works if the newest is last.
+        SeedDocument("CS-ORDER-1.pdf", DateTime.UtcNow.AddMinutes(-30));
+        SeedDocument("CS-ORDER-2.pdf", DateTime.UtcNow.AddMinutes(-20));
+        SeedDocument("CS-ORDER-3.pdf", DateTime.UtcNow.AddMinutes(-10));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var body = await GetJsonAsync(client,
+            $"{Base}/changed-since?since={Iso(DateTime.UtcNow.AddHours(-1))}");
+        var stamps = body.GetProperty("items").EnumerateArray()
+            .Where(i => i.GetProperty("fileName").GetString()!.StartsWith("CS-ORDER-"))
+            .Select(i => i.GetProperty("changedAt").GetDateTime())
+            .ToList();
+
+        Assert.Equal(3, stamps.Count);
+        Assert.Equal(stamps.OrderBy(s => s), stamps);
+    }
+
+    [Fact]
+    public async Task A_future_since_returns_nothing_rather_than_everything()
+    {
+        // Clock skew on a laptop is normal. "Since tomorrow" must be an empty
+        // delta, not a fallback to the initial-sync behaviour — that would make a
+        // skewed machine re-download the whole project on every reconnect.
+        SeedDocument("CS-FUTURE.pdf", DateTime.UtcNow.AddMinutes(-5));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var body = await GetJsonAsync(client,
+            $"{Base}/changed-since?since={Iso(DateTime.UtcNow.AddDays(1))}");
+
+        Assert.Equal(0, body.GetProperty("count").GetInt32());
+    }
+
+    // ── The timestamp contract ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Response_carries_a_server_clock_for_the_caller_to_chain()
+    {
+        // The Companion must never use its own clock to build the next `since`.
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var body = await GetJsonAsync(client, $"{Base}/changed-since");
+        var serverTime = body.GetProperty("serverTimeUtc").GetDateTime();
+
+        Assert.True(serverTime > DateTime.UtcNow.AddMinutes(-5),
+            "serverTimeUtc should be roughly now");
+        Assert.True(serverTime <= DateTime.UtcNow.AddMinutes(5));
+    }
+
+    [Fact]
+    public async Task Chaining_serverTimeUtc_into_the_next_since_loses_nothing()
+    {
+        // The actual loop the Companion runs, end to end: sync, remember the
+        // server's clock, sync again, and a document written in between must
+        // appear in the second call.
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var first = await GetJsonAsync(client, $"{Base}/changed-since");
+        var checkpoint = first.GetProperty("serverTimeUtc").GetDateTime();
+
+        SeedDocument("CS-CHAIN.pdf", DateTime.UtcNow.AddSeconds(5));
+
+        var names = await FileNamesAsync(client, $"{Base}/changed-since?since={Iso(checkpoint)}");
+        Assert.Contains("CS-CHAIN.pdf", names);
+    }
+
+    [Fact]
+    public async Task hasMore_flags_a_full_page_so_the_caller_keeps_going()
+    {
+        // Without this the tail of a large backlog is silently dropped: the
+        // Companion would take one page, store the newest timestamp and believe
+        // it had caught up.
+        for (var i = 0; i < 3; i++)
+            SeedDocument($"CS-PAGE-{i}.pdf", DateTime.UtcNow.AddMinutes(-10 + i));
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var full = await GetJsonAsync(client, $"{Base}/changed-since?limit=1");
+        Assert.Equal(1, full.GetProperty("count").GetInt32());
+        Assert.True(full.GetProperty("hasMore").GetBoolean());
+
+        var roomy = await GetJsonAsync(client, $"{Base}/changed-since?limit=2000");
+        Assert.False(roomy.GetProperty("hasMore").GetBoolean());
+    }
+
+    // ── Visibility ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Never_returns_a_document_the_documents_list_does_not()
+    {
+        // The invariant that actually matters, expressed as a comparison rather
+        // than as a hard-coded expectation: sync writes files to disk, so its
+        // surface must be a SUBSET of what the same caller can already see.
+        //
+        // Stated as a subset check on purpose. ProjectMemberAcl.ResolveAsync
+        // currently hard-codes its three allow-list columns to null (a deliberate
+        // migration-safety choice — see its comment), so no narrowing happens for
+        // anyone today. Asserting "PUBLISHED is filtered out" would therefore be
+        // asserting a behaviour that does not exist. This assertion holds now AND
+        // keeps holding the day those columns are read for real, because both
+        // endpoints route through the same helper.
+        SeedDocument("CS-SUBSET-WIP.pdf", DateTime.UtcNow.AddMinutes(-5), cdeStatus: "WIP");
+        SeedDocument("CS-SUBSET-PUB.pdf", DateTime.UtcNow.AddMinutes(-5), cdeStatus: "PUBLISHED");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var listed = await GetJsonAsync(client, $"{Base}?pageSize=500");
+        var listedNames = listed.GetProperty("items").EnumerateArray()
+            .Select(i => i.GetProperty("fileName").GetString()!).ToHashSet();
+
+        var syncNames = await FileNamesAsync(client, $"{Base}/changed-since?limit=2000");
+
+        Assert.NotEmpty(syncNames);
+        Assert.All(syncNames, n => Assert.Contains(n, listedNames));
+    }
+
+    [Fact]
+    public async Task Another_firm_cannot_read_the_delta()
+    {
+        // Two-firm isolation on the sync surface. The other tenant's admin is a
+        // legitimate, authenticated user — they simply must not be able to enumerate
+        // this project's documents by any route.
+        SeedDocument("CS-ISOLATED.pdf", DateTime.UtcNow.AddMinutes(-5));
+        var client = await _factory.CreateAuthenticatedClientAsync(
+            "admin@other.org", "Password123!");
+
+        var res = await client.GetAsync($"{Base}/changed-since");
+
+        Assert.True(res.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Forbidden,
+            $"expected the project to be invisible to another firm, got {(int)res.StatusCode}");
+    }
+
+    [Fact]
+    public async Task Requires_authentication()
+    {
+        var res = await _factory.CreateClient().GetAsync($"{Base}/changed-since");
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static string Iso(DateTime utc) =>
+        Uri.EscapeDataString(DateTime.SpecifyKind(utc, DateTimeKind.Utc).ToString("O"));
+
+    private static async Task<JsonElement> GetJsonAsync(HttpClient client, string url)
+    {
+        var res = await client.GetAsync(url);
+        res.EnsureSuccessStatusCode();
+        return await res.Content.ReadFromJsonAsync<JsonElement>();
+    }
+
+    private static async Task<List<string>> FileNamesAsync(HttpClient client, string url)
+    {
+        var body = await GetJsonAsync(client, url);
+        return body.GetProperty("items").EnumerateArray()
+            .Select(i => i.GetProperty("fileName").GetString()!)
+            .ToList();
+    }
+
+    private DocumentRecord SeedDocument(
+        string fileName, DateTime uploadedAt, DateTime? updatedAt = null, string cdeStatus = "SHARED")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        var existing = db.Documents.FirstOrDefault(d => d.FileName == fileName);
+        if (existing != null) return existing;
+
+        var doc = new DocumentRecord
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestData.TenantId,
+            ProjectId = TestData.ProjectId,
+            FileName = fileName,
+            DocumentType = "DR",
+            CdeStatus = cdeStatus,
+            SuitabilityCode = cdeStatus == "PUBLISHED" ? "S4" : "S3",
+            Revision = "P01",
+            UploadedBy = "Test Admin",
+            UploadedAt = uploadedAt,
+            UpdatedAt = updatedAt,
+            ScanStatus = "CLEAN",
+        };
+        db.Documents.Add(doc);
+        db.SaveChanges();
+        return doc;
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/DocumentSyncHubTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/DocumentSyncHubTests.cs
@@ -1,0 +1,226 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.SignalR;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Document sync — the hub half.
+///
+/// The one property worth real tests here is the tenant gate. A hub connection
+/// has no HttpContext, so the DbContext's tenant query filter resolves to an
+/// empty TenantId and cannot be relied on; the gate is an explicit claims check
+/// (<c>HubTenantGuard.OwnsProjectAsync</c>) against a query that ignores filters.
+/// Get that wrong and any authenticated user joins another firm's project group
+/// by guessing a GUID — and nothing throws, so the failure is silent and the
+/// symptom is one firm's document traffic arriving on another firm's machines.
+///
+/// These are unit tests with a hand-rolled hub context (no Moq in this repo, and
+/// the existing doubles are hand-rolled too). Over-the-wire confirmation is in
+/// the plan's PENDING-HUMAN-VERIFY list.
+/// </summary>
+public class DocumentSyncHubTests
+{
+    private static readonly Guid FirmA = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+    private static readonly Guid FirmB = Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222");
+    private static readonly Guid FirmAProject = Guid.Parse("cccccccc-3333-3333-3333-333333333333");
+    private static readonly Guid FirmBProject = Guid.Parse("dddddddd-4444-4444-4444-444444444444");
+
+    private static PlanscapeDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<PlanscapeDbContext>()
+            .UseInMemoryDatabase($"docsync_{Guid.NewGuid():N}")
+            .ConfigureWarnings(w => w.Ignore(
+                Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+        var db = new PlanscapeDbContext(options);
+        db.Projects.Add(new Project { Id = FirmAProject, TenantId = FirmA, Name = "A", Code = "A-1" });
+        db.Projects.Add(new Project { Id = FirmBProject, TenantId = FirmB, Name = "B", Code = "B-1" });
+        db.SaveChanges();
+        return db;
+    }
+
+    private static DocumentSyncHub HubFor(PlanscapeDbContext db, Guid tenantId, out FakeGroups groups)
+    {
+        groups = new FakeGroups();
+        return new DocumentSyncHub(db)
+        {
+            Context = new FakeHubContext(tenantId),
+            Groups = groups,
+        };
+    }
+
+    // ── The gate ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task JoinProject_joins_a_project_in_the_callers_own_tenant()
+    {
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.JoinProject(FirmAProject.ToString());
+
+        Assert.Equal(new[] { $"docsync:{FirmAProject}" }, groups.Added);
+    }
+
+    [Fact]
+    public async Task JoinProject_refuses_another_firms_project()
+    {
+        // The regression this whole class exists for. Firm A's connection naming
+        // firm B's project GUID must join nothing at all.
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.JoinProject(FirmBProject.ToString());
+
+        Assert.Empty(groups.Added);
+    }
+
+    [Fact]
+    public async Task JoinProject_refuses_a_connection_with_no_tenant_claim()
+    {
+        // An absent tenant claim must be "no tenant", never a wildcard.
+        using var db = NewDb();
+        var hub = new DocumentSyncHub(db)
+        {
+            Context = new FakeHubContext(null),
+            Groups = new FakeGroups(),
+        };
+
+        await hub.JoinProject(FirmAProject.ToString());
+
+        Assert.Empty(((FakeGroups)hub.Groups).Added);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-guid")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public async Task JoinProject_ignores_a_malformed_or_empty_project_id(string projectId)
+    {
+        // Guid.Empty specifically: OwnsProjectAsync treats it as a refusal, and a
+        // row could otherwise be matched by a default-valued ProjectId.
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.JoinProject(projectId);
+
+        Assert.Empty(groups.Added);
+    }
+
+    [Fact]
+    public async Task JoinProject_refuses_a_project_that_does_not_exist()
+    {
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.JoinProject(Guid.NewGuid().ToString());
+
+        Assert.Empty(groups.Added);
+    }
+
+    // ── Leaving ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LeaveProject_removes_the_group()
+    {
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.JoinProject(FirmAProject.ToString());
+        await hub.LeaveProject(FirmAProject.ToString());
+
+        Assert.Equal(new[] { $"docsync:{FirmAProject}" }, groups.Removed);
+    }
+
+    [Fact]
+    public async Task LeaveProject_is_not_tenant_gated()
+    {
+        // Deliberate: leaving a group you were never in is a no-op, and refusing
+        // to let someone leave is not a security property. Asserting it so a
+        // later "tighten every method" pass doesn't add a gate that can strand a
+        // client subscribed to a project it just lost access to.
+        using var db = NewDb();
+        var hub = HubFor(db, FirmA, out var groups);
+
+        await hub.LeaveProject(FirmBProject.ToString());
+
+        Assert.Equal(new[] { $"docsync:{FirmBProject}" }, groups.Removed);
+    }
+
+    // ── Wire format ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Group_name_is_project_scoped_and_stable()
+    {
+        // The group name is load-bearing in two places that must not drift apart:
+        // JoinProject builds it, and NotifyDocumentChanged pushes to it. A
+        // mismatch is silent — the push just reaches nobody.
+        Assert.Equal($"docsync:{FirmAProject}", DocumentSyncHub.Group(FirmAProject));
+        Assert.Equal(DocumentSyncHub.Group(FirmAProject), DocumentSyncHub.Group(FirmAProject));
+        Assert.NotEqual(DocumentSyncHub.Group(FirmAProject), DocumentSyncHub.Group(FirmBProject));
+    }
+
+    [Fact]
+    public void Payload_carries_a_reference_and_never_the_document_itself()
+    {
+        // The Companion answers a push by calling changed-since, which re-runs the
+        // caller's ACL server-side. If the payload ever started carrying file
+        // paths or content, a project-scoped push would become the thing that
+        // widens what a client sees, bypassing per-user CDE narrowing entirely.
+        var docId = Guid.NewGuid();
+        var payload = DocumentSyncHub.Payload(FirmAProject, docId, "cde_transition", "PUBLISHED");
+        var json = System.Text.Json.JsonSerializer.Serialize(payload);
+
+        Assert.Contains(docId.ToString(), json);
+        Assert.Contains("cde_transition", json);
+        Assert.Contains("PUBLISHED", json);
+        Assert.DoesNotContain("filePath", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("contentHash", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("fileName", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── Hand-rolled doubles ───────────────────────────────────────────────────
+
+    private sealed class FakeGroups : IGroupManager
+    {
+        public List<string> Added { get; } = new();
+        public List<string> Removed { get; } = new();
+
+        public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken ct = default)
+        {
+            Added.Add(groupName);
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken ct = default)
+        {
+            Removed.Add(groupName);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeHubContext : HubCallerContext
+    {
+        private readonly Dictionary<object, object?> _items = new();
+
+        public FakeHubContext(Guid? tenantId)
+        {
+            var claims = new List<Claim>();
+            if (tenantId.HasValue) claims.Add(new Claim("tenant_id", tenantId.Value.ToString()));
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+        }
+
+        public override string ConnectionId => "conn-1";
+        public override string? UserIdentifier => "user-1";
+        public override ClaimsPrincipal? User { get; }
+        public override IDictionary<object, object?> Items => _items;
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted => CancellationToken.None;
+        public override void Abort() { }
+    }
+}

--- a/StingTools.LinkHandler/Program.cs
+++ b/StingTools.LinkHandler/Program.cs
@@ -1,0 +1,165 @@
+// StingLink.exe — the registered handler for planscape:// URLs.
+//
+// Windows launches this with one argument, the whole URL. The job is small on
+// purpose:
+//
+//   1. Drop the URL into the shared inbox (StingTools.Core.PlanscapeProtocol).
+//   2. If a Revit window is up, bring it to the front — the plugin's Idling
+//      watcher takes it from there, usually within a tick.
+//   3. If Revit is NOT running, say so. Launching Revit from here is NOT
+//      implemented; see the note at LaunchNote below, and
+//      docs/PLANSCAPE_PROTOCOL.md for exactly how far this got.
+//
+// It must never hang: it runs on a user's click, and a stuck handler shows up
+// as "the link does nothing" with a stray process in Task Manager.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using StingTools.Core;
+
+namespace StingTools.LinkHandler
+{
+    internal static class Program
+    {
+        private const uint MB_OK = 0x0;
+        private const uint MB_ICONINFORMATION = 0x40;
+        private const uint MB_ICONERROR = 0x10;
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int MessageBoxW(IntPtr hWnd, string text, string caption, uint type);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool IsIconic(IntPtr hWnd);
+
+        private const int SW_RESTORE = 9;
+
+        [STAThread]
+        private static int Main(string[] args)
+        {
+            // No argument at all = someone ran the exe directly. Tell them what
+            // it is instead of exiting silently, and offer the one thing that is
+            // useful without a URL: re-registering the protocol.
+            if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+                return Explain();
+
+            string raw = args[0].Trim();
+
+            if (string.Equals(raw, "--register", StringComparison.OrdinalIgnoreCase))
+                return RegisterSelf();
+            if (string.Equals(raw, "--unregister", StringComparison.OrdinalIgnoreCase))
+            {
+                PlanscapeProtocol.Unregister(out string undetail);
+                Info("planscape:// links are no longer handled by StingTools."
+                     + (string.IsNullOrEmpty(undetail) ? "" : "\n\n" + undetail));
+                return 0;
+            }
+
+            var link = PlanscapeProtocol.Parse(raw);
+            if (link == null)
+            {
+                Error($"That does not look like a Planscape link:\n\n{raw}\n\n"
+                      + "Expected something like planscape://issue/<id>.");
+                return 2;
+            }
+
+            if (PlanscapeProtocol.Drop(raw) == null)
+            {
+                Error("Could not hand the link to StingTools.\n\n"
+                      + "The link inbox could not be written:\n"
+                      + PlanscapeProtocol.InboxDir);
+                return 3;
+            }
+
+            IntPtr revit = FindRevitWindow();
+            if (revit != IntPtr.Zero)
+            {
+                // Restore first: a minimised window ignores SetForegroundWindow.
+                if (IsIconic(revit)) ShowWindowAsync(revit, SW_RESTORE);
+                SetForegroundWindow(revit);
+                // Nothing more to say — the plugin picks the link up on its next
+                // Idling tick and opens the Coordination Center itself. A dialog
+                // here would be a second thing to dismiss.
+                return 0;
+            }
+
+            Info(LaunchNote(link));
+            return 0;
+        }
+
+        /// <summary>
+        /// The honest version of the not-running case.
+        ///
+        /// Auto-launching Revit is NOT implemented: there are up to three
+        /// versions installed (2025/2026/2027), the link carries no project file
+        /// path, and starting the wrong Revit — or any Revit, unasked, because
+        /// someone clicked a chat link — is worse than saying nothing happened.
+        /// The link is already queued, so opening Revit by hand within
+        /// PlanscapeProtocol.MaxAge completes the journey.
+        /// </summary>
+        private static string LaunchNote(PlanscapeLink link) =>
+            "Revit does not appear to be running.\n\n"
+            + $"The link ({link}) has been queued. Open Revit with the STING Tools "
+            + $"plugin loaded within {(int)PlanscapeProtocol.MaxAge.TotalMinutes} minutes "
+            + "and the Coordination Center will jump to it.";
+
+        /// <summary>
+        /// Revit's main window class is "Rvt_MainWindow" — the same string
+        /// BIMCoordinationCenter.Show uses to anchor itself. Enumerating
+        /// processes is the fallback because a Revit that is still starting up
+        /// may not have registered the class yet.
+        /// </summary>
+        private static IntPtr FindRevitWindow()
+        {
+            try
+            {
+                foreach (var p in Process.GetProcessesByName("Revit"))
+                {
+                    using (p)
+                    {
+                        if (p.MainWindowHandle != IntPtr.Zero) return p.MainWindowHandle;
+                    }
+                }
+            }
+            catch (Exception) { /* fall through — treated as "not running" */ }
+            return IntPtr.Zero;
+        }
+
+        private static int Explain()
+        {
+            string current = PlanscapeProtocol.RegisteredCommand();
+            Info("StingLink — the Windows handler for planscape:// links.\n\n"
+                 + "It is not meant to be run directly; Windows launches it when you click a "
+                 + "planscape:// link.\n\n"
+                 + "Currently registered command:\n"
+                 + (string.IsNullOrEmpty(current) ? "(none)" : current)
+                 + "\n\nRun with --register to point the protocol at this copy, or --unregister to remove it.");
+            return 0;
+        }
+
+        private static int RegisterSelf()
+        {
+            string exe = Process.GetCurrentProcess().MainModule?.FileName;
+            bool changed = PlanscapeProtocol.EnsureRegistered(exe, out string detail);
+            Info(changed
+                ? "planscape:// links now open through StingTools.\n\n" + detail
+                : "No change was made.\n\n" + detail);
+            return changed ? 0 : 1;
+        }
+
+        private static void Info(string text) =>
+            MessageBoxW(IntPtr.Zero, text, "Planscape link", MB_OK | MB_ICONINFORMATION);
+
+        private static void Error(string text) =>
+            MessageBoxW(IntPtr.Zero, text, "Planscape link", MB_OK | MB_ICONERROR);
+    }
+}

--- a/StingTools.LinkHandler/StingTools.LinkHandler.csproj
+++ b/StingTools.LinkHandler/StingTools.LinkHandler.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    StingLink.exe — the standalone target Windows launches for planscape:// URLs.
+
+    It exists because a protocol handler must be an .exe and StingTools is a DLL
+    hosted inside Revit.exe. Everything it does is in Program.cs: drop the URL
+    into the inbox, bring Revit forward, exit. It is deliberately tiny — it runs
+    on a user's double-click and must never be the thing that hangs.
+
+    WinExe, not Exe: Exe would flash a console window on every click.
+    No WPF / WinForms: the one message box it can show is a user32 P/Invoke, so
+    the whole program stays a few files with no UI framework to load.
+  -->
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>StingLink</AssemblyName>
+    <RootNamespace>StingTools.LinkHandler</RootNamespace>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <Version>1.0.0</Version>
+    <Company>Planscape</Company>
+    <Product>Planscape link handler</Product>
+    <!-- Invariant globalization keeps the runtime dependency set minimal; this
+         program formats no dates for humans and compares no culture-sensitive
+         strings. -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Compiled IN rather than referenced: referencing StingTools.dll would drag
+      the entire Revit API surface into a 3-file console-less utility. This is
+      the same pattern tools/StampDrawingTypeChecksums uses, and it is why
+      PlanscapeProtocol.cs may not touch Revit, WPF or anything else.
+
+      If a build error points here, the cause is almost certainly a Revit or WPF
+      type newly introduced into PlanscapeProtocol.cs. Move it out rather than
+      adding a reference.
+    -->
+    <Compile Include="..\StingTools\Core\PlanscapeProtocol.cs" Link="Shared\PlanscapeProtocol.cs" />
+  </ItemGroup>
+
+</Project>

--- a/StingTools/BIMManager/CompanionSyncBridge.cs
+++ b/StingTools/BIMManager/CompanionSyncBridge.cs
@@ -1,0 +1,169 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Planscape.Companion;
+using StingTools.Core;
+
+namespace StingTools.BIMManager
+{
+    /// <summary>
+    /// What a synced document looks like on THIS machine. Derived from the file
+    /// system, not from the server — the point of the badge is to answer "do I
+    /// have this, and may I edit it", which is a local question.
+    /// </summary>
+    internal enum LocalSyncState
+    {
+        /// <summary>No local copy — either not synced yet, or not visible to this account.</summary>
+        NotSynced,
+
+        /// <summary>A writable WIP working copy. The one you are meant to edit.</summary>
+        WorkingCopy,
+
+        /// <summary>A read-only reference copy (SHARED / PUBLISHED).</summary>
+        Reference,
+    }
+
+    /// <summary>
+    /// BCC's window onto the Planscape Companion.
+    ///
+    /// <para>Two jobs, and deliberately no third: read the Companion's status, and
+    /// ask it to sync. <b>BCC never runs sync logic itself</b> — that is the whole
+    /// reason the Companion is a separate process (it has to work when Revit is
+    /// closed), and a second implementation living in the plugin would be the
+    /// thing that eventually disagrees with the first.</para>
+    ///
+    /// <para>Every call here treats "the Companion is not running" as a normal
+    /// answer rather than an error. It is by far the most likely outcome on a
+    /// machine where nobody has set sync up, and a plugin that throws or logs
+    /// scary things about it would be wrong about its own product.</para>
+    /// </summary>
+    internal static class CompanionSyncBridge
+    {
+        /// <summary>
+        /// Live status, or a not-running placeholder. Never throws.
+        ///
+        /// Synchronous by necessity — BCC is WPF and the call sites are click
+        /// handlers and cell renderers. The underlying connect is bounded by
+        /// <see cref="CompanionIpc.ConnectTimeoutMs"/>, so the worst case a UI
+        /// thread can see is that timeout, not an indefinite block.
+        /// </summary>
+        public static CompanionStatus GetStatus()
+        {
+            try
+            {
+                return CompanionIpcClient.GetStatusAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Companion status: {ex.Message}");
+                return CompanionStatus.NotRunning();
+            }
+        }
+
+        /// <summary>
+        /// Ask the Companion to sync. Returns false only when it is not running —
+        /// true means STARTED, not finished, because the reply comes back
+        /// immediately and the download happens in the Companion's own time.
+        /// </summary>
+        public static bool SyncNow(string projectId = null)
+        {
+            try
+            {
+                return CompanionIpcClient.SyncNowAsync(projectId).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Companion sync-now: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Resolve a document's local state by looking for it in the project's
+        /// sync folder.
+        ///
+        /// <para>Matched on FILE NAME, which is the only key the two sides share:
+        /// BCC's deliverable rows come from the local
+        /// <c>_BIM_COORD/deliverables.json</c> register and carry no server
+        /// document GUID. That makes this a best-effort match — a deliverable
+        /// whose register name differs from the uploaded file name reads as
+        /// NotSynced even when a copy exists. Stated plainly rather than papered
+        /// over; the fix is a document id on the register, which is a bigger
+        /// change than a badge.</para>
+        ///
+        /// <para>WorkingCopy vs Reference comes from the read-only ATTRIBUTE the
+        /// sync engine sets — a removable hint, never a lock. A user who clears
+        /// it will see the badge change, which is honest: the badge reports what
+        /// is on disk, not what the server wishes were on disk.</para>
+        /// </summary>
+        public static LocalSyncState ResolveState(string projectCode, string fileName)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(fileName)) return LocalSyncState.NotSynced;
+                string folder = CompanionPaths.ResolveProjectFolder(projectCode);
+                if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+                    return LocalSyncState.NotSynced;
+
+                string path = Path.Combine(folder, Path.GetFileName(fileName));
+                if (!File.Exists(path))
+                {
+                    // The register often carries a name without an extension (a
+                    // document code rather than a file). Fall back to a prefix
+                    // match so those rows still badge rather than all reading
+                    // NotSynced, which would make the column useless.
+                    string stem = Path.GetFileNameWithoutExtension(fileName);
+                    if (string.IsNullOrWhiteSpace(stem)) return LocalSyncState.NotSynced;
+                    foreach (var candidate in Directory.EnumerateFiles(folder, stem + ".*"))
+                    {
+                        // Never match a superseded copy — it is history, not the
+                        // live document, and badging a row from it would say
+                        // "you have this" about a file that is no longer current.
+                        if (Path.GetFileName(candidate).IndexOf("(superseded ", StringComparison.Ordinal) >= 0)
+                            continue;
+                        path = candidate;
+                        break;
+                    }
+                    if (!File.Exists(path)) return LocalSyncState.NotSynced;
+                }
+
+                var attrs = File.GetAttributes(path);
+                return (attrs & FileAttributes.ReadOnly) == FileAttributes.ReadOnly
+                    ? LocalSyncState.Reference
+                    : LocalSyncState.WorkingCopy;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Companion local state for '{fileName}': {ex.Message}");
+                return LocalSyncState.NotSynced;
+            }
+        }
+
+        /// <summary>Short chip label, or empty for a row with nothing to say.</summary>
+        public static string BadgeLabel(LocalSyncState state)
+        {
+            switch (state)
+            {
+                case LocalSyncState.WorkingCopy: return "WORKING";
+                case LocalSyncState.Reference: return "REF";
+                default: return "";
+            }
+        }
+
+        /// <summary>Tooltip for the chip. Spells out the read-only hint, since that is the part users query.</summary>
+        public static string BadgeTooltip(LocalSyncState state)
+        {
+            switch (state)
+            {
+                case LocalSyncState.WorkingCopy:
+                    return "Synced to this machine as an editable working copy (WIP).";
+                case LocalSyncState.Reference:
+                    return "Synced to this machine as a read-only reference copy.\n"
+                         + "The read-only flag is a hint, not a lock — you can clear it, "
+                         + "but a newer revision will still replace this file.";
+                default:
+                    return "No local copy on this machine.";
+            }
+        }
+    }
+}

--- a/StingTools/Commands/Delivery/DeliveryCommands.cs
+++ b/StingTools/Commands/Delivery/DeliveryCommands.cs
@@ -327,8 +327,12 @@ namespace StingTools.Commands.Delivery
         /// (&lt;root&gt;/_data/_BIM_COORD/), falling back to the legacy sibling-of-RVT
         /// location for projects not yet migrated. This is the same path
         /// <see cref="Planscape.Docs.Templates.DeliverableLifecycle"/> persists to.
+        /// Internal (not private): WarningsManager.BuildCoordData reads the same file to
+        /// populate the BCC Deliverables tab — reusing this resolver rather than growing a
+        /// fourth copy of the path logic is exactly what DocumentIdentity.cs's own header
+        /// comment warns against.
         /// </summary>
-        private static string ResolveDeliverablesPath(Document doc)
+        internal static string ResolveDeliverablesPath(Document doc)
         {
             try
             {

--- a/StingTools/Core/PlanscapeLinkWatcher.cs
+++ b/StingTools/Core/PlanscapeLinkWatcher.cs
@@ -1,0 +1,153 @@
+// The plugin half of planscape:// link handling. See PlanscapeProtocol.cs for
+// the whole flow and why the handler is a separate .exe.
+//
+// This is an IIdlingJob rather than a FileSystemWatcher on purpose. A watcher
+// fires on a threadpool thread, and everything it would want to do — open the
+// Coordination Center, read the document — must happen on Revit's API thread
+// anyway. That means a watcher's only real job would be to push into a queue
+// that an Idling job then drains, so the watcher is a thread with no work.
+// Polling a directory once a second costs a directory enumeration of an almost
+// always empty folder.
+//
+// The job never completes (Execute always returns false), so it stays queued for
+// the life of the session. That is what IIdlingJob's contract means by "still
+// has work to do".
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace StingTools.Core
+{
+    internal sealed class PlanscapeLinkWatcher : IIdlingJob
+    {
+        /// <summary>Idling fires 10–100×/s. Checking the inbox that often would be absurd.</summary>
+        private const int PollIntervalMs = 1000;
+
+        private readonly Stopwatch _sinceLastPoll = Stopwatch.StartNew();
+        private bool _firstPoll = true;
+
+        public string Name => "PlanscapeLinkWatcher";
+
+        /// <summary>Lowest priority — a queued link can wait behind a compliance scan.</summary>
+        public int Priority => 5;
+
+        public int BudgetMs => 5;
+
+        public bool Execute(UIApplication uiApp)
+        {
+            try
+            {
+                if (!_firstPoll && _sinceLastPoll.ElapsedMilliseconds < PollIntervalMs)
+                    return false;
+                _firstPoll = false;
+                _sinceLastPoll.Restart();
+
+                List<PlanscapeLink> links = PlanscapeProtocol.TakePending();
+                if (links.Count == 0) return false;
+
+                // More than one queued link means the user clicked several while
+                // Revit was busy or shut. Acting on all of them would open and
+                // re-open the same window; the newest is the one they meant.
+                if (links.Count > 1)
+                    StingLog.Info($"PlanscapeLink: {links.Count} queued links; handling the newest and discarding the rest.");
+
+                Handle(uiApp, links[links.Count - 1]);
+            }
+            catch (Exception ex)
+            {
+                // A throw here would be raised on every Idling tick. Log once per
+                // occurrence and keep the job alive.
+                StingLog.Warn($"PlanscapeLinkWatcher: {ex.Message}");
+            }
+            return false; // never done
+        }
+
+        private static void Handle(UIApplication uiApp, PlanscapeLink link)
+        {
+            StingLog.Info($"PlanscapeLink received: {link.Raw}");
+
+            Document doc = uiApp?.ActiveUIDocument?.Document;
+            if (doc == null)
+            {
+                // Shouldn't happen — the scheduler only ticks with a document
+                // open — but the link is already consumed at this point, so say
+                // so rather than dropping it in silence.
+                TaskDialog.Show("Planscape link",
+                    $"Open a model first — the link ({link}) needs a project to open the Coordination Center against.");
+                return;
+            }
+
+            if (!ConfirmProjectMatch(doc, link)) return;
+
+            string tab = TabFor(link.Kind);
+            if (!BIMCoordinationCenterCommand.ShowFor(uiApp, tab, out string error))
+            {
+                TaskDialog.Show("Planscape link",
+                    $"Could not open the Coordination Center for {link}.\n\n{error}");
+                return;
+            }
+
+            // Honest about the limit: the tab opens, the individual row is not
+            // selected. Resolving an issue GUID or a deliverable code to a row
+            // means reaching into the BCC's grids, which is a larger change than
+            // this slice took on — see docs/PLANSCAPE_PROTOCOL.md.
+            if (!string.IsNullOrEmpty(link.Target) && link.Kind != "dashboard")
+                StingLog.Info($"PlanscapeLink: opened the {tab} tab; target '{link.Target}' is not row-selected yet.");
+        }
+
+        /// <summary>
+        /// A <c>dashboard</c> link names the project it was shared from. Opening
+        /// a different project's coordination data because the recipient happened
+        /// to have another model open would be quietly wrong, so ask.
+        /// Non-dashboard links carry an id, not a project, and skip this.
+        /// </summary>
+        private static bool ConfirmProjectMatch(Document doc, PlanscapeLink link)
+        {
+            if (link.Kind != "dashboard" || string.IsNullOrWhiteSpace(link.Target)) return true;
+
+            string open = ResolveProjectName(doc);
+            if (string.IsNullOrWhiteSpace(open)) return true; // nothing to compare against
+            if (string.Equals(open.Trim(), link.Target.Trim(), StringComparison.OrdinalIgnoreCase)) return true;
+
+            var td = new TaskDialog("Planscape link")
+            {
+                MainInstruction = "This link is for a different project.",
+                MainContent = $"The link points at “{link.Target}”, but the open model is “{open}”.",
+                CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                DefaultButton = TaskDialogResult.No,
+                FooterText = $"Open the Coordination Center for “{open}” anyway?"
+            };
+            return td.Show() == TaskDialogResult.Yes;
+        }
+
+        private static string ResolveProjectName(Document doc)
+        {
+            try
+            {
+                // The share link is built from the same project name the BCC
+                // shows, which comes from ProjectInformation. Fall back to the
+                // file title, which is what a user recognises.
+                string name = doc.ProjectInformation?.Name;
+                if (!string.IsNullOrWhiteSpace(name)) return name;
+                return doc.Title;
+            }
+            catch (Exception) { return null; }
+        }
+
+        private static string TabFor(string kind)
+        {
+            switch (kind)
+            {
+                case "issue": return "ISSUES";
+                case "deliverable": return "DELIVERABLES";
+                case "warning": return "WARNINGS";
+                case "meeting": return "MEETINGS";
+                case "dashboard":
+                default: return "OVERVIEW";
+            }
+        }
+    }
+}

--- a/StingTools/Core/PlanscapeProtocol.cs
+++ b/StingTools/Core/PlanscapeProtocol.cs
@@ -1,0 +1,309 @@
+// planscape:// URL protocol — the shared contract.
+//
+// WHY THIS FILE EXISTS AS A SEPARATE, REVIT-FREE UNIT
+// ---------------------------------------------------
+// StingTools generates `planscape://dashboard/{name}/{ts}` links (see
+// PlanscapeServerClient.BuildDashboardShareLink) and also
+// `planscape://issue/{id}` and `planscape://deliverable/{code}` from the BCC.
+// Until now nothing on Windows knew what `planscape://` meant, so those links
+// were formatted strings and clicking one did nothing.
+//
+// Windows protocol handlers must point at a standalone .exe. StingTools is a
+// DLL loaded inside Revit.exe, so it cannot be the registered target. The
+// registered target is the tiny StingLink.exe helper in
+// StingTools.LinkHandler/, which shares THIS file via <Compile Include> — the
+// same trick tools/StampDrawingTypeChecksums uses. That is why nothing here may
+// touch the Revit API, WPF, or anything else the helper cannot load.
+//
+// Flow (Revit already running — the case this ships working):
+//
+//   user clicks planscape://issue/abc
+//     → Windows launches StingLink.exe "planscape://issue/abc"
+//     → helper writes one .link file into the inbox and foregrounds Revit
+//     → PlanscapeLinkWatcher (an IIdlingJob inside the plugin) picks it up on
+//       the next Idling tick and opens/focuses the BCC on the right tab.
+//
+// A file inbox rather than a named pipe: the plugin has no listener thread and
+// should not grow one — everything in Revit must end up on the API thread via
+// Idling anyway, so a pipe would only add a thread whose job is to write to a
+// queue the Idling job already reads. The inbox also survives the "Revit is not
+// running yet" case for free.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Microsoft.Win32;
+
+namespace StingTools.Core
+{
+    /// <summary>One parsed <c>planscape://</c> link.</summary>
+    public sealed class PlanscapeLink
+    {
+        /// <summary>The first path segment, lower-cased: dashboard | issue | deliverable | …</summary>
+        public string Kind { get; set; } = "";
+
+        /// <summary>The second segment, URL-decoded: a project name, an issue id, a deliverable code.</summary>
+        public string Target { get; set; } = "";
+
+        /// <summary>The optional third segment. Only <c>dashboard</c> carries one (a yyyyMMdd-HHmm stamp).</summary>
+        public string Stamp { get; set; } = "";
+
+        /// <summary>The URI exactly as received, for logging.</summary>
+        public string Raw { get; set; } = "";
+
+        public override string ToString() =>
+            string.IsNullOrEmpty(Stamp) ? $"{Kind}/{Target}" : $"{Kind}/{Target}/{Stamp}";
+    }
+
+    public static class PlanscapeProtocol
+    {
+        public const string Scheme = "planscape";
+        private const string Prefix = Scheme + "://";
+
+        /// <summary>File name of the registered helper executable.</summary>
+        public const string HelperExeName = "StingLink.exe";
+
+        /// <summary>
+        /// Links older than this are dropped unread. A link is a "take me there
+        /// now" gesture; acting on one a user clicked last Tuesday, because Revit
+        /// happened to be shut at the time, would be a jump-scare.
+        /// </summary>
+        public static readonly TimeSpan MaxAge = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Where the helper drops links and the plugin collects them.
+        /// LocalApplicationData, so it is per-user and needs no elevation, and
+        /// so a roaming profile does not carry a stale link between machines.
+        /// </summary>
+        public static string InboxDir =>
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "STING", "link-inbox");
+
+        // ────────────────────────────────────────────────────────────────
+        //  Formatting + parsing
+        // ────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Percent-encode one path segment. Project names contain spaces
+        /// ("Kampala Uganda Temple") and the original link builder did not escape
+        /// them, which produced a URI Windows silently truncates at the space.
+        /// </summary>
+        public static string EscapeSegment(string value) =>
+            Uri.EscapeDataString(value ?? string.Empty);
+
+        /// <summary>
+        /// Parse a link. Returns null for anything that is not a
+        /// <c>planscape://</c> URI with at least a kind and a target.
+        ///
+        /// Hand-parsed rather than via <see cref="Uri"/> on purpose: links minted
+        /// before this pass are unescaped, so <c>new Uri(...)</c> throws on the
+        /// very links already sitting in people's clipboards and chat history.
+        /// Being lenient here is what makes those still work.
+        /// </summary>
+        public static PlanscapeLink Parse(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+            var s = raw.Trim().Trim('"');
+            if (!s.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)) return null;
+
+            var rest = s.Substring(Prefix.Length).TrimEnd('/');
+            if (rest.Length == 0) return null;
+
+            var parts = rest.Split('/');
+            var link = new PlanscapeLink
+            {
+                Raw = s,
+                Kind = Unescape(parts[0]).ToLowerInvariant(),
+                Target = parts.Length > 1 ? Unescape(parts[1]) : string.Empty,
+                Stamp = parts.Length > 2 ? Unescape(parts[2]) : string.Empty,
+            };
+            return string.IsNullOrEmpty(link.Kind) ? null : link;
+        }
+
+        private static string Unescape(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            try { return Uri.UnescapeDataString(s); }
+            catch (UriFormatException) { return s; } // a stray % — better raw than lost
+        }
+
+        // ────────────────────────────────────────────────────────────────
+        //  Inbox
+        // ────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Write a link into the inbox. Called by the helper .exe. Returns the
+        /// file path, or null if it could not be written.
+        /// </summary>
+        public static string Drop(string rawUri)
+        {
+            if (string.IsNullOrWhiteSpace(rawUri)) return null;
+            try
+            {
+                Directory.CreateDirectory(InboxDir);
+                // Time-ordered name + a GUID tail: two links clicked in the same
+                // millisecond must not overwrite one another.
+                var name = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0:yyyyMMdd-HHmmss-fff}-{1}.link",
+                    DateTime.UtcNow, Guid.NewGuid().ToString("N").Substring(0, 8));
+                var path = Path.Combine(InboxDir, name);
+                File.WriteAllText(path, rawUri.Trim(), new UTF8Encoding(false));
+                return path;
+            }
+            catch (Exception)
+            {
+                // The helper has no logger and no console. Swallowing here is
+                // deliberate; the caller reports failure to the user instead.
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Collect and DELETE every pending link. Called by the plugin.
+        ///
+        /// Deleting as we read is what makes this safe with two Revit instances
+        /// open: whichever one reads the file first owns the link, and the other
+        /// never sees it. Two Revits both jumping to the same issue would be
+        /// worse than one of them missing it.
+        /// </summary>
+        public static List<PlanscapeLink> TakePending()
+        {
+            var found = new List<PlanscapeLink>();
+            string dir = InboxDir;
+            if (!Directory.Exists(dir)) return found;
+
+            string[] files;
+            try { files = Directory.GetFiles(dir, "*.link"); }
+            catch (Exception) { return found; }
+
+            Array.Sort(files, StringComparer.OrdinalIgnoreCase); // oldest first
+            var cutoff = DateTime.UtcNow - MaxAge;
+
+            foreach (var file in files)
+            {
+                string raw = null;
+                bool stale = false;
+                try
+                {
+                    stale = File.GetLastWriteTimeUtc(file) < cutoff;
+                    if (!stale) raw = File.ReadAllText(file);
+                }
+                catch (IOException)
+                {
+                    // The helper may still be writing it. Leave it; the next tick
+                    // gets it. Do NOT delete a file we failed to read.
+                    continue;
+                }
+                catch (UnauthorizedAccessException) { continue; }
+
+                try { File.Delete(file); } catch (Exception) { /* best effort */ }
+
+                if (stale || raw == null) continue;
+                var link = Parse(raw);
+                if (link != null) found.Add(link);
+            }
+            return found;
+        }
+
+        // ────────────────────────────────────────────────────────────────
+        //  Windows registration — HKEY_CURRENT_USER ONLY
+        // ────────────────────────────────────────────────────────────────
+        //
+        // Deliberately never HKLM. HKCU\Software\Classes needs no elevation, is
+        // scoped to the signed-in user, and takes precedence over HKLM for the
+        // same key. Writing machine-wide state from a plugin's OnStartup — which
+        // runs unattended every time Revit launches — is not something to do
+        // without a human saying yes.
+
+        private static string KeyPath => @"Software\Classes\" + Scheme;
+
+        /// <summary>The command line currently registered for the scheme, or null.</summary>
+        public static string RegisteredCommand()
+        {
+            try
+            {
+                using (var key = Registry.CurrentUser.OpenSubKey(KeyPath + @"\shell\open\command"))
+                    return key?.GetValue(null) as string;
+            }
+            catch (Exception) { return null; }
+        }
+
+        /// <summary>Build the exact command string for a helper path.</summary>
+        public static string CommandFor(string helperExePath) => "\"" + helperExePath + "\" \"%1\"";
+
+        /// <summary>
+        /// Register (or repair) the scheme for the current user so it points at
+        /// <paramref name="helperExePath"/>. Idempotent — returns false with a
+        /// reason when it did nothing, including the common "already correct".
+        ///
+        /// Re-registering on every startup is intentional: the plugin folder
+        /// moves (it currently lives in CompiledPlugin, and has moved before), and
+        /// a protocol pointing at a deleted exe fails silently and confusingly.
+        /// </summary>
+        public static bool EnsureRegistered(string helperExePath, out string detail)
+        {
+            detail = "";
+            if (string.IsNullOrWhiteSpace(helperExePath))
+            {
+                detail = "no helper path";
+                return false;
+            }
+            if (!File.Exists(helperExePath))
+            {
+                // Expected when the plugin is deployed without the helper —
+                // registering a path that does not exist is worse than not
+                // registering, because Windows then reports a broken handler
+                // instead of "no handler".
+                detail = $"{HelperExeName} not found beside the plugin ({helperExePath})";
+                return false;
+            }
+
+            string want = CommandFor(helperExePath);
+            if (string.Equals(RegisteredCommand(), want, StringComparison.OrdinalIgnoreCase))
+            {
+                detail = "already registered";
+                return false;
+            }
+
+            try
+            {
+                using (var root = Registry.CurrentUser.CreateSubKey(KeyPath))
+                {
+                    if (root == null) { detail = "could not create HKCU key"; return false; }
+                    root.SetValue(null, "URL:Planscape Protocol");
+                    // The presence of "URL Protocol" — empty value and all — is
+                    // what marks a key as a protocol handler. Without it Windows
+                    // ignores the whole branch.
+                    root.SetValue("URL Protocol", "");
+                    using (var icon = root.CreateSubKey("DefaultIcon"))
+                        icon?.SetValue(null, helperExePath + ",0");
+                    using (var cmd = root.CreateSubKey(@"shell\open\command"))
+                        cmd?.SetValue(null, want);
+                }
+                detail = want;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                detail = ex.Message;
+                return false;
+            }
+        }
+
+        /// <summary>Remove the registration. Not called automatically — uninstall is a human decision.</summary>
+        public static bool Unregister(out string detail)
+        {
+            detail = "";
+            try
+            {
+                Registry.CurrentUser.DeleteSubKeyTree(KeyPath, throwOnMissingSubKey: false);
+                return true;
+            }
+            catch (Exception ex) { detail = ex.Message; return false; }
+        }
+    }
+}

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -97,6 +97,11 @@ namespace StingTools.Core
                 RegisterPlanscapeProtocol();
                 StingIdlingScheduler.Enqueue(new PlanscapeLinkWatcher());
 
+                // Document sync — start the Planscape Companion if it shipped
+                // with this plugin and isn't already up. This is the piece that
+                // makes sync zero-touch for a user who only ever opens Revit.
+                LaunchCompanionIfInstalled();
+
                 // Register the dockable panel — the single unified UI.
                 // Create the shared "STING Tools" ribbon tab FIRST and in its
                 // own try/catch so a failure inside any single panel
@@ -421,6 +426,81 @@ namespace StingTools.Core
             catch (Exception ex)
             {
                 StingLog.Warn($"planscape:// registration: {ex.Message}");
+            }
+        }
+
+        /// <summary>File name of the document-sync tray app, shipped beside this DLL.</summary>
+        internal const string CompanionExeName = "Planscape.Companion.exe";
+
+        /// <summary>
+        /// Start the Planscape Companion if it is installed beside this plugin and
+        /// is not already running. Document sync has to work while Revit is
+        /// closed, so the Companion runs on its own; this is only the convenience
+        /// that gets it going for a user whose first act of the day is opening
+        /// Revit.
+        ///
+        /// <para><b>"Installed" means present in the plugin's own output
+        /// directory</b> — the same place <c>StingLink.exe</c> lives, put there by
+        /// the <c>CopyPlanscapeCompanion</c> MSBuild target. If it is absent that
+        /// is a packaging problem, and it is logged as one rather than worked
+        /// around by hunting for a copy somewhere else on disk: launching an
+        /// unknown build from a stale dev path is worse than not launching.</para>
+        ///
+        /// <para>Fire-and-forget on a background thread. The "is it running"
+        /// probe is a pipe connect with a short timeout, and Revit's startup path
+        /// must not wait on it — startup is already the most contended moment in
+        /// the session.</para>
+        /// </summary>
+        private static void LaunchCompanionIfInstalled()
+        {
+            try
+            {
+                string dir = Path.GetDirectoryName(AssemblyPath);
+                if (string.IsNullOrEmpty(dir)) return;
+                string exe = Path.Combine(dir, CompanionExeName);
+
+                if (!File.Exists(exe))
+                {
+                    StingLog.Info(
+                        $"Planscape Companion not installed ({exe}); document sync will not run. "
+                        + "This is a packaging issue if sync is expected — the build copies it next to the plugin.");
+                    return;
+                }
+
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    try
+                    {
+                        // Ask the Companion itself rather than scanning the process
+                        // list: a process by that name might be another user's
+                        // session, and what actually matters is whether THIS user's
+                        // pipe answers.
+                        if (await Planscape.Companion.CompanionIpcClient.IsRunningAsync())
+                        {
+                            StingLog.Info("Planscape Companion already running.");
+                            return;
+                        }
+
+                        var psi = new System.Diagnostics.ProcessStartInfo(exe)
+                        {
+                            UseShellExecute = false,
+                            CreateNoWindow = true,
+                            WorkingDirectory = dir,
+                        };
+                        using var started = System.Diagnostics.Process.Start(psi);
+                        StingLog.Info($"Planscape Companion started (pid {started?.Id}).");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Never fatal. Sync not running is a degraded state, not a
+                        // reason to fail Revit startup.
+                        StingLog.Warn($"Planscape Companion launch: {ex.Message}");
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Planscape Companion launch: {ex.Message}");
             }
         }
 

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -86,6 +86,17 @@ namespace StingTools.Core
                 // via StingIdlingScheduler.Enqueue(job).
                 StingIdlingScheduler.Register(application);
 
+                // planscape:// deep links. Two halves, both cheap:
+                //   1. Point HKCU\Software\Classes\planscape at StingLink.exe
+                //      beside this DLL, so Windows knows what the scheme means.
+                //      HKCU only — no elevation, no machine-wide state.
+                //   2. Queue the inbox watcher so a link clicked while Revit is
+                //      running opens the Coordination Center.
+                // Both are non-fatal: a plugin folder without StingLink.exe just
+                // means links stay inert, exactly as they were before.
+                RegisterPlanscapeProtocol();
+                StingIdlingScheduler.Enqueue(new PlanscapeLinkWatcher());
+
                 // Register the dockable panel — the single unified UI.
                 // Create the shared "STING Tools" ribbon tab FIRST and in its
                 // own try/catch so a failure inside any single panel
@@ -377,6 +388,39 @@ namespace StingTools.Core
                     "Failed to initialise STING Tools:\n" + ex.Message);
                 StingLog.Error("Startup failed", ex);
                 return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Point the <c>planscape://</c> scheme at the StingLink.exe helper
+        /// shipped beside this DLL.
+        ///
+        /// Re-checked on every startup rather than once: the plugin folder moves
+        /// between deployments, and a protocol registered against a path that no
+        /// longer exists fails in a way Windows reports as a broken app rather
+        /// than a missing one. <see cref="PlanscapeProtocol.EnsureRegistered"/>
+        /// is a no-op when the command is already correct, so the common case
+        /// costs one registry read.
+        ///
+        /// HKEY_CURRENT_USER only — writing a machine-wide handler unattended
+        /// from a plugin's startup is not something to do without being asked.
+        /// </summary>
+        private static void RegisterPlanscapeProtocol()
+        {
+            try
+            {
+                string dir = Path.GetDirectoryName(AssemblyPath);
+                if (string.IsNullOrEmpty(dir)) return;
+                string helper = Path.Combine(dir, PlanscapeProtocol.HelperExeName);
+
+                if (PlanscapeProtocol.EnsureRegistered(helper, out string detail))
+                    StingLog.Info($"planscape:// protocol registered → {detail}");
+                else
+                    StingLog.Info($"planscape:// protocol not registered: {detail}");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"planscape:// registration: {ex.Message}");
             }
         }
 

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -5817,6 +5817,53 @@ namespace StingTools.Core
                 catch (Exception ex) { StingLog.Warn($"ViewDocument dispatch: {ex.Message}"); }
                 return;
             }
+            // Slice E — "Download full version history" from the register context
+            // menu. Opt-in per document; nothing automatic ever reaches here.
+            if (action.StartsWith("DownloadDocumentHistory_", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    string code = action.Substring("DownloadDocumentHistory_".Length);
+                    var client = BIMManager.PlanscapeServerClient.Instance;
+
+                    // Two things must be true and both fail loudly rather than
+                    // silently doing nothing: a linked cloud project (the history
+                    // lives server-side) and a running Companion (it owns every
+                    // download — BCC never fetches files itself).
+                    if (client == null || !client.IsConnected || client.CurrentProjectId == Guid.Empty)
+                    {
+                        TaskDialog.Show("Document history",
+                            "Connect to Planscape Server and link this model to a cloud project first "
+                            + "— version history lives on the server.");
+                        return;
+                    }
+
+                    var status = BIMManager.CompanionSyncBridge.GetStatus();
+                    if (!status.Running)
+                    {
+                        TaskDialog.Show("Document history",
+                            "The Planscape Companion is not running on this machine."
+                            + Environment.NewLine + Environment.NewLine
+                            + "It performs the download, so start it and try again.");
+                        return;
+                    }
+
+                    // The register row carries an ISO code, not a server document
+                    // GUID. Resolving one to the other needs a document id on the
+                    // register, which it does not have yet — say so plainly rather
+                    // than guessing at a match and downloading the wrong file.
+                    string nl = Environment.NewLine;
+                    TaskDialog.Show("Document history",
+                        $"Requesting full version history for '{code}'." + nl + nl
+                        + "Note: the deliverable register does not yet carry the server document id, "
+                        + "so this cannot be resolved automatically. Use the Companion directly:" + nl + nl
+                        + $"    Planscape.Companion.exe --history {client.CurrentProjectId} <documentId>" + nl + nl
+                        + "The document id is shown in the web app's Documents list.");
+                }
+                catch (Exception ex) { StingLog.Warn($"DownloadDocumentHistory dispatch: {ex.Message}"); }
+                return;
+            }
+
             // Targeted revision deletion from the BCC register context menu:
             // "DeleteRevision_<elementId>" → RevisionDeleteCommand via ExtraParam.
             if (action.StartsWith("DeleteRevision_", StringComparison.OrdinalIgnoreCase))

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -3282,12 +3282,33 @@ namespace StingTools.Core
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
+            var uiApp = ParameterHelpers.GetApp(commandData);
+            if (ShowFor(uiApp, null, out string error)) return Result.Succeeded;
+            message = error;
+            return Result.Failed;
+        }
+
+        /// <summary>
+        /// Open — or focus, if it is already up — the BIM Coordination Center.
+        ///
+        /// Split out of <see cref="Execute"/> so callers that have a
+        /// <see cref="UIApplication"/> but no <see cref="ExternalCommandData"/>
+        /// can use it. The planscape:// link watcher is one: it runs on the
+        /// Idling event, which hands out a UIApplication and nothing else, and
+        /// ExternalCommandData cannot be constructed.
+        /// </summary>
+        /// <param name="tabName">
+        /// Optional BCC nav tab to land on (e.g. "ISSUES"). Null keeps whatever
+        /// tab the user last had open, which is the right default for the ribbon
+        /// button — only a deep link knows better.
+        /// </param>
+        internal static bool ShowFor(UIApplication uiApp, string tabName, out string error)
+        {
+            error = "";
             try
             {
-                var uiApp = ParameterHelpers.GetApp(commandData);
-                var uidoc = uiApp?.ActiveUIDocument;
-                Document doc = uidoc?.Document;
-                if (doc == null) { message = "No document open."; return Result.Failed; }
+                Document doc = uiApp?.ActiveUIDocument?.Document;
+                if (doc == null) { error = "No document open."; return false; }
 
                 // Phase 76: Singleton — if BCC is already open, just activate it
                 if (UI.BIMCoordinationCenter.CurrentInstance != null)
@@ -3296,8 +3317,10 @@ namespace StingTools.Core
                     {
                         UI.BIMCoordinationCenter.CurrentInstance.Activate();
                         UI.BIMCoordinationCenter.CurrentInstance.Focus();
+                        if (!string.IsNullOrEmpty(tabName))
+                            UI.BIMCoordinationCenter.CurrentInstance.NavigateToTab(tabName);
                     });
-                    return Result.Succeeded;
+                    return true;
                 }
 
                 // Create ExternalEvent for modeless dispatch (once per Revit session)
@@ -3315,16 +3338,18 @@ namespace StingTools.Core
                 };
 
                 var coordData = BuildCoordData(doc);
-                if (coordData == null) { message = "Could not build coordination data."; return Result.Failed; }
+                if (coordData == null) { error = "Could not build coordination data."; return false; }
 
                 UI.BIMCoordinationCenter.Show(coordData);
-                return Result.Succeeded;
+                if (!string.IsNullOrEmpty(tabName))
+                    UI.BIMCoordinationCenter.CurrentInstance?.NavigateToTab(tabName);
+                return true;
             }
             catch (Exception ex)
             {
                 StingLog.Error("BIMCoordinationCenter failed", ex);
-                message = ex.Message;
-                return Result.Failed;
+                error = ex.Message;
+                return false;
             }
         }
 

--- a/StingTools/Core/WarningsManager.cs
+++ b/StingTools/Core/WarningsManager.cs
@@ -13,6 +13,7 @@ using Autodesk.Revit.UI;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StingTools.Tags;
+using StingTools.Commands.Delivery;
 
 namespace StingTools.Core
 {
@@ -4387,6 +4388,71 @@ namespace StingTools.Core
                     }
                 }
                 catch (Exception ex) { StingLog.Warn($"BuildCoordData: My Queue load failed: {ex.Message}"); }
+
+                // Deliverables tab — deliverables.json already exists (DeliverableLifecycle.Persist
+                // writes it, ReconcileAsync/JoinLifecycle already read it) but nothing populated
+                // coordData.Deliverables, so the tab was permanently empty regardless of project
+                // state. Same resolver DeliveryCommands uses for the MIDP drift report, so this
+                // can never disagree with that reader about where the file lives.
+                //
+                // The file's schema is intentionally loose (DeliverableLifecycle.Persist writes
+                // whatever properties the calling command happened to set — see its own comment),
+                // so every field is read via DocumentIdentity.FirstNonBlank's candidate-list
+                // pattern, the same tolerant-read rule ReconcileAsync/JoinLifecycle already rely
+                // on, rather than a strict shape that would silently show blanks the moment a
+                // caller used a different alias.
+                try
+                {
+                    string path = MidpDriftReportCommand.ResolveDeliverablesPath(doc);
+                    if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    {
+                        var arr = JArray.Parse(File.ReadAllText(path));
+                        var now = DateTime.Now;
+                        foreach (var o in arr.OfType<JObject>())
+                        {
+                            string code = Core.DocumentIdentity.FirstNonBlank(o, Core.DocumentIdentity.DeliverableKeys);
+                            if (string.IsNullOrEmpty(code)) continue; // unkeyed row — Persist itself refuses these, but tolerate hand-edited files
+
+                            // No lowercase "status" fallback here on purpose: JoinLifecycle's own
+                            // comment shows "status" has historically been overloaded to mean
+                            // SUITABILITY in some legacy rows (o["Suitability"] ?? o["suitability"]
+                            // ?? o["status"]) — adding it here would misread a suitability code as
+                            // a workflow state on exactly the files most likely to need the fallback.
+                            string status = Core.DocumentIdentity.FirstNonBlank(o, "Status", "WorkflowStatus") ?? "Pending";
+                            string dueRaw = Core.DocumentIdentity.FirstNonBlank(o, "DueDate", "PlannedDate", "Due", "duedate", "planneddate");
+                            bool overdue = status != "Approved"
+                                && DateTime.TryParse(dueRaw, out var due) && due.Date < now.Date;
+
+                            coordData.Deliverables.Add(new UI.BIMCoordinationCenter.DeliverableRow
+                            {
+                                Code = code,
+                                Name = Core.DocumentIdentity.FirstNonBlank(o, "Title", "Name", "Description", "title", "description") ?? code,
+                                Discipline = Core.DocumentIdentity.FirstNonBlank(o, "Discipline", "DISC", "discipline") ?? "",
+                                Type = Core.DocumentIdentity.FirstNonBlank(o, "Type", "Kind", "DocType", "type") ?? "",
+                                DataDrop = Core.DocumentIdentity.FirstNonBlank(o, "DataDrop", "Milestone", "Stage", "milestone") ?? "",
+                                Status = status,
+                                Suitability = Core.DocumentIdentity.FirstNonBlank(o, "Suitability", "ActualSuitability", "RequiredSuitability", "suitability") ?? "",
+                                CDE = Core.DocumentIdentity.FirstNonBlank(o, "CDE", "CdeStatus", "cde") ?? "",
+                                Owner = Core.DocumentIdentity.FirstNonBlank(o, "Owner", "Originator", "OrgCode", "originator") ?? "",
+                                DueDate = dueRaw ?? "",
+                                IsOverdue = overdue,
+                                // SyncBadge/SyncTooltip stay at their "" default — that is the
+                                // documented normal case on a machine with no Companion running.
+                                // Populating them from the Companion's local sync-folder state is
+                                // a separate follow-up, not part of getting the list itself to
+                                // stop being permanently empty.
+                            });
+                        }
+
+                        coordData.DeliverablesPending = coordData.Deliverables.Count(d => d.Status == "Pending");
+                        coordData.DeliverablesSubmitted = coordData.Deliverables.Count(d => d.Status == "Submitted");
+                        coordData.DeliverablesApproved = coordData.Deliverables.Count(d => d.Status == "Approved");
+                        coordData.DeliverablesOverdue = coordData.Deliverables.Count(d => d.IsOverdue);
+                    }
+                    // No file ⇒ project has never imported an MIDP. Deliverables stays empty —
+                    // that is correct, not a fallback to hide.
+                }
+                catch (Exception ex) { StingLog.Warn($"BuildCoordData: deliverables load failed: {ex.Message}"); }
 
                 StingLog.Info($"BIMCoordCenter built: health={healthScore}, warnings={warningReport.Total}, compliance={tagPct:F1}%");
                 return coordData;

--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -156,6 +156,59 @@
           SkipUnchangedFiles="true" Condition="Exists('%(StingLinkPayload.FullPath)')" />
   </Target>
 
+  <!--
+    Planscape.Companion — the document-sync tray app. Same arrangement as
+    StingLink.exe above and for the same reasons: StingToolsApp.OnStartup looks
+    for it NEXT TO this DLL (LaunchCompanionIfInstalled), and the deploy step is
+    "copy bin\Release over the live plugin folder", so anything outside the
+    output directory never reaches a user.
+
+    Framework-dependent .NET 8 exes need all four files — the apphost, the
+    managed dll, runtimeconfig.json and deps.json. Shipping the .exe alone
+    produces a process that refuses to start with no useful message.
+
+    ReferenceOutputAssembly=false: nothing in the plugin links against the
+    Companion's assembly. The one type they share (CompanionIpcContract.cs) is
+    compiled into both by the <Compile Include> below, so an assembly reference
+    would be circular as well as unnecessary.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Planscape.Companion\Planscape.Companion.csproj"
+                      ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
+
+  <Target Name="CopyPlanscapeCompanion" AfterTargets="Build">
+    <ItemGroup>
+      <CompanionPayload Include="$(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Planscape.Companion.exe;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Planscape.Companion.dll;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Planscape.Companion.runtimeconfig.json;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Planscape.Companion.deps.json" />
+      <!-- The Companion's own NuGet closure (SignalR client + its transitive
+           deps). Unlike StingLink, which has none, this one will not start
+           without them. Globbed rather than listed because the SignalR client's
+           transitive set is not something to hand-maintain in an MSBuild item. -->
+      <CompanionPayload Include="$(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Microsoft.AspNetCore.*.dll;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\Microsoft.Extensions.*.dll;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\System.IO.Pipelines.dll;
+                                 $(MSBuildThisFileDirectory)..\Planscape.Companion\bin\$(Configuration)\System.Threading.Channels.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(CompanionPayload)" DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true" Condition="Exists('%(CompanionPayload.FullPath)')" />
+  </Target>
+
+  <!--
+    The Companion↔BCC pipe contract, compiled into BOTH assemblies so the request
+    and response shapes cannot drift apart. Exactly the trick StingLink.exe uses
+    with Core\PlanscapeProtocol.cs, in the opposite direction.
+
+    A build error pointing at this file almost always means Revit/WPF crept into
+    it — it has to stay loadable by a tray app that references neither.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Planscape.Companion\CompanionIpcContract.cs"
+             Link="BIMManager\Shared\CompanionIpcContract.cs" />
+  </ItemGroup>
+
   <!-- Phase 95: BcfEngine physically lives here but is compiled into
        Planscape.Shared.dll (via <Compile Include="..\..\..\StingTools\..."/>
        in Planscape.Shared.csproj). Exclude it from the StingTools assembly to

--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -125,7 +125,36 @@
     <!-- Phase 110: Standards & compliance calc library. Pure C#, no
          Revit dependency; StingTools commands wrap the APIs. -->
     <ProjectReference Include="..\StingTools.Standards\StingTools.Standards.csproj" />
+    <!-- StingLink.exe — the registered planscape:// handler. ReferenceOutputAssembly=false
+         because nothing here calls into it: this reference exists ONLY to make the
+         helper build alongside the plugin. It shares Core\PlanscapeProtocol.cs by
+         <Compile Include>, so an actual assembly reference would be circular. -->
+    <ProjectReference Include="..\StingTools.LinkHandler\StingTools.LinkHandler.csproj"
+                      ReferenceOutputAssembly="false" Private="false" />
   </ItemGroup>
+
+  <!--
+    Ship StingLink.exe beside StingTools.dll.
+
+    It has to sit next to the plugin because that is where StingToolsApp looks
+    for it when registering the protocol (RegisterPlanscapeProtocol), and because
+    the deploy step is "copy bin\Release over CompiledPlugin" — anything not in
+    the output directory does not reach a user's machine.
+
+    All four files are needed: a framework-dependent .NET 8 exe is an apphost
+    (.exe) plus the managed .dll plus .runtimeconfig.json plus .deps.json. Ship
+    the .exe alone and it fails to start. The .pdb is deliberately not copied.
+  -->
+  <Target Name="CopyStingLinkHelper" AfterTargets="Build">
+    <ItemGroup>
+      <StingLinkPayload Include="$(MSBuildThisFileDirectory)..\StingTools.LinkHandler\bin\$(Configuration)\StingLink.exe;
+                                 $(MSBuildThisFileDirectory)..\StingTools.LinkHandler\bin\$(Configuration)\StingLink.dll;
+                                 $(MSBuildThisFileDirectory)..\StingTools.LinkHandler\bin\$(Configuration)\StingLink.runtimeconfig.json;
+                                 $(MSBuildThisFileDirectory)..\StingTools.LinkHandler\bin\$(Configuration)\StingLink.deps.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(StingLinkPayload)" DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true" Condition="Exists('%(StingLinkPayload.FullPath)')" />
+  </Target>
 
   <!-- Phase 95: BcfEngine physically lives here but is compiled into
        Planscape.Shared.dll (via <Compile Include="..\..\..\StingTools\..."/>

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -820,6 +820,15 @@ namespace StingTools.UI
             public string DueDate { get; set; }
             public bool IsOverdue { get; set; }
 
+            /// <summary>
+            /// Document sync — the local state of this deliverable on THIS
+            /// machine, resolved from the Planscape Companion's sync folder.
+            /// Set by BuildCoordData; empty when nothing is synced, which is the
+            /// normal case on a machine with no Companion.
+            /// </summary>
+            public string SyncBadge { get; set; } = "";
+            public string SyncTooltip { get; set; } = "";
+
             // ── v1.0 template-engine fields (S02) ──
             public string DocNumber { get; set; }
             public string Revision { get; set; }
@@ -1567,6 +1576,103 @@ namespace StingTools.UI
             btn.MouseEnter += (s, e) => { if (btn != _activeNav) btn.Background = Br(CNavHover); };
             btn.MouseLeave += (s, e) => { if (btn != _activeNav) btn.Background = Brushes.Transparent; };
             return btn;
+        }
+
+        /// <summary>
+        /// Document sync status + a "Sync now" button, talking to the Planscape
+        /// Companion over its named pipe.
+        ///
+        /// <para><b>Not running is information, not an error</b> (plan §1a/§1c).
+        /// A machine where nobody set sync up is the common case, and it renders
+        /// as a plain grey line explaining what is missing — not a red banner
+        /// implying something broke.</para>
+        ///
+        /// <para>Equally, <b>Offline is not an error</b>: a closed laptop or a
+        /// dropped VPN is expected and self-healing, so it reads grey. Only the
+        /// Error state gets the red treatment, because only Error needs a human.</para>
+        /// </summary>
+        private Border BuildDocumentSyncStrip()
+        {
+            var host = new Border
+            {
+                Background = Br(Color.FromRgb(0xF5, 0xF7, 0xFA)),
+                BorderBrush = Br(CBorder),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(10, 6, 10, 6),
+                Margin = new Thickness(0, 0, 0, 10),
+            };
+            var row = new StackPanel { Orientation = Orientation.Horizontal };
+
+            var dot = new Border
+            {
+                Width = 8, Height = 8, CornerRadius = new CornerRadius(4),
+                VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(0, 0, 8, 0),
+            };
+            var label = new TextBlock
+            {
+                FontSize = 11, VerticalAlignment = VerticalAlignment.Center, TextWrapping = TextWrapping.Wrap,
+            };
+            var syncBtn = new Button
+            {
+                Content = "Sync now", FontSize = 11, Cursor = Cursors.Hand,
+                Padding = new Thickness(10, 2, 10, 2), Margin = new Thickness(12, 0, 0, 0),
+                Background = Br(CHeaderBg), Foreground = Brushes.White, BorderThickness = new Thickness(0),
+            };
+
+            Action refresh = () =>
+            {
+                // Bounded by the pipe connect timeout, so the worst this can cost
+                // the UI thread is that timeout — not an indefinite block.
+                var st = BIMManager.CompanionSyncBridge.GetStatus();
+                if (!st.Running)
+                {
+                    dot.Background = Br(Color.FromRgb(0x9E, 0x9E, 0x9E));
+                    label.Text = "Document sync: the Planscape Companion is not running on this machine.";
+                    label.Foreground = Br(Color.FromRgb(0x55, 0x55, 0x55));
+                    syncBtn.IsEnabled = false;
+                    return;
+                }
+                syncBtn.IsEnabled = true;
+                bool error = st.NeedsAttention;
+                dot.Background = Br(error
+                    ? Color.FromRgb(0xC6, 0x28, 0x28)
+                    : string.Equals(st.State, "Offline", StringComparison.OrdinalIgnoreCase)
+                        ? Color.FromRgb(0x9E, 0x9E, 0x9E)
+                        : Color.FromRgb(0x2E, 0x7D, 0x32));
+                label.Text = st.Summary
+                    + (st.LinkedProjects > 0 ? $"  ·  {st.LinkedProjects} linked project(s)" : "")
+                    + (error && !string.IsNullOrEmpty(st.LastError) ? $"  ·  {st.LastError}" : "");
+                label.Foreground = Br(error ? Color.FromRgb(0xC6, 0x28, 0x28) : Color.FromRgb(0x33, 0x33, 0x33));
+            };
+
+            syncBtn.Click += (s, e) =>
+            {
+                // Starts a sync; it does not wait for one. The Companion answers
+                // immediately and downloads in its own time.
+                bool started = BIMManager.CompanionSyncBridge.SyncNow();
+                label.Text = started
+                    ? "Sync requested — the Companion is working in the background."
+                    : "Could not reach the Planscape Companion. Is it running?";
+                Dispatcher.BeginInvoke(new Action(() => refresh()),
+                    System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+            };
+
+            var refreshBtn = new Button
+            {
+                Content = "Refresh", FontSize = 11, Cursor = Cursors.Hand,
+                Padding = new Thickness(8, 2, 8, 2), Margin = new Thickness(6, 0, 0, 0),
+                Background = Brushes.Transparent, BorderBrush = Br(CBorder), BorderThickness = new Thickness(1),
+            };
+            refreshBtn.Click += (s, e) => refresh();
+
+            row.Children.Add(dot);
+            row.Children.Add(label);
+            row.Children.Add(syncBtn);
+            row.Children.Add(refreshBtn);
+            host.Child = row;
+            refresh();
+            return host;
         }
 
         private void Nav_Click(object sender, RoutedEventArgs e)
@@ -8683,6 +8789,13 @@ namespace StingTools.UI
             }
 
             // ── DELIVERABLES DATA GRID ──────────────────────────────────
+            // ── DOCUMENT SYNC STRIP ─────────────────────────────────────
+            // The user-facing payoff of the Companion pipe client: is sync
+            // running, when did it last succeed, and a way to kick it. Placed
+            // above the register because that is where a user asks "do I have
+            // these files".
+            root.Children.Add(BuildDocumentSyncStrip());
+
             root.Children.Add(MakeSectionHeader("DELIVERABLE REGISTER"));
 
             // ── ISO Discipline legend strip ─────────────────────────────
@@ -8812,6 +8925,39 @@ namespace StingTools.UI
                 dg.Columns.Add(new DataGridTextColumn { Header = "Status",     Binding = new Binding("Status"),     Width = 80 });
                 dg.Columns.Add(new DataGridTextColumn { Header = "Suit.",      Binding = new Binding("Suitability"),Width = 35 });
                 dg.Columns.Add(new DataGridTextColumn { Header = "CDE",        Binding = new Binding("CDE"),        Width = 60 });
+
+                // Document sync — local state of the file on THIS machine.
+                //
+                // The design asks for "the same visual pattern already used for
+                // the Live meeting badge". That badge lives in the WEB app, not
+                // here — BCC has no meetings badge to copy. Rather than invent a
+                // new look, this reuses BCC's OWN existing chip idiom: the
+                // rounded Border + small bold white text used by the discipline
+                // legend a few lines above. Same instinct the design had (no new
+                // UI language), applied to the language this window actually
+                // speaks. Flagged in the plan so the discrepancy is a decision,
+                // not a drift.
+                var syncChip = new FrameworkElementFactory(typeof(Border));
+                syncChip.SetValue(Border.CornerRadiusProperty, new CornerRadius(3));
+                syncChip.SetValue(Border.PaddingProperty, new Thickness(5, 1, 5, 1));
+                syncChip.SetValue(Border.HorizontalAlignmentProperty, HorizontalAlignment.Left);
+                syncChip.SetValue(Border.VerticalAlignmentProperty, VerticalAlignment.Center);
+                syncChip.SetBinding(Border.ToolTipProperty, new Binding("SyncTooltip"));
+                syncChip.SetBinding(Border.BackgroundProperty,
+                    new Binding("SyncBadge") { Converter = new SyncBadgeBrushConverter() });
+                syncChip.SetBinding(Border.VisibilityProperty,
+                    new Binding("SyncBadge") { Converter = new EmptyToCollapsedConverter() });
+                var syncText = new FrameworkElementFactory(typeof(TextBlock));
+                syncText.SetBinding(TextBlock.TextProperty, new Binding("SyncBadge"));
+                syncText.SetValue(TextBlock.FontSizeProperty, 9.0);
+                syncText.SetValue(TextBlock.FontWeightProperty, FontWeights.Bold);
+                syncText.SetValue(TextBlock.ForegroundProperty, Brushes.White);
+                syncChip.AppendChild(syncText);
+                var syncTemplate = new DataTemplate { VisualTree = syncChip };
+                dg.Columns.Add(new DataGridTemplateColumn
+                {
+                    Header = "Local", Width = 70, CellTemplate = syncTemplate, CanUserSort = false,
+                });
                 dg.Columns.Add(new DataGridTextColumn { Header = "Owner",      Binding = new Binding("Owner"),      Width = 80 });
                 dg.Columns.Add(new DataGridTextColumn { Header = "Due",        Binding = new Binding("DueDate"),    Width = 80 });
                 dg.ItemsSource = _data.Deliverables;
@@ -11561,6 +11707,52 @@ namespace StingTools.UI
         public IsCheckedSetConverter(System.Collections.Generic.HashSet<string> set) { _set = set; }
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
             => value is string s && _set.Contains(s);
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => System.Windows.Data.Binding.DoNothing;
+    }
+
+    /// <summary>
+    /// Document sync — badge label to chip colour.
+    ///
+    /// Green for a working copy (yours to edit), grey for a read-only reference
+    /// copy. Deliberately NOT red or amber for either: neither state is a
+    /// problem, and this window already spends red on overdue deliverables and
+    /// failing warnings. A colour that means "attention" spent on a routine state
+    /// is a colour that stops meaning attention.
+    /// </summary>
+    public sealed class SyncBadgeBrushConverter : System.Windows.Data.IValueConverter
+    {
+        private static readonly System.Windows.Media.SolidColorBrush Working =
+            new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x2E, 0x7D, 0x32));
+        private static readonly System.Windows.Media.SolidColorBrush Reference =
+            new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(0x78, 0x90, 0x9C));
+
+        static SyncBadgeBrushConverter()
+        {
+            // Frozen: these are shared across every row of the grid, and an
+            // unfrozen brush bound into hundreds of cells is pure overhead.
+            Working.Freeze();
+            Reference.Freeze();
+        }
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => string.Equals(value as string, "WORKING", StringComparison.Ordinal)
+                ? Working
+                : (object)Reference;
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => System.Windows.Data.Binding.DoNothing;
+    }
+
+    /// <summary>Empty string → Collapsed, so a row with no local copy shows nothing
+    /// rather than an empty chip.</summary>
+    public sealed class EmptyToCollapsedConverter : System.Windows.Data.IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => string.IsNullOrEmpty(value as string)
+                ? System.Windows.Visibility.Collapsed
+                : System.Windows.Visibility.Visible;
+
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
             => System.Windows.Data.Binding.DoNothing;
     }

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -9009,6 +9009,26 @@ namespace StingTools.UI
                 ctxCopyLink.Click += (s, e) => { var r = CtxDelRow(); if (r != null) { try { Clipboard.SetText($"planscape://deliverable/{r.Code}"); } catch (Exception ex3) { StingLog.Warn($"Suppressed: {ex3.Message}"); } } };
                 dgCtx.Items.Add(ctxCopyLink);
                 dgCtx.Items.Add(new Separator());
+
+                // Slice E — full version history, per document, on request only.
+                // The design is explicit that this is never a default: a drawing
+                // with forty revisions would otherwise multiply the sync folder
+                // by forty on every machine for nobody's benefit. A menu item is
+                // the deliberate click that opts in.
+                var ctxHistory = new MenuItem { Header = "⤓ Download full version history" };
+                ctxHistory.Click += (s, e) =>
+                {
+                    var r = CtxDelRow();
+                    if (r == null) return;
+                    // The register carries no server document GUID (see the
+                    // CompanionSyncBridge remarks), so this hands the row code to
+                    // the dispatcher, which resolves it against the live project
+                    // before asking the Companion. Reported through the same
+                    // action pipeline as every other row command.
+                    DispatchAction("DownloadDocumentHistory_" + r.Code);
+                };
+                dgCtx.Items.Add(ctxHistory);
+                dgCtx.Items.Add(new Separator());
                 var ctxCDE = new MenuItem { Header = "Update CDE Status" };
                 ctxCDE.Click += (s, e) => { DispatchAction("CDEStatus"); };
                 dgCtx.Items.Add(ctxCDE);

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -1575,6 +1575,31 @@ namespace StingTools.UI
                 NavigateTo(tabName);
         }
 
+        /// <summary>
+        /// Public face of <see cref="NavigateTo"/>, for callers that opened the
+        /// BCC to land on a specific tab — currently the planscape:// link
+        /// handler (<c>planscape://issue/…</c> should arrive on ISSUES, not on
+        /// whatever tab was last used).
+        ///
+        /// Marshals to the window's own dispatcher: the link watcher runs on
+        /// Revit's Idling event, which is not the WPF UI thread.
+        /// An unknown tab name is a no-op, never a crash — the nav is built from
+        /// data and an optional tab (HVAC, HEALTHCARE) may not exist.
+        /// </summary>
+        internal void NavigateToTab(string tabName)
+        {
+            if (string.IsNullOrWhiteSpace(tabName)) return;
+            try
+            {
+                if (Dispatcher.CheckAccess()) NavigateTo(tabName);
+                else Dispatcher.Invoke(() => NavigateTo(tabName));
+            }
+            catch (Exception ex)
+            {
+                StingTools.Core.StingLog.Warn($"BCC NavigateToTab('{tabName}'): {ex.Message}");
+            }
+        }
+
         private void NavigateTo(string tabName)
         {
             // Phase 75: Remember tab for cross-reopen persistence

--- a/docs/ACC_UI_SHELL_GRID_CONTRACT.md
+++ b/docs/ACC_UI_SHELL_GRID_CONTRACT.md
@@ -28,6 +28,20 @@ the controllers, not guessed:
 | **Documents** | `PUT …/documents/{docId}/state` | `newState`, `suitabilityCode`, `revision` — a **state transition**, not a free edit | read-only |
 | **Members** | `PUT …/members/{memberId}` | `projectRole`, `iso19650Role` | read-only |
 | **Transmittals** | `PUT …/transmittals/{txId}/{send\|acknowledge\|respond}` | **no inline cells** — these are *actions*, not field edits; they render as row buttons | read-only |
+| **Projects** | `PUT /api/projects/{id}` (`UpdateProjectRequest`) | `name`, `phase` | read-only |
+| **Team** (firm users) | *(none — `TenantAdminController` has no per-user update)* | **nothing** | read-only |
+
+**Two rows above need their reasoning stated, because "what the endpoint accepts"
+is a floor, not a ceiling:**
+
+- **Projects — `status` is accepted by the PUT and is still read-only.** Making it
+  an editable cell would create a second route to `Archived` that skips the
+  `?confirmCode=` gate `ArchiveProject` exists to enforce. The contract's rule is
+  "never *wider* than the endpoint", not "always exactly as wide". Archiving is a
+  row action with a type-the-code modal.
+- **Projects — `code` is read-only** because no endpoint writes it *and* because
+  it is the token the archive route demands as proof of intent. A renameable
+  confirmation token is not a confirmation.
 
 Two consequences worth stating rather than discovering later:
 - **Documents and transmittals are not really "editable grids"** — their write surface is a state
@@ -58,6 +72,10 @@ three-way merge before anyone has hit a conflict is speculative.
 - **Selection** — checkbox column; bulk actions apply the same single-field write per row, sequentially, and report `n succeeded, m failed`.
 - **Empty / loading / error** — `EmptyState` and `Skeleton` primitives, never a bare blank panel.
 - **Row click** — opens the existing detail route. Inline edit never navigates.
+- **Right-click (U6)** — `rowMenu` on the grid opens the shell's `Menu` at the
+  pointer. **It may only contain actions the row already offers** as a button or
+  a link. A right-click menu is a shortcut; an action reachable *only* by
+  right-clicking is undiscoverable, and on a touch device it does not exist at all.
 
 ### 1d. Open questions for the user (defaults chosen, easy to change)
 
@@ -93,6 +111,10 @@ contrast passes, that a grid edit round-trips against a live API. All of that is
 | U3 primitives | DONE | typecheck clean · build ✓ · `npm test` **59 passed** incl. 14 DataGrid tests that assert the contract itself — optimistic apply, **rollback + server message on failure**, no-op on unchanged value, Escape abandons, edit never navigates |
 | U4 route migration | DONE | typecheck clean · build ✓ · `npm test` **62 passed** incl. 3 new route invariants: no hard-coded palette utility survives anywhere, every rail link has a real `page.tsx`, every page is inside the AppShell |
 | U5 polish + a11y | DONE | typecheck clean · build ✓ · `npm test` **69 passed** incl. 7 new Menu keyboard/ARIA tests (arrow keys, Home/End, Escape restores focus, disabled items skipped) |
+| U6.1 archive endpoint wired | DONE | typecheck clean · build ✓ · `npm test` **71 passed** incl. 2 new (`archiveProject` sends `?confirmCode=`, URL-encodes reserved characters) |
+| U6.2 projects grid | DONE | typecheck clean · build ✓ · `npm test` **71** · `dotnet build Planscape.API` **0 errors** (one read-only `OpenIssueCount` added to the list projection) |
+| U6.3 tenant-wide invite | DONE | typecheck clean · build ✓ · `npm test` **74 passed** incl. 3 new (tenant route not a project route; `ApiError.body` survives so a 402 can be read) |
+| U6.4 right-click menu + richer columns | DONE | typecheck clean · build ✓ · `npm test` **79 passed** incl. 5 new context-menu tests (opens on the row that was clicked, acts on *that* row, closes after acting, Escape closes, right-click does not fire row navigation) |
 
 ---
 
@@ -195,6 +217,94 @@ Run `cd planscape-web && npm install && npm run dev`, point `NEXT_PUBLIC_API_BAS
 - [ ] **Focus visible on every control**, including inside modals and inside grid cells, in dark
       mode as well as light.
 
+### U6 — archive · projects grid · tenant invite · right-click
+
+**Still no browser in this environment** (checked: no playwright/puppeteer/cypress
+in `node_modules/.bin`, no browser MCP). Everything below is unverified visually.
+
+#### U6.1 — archive a project
+- [ ] **The confirm gate holds:** project overview → Archive. The red button is
+      **disabled** until you type the project's code exactly. Typing a wrong code
+      keeps it disabled — you should never be able to reach the server's 400.
+- [ ] **Case and whitespace:** ` abc-01 ` (lower-case, padded) enables the button
+      for a project coded `ABC-01`, and archiving succeeds. The client compare is
+      trimmed + case-insensitive to match the server's `OrdinalIgnoreCase`; if the
+      client is stricter than the server, this is where you find out.
+- [ ] **403 reads as permission, not failure:** sign in as someone who is neither
+      the project author nor a tenant Owner/Admin, archive a project they can see.
+      The dialog should say *"You do not have permission… Only the person who
+      created it, or a tenant Owner/Admin, can."* — inside the modal, not a toast
+      that vanishes.
+- [ ] **It is a SOFT delete:** after archiving, the project still exists — its
+      issues, documents and models are intact and it is reachable by URL. If
+      anything is *gone*, stop: the route is documented as archive-only.
+- [ ] **Idempotent:** archiving an already-archived project returns 204 and does
+      not error.
+
+#### U6.2 — projects grid
+- [ ] **It is a grid now,** not card tiles, with columns: Project, Code,
+      Compliance, Open issues, Phase, Status, Members, Last sync.
+- [ ] **Open-issue count is real** — cross-check one project's number against its
+      Issues tab with the status filter on "All" minus CLOSED. This is a new
+      server-side projection (`OpenIssueCount`); a wrong number here means the
+      predicate disagrees with `{id}/dashboard`.
+- [ ] **Name and Phase edit inline and survive a reload.** Code, Status,
+      Compliance, Open issues, Members and Last sync do **not** become editors
+      when clicked — Status especially, and that is deliberate (see §1a).
+- [ ] **Row click opens the project; clicking the open-issue count opens Issues**
+      and does *not* also navigate to the project overview.
+- [ ] **Archive from the row action** works and the row disappears/greys after the
+      list reloads.
+
+#### U6.3 — tenant-wide invite
+- [ ] **Reachable outside a project:** avatar menu → Team, from anywhere.
+- [ ] **As Owner/Admin:** the page lists everyone in the firm with quota tiles
+      (Authors / Coordinators / Projects / Storage). The tiles' numbers should
+      match `GET /api/tenant/dashboard` in the network tab.
+- [ ] **As a non-admin:** the page shows *"You need the Owner or Admin role…"* —
+      an explanation, not an error banner and not an empty grid.
+- [ ] **Invite succeeds:** invite a new email as Coordinator → the person appears
+      in the grid marked **Invited** (amber), not **Active**. They are inactive
+      until they set a password; the server's invite *email* is still a TODO on
+      its side, so nobody actually receives a link yet — confirm the copy does not
+      promise one.
+- [ ] **409 duplicate:** invite an email that already has an account → *"Someone
+      already has an account with that email."*
+- [ ] **402 quota (the one most likely to be wrong):** fill the plan's Author cap,
+      then invite another Author. Expect *"Your plan's seat limit is full.
+      Authors cap reached (N of N). Upgrade your plan…"* — the server's own reason
+      sentence. If you instead see the literal string **"quota_exceeded"**, the
+      `ApiError.body` plumbing is not reaching the handler.
+- [ ] **Unlimited plans:** on a plan with `int.MaxValue` limits, a quota tile shows
+      `∞`, never `2147483647`.
+
+#### U6.4 — right-click menu + richer columns
+- [ ] **Right-click a row** in Projects / Issues / Clashes / Members → a menu
+      appears **at the pointer**, the browser's own context menu does not.
+- [ ] **It acts on the row you clicked**, not the first or the last row. Right-click
+      the third row and pick Open — verify you land on the third row's record.
+- [ ] **Viewport clamping** (untestable in jsdom — `getBoundingClientRect` returns
+      zeroes there, so this is *only* verifiable by hand): right-click a row near
+      the **bottom-right corner** of the window. The menu must flip/clamp fully
+      into view, not hang off the edge.
+- [ ] **Keyboard:** with the menu open, ↑/↓ move between items, Home/End jump,
+      Escape closes and focus returns to where it was.
+- [ ] **Scroll interaction:** open a row menu on a long grid, then scroll. The
+      panel is `position: fixed`, so it will **stay put while the rows move** —
+      decide whether that is acceptable or whether it should close on scroll. It
+      is currently *not* wired to close on scroll.
+- [ ] **Disabled items:** on a clash with no linked issue, "Open linked issue" is
+      greyed and unclickable; arrow keys skip it.
+- [ ] **No new actions:** every menu item also exists as a visible button or link
+      on the same screen (§1c). If you find one that doesn't, that is a bug.
+- [ ] **New read-only columns show real data:** Issues → Type, Raised, and the
+      assignee's email under their name. Clashes → Kind, Issue (a "View" link only
+      on promoted clashes), Detected. Members → Invited by. Any column that is
+      empty for *every* row means the API isn't returning it and the column should
+      go, not stay as decoration.
+- [ ] **Touch devices have no right-click.** Confirm on a tablet that nothing is
+      unreachable — everything in a row menu must still be a visible control.
+
 ---
 
 ## 5. What is NOT done
@@ -211,3 +321,25 @@ Written down so nobody assumes it was covered:
 - **No bulk-edit UI.** The DataGrid supports selection and the contract describes bulk semantics,
   but no grid currently exposes a bulk action.
 - **No server-side sort/filter.** Client-side only, per the contract's default.
+
+### 6. Left deliberately unwired (U6)
+
+Named here so the next session doesn't assume they were missed:
+
+- **`DELETE /api/tenant/users/{userId}`** exists and works (it refuses to remove
+  the tenant Owner). The Team page does **not** call it. Removing someone from the
+  firm is a bigger action than removing them from a project — it wants the same
+  type-to-confirm treatment archive got, plus a decision about what happens to
+  their project memberships, and neither was in scope.
+- **Per-user role changes on the Team page.** `TenantAdminController` has no
+  update route at all, so every column there is read-only. Adding one would mean
+  widening the API, which the contract forbids doing to suit a grid.
+- **Documents and Transmittals have no `rowMenu`.** Their row actions are state
+  transitions with their own confirmations; folding those into a right-click menu
+  needs a decision about whether a transition should be one click away, and that
+  is a product call, not a UI chore.
+- **The row menu does not close on scroll.** It is `position: fixed`, so scrolling
+  leaves it hovering over different rows. Flagged in §4 for a human to judge.
+- **Item 6 from the session brief — syncing cloud documents down to a watched
+  local folder — was explicitly out of scope** for this pass and has no
+  scaffolding here.

--- a/docs/PLANSCAPE_PROTOCOL.md
+++ b/docs/PLANSCAPE_PROTOCOL.md
@@ -1,0 +1,207 @@
+# `planscape://` deep links — what works, what doesn't, and how to test it
+
+Branch `claude/livekit-corporate-ui-research-3233e0`. Companion to
+[`ACC_UI_SHELL_GRID_CONTRACT.md`](ACC_UI_SHELL_GRID_CONTRACT.md) (the web half of
+the same pass).
+
+---
+
+## 1. The problem
+
+StingTools has generated `planscape://` links for a long time:
+
+| Link | Minted by |
+|---|---|
+| `planscape://dashboard/{project}/{yyyyMMdd-HHmm}` | `PlanscapeServerClient.BuildDashboardShareLink` — copied to the clipboard from `WarningsManager.cs:4647` and `StingCommandHandler.cs:9150` |
+| `planscape://issue/{id}` | BCC Issues tab context menu (`BIMCoordinationCenter.cs:3274`) |
+| `planscape://deliverable/{code}` | BCC Deliverables tab context menu (`BIMCoordinationCenter.cs:8838`) |
+
+Nothing registered `planscape://` with Windows, so **clicking one did nothing**.
+They were formatted strings that looked like links.
+
+**The constraint that shapes the whole solution:** a Windows URL protocol handler
+must point at a standalone `.exe`. StingTools is a DLL loaded inside `Revit.exe`,
+so it cannot be the registered target. This could never be "add a registry key
+pointing at StingTools.dll".
+
+---
+
+## 2. What was built
+
+Option (a) from the brief — a minimal helper executable plus a file inbox.
+
+```
+user clicks planscape://issue/abc-123
+  └─ Windows reads HKCU\Software\Classes\planscape\shell\open\command
+       └─ launches  StingLink.exe "planscape://issue/abc-123"
+            ├─ writes ONE file into %LOCALAPPDATA%\STING\link-inbox\*.link
+            └─ finds the Revit window, restores + foregrounds it
+                 └─ PlanscapeLinkWatcher (IIdlingJob, inside the plugin)
+                      polls the inbox ~1×/s, takes the link, deletes the file
+                        └─ BIMCoordinationCenterCommand.ShowFor(uiApp, "ISSUES")
+```
+
+| File | Role |
+|---|---|
+| `StingTools/Core/PlanscapeProtocol.cs` | The shared contract — parse, escape, inbox read/write, HKCU registration. **Revit-free**, because the helper compiles it in. |
+| `StingTools.LinkHandler/` (`StingLink.exe`) | The registered target. ~180 lines, no UI framework, one `user32` message box for its three failure cases. |
+| `StingTools/Core/PlanscapeLinkWatcher.cs` | `IIdlingJob` that drains the inbox on Revit's API thread. |
+| `StingTools/Core/StingToolsApp.cs` | `RegisterPlanscapeProtocol()` on startup + enqueues the watcher. |
+| `StingTools/Core/WarningsManager.cs` | `BIMCoordinationCenterCommand.ShowFor(uiApp, tab, out error)` — `Execute` now delegates to it. |
+| `StingTools/UI/BIMCoordinationCenter.cs` | `NavigateToTab(string)` — an internal, dispatcher-marshalled face for the private `NavigateTo`. |
+
+### Decisions worth knowing
+
+- **Why a file inbox and not a named pipe.** A pipe needs a listener thread, and
+  anything that thread receives must be marshalled onto Revit's API thread
+  anyway — which is what the Idling job already does. The pipe would be a thread
+  whose only job is to write to a queue the Idling job reads. The inbox also
+  handles "Revit isn't running yet" for free.
+- **Why not `FileSystemWatcher`.** Same reason: it fires on a threadpool thread.
+  Polling an almost-always-empty directory once a second is cheaper than the
+  thread it would replace.
+- **HKCU only, never HKLM.** `HKCU\Software\Classes` needs no elevation, is
+  scoped to the signed-in user, and takes precedence over HKLM for the same key.
+  Writing machine-wide state unattended from a plugin's `OnStartup` is not
+  something to do without a human agreeing to it.
+- **Re-registered on every startup.** `EnsureRegistered` is a no-op when the
+  command already matches, so the usual cost is one registry read. It re-points
+  when the plugin folder moves — which it does; see the deploy-target memory —
+  because a protocol registered against a deleted `.exe` fails as "broken app",
+  which is more confusing than "no handler".
+- **Links are parsed by hand, not via `System.Uri`.** Links minted before this
+  pass never escaped the project name, so `planscape://dashboard/Kampala Uganda
+  Temple/…` is not a legal URI and `new Uri(...)` throws on it. Being lenient is
+  what keeps links already sitting in people's chat history working.
+  `EscapeSegment` exists for new links.
+- **Queued links expire after 30 minutes** (`PlanscapeProtocol.MaxAge`). A link
+  is a "take me there now" gesture; acting on one clicked last Tuesday, because
+  Revit happened to be shut, would be a jump-scare.
+- **Reading a link deletes it.** With two Revit instances open, whichever reads
+  first owns the link and the other never sees it. Both jumping to the same issue
+  would be worse than one of them missing it.
+- **A `dashboard` link naming a different project asks before opening.** It
+  carries a project name; silently showing another model's coordination data
+  because that is what happened to be open would be quietly wrong.
+
+---
+
+## 3. Honest status — read this before assuming anything works
+
+### ✅ Built and machine-verified
+
+- `dotnet build StingTools.LinkHandler -c Release` → **0 warnings, 0 errors**.
+- `dotnet build StingTools -c Debug` and `-c Release` → **0 warnings, 0 errors**,
+  matching the repo baseline, with `StingLink.{exe,dll,runtimeconfig.json,deps.json}`
+  copied into the plugin output by the `CopyStingLinkHelper` target.
+- **The helper was actually run** outside Revit:
+  `StingLink.exe "planscape://dashboard/Kampala%20Uganda%20Temple/20260731-1430"`
+  → wrote `%LOCALAPPDATA%\STING\link-inbox\20260731-112742-793-bd6c62bb.link`
+  containing the URL verbatim, and (Revit not running) showed the queued-link
+  notice. The test file was deleted afterwards.
+
+### ⚠️ NOT verified — nobody has clicked a real link
+
+**The end-to-end path has never run.** No Revit session with this build has been
+started, no protocol has been registered on any machine, and no link has been
+clicked. Everything in §4 is open.
+
+### ❌ Not built at all — the "Revit is not running" case
+
+The brief called this out as lower priority and it is **not implemented**. When
+no Revit window is found, `StingLink.exe` queues the link and shows a message
+saying so; it does not launch Revit. That is a decision, not an omission:
+
+- Up to three Revit versions may be installed (2025 / 2026 / 2027) and the link
+  says nothing about which to use.
+- The link carries no `.rvt` path, so a launched Revit would open empty and the
+  30-minute window would likely expire before the user opened the right model.
+- Starting a multi-gigabyte application unprompted because someone clicked a link
+  in a chat message is a bigger action than the click implies.
+
+The queue makes the manual path work: open Revit within 30 minutes and the link
+fires. **If auto-launch is wanted later**, the missing pieces are (a) a Revit
+version/path lookup — `HKLM\SOFTWARE\Autodesk\Revit\<ver>\InstallationLocation`
+is the usual source — (b) a decision about which version wins, and (c) extending
+`MaxAge` for the launch case only, since startup plus model-open can exceed 30
+minutes on a large central model.
+
+### ❌ Also not done
+
+- **The target row is not selected.** `planscape://issue/{id}` opens the ISSUES
+  tab, not that issue. Resolving an id to a grid row means reaching into the
+  BCC's grids inside an 11,900-line file; the tab navigation is the MVP.
+- **Nothing generates the escaped form yet.** `EscapeSegment` exists and the
+  parser handles both, but `BuildDashboardShareLink` still emits the unescaped
+  project name. Changing it is a one-line follow-up; it was left alone so this
+  slice did not also alter what the existing copy-link buttons put on the
+  clipboard.
+- **No uninstall hook.** `PlanscapeProtocol.Unregister` exists and
+  `StingLink.exe --unregister` calls it, but nothing runs it automatically.
+
+---
+
+## 4. PENDING-HUMAN-VERIFY
+
+Needs a machine with Revit and the plugin deployed. Nothing below has been done.
+
+### Registration
+1. Build Release and deploy (`StingTools\bin\Release` → the live plugin folder;
+   grep the live `.addin` for the `<Assembly>` path first — it moves).
+   Confirm **`StingLink.exe` is in the deployed folder** next to `StingTools.dll`.
+   If it isn't, the copy target didn't reach the deploy step and nothing else
+   here can work.
+2. Start Revit. In `StingTools.log`, expect one of:
+   - `planscape:// protocol registered → "…\StingLink.exe" "%1"`
+   - `planscape:// protocol not registered: already registered`
+   - `planscape:// protocol not registered: StingLink.exe not found beside the plugin (…)` ← the failure to look for
+3. Check the key: `reg query HKCU\Software\Classes\planscape\shell\open\command`
+   → the command must quote the exe path **and** `%1`, and the path must exist.
+4. **Confirm nothing was written to HKLM:** `reg query HKLM\Software\Classes\planscape`
+   should say the key does not exist. If it does exist, stop and report it — this
+   feature is user-scope by design.
+
+### The case that is supposed to work: Revit already running
+5. With Revit open and a model loaded, use the BCC's copy-link on an issue, then
+   paste the link into the Run dialog (Win+R) and press Enter.
+   Expect: Revit comes to the front, the Coordination Center opens (or focuses)
+   **on the ISSUES tab**, within a second or so.
+6. Repeat for a deliverable link → DELIVERABLES tab.
+7. Repeat for a dashboard link **whose project name matches** the open model →
+   OVERVIEW tab, no prompt.
+8. Dashboard link for a **different** project → a dialog naming both projects and
+   asking whether to open the Coordination Center for the open one. "No" must do
+   nothing at all.
+9. **Minimised Revit:** minimise it, click a link. It should restore and come
+   forward, not just flash in the taskbar.
+10. **BCC already open on another tab:** it should switch tabs, not reopen.
+11. **Rapid clicks:** click three links quickly. Exactly one navigation happens
+    (the newest), and `StingTools.log` records
+    `PlanscapeLink: 3 queued links; handling the newest…`.
+12. **Idle cost:** leave Revit open and idle for a few minutes with no links.
+    Nothing appears in the log and there is no perceptible CPU from the watcher —
+    it should poll roughly once a second and find an empty directory.
+
+### The case that is NOT built
+13. Close Revit entirely, click a link. Expect a message box saying the link is
+    queued and to open Revit within 30 minutes. **Revit must NOT launch.**
+14. Then open Revit and a model. The queued link should fire once, shortly after
+    the model finishes loading.
+15. Wait more than 30 minutes with a queued link, then open Revit: the link is
+    silently discarded and the inbox is empty. Confirm no jump happens.
+
+### Edge cases
+16. **Old, unescaped link:** paste `planscape://dashboard/Some Project Name/20260101-0900`.
+    It should still parse — this is the compatibility case the hand-written
+    parser exists for. (Note: Windows itself may mangle a link with raw spaces
+    before it ever reaches the helper; if it does, that is a Windows limitation,
+    and the fix is switching `BuildDashboardShareLink` to `EscapeSegment`.)
+17. **Junk:** `planscape://` alone, and `planscape://nonsense` → the helper says
+    it is not a Planscape link (or opens OVERVIEW for an unknown kind) and does
+    not throw.
+18. **Read-only inbox:** deny write on `%LOCALAPPDATA%\STING\link-inbox`, click a
+    link → a clear "could not hand the link to StingTools" message naming the
+    path, not a silent failure.
+19. **Two Revits open**, click one link → exactly one of them navigates.
+20. `StingLink.exe --unregister` then click a link → Windows offers to search for
+    an app, i.e. the handler is genuinely gone. Re-register with `--register`.

--- a/docs/superpowers/plans/2026-07-31-document-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-31-document-sync-plan.md
@@ -182,7 +182,7 @@ Updated as each slice lands. Anything not marked DONE was not built.
 | B — Companion skeleton | **DONE** | builds 0 warnings / 0 errors · **run**: tray started, named pipe answered three real requests from a separate process, "not running" detected in 567 ms |
 | C — sync engine | **DONE, and proven end-to-end against a live server** | see §4a |
 | D — BCC integration | **DONE** | plugin + Companion build **0 warnings / 0 errors**; `dotnet test` **515 / 0 / 9** (unchanged from Slice A — no regressions); the per-project toggle proven end-to-end against a live server — see §4c |
-| E — tray polish | IN PROGRESS | — |
+| E — tray polish | **DONE** | Companion builds 0/0; full version history, the checked-out count and its discrimination all proven against a live server — see §4e. The tray GLYPHS are the one part nobody has looked at. |
 
 ### 4a. What was actually run
 
@@ -276,6 +276,27 @@ invent a new look for a WPF window, the badge reuses BCC's own existing chip idi
 above the register). Same instinct the spec had — no new UI language — applied to
 the language this window actually speaks.
 
+### 4e. Slice E — what was actually run
+
+Same harness as §4c: the API from this branch's source on `:5099` against the
+docker PostgreSQL, a real document with five stored versions.
+
+| Behaviour | Observed |
+|---|---|
+| **Full version history** | `--history <projectId> <documentId>` wrote all five versions into `_history\A-101-Floor-Plan\` as `… v001.pdf … v005.pdf`, each holding its own distinct revision text (P01, P02, P05, P10, P11) |
+| History is idempotent | a second run reported `0 downloaded, 5 already present` — content-addressed, like the main path |
+| History is read-only | all five carry `ReadOnly, Archive`; the live copy does not |
+| History is opt-in | nothing automatic ever calls it — it exists only behind `--history`, the IPC `sync-history` command, and the BCC menu item |
+| **Checked-out count** | `1 checked out` with one writable WIP copy present, correctly **excluding** two superseded copies and five read-only history files in the same tree |
+| Count discriminates | transitioning WIP→SHARED made the local copy read-only and the count dropped to **0**, with the tooltip losing the suffix |
+| Over the wire | `status` returns `checkedOutCount: 1` and `checkedOut: ["RIVERSIDETOW-2/A-101-Floor-Plan.pdf"]` — the exact shape BCC reads |
+
+**Naming caveat, recorded because the tray says "checked out":** this schema has
+no per-user checkout owner on `DocumentRecord`, so the count is really "WIP
+documents visible to this account and synced here". With the ACL narrowing
+currently inert (§4b) that set is wider than "checked out to me" would be. The
+code says so at `SyncEngine.WorkingCopiesIn`.
+
 ---
 
 ## 5. PENDING-HUMAN-VERIFY
@@ -363,3 +384,32 @@ unverified is the Revit-side wiring and how any of it looks.
     sync" card; unticking it says *Auto-sync paused*, and the copy makes clear that
     linked machines keep the project. Reload and confirm it stuck. This is
     server-verified in §4c but has never been **seen** rendering.
+
+### Companion tray (Slice E) — the glyphs have never been looked at
+
+The behaviour behind them is proven (§4e); what nobody has seen is the tray.
+
+21. **Four distinct glyphs.** Force each state and look at the icon at real size:
+    Idle = filled green disc · Syncing = blue arc with a gap · Offline = hollow
+    grey ring · Error = red disc with a white bar. **They must differ in SHAPE,
+    not only colour** — check by squinting, and ideally with a colour-blindness
+    simulator. If two states are only distinguishable by hue, the drawing needs
+    changing.
+22. **Offline still reads as calm.** Stop the API with the Companion running: the
+    icon becomes a hollow grey ring, the tooltip says "offline, will retry", and
+    **no notification of any kind appears** (plan §1c).
+23. **Error reads as urgent and names the cause.** Revoke the access token and
+    force a sync: red disc-with-bar, and the tooltip carries the server's own
+    message rather than a generic failure.
+24. **Checked-out list.** Right-click the tray with at least one WIP working copy
+    synced: the first item reads "N checked out" and expands to
+    `PROJECTCODE/filename` entries. Clicking one opens Explorer with that file
+    selected. With none synced it reads "No working copies" and is disabled.
+25. **Tooltip truncation.** With several projects linked, confirm the tooltip is
+    not silently cut off — Windows truncates `NotifyIcon.Text` past 63 characters
+    and gives no warning that it did.
+26. **History from BCC.** Right-click a deliverable row → "Download full version
+    history". Today this reports that the register carries no server document id
+    and tells the user the exact `--history` command instead. Confirm that message
+    is accurate and useful; when the register gains a document id (§4d), this is
+    the call site to finish.

--- a/docs/superpowers/plans/2026-07-31-document-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-31-document-sync-plan.md
@@ -181,8 +181,8 @@ Updated as each slice lands. Anything not marked DONE was not built.
 | A — server foundation | **DONE** | `dotnet build` 0 errors · `dotnet test` **515 / 0 failed / 9 skipped** (baseline 493/0/9 — **22 new**, no regressions) |
 | B — Companion skeleton | **DONE** | builds 0 warnings / 0 errors · **run**: tray started, named pipe answered three real requests from a separate process, "not running" detected in 567 ms |
 | C — sync engine | **DONE, and proven end-to-end against a live server** | see §4a |
-| D — BCC integration | NOT STARTED (next session) | — |
-| E — tray polish | NOT STARTED (next session) | — |
+| D — BCC integration | **DONE** | plugin + Companion build **0 warnings / 0 errors**; `dotnet test` **515 / 0 / 9** (unchanged from Slice A — no regressions); the per-project toggle proven end-to-end against a live server — see §4c |
+| E — tray polish | IN PROGRESS | — |
 
 ### 4a. What was actually run
 
@@ -220,6 +220,28 @@ recorded here because they are the class of bug this feature is most exposed to:
 created under `%APPDATA%\StingTools\` were removed (they did not exist before), and
 **no autostart registry entry was created** — confirmed absent afterwards.
 
+### 4c. Slice D — what was actually run
+
+The API was again run from this branch's source on `:5099` against the docker
+PostgreSQL, with a real PAT and a real document.
+
+| Behaviour | Observed |
+|---|---|
+| Schema column | `ALTER TABLE "Projects" ADD COLUMN IF NOT EXISTS "DocumentSyncAutoEnabled"` applied by the existing idempotent patcher — `[schema-patch] done — 21 ok, 0 failed`, and `\d "Projects"` shows `DocumentSyncAutoEnabled | boolean | not null | true` |
+| Default | a project that predates the column reads `documentSyncAutoEnabled = True` on the list payload |
+| **Toggle OFF** | `PUT /api/projects/{id} {"documentSyncAutoEnabled":false}` → a subsequent CDE transition pushed `(auto-sync off)` and the Companion logged the push and **stopped**. The file on disk stayed at the previous revision. |
+| **Manual overrides the toggle** | with auto-sync still OFF, `sync-now` over the pipe returned `{"ok":true,"started":true}` and downloaded the new revision, superseding the old copy — exactly what the design says manual should do |
+| **Toggle ON** | the next transition pushed `(auto-sync on)` and synced by itself |
+| Companion ships with the plugin | `Planscape.Companion.{exe,dll,runtimeconfig.json,deps.json}` + the SignalR client closure land in `StingTools/bin/Debug`, and the copied exe **runs from there** (`--status` succeeded), proving the dependency set is complete |
+| Shared pipe client | `--ping` (which calls the same `CompanionIpcClient` compiled into StingTools) reports `running: False` with the Companion stopped and full live status with it running |
+
+**One cross-project build constraint worth knowing:** `CompanionIpcContract.cs` is
+compiled into two projects with different settings — the Companion enables
+`ImplicitUsings` and nullable reference types, StingTools disables both. The file
+therefore declares every `using` explicitly and opens with `#nullable enable`.
+Without that it builds on one side and fails (or warns) on the other, which is
+how it was found.
+
 ### 4b. Known gap found while building, not a regression
 
 `ProjectMemberAcl.ResolveAsync` currently **hard-codes its three allow-list columns
@@ -230,6 +252,29 @@ cannot be *wider* than the list — and the test asserts exactly that subset
 invariant rather than a filtering behaviour that does not currently exist. When
 those columns are read for real, both endpoints narrow together. Flagged so nobody
 reads "respects `AllowedCdeStates`" as "filters today".
+
+### 4d. Second inert-plumbing finding (Slice D), same shape as §4b
+
+`CoordData.Deliverables` — the list behind BCC's DELIVERABLE REGISTER — **is never
+populated**. It is declared, read by the KPI cards and the grid, and appended to by
+the inline "add row" button, but nothing in `BuildCoordData` loads
+`_BIM_COORD/deliverables.json` into it. The register therefore renders empty in the
+normal flow, and the new **Local** sync badge column, though correct, has nothing to
+badge until rows exist.
+
+Not fixed here, deliberately: wiring the register to the deliverables file is a
+feature in its own right with its own schema-mapping decisions, and bundling it into
+a badge change would be exactly the drive-by this pass was told to avoid. It is
+recorded next to §4b because the two are the same kind of thing — correct code
+sitting on top of plumbing that was never connected.
+
+**A related design mismatch, decided rather than drifted:** the spec asks the badge
+to reuse "the same visual pattern already used for the Live meeting badge". That
+badge does not exist in BCC — it is in the *web* app's project overview. Rather than
+invent a new look for a WPF window, the badge reuses BCC's own existing chip idiom
+(the rounded `Border` + small bold white text of the discipline legend directly
+above the register). Same instinct the spec had — no new UI language — applied to
+the language this window actually speaks.
 
 ---
 
@@ -281,3 +326,40 @@ connection has ever been pointed at another firm's project on a live hub.
     attribute by hand is *not* fought over — it is a hint, not a lock.
 13. Break the target folder (deny write) and force a sync: the tray must enter the **Error** state
     with a tooltip naming the folder, and recover on its own once the permission is restored.
+
+### BCC / StingTools (Slice D) — none of this is verifiable without Revit
+
+There is no Revit session in this environment, so **nothing below has been seen**.
+The pipe client underneath it all IS proven headlessly (`--ping`, §4c); what is
+unverified is the Revit-side wiring and how any of it looks.
+
+14. **The Companion starts itself.** With `Planscape.Companion.exe` beside
+    `StingTools.dll` and no Companion running, launch Revit. `StingTools.log` must
+    say `Planscape Companion started (pid …)`. Launch Revit again with it already
+    running — the log must say `already running` and **no second process** appears
+    in Task Manager.
+15. **Missing Companion is reported, not worked around.** Delete
+    `Planscape.Companion.exe` from the plugin folder and start Revit: the log must
+    say `not installed (…); document sync will not run`, Revit must start normally,
+    and nothing should be launched from any other directory.
+16. **The sync strip.** Open BCC → DELIVERABLES. The strip above the register
+    shows a grey dot and "the Planscape Companion is not running" when it is
+    stopped; a green dot and the last-sync time when it is running and idle.
+    **Confirm the not-running case does not read as an error** — no red, no
+    warning icon (plan §1c).
+17. **Sync now.** With the Companion running, click *Sync now* → the strip says a
+    sync was requested and `companion.log` shows a `Manual` pass. With it stopped,
+    the button is disabled rather than silently doing nothing.
+18. **Offline is not red.** Stop the API, leave the Companion running, click
+    *Refresh* → the dot must be **grey**, not red. Then break something real (a
+    revoked token) → the dot must be **red** and the strip must name the error.
+19. **The Local badge.** See the caveat in §4d first — the register is empty in the
+    normal flow, so this most likely shows nothing at all. If rows are present
+    (added by hand in the editable register), a document synced as WIP shows a
+    green `WORKING` chip and a SHARED/PUBLISHED one a grey `REF` chip, with the
+    tooltip explaining the read-only hint. A row with no local copy shows an empty
+    cell, not an empty chip.
+20. **The auto-sync toggle in the web app.** `/projects/{id}` shows the "Document
+    sync" card; unticking it says *Auto-sync paused*, and the copy makes clear that
+    linked machines keep the project. Reload and confirm it stuck. This is
+    server-verified in §4c but has never been **seen** rendering.

--- a/docs/superpowers/plans/2026-07-31-document-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-31-document-sync-plan.md
@@ -178,18 +178,74 @@ Updated as each slice lands. Anything not marked DONE was not built.
 
 | Slice | Status | Proof |
 |---|---|---|
-| A — server foundation | NOT STARTED | — |
-| B — Companion skeleton | NOT STARTED | — |
-| C — sync engine | NOT STARTED | — |
+| A — server foundation | **DONE** | `dotnet build` 0 errors · `dotnet test` **515 / 0 failed / 9 skipped** (baseline 493/0/9 — **22 new**, no regressions) |
+| B — Companion skeleton | **DONE** | builds 0 warnings / 0 errors · **run**: tray started, named pipe answered three real requests from a separate process, "not running" detected in 567 ms |
+| C — sync engine | **DONE, and proven end-to-end against a live server** | see §4a |
 | D — BCC integration | NOT STARTED (next session) | — |
 | E — tray polish | NOT STARTED (next session) | — |
+
+### 4a. What was actually run
+
+The API was run **from this branch's source** on `:5099` against the docker
+PostgreSQL (the running `docker-api-1` container is an older image — it 404s on
+`changed-since`, which is how the version gap was spotted). A real personal access
+token, a real uploaded document, a real Companion process.
+
+| Behaviour | Observed |
+|---|---|
+| Initial sync | `1 downloaded`; SHA-256 on disk **matches the server's `contentHash` exactly** |
+| Idempotent re-run | `0 downloaded`, delta mark advanced, nothing re-fetched |
+| Read-only hint | WIP copy writable; after WIP→SHARED the copy is `ReadOnly`; the superseded copy is **not** (so it can still be moved) |
+| It is a hint, not a lock | cleared the attribute by hand and appended to the file — nothing fought back |
+| Supersede | old copy → `A-101-Floor-Plan (superseded 2026-07-31).pdf` with the **P01 bytes intact**, new bytes live |
+| Same-day collision | resolved as `(superseded 2026-07-31 #2).pdf`, `#3` |
+| **SignalR push** | with only the tray running, a transition on another connection produced `push: cde_transition` → `sync (Push)` → supersede + download. **Nobody touched the Companion.** |
+| Purge | 9-day-old *superseded* file deleted; a recent superseded file **and** a 9-day-old *non-superseded* user file both untouched |
+| Foreign project | reports "not visible to this account" rather than failing opaquely |
+| IPC | `ping` returned the matching pid; `status` returned live state; unknown command refused |
+
+**Two silent-failure bugs were found by running it, not by building it** — both
+recorded here because they are the class of bug this feature is most exposed to:
+
+1. The Companion registered `On<JObject>`. SignalR's default protocol is
+   System.Text.Json, which cannot materialise a Newtonsoft `JObject`, so **the
+   handler never fired** — connection healthy, server logging a successful push,
+   client doing nothing at all. Fixed with a concrete payload type.
+2. `DocumentSyncHub` refused joins silently *and* logged nothing server-side, so a
+   tenant mismatch would have been undiagnosable. It now logs both the refusal
+   (with the connection's tenant) and the grant, and the controller logs when the
+   hub context is missing.
+
+**Test artefacts were cleaned up:** the settings, status and log files this session
+created under `%APPDATA%\StingTools\` were removed (they did not exist before), and
+**no autostart registry entry was created** — confirmed absent afterwards.
+
+### 4b. Known gap found while building, not a regression
+
+`ProjectMemberAcl.ResolveAsync` currently **hard-codes its three allow-list columns
+to `null`** (a deliberate migration-safety choice — see its own comment), so no
+CDE/discipline/suitability narrowing happens for anyone today, on the documents
+list or on `changed-since`. `changed-since` routes through the same helper, so it
+cannot be *wider* than the list — and the test asserts exactly that subset
+invariant rather than a filtering behaviour that does not currently exist. When
+those columns are read for real, both endpoints narrow together. Flagged so nobody
+reads "respects `AllowedCdeStates`" as "filters today".
 
 ---
 
 ## 5. PENDING-HUMAN-VERIFY
 
-No second machine and no live multi-user session exist in this environment, so the following are
-written down rather than claimed. Everything here is genuinely untested.
+**Updated after the live run.** Items 1, 3 and 5–8 below were exercised in §4a and are marked
+accordingly. What remains genuinely untested is everything needing a **second machine, a second
+user, or a real network interruption** — none of which exist in this environment.
+
+- ✅ **Exercised in §4a:** the push path, the delta with and without `since`, the initial-link
+  sync, supersede, purge, the read-only hint, and the IPC surface.
+- ❌ **Still open:** everything in items 2, 4, 6, 8, 9–13 below.
+
+The single most important one still open is **item 2** (cross-tenant isolation over the wire).
+It is unit-tested with a fake hub context, and the server now logs a refusal, but no second firm's
+connection has ever been pointed at another firm's project on a live hub.
 
 ### Server (Slice A)
 1. With the docker stack up (`cd Planscape.Server/docker && docker compose up -d`), sign in and

--- a/docs/superpowers/plans/2026-07-31-document-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-31-document-sync-plan.md
@@ -1,0 +1,227 @@
+# Document sync — implementation plan
+
+**Design:** [`docs/superpowers/specs/2026-07-31-document-sync-design.md`](../specs/2026-07-31-document-sync-design.md)
+(approved by Sting, 2026-07-31). This plan implements it; it does not revisit it.
+
+**Branch:** `claude/livekit-corporate-ui-research-3233e0` · PR #503.
+
+**Baseline before any of this work:** `Planscape.Tests` — **493 passed, 0 failed, 9 skipped
+(502 total)**. Every slice below re-runs the full suite against that number.
+
+---
+
+## 1. Resolving the spec's three open items
+
+The design deferred three decisions to this plan by name. Each is settled here, with the
+reasoning, because the reasoning is what a future session needs when the decision looks wrong.
+
+### 1a. Companion↔BCC IPC transport → **named pipe**
+
+BCC needs exactly two things: read status, and trigger "sync now". Nothing else. Three candidates
+were considered against that:
+
+| Option | Verdict |
+|---|---|
+| **Loopback HTTP via `HttpListener`** | **Rejected — needs elevation.** Binding a fixed `http://127.0.0.1:{port}/` prefix as a non-admin requires a pre-existing URL ACL (`netsh http add urlacl`). That is machine-wide state and an elevation prompt, which this feature's whole posture rules out. |
+| **Loopback HTTP via Kestrel** | **Rejected — cost.** Avoids the URL-ACL problem (raw socket bind), but pulls ASP.NET Core hosting into a tray app to serve two verbs. A listening TCP port is also reachable by *any* local process, including a browser tab, so it would need its own bearer token — more code than the thing it is protecting. |
+| **File drop + status file** (the StingLink precedent) | **Rejected, narrowly — see below.** |
+| **Named pipe** | **Chosen.** |
+
+**Why not the file-inbox precedent, given StingLink.exe used it.** That precedent was reasoned
+about a *specific* asymmetry: StingLink is short-lived and its receiver (Revit) had no listener,
+so a pipe's only job would have been handing work to an `IIdlingJob` that already existed. Neither
+half of that holds here. The Companion is long-lived and has a natural place to host an accept
+loop, and BCC is asking a *question* rather than dropping a job.
+
+The deciding factor is the failure mode. With a file drop, "the Companion isn't running" and "the
+Companion is running but busy" look identical at click time — BCC would have to write, then poll a
+status file, then decide how stale is too stale. That staleness heuristic is a fuzzy judgement a
+pipe makes exact: a connect that fails in 200 ms is a definite "not running", which is precisely
+the answer a user clicking "Sync now" into the void needs to see.
+
+Concretely: `System.IO.Pipes.NamedPipeServerStream`, one line of JSON per request, one per
+response. No package dependency, no port, no firewall prompt, and Windows ACLs the pipe to the
+creating user by default — matching the per-user, no-elevation posture of the rest of the feature.
+
+Pipe name: `planscape-companion` (per-user by ACL, so no user suffix is needed for isolation).
+
+### 1b. Installer → **piggyback on StingTools, with the Companion self-registering**
+
+No new installer. The Companion ships in the plugin output directory exactly as `StingLink.exe`
+does (same `CopyStingLinkHelper`-style MSBuild target), and autostart is an **HKCU
+`…\CurrentVersion\Run` value** — the same user-scope, no-elevation, idempotent, re-checked-every-start
+pattern `RegisterPlanscapeProtocol` already established for the protocol handler.
+
+Split of responsibility, chosen to keep this session's changes out of the Revit plugin entirely:
+
+- **The Companion registers its own autostart** on first run (`--install-autostart`, and
+  automatically on a normal first launch). This is Slice B.
+- **`StingToolsApp.OnStartup` launching it if absent** is deferred to Slice D. It is the piece
+  that makes the whole thing zero-touch for a user who only ever opens Revit, and it is one
+  `Process.Start` next to the existing `RegisterPlanscapeProtocol()` call.
+
+**Honest caveat, written down rather than discovered later:** until Slice D lands, the Companion
+must be started once by hand. And even after Slice D, a machine that never opens Revit never gets
+a Companion. That is acceptable — the Companion exists to serve an Author, and an Author runs
+Revit. A Coordinator-only machine needing this is the point at which a real installer earns its
+keep, not before.
+
+### 1c. Background failure visibility → **tray state + pull-on-demand, never a toast**
+
+A background sync can fail in two materially different ways, and conflating them is what makes
+this kind of notification useless:
+
+| Class | Examples | Treatment |
+|---|---|---|
+| **Offline** — expected, self-healing | laptop closed, VPN down, server restarting | **Silent.** Tray icon shows a muted/disconnected glyph. No notification, ever. The reconnect delta fixes it with nobody involved. |
+| **Error** — needs a human | auth rejected, target folder unwritable, disk full, 403 on every document | **Tray icon changes state**, tooltip names the failure, and the status is available to BCC over the pipe. |
+
+**No Windows toast.** The most frequent failure by far is the offline case, which is expected and
+resolves itself; toasting it trains the user to mute the app, at which point the *real* errors go
+unseen too. Pull-on-demand (BCC reads status when it opens; the user hovers the tray icon) cannot
+spam by construction.
+
+The tray icon is already in the design for checked-out counts, so an error state on that same icon
+introduces no new UI language — the same instinct the spec applies to the BCC badge.
+
+Persisted shape (survives a Companion restart, so a failure at 5 pm is still visible at 9 am):
+
+```
+SyncStatus { State: Idle | Syncing | Offline | Error,
+             LastSuccessUtc, LastError, LastErrorUtc, ConsecutiveFailures }
+```
+
+---
+
+## 2. Slices
+
+Each is independently committable and provable. **This session: A, B, C.** D and E are explicitly
+a later pass — see §3.
+
+### Slice A — server-side foundation *(this session)*
+
+1. **`DocumentSyncHub`** (`Planscape.Infrastructure/SignalR/DocumentSyncHub.cs`), modelled on
+   `MeetingHub`:
+   - `JoinProject(projectId)` / `LeaveProject(projectId)`, group `docsync:{projectId}`.
+   - Gated by `HubTenantGuard.OwnsProjectAsync` — the same guard, for the same reason: a hub
+     connection has no `HttpContext`, so the DbContext tenant filter resolves to an empty
+     `TenantId` and cannot be relied on. A per-connection authorised set caches the check.
+   - `NotifyDocumentChanged(IHubContext<DocumentSyncHub>, projectId, payload)` static push.
+   - Mapped at `/hubs/document-sync` in `Program.cs`.
+2. **Call sites** — both places a document actually changes:
+   - `DocumentsController.PerformCdeTransitionAsync` (the single shared core for web PUT, mobile
+     POST and plugin sync — it already mints a `DocumentRevision` and broadcasts on
+     `NotificationHub`).
+   - `DocumentRevisionsController` manual revision creation.
+3. **`GET /api/projects/{id}/documents/changed-since?since={iso}`** on `DocumentsController`:
+   - Delta on `UpdatedAt ?? UploadedAt`; `since` omitted ⇒ everything currently visible.
+   - Scoped by `ProjectMemberAcl` (the existing `AllowedCdeStates` / discipline / suitability
+     ACL) — the sync surface must not be wider than the documents list.
+   - **Latest-revision-only metadata**, not history.
+4. **Tests** to the `LiveKitRoomTenancyTests` bar — real assertions, and specifically the
+   cross-tenant refusal, which is the one that matters.
+
+### Slice B — Planscape Companion skeleton *(this session)*
+
+New `Planscape.Companion/` project — a sibling of `StingTools.LinkHandler`, **not** a modification
+of it. `StingLink.exe` is finished and out of scope per the spec's own reasoning.
+
+- WinExe, `net8.0-windows`, `UseWindowsForms` for `NotifyIcon` only.
+- SignalR client with backoff reconnect; on reconnect, immediately call `changed-since` per linked
+  project with that project's last-known sync timestamp.
+- Named-pipe server (§1a): `status`, `sync-now`, `ping`.
+- Settings at `%APPDATA%\StingTools\planscape_sync.json`, Newtonsoft, merge-into-existing-JObject
+  — the same shape and directory as `PlanscapeServerClient.MachineSettingsPath`.
+- HKCU `Run` autostart self-registration.
+- **`--diagnose`**: a headless one-shot mode (no tray) that proves the thing works from a terminal
+  and doubles as a support tool.
+
+### Slice C — core sync engine *(this session)*
+
+Inside the Companion. One code path; four triggers (SignalR push, reconnect delta, initial link,
+manual "Sync now").
+
+- Target `%USERPROFILE%\Planscape\{ProjectCode}\`, per-project override in the settings file.
+- **No OS-level locking.** No `FileShare.None`, no lock files as truth. The CDE state is the only
+  ownership record. Non-WIP copies get the `ReadOnly` *file attribute* — a removable hint that a
+  reference copy is not for editing, explicitly **not** a lock and not a source of truth.
+- Superseded safety net: rename outgoing to `{Name} (superseded {yyyy-MM-dd}).{ext}`, purge those
+  older than 7 days on startup and on each tick.
+- Latest revision only, ACL-scoped. No full history.
+
+### Slice D — StingTools/BCC integration *(NEXT SESSION — not started)*
+
+- Pipe client in the plugin; BCC reads status, triggers "Sync now".
+- `StingToolsApp.OnStartup` launches the Companion if it is installed and not running (§1b).
+- Per-project auto/manual toggle (on by default).
+- BCC Documents-grid badge, reusing the "Live" meeting badge pattern.
+
+### Slice E — Companion tray polish *(NEXT SESSION — not started)*
+
+- Checked-out count on the icon, click-to-expand list.
+- Error-state glyph + tooltip wording (§1c decides the behaviour; this builds it).
+- Per-document "download full history" opt-in action.
+
+---
+
+## 3. Scope boundary for this session
+
+**In:** A, B, C. **Out, deliberately:** D, E, and everything the spec already rules out
+(bidirectional sync, OS-level file locking, per-document toggles, full history by default, a
+Windows Service, any change to `StingLink.exe`).
+
+---
+
+## 4. Status — what actually shipped
+
+Updated as each slice lands. Anything not marked DONE was not built.
+
+| Slice | Status | Proof |
+|---|---|---|
+| A — server foundation | NOT STARTED | — |
+| B — Companion skeleton | NOT STARTED | — |
+| C — sync engine | NOT STARTED | — |
+| D — BCC integration | NOT STARTED (next session) | — |
+| E — tray polish | NOT STARTED (next session) | — |
+
+---
+
+## 5. PENDING-HUMAN-VERIFY
+
+No second machine and no live multi-user session exist in this environment, so the following are
+written down rather than claimed. Everything here is genuinely untested.
+
+### Server (Slice A)
+1. With the docker stack up (`cd Planscape.Server/docker && docker compose up -d`), sign in and
+   `PUT /api/projects/{id}/documents/{docId}/state` to move a document WIP→SHARED. A client
+   subscribed to `/hubs/document-sync` and joined to that project must receive `DocumentChanged`
+   with `kind: "cde_transition"`.
+2. **Cross-tenant refusal, the one that matters:** connect as a user in firm B, call
+   `JoinProject` with firm A's project GUID, then have firm A transition a document. Firm B must
+   receive **nothing**. (Unit-tested with a fake hub context; this is the over-the-wire confirmation.)
+3. `GET …/documents/changed-since` with no `since` returns everything visible; with `since` set to
+   just after an upload returns only what changed after it.
+4. As a member whose `AllowedCdeStates` excludes `PUBLISHED`, confirm `changed-since` omits
+   published documents — the sync surface must not be wider than the documents list.
+
+### Companion (Slices B + C)
+5. Start `Planscape.Companion.exe` with no arguments — a tray icon appears; it does not steal focus.
+6. `--install-autostart`, sign out and back in, confirm it starts. Then `--uninstall-autostart` and
+   confirm it stops starting. **Confirm nothing was written to HKLM** (`reg query
+   HKLM\Software\Microsoft\Windows\CurrentVersion\Run` must not mention Planscape).
+7. Point it at a live server, link a project, and confirm files land in
+   `%USERPROFILE%\Planscape\{ProjectCode}\`.
+8. **The real test of the push path:** with the Companion running on machine A, publish a document
+   from the web app as a coordinator on machine B. The file must appear on A without anyone
+   touching it.
+9. Pull the network cable mid-session, publish two documents, restore the network. On reconnect
+   both must arrive via the `changed-since` delta — **and the tray icon must have shown the quiet
+   offline state throughout, with no toast** (§1c).
+10. Open a synced PDF in Acrobat, publish a newer revision. The open file must be renamed to
+    `{Name} (superseded {date}).pdf` rather than vanishing, and Acrobat must not error.
+11. Set a machine clock forward 8 days and restart the Companion — superseded copies are purged,
+    live files are not.
+12. Confirm a `PUBLISHED` reference copy is read-only in Explorer, and that clearing the read-only
+    attribute by hand is *not* fought over — it is a hint, not a lock.
+13. Break the target folder (deny write) and force a sync: the tray must enter the **Error** state
+    with a tooltip naming the folder, and recover on its own once the permission is restored.

--- a/docs/superpowers/specs/2026-07-31-document-sync-design.md
+++ b/docs/superpowers/specs/2026-07-31-document-sync-design.md
@@ -1,0 +1,151 @@
+# Document sync design — cloud documents on an Author's local disk via StingTools/BCC
+
+**Status:** Approved by Sting, 2026-07-31. Not yet implemented — no code exists for anything in
+this document. Next step is an implementation plan (writing-plans), not this doc.
+
+## Problem
+
+An Author works in Revit against local files. Coordinators publish documents (drawings, PDFs,
+specs) to the cloud (Planscape.Server, via `DocumentsController`). Today the only way those
+documents reach an Author's machine is a manual download through the web app. The ask: a
+coordinator's upload should reach a local folder on the Author's machine automatically, integrated
+with StingTools/BCC, without reinventing what a general-purpose file-sync tool already does badly
+for this exact problem.
+
+## Prior art consulted
+
+Autodesk Desktop Connector (ACC/BIM 360's own answer to this problem) — a virtual mapped drive,
+selectively synced per project. Its recurring real-world failure, even in a mature Autodesk
+product: files get stuck "checked out" in the cloud after the local app closes, sometimes
+requiring manual unlock, and a conflicting cloud revision landing mid-edit can silently send the
+local copy to the Recycle Bin rather than preserving it visibly.
+([Autodesk product page](https://www.autodesk.com/products/desktop-connector/overview),
+[lock issue reports](https://forums.autodesk.com/t5/bim-360-support-forum/desktop-connector-v16-issue-with-locking-revit-files/td-p/11623259))
+
+The lesson taken from that: don't use OS-level file locking as the source of truth for who owns an
+edit. This repo already has something better to use instead (see below).
+
+## What already exists and this design builds on, not around
+
+- **A full ISO 19650 CDE state machine**, server-side, already implemented:
+  `DocumentRecord.CdeStatus` (`WIP` / `SHARED` / `PUBLISHED` / `ARCHIVE`), `SuitabilityCode`
+  (S0–S7, CR, AB), per-revision state history (`DocumentRevision.CdeStateAtRevision`), and
+  per-member visibility scoping (`ProjectMember.AllowedCdeStates`,
+  `SuitabilityTransitionRule`). This is the locking/ownership/visibility model for sync — no new
+  permission system gets invented.
+- **`StingTools.LinkHandler` → `StingLink.exe`** (landed today, commit `3e0a60f6e`,
+  `docs/PLANSCAPE_PROTOCOL.md`): a standalone, non-Revit .NET 8 exe that Windows launches on
+  `planscape://` activation. It drops the incoming URL into `%LOCALAPPDATA%\STING\link-inbox` and
+  exits — it does not stay running. Draining the inbox happens inside StingTools via
+  `PlanscapeLinkWatcher`, an `IIdlingJob`, which only runs while Revit is open.
+  **This does not solve "sync while Revit is closed"** — it was never meant to; it solves
+  protocol-link activation, which is a different problem with a different lifetime requirement.
+  Leave it exactly as built. Do not extend or repurpose it into the sync engine.
+- **SignalR is proven working** in this codebase (`MeetingHub`, used all through Track B). Reuse
+  the pattern, not the hub.
+
+## Architecture
+
+Two small, single-purpose standalone processes, not one:
+
+1. **`StingLink.exe`** (exists, unchanged) — protocol link activation only, short-lived, drop-file
+   handoff to Revit's idling loop.
+2. **Planscape Companion** (new) — a standalone .NET tray app, starts on Windows login, stays
+   running for the whole session regardless of whether Revit is open. Owns exactly one job: the
+   document sync engine. StingTools/BCC talks to it over a local loopback HTTP endpoint (or named
+   pipe) for status display and the manual "Sync now" trigger — BCC never runs sync logic itself,
+   it only asks the Companion to do things and reads its status.
+
+Rationale for keeping these separate rather than merging: `StingLink.exe` is deliberately minimal
+and short-lived by design (documented reasoning: a pipe's only job would be handing work to an
+idling job that already exists, so a file inbox was simpler). Retrofitting it into an always-running
+service would fight that design rather than extend it. Two small processes, each doing one thing,
+matches this codebase's existing taste better than one merged one.
+
+## Sync model
+
+**One-way, read-down only.** No bidirectional sync, no client-authored uploads through this
+pipeline (uploads already go through the existing web/API path). Gated entirely by the CDE state
+machine already described above:
+
+- `PUBLISHED` / `SHARED` documents an Author can see (per `AllowedCdeStates`) sync down as
+  **read-only reference copies**. No lock needed — nobody edits a reference copy, so there is
+  nothing to conflict over.
+- `WIP` documents specifically checked out to an Author sync down as the editable working copy.
+  "Checked out" is a fact recorded in the CDE state machine (already has an owner, already has an
+  audit trail) — **never an OS-level file lock**. This is the specific mechanism that breaks in
+  Desktop Connector; it is not reproduced here.
+
+## Trigger
+
+Push, not polling, as the normal path:
+
+- A `DocumentSyncHub` (SignalR, same pattern as `MeetingHub`) pushes a "document changed" event to
+  every connected Companion instance for that project the moment a coordinator changes a document's
+  state or a new revision is published.
+- Polling exists only as the **reconnect fallback**: `GET /api/projects/{id}/documents/changed-since
+  ?since={lastKnownSyncUtc}` — a delta query, never a full re-scan, used once when the Companion
+  reconnects after being offline (laptop closed, VPN down, etc.).
+- A project newly linked on a machine triggers a one-time initial sync using the same
+  changed-since-style call with `since` unset (i.e. "everything currently visible").
+- Manual "Sync now" (see Flexibility below) calls the identical sync routine on demand.
+
+All four triggers feed one code path; only what invokes it differs.
+
+## Scope pulled per project
+
+**Latest revision only**, filtered by `AllowedCdeStates` — not full history, by default. Full
+revision history for a specific document is an explicit, per-document "download full history"
+action a user takes deliberately, never a default that silently grows on every machine.
+
+## Flexibility: per-project auto/manual toggle
+
+One toggle per project (not per-document — too fine-grained to manage day to day):
+**"Auto-sync this project"**, on by default. Off means the Companion still knows the project is
+linked but does nothing until the user explicitly triggers "Sync now" from BCC or the Companion's
+tray icon. Same underlying sync routine either way; the toggle only gates whether the push
+trigger is allowed to fire automatically.
+
+## Conflict / external-edit safety net
+
+A read-only reference copy that gets superseded by a newer revision while something external
+(Acrobat, Word, anything that isn't Revit/BCC) might have it open: rename the outgoing file to
+`{Name} (superseded {date}).{ext}` rather than overwriting or deleting it outright, auto-purge
+those renamed copies after 7 days. Cheap, self-cleaning, avoids the "file vanished while I had it
+open" complaint without building real conflict-resolution UI for a case that, by construction
+(read-only reference copies are never edited locally), isn't a true edit conflict.
+
+## Local folder convention
+
+`%USERPROFILE%\Planscape\{ProjectCode}\`, overridable per project. Deliberately not buried in
+`%APPDATA%` — Authors need to find and open these files from Explorer or Revit's own file-open
+dialog. The override mechanism follows the same pattern already established by
+`PlanscapeServerClient.MachineSettingsPath` (a small JSON settings file, not a new convention).
+
+## Checkout-state visibility
+
+- **In BCC**: a badge on the relevant Documents grid row, reusing the same visual pattern already
+  used for the "Live" meeting badge — no new UI language introduced.
+- **In the Companion tray icon**: a lightweight count (e.g. "3 checked out") for at-a-glance status
+  even when Revit is closed, click-to-expand to a short list. Not a second full UI surface to
+  maintain — status only, no editing happens here.
+
+## Explicitly out of scope for this design
+
+- Bidirectional sync / local edits flowing back to the cloud through this pipeline.
+- Any OS-level file locking.
+- Extending or repurposing `StingLink.exe` — it stays exactly as built for protocol links only.
+- Per-document (as opposed to per-project) auto/manual granularity.
+- A Windows Service running independent of any logged-in user (this is a per-user, start-on-login
+  tray app, not a machine-wide service) — revisit only if a genuine multi-user-per-machine need
+  shows up later.
+- Full revision history sync by default.
+
+## Open items for the implementation plan to resolve, not this spec
+
+- Exact Companion↔BCC IPC transport (loopback HTTP vs named pipe) — pick whichever is less new
+  code given what StingLink.exe's inbox mechanism already proved out.
+- Whether the Companion needs its own installer step or piggybacks on the existing StingTools
+  plugin installer/first-run flow.
+- Telemetry/error visibility when a sync fails silently in the background (a toast the next time
+  BCC opens? a persistent tray icon state? — needs a decision, not a default).

--- a/planscape-web/app/projects/[id]/clashes/page.tsx
+++ b/planscape-web/app/projects/[id]/clashes/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import {
   Badge,
   Button,
   DataGrid,
+  MenuItem,
   PageHeader,
   Select,
   toneForStatus,
@@ -101,6 +103,9 @@ export default function ClashesPage() {
       edit: { save: (c, v) => updateClash(projectId, c.id, { resolutionNote: v } as Partial<ClashRecord>) },
     },
     { key: 'discipline', header: 'Discipline', className: 'w-28' },
+    // `kind` is hard-vs-clearance — two clashes with identical severity mean
+    // different things, and the detector has always returned it.
+    { key: 'kind', header: 'Kind', className: 'w-28' },
     {
       key: 'overlapVolumeMm3',
       header: 'Overlap',
@@ -112,6 +117,32 @@ export default function ClashesPage() {
         ) : (
           <span className="text-fg-subtle">—</span>
         ),
+    },
+    {
+      key: 'issueId',
+      header: 'Issue',
+      className: 'w-24',
+      // Promotion to an issue already worked; nothing showed which clashes had
+      // been promoted, so the same clash got raised twice.
+      render: (c) =>
+        c.issueId ? (
+          <Link
+            href={`/projects/${projectId}/issues/${c.issueId}`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-accent hover:underline"
+          >
+            View
+          </Link>
+        ) : (
+          <span className="text-fg-subtle">—</span>
+        ),
+    },
+    {
+      key: 'detectedAt',
+      header: 'Detected',
+      className: 'w-28',
+      render: (c) =>
+        c.detectedAt ? new Date(c.detectedAt).toLocaleDateString() : <span className="text-fg-subtle">—</span>,
     },
   ];
 
@@ -134,6 +165,27 @@ export default function ClashesPage() {
         error={error}
         selectable
         onRowClick={(c) => router.push(`/projects/${projectId}/clashes/${c.id}`)}
+        rowMenu={(c, close) => (
+          <>
+            <MenuItem
+              onClick={() => {
+                close();
+                router.push(`/projects/${projectId}/clashes/${c.id}`);
+              }}
+            >
+              Open clash
+            </MenuItem>
+            <MenuItem
+              disabled={!c.issueId}
+              onClick={() => {
+                close();
+                if (c.issueId) router.push(`/projects/${projectId}/issues/${c.issueId}`);
+              }}
+            >
+              Open linked issue
+            </MenuItem>
+          </>
+        )}
         emptyTitle="No clashes"
         emptyDescription="Run detection to populate this list."
         toolbar={() => (

--- a/planscape-web/app/projects/[id]/issues/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
-import { Badge, Button, DataGrid, PageHeader, Select, toneForStatus, type Column } from '@/components/ui';
+import { Badge, Button, DataGrid, MenuItem, PageHeader, Select, toneForStatus, type Column } from '@/components/ui';
 import { listIssues, updateIssue } from '@/lib/data';
 import type { BimIssue, IssuePriority, IssueStatus } from '@/lib/types';
 
@@ -66,14 +66,35 @@ export default function IssuesPage() {
       key: 'assignee',
       header: 'Assignee',
       className: 'w-44',
+      // The API returns assigneeEmail alongside the name and nothing showed it,
+      // so two people called "D. Mayanja" were indistinguishable. It rides in
+      // this cell rather than a column of its own — it identifies the assignee,
+      // it isn't a separate fact to sort by.
+      render: (i) =>
+        i.assignee ? (
+          <span className="flex flex-col leading-tight">
+            <span>{i.assignee}</span>
+            {i.assigneeEmail && <span className="text-2xs text-fg-subtle">{i.assigneeEmail}</span>}
+          </span>
+        ) : (
+          <span className="text-fg-subtle">Unassigned</span>
+        ),
       edit: { save: (i, v) => updateIssue(projectId, i.id, { assignee: v }) },
     },
+    { key: 'type', header: 'Type', className: 'w-28' },
     { key: 'discipline', header: 'Discipline', className: 'w-28' },
     {
       key: 'dueDate',
       header: 'Due',
       className: 'w-28',
       render: (i) => (i.dueDate ? new Date(i.dueDate).toLocaleDateString() : <span className="text-fg-subtle">—</span>),
+    },
+    {
+      key: 'createdAt',
+      header: 'Raised',
+      className: 'w-28',
+      render: (i) =>
+        i.createdAt ? new Date(i.createdAt).toLocaleDateString() : <span className="text-fg-subtle">—</span>,
     },
   ];
 
@@ -96,6 +117,16 @@ export default function IssuesPage() {
         error={error}
         selectable
         onRowClick={(i) => router.push(`/projects/${projectId}/issues/${i.id}`)}
+        rowMenu={(i, close) => (
+          <MenuItem
+            onClick={() => {
+              close();
+              router.push(`/projects/${projectId}/issues/${i.id}`);
+            }}
+          >
+            Open issue
+          </MenuItem>
+        )}
         emptyTitle="No issues"
         emptyDescription="Raise one from the model viewer or with New issue."
         toolbar={() => (

--- a/planscape-web/app/projects/[id]/members/page.tsx
+++ b/planscape-web/app/projects/[id]/members/page.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   DataGrid,
   Input,
+  MenuItem,
   Modal,
   PageHeader,
   Select,
@@ -127,6 +128,9 @@ export default function MembersPage() {
       render: (m) =>
         m.joinedAt ? new Date(m.joinedAt).toLocaleDateString() : <span className="text-fg-subtle">—</span>,
     },
+    // Already in the payload, never shown — and it is the field that answers
+    // "who let this person in", which is the question an audit actually asks.
+    { key: 'invitedBy', header: 'Invited by', className: 'w-40' },
     {
       key: 'actions',
       header: '',
@@ -157,6 +161,16 @@ export default function MembersPage() {
         rowId={(m) => m.id}
         loading={!members && !error}
         error={error}
+        rowMenu={(m, close) => (
+          <MenuItem
+            onClick={() => {
+              close();
+              void onRemove(m);
+            }}
+          >
+            Remove from project
+          </MenuItem>
+        )}
         emptyTitle="No members yet"
         emptyDescription="Invite someone to give them access to this project."
       />

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { ArchiveProjectDialog } from '@/components/ArchiveProjectDialog';
 import { RagBadge } from '@/components/RagBadge';
 import { Badge, Button, Card, EmptyState, ErrorNote, PageHeader, Skeleton, toneForStatus } from '@/components/ui';
 import { getProject, listClashes, listIssues } from '@/lib/data';
@@ -21,7 +22,9 @@ import type { BimIssue, ClashRecord, Project } from '@/lib/types';
  */
 export default function ProjectPage() {
   const { id: projectId } = useParams<{ id: string }>();
+  const router = useRouter();
   const [project, setProject] = useState<Project | null>(null);
+  const [archiveOpen, setArchiveOpen] = useState(false);
   const [issues, setIssues] = useState<BimIssue[] | null>(null);
   const [clashes, setClashes] = useState<ClashRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -77,9 +80,29 @@ export default function ProjectPage() {
             <Button asChild variant="primary">
               <Link href={`/projects/${projectId}/issues/new`}>New issue</Link>
             </Button>
+            {/* Shown to everyone: the server decides who may actually archive
+                (author or tenant admin) and the dialog reports its 403 plainly.
+                Hiding it client-side would need a permission the API doesn't
+                currently tell us on this payload. */}
+            {project?.status !== 'Archived' && (
+              <Button variant="ghost" onClick={() => setArchiveOpen(true)}>
+                Archive
+              </Button>
+            )}
           </>
         }
       />
+
+      {project && (
+        <ArchiveProjectDialog
+          open={archiveOpen}
+          onOpenChange={setArchiveOpen}
+          projectId={projectId}
+          projectCode={project.code}
+          projectName={project.name}
+          onArchived={() => router.push('/projects')}
+        />
+      )}
 
       {error && (
         <div className="mb-4">

--- a/planscape-web/app/projects/[id]/page.tsx
+++ b/planscape-web/app/projects/[id]/page.tsx
@@ -6,8 +6,18 @@ import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { ArchiveProjectDialog } from '@/components/ArchiveProjectDialog';
 import { RagBadge } from '@/components/RagBadge';
-import { Badge, Button, Card, EmptyState, ErrorNote, PageHeader, Skeleton, toneForStatus } from '@/components/ui';
-import { getProject, listClashes, listIssues } from '@/lib/data';
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  ErrorNote,
+  PageHeader,
+  Skeleton,
+  toneForStatus,
+  useToast,
+} from '@/components/ui';
+import { getProject, listClashes, listIssues, updateProject } from '@/lib/data';
 import { useProjectRealtime } from '@/lib/realtime';
 import type { BimIssue, ClashRecord, Project } from '@/lib/types';
 
@@ -122,6 +132,15 @@ export default function ProjectPage() {
         <Stat label="Compliance" value={project?.compliancePercent} suffix="%" />
       </div>
 
+      {project && (
+        <div className="mb-4">
+          <AutoSyncToggle
+            project={project}
+            onChanged={(v) => setProject((p) => (p ? { ...p, documentSyncAutoEnabled: v } : p))}
+          />
+        </div>
+      )}
+
       <Card>
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-sm font-semibold text-fg">Needs attention</h2>
@@ -154,6 +173,75 @@ export default function ProjectPage() {
         )}
       </Card>
     </AppShell>
+  );
+}
+
+/**
+ * The per-project "Auto-sync this project" toggle from the document-sync design.
+ *
+ * It lives on the overview rather than behind a project-settings page because no
+ * such page exists, and inventing one to hold a single checkbox would be a worse
+ * answer than putting the checkbox where the project already is.
+ *
+ * Optimistic, with rollback — the same contract the grids use. The copy spells
+ * out what OFF actually does, because "auto-sync off" reads like "sync off" and
+ * it very deliberately is not: linked machines keep the project and keep syncing
+ * on an explicit Sync now.
+ */
+function AutoSyncToggle({
+  project,
+  onChanged,
+}: {
+  project: Project;
+  onChanged: (value: boolean) => void;
+}) {
+  const { toast } = useToast();
+  const [busy, setBusy] = useState(false);
+  // The server defaults it to true; an older payload without the field must read
+  // as on, never off.
+  const enabled = project.documentSyncAutoEnabled !== false;
+
+  async function toggle() {
+    const next = !enabled;
+    setBusy(true);
+    onChanged(next);
+    try {
+      await updateProject(project.id, { documentSyncAutoEnabled: next });
+      toast(next ? 'Auto-sync enabled for this project.' : 'Auto-sync paused for this project.', 'success');
+    } catch (e) {
+      onChanged(enabled); // roll back — never leave a switch showing a state the server rejected
+      toast(e instanceof Error ? e.message : 'Could not change auto-sync', 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-fg">Document sync</h2>
+          <p className="mt-0.5 text-sm text-fg-muted">
+            {enabled
+              ? 'Published and shared documents reach linked machines automatically.'
+              : 'Paused. Linked machines keep this project and still sync when someone chooses “Sync now”.'}
+          </p>
+        </div>
+        <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={busy}
+            onChange={() => void toggle()}
+            className="h-4 w-4 accent-accent"
+            aria-label="Auto-sync this project"
+          />
+          <span className={enabled ? 'text-fg' : 'text-fg-muted'}>
+            {busy ? 'Saving…' : enabled ? 'Auto-sync on' : 'Auto-sync off'}
+          </span>
+        </label>
+      </div>
+    </Card>
   );
 }
 

--- a/planscape-web/app/projects/page.tsx
+++ b/planscape-web/app/projects/page.tsx
@@ -1,60 +1,163 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
-import { LoadingBlock } from '@/components/ui';
+import { ArchiveProjectDialog } from '@/components/ArchiveProjectDialog';
 import { RagBadge } from '@/components/RagBadge';
-import { listProjects } from '@/lib/data';
+import { Badge, Button, DataGrid, PageHeader, toneForStatus, type Column } from '@/components/ui';
+import { listProjects, updateProject } from '@/lib/data';
 import type { Project } from '@/lib/types';
 
+/**
+ * The last list in the app still rendering card tiles. Now a DataGrid like
+ * Issues / Clashes / Members, per `docs/ACC_UI_SHELL_GRID_CONTRACT.md`.
+ *
+ * Editability was checked against `ProjectsController` rather than assumed:
+ *  - `name`, `phase` — `PUT /api/projects/{id}` (`UpdateProjectRequest`) accepts
+ *    both, so both edit inline.
+ *  - `code` — no write anywhere in the controller, AND it is the token the
+ *    archive endpoint demands as proof of intent. Read-only.
+ *  - `status` — the PUT *does* accept it, and it is still read-only here. Making
+ *    it an editable cell would be a second route to `Archived` that skips the
+ *    confirm-code gate the server put there deliberately. Archiving goes through
+ *    the row action.
+ *  - RAG / compliance %, open issues, members, elements — server-computed, no
+ *    write endpoint. Read-only.
+ */
+const PHASES = ['', 'Concept', 'Design', 'Technical', 'Construction', 'Handover', 'Operation'];
+
 export default function ProjectsPage() {
+  const router = useRouter();
   const [projects, setProjects] = useState<Project[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [archiving, setArchiving] = useState<Project | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     listProjects()
       .then(setProjects)
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load projects'));
   }, []);
 
+  useEffect(load, [load]);
+
+  const columns: Column<Project>[] = [
+    {
+      key: 'name',
+      header: 'Project',
+      className: 'min-w-[14rem] font-medium',
+      edit: { save: (p, v) => updateProject(p.id, { name: v }) },
+    },
+    { key: 'code', header: 'Code', className: 'w-32 font-mono text-xs' },
+    {
+      key: 'compliancePercent',
+      header: 'Compliance',
+      className: 'w-32',
+      value: (p) => p.compliancePercent ?? -1,
+      render: (p) =>
+        p.compliancePercent == null && !p.ragStatus ? (
+          <span className="text-fg-subtle">—</span>
+        ) : (
+          <RagBadge rag={p.ragStatus} percent={p.compliancePercent} />
+        ),
+    },
+    {
+      key: 'openIssueCount',
+      header: 'Open issues',
+      className: 'w-28',
+      value: (p) => p.openIssueCount ?? 0,
+      render: (p) =>
+        p.openIssueCount ? (
+          <Link
+            href={`/projects/${p.id}/issues`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-accent hover:underline"
+          >
+            {p.openIssueCount}
+          </Link>
+        ) : (
+          <span className="text-fg-subtle">0</span>
+        ),
+    },
+    {
+      key: 'phase',
+      header: 'Phase',
+      className: 'w-36',
+      edit: { options: PHASES, save: (p, v) => updateProject(p.id, { phase: v }) },
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      className: 'w-28',
+      render: (p) =>
+        p.status ? <Badge tone={toneForStatus(p.status)}>{p.status}</Badge> : <span className="text-fg-subtle">—</span>,
+    },
+    { key: 'memberCount', header: 'Members', className: 'w-24' },
+    {
+      key: 'lastSyncAt',
+      header: 'Last sync',
+      className: 'w-28',
+      render: (p) =>
+        p.lastSyncAt ? new Date(p.lastSyncAt).toLocaleDateString() : <span className="text-fg-subtle">Never</span>,
+    },
+    {
+      key: 'actions',
+      header: '',
+      className: 'w-24',
+      sortable: false,
+      render: (p) =>
+        p.status === 'Archived' ? null : (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={(e) => {
+              e.stopPropagation();
+              setArchiving(p);
+            }}
+          >
+            Archive
+          </Button>
+        ),
+    },
+  ];
+
   return (
     <AppShell>
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Projects</h1>
-        <Link
-          href="/projects/new"
-          className="rounded bg-accent px-3 py-2 text-sm font-medium text-fg-on-accent hover:bg-accent-hover"
-        >
-          New project
-        </Link>
-      </div>
+      <PageHeader
+        title="Projects"
+        description="Name and phase are editable inline."
+        actions={
+          <Button asChild variant="primary">
+            <Link href="/projects/new">New project</Link>
+          </Button>
+        }
+      />
 
-      {error && <p className="mb-3 rounded bg-danger-subtle px-3 py-2 text-sm text-danger">{error}</p>}
-      {!projects && !error && <LoadingBlock />}
-      {projects && projects.length === 0 && <p className="text-fg-muted">No projects yet.</p>}
+      <DataGrid<Project>
+        rows={projects}
+        columns={columns}
+        rowId={(p) => p.id}
+        loading={!projects && !error}
+        error={error}
+        onRowClick={(p) => router.push(`/projects/${p.id}`)}
+        emptyTitle="No projects yet"
+        emptyDescription="Create one to start syncing models, issues and documents."
+      />
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        {projects?.map((p) => (
-          <Link
-            key={p.id}
-            href={`/projects/${p.id}`}
-            className="rounded-lg bg-surface p-4 ring-1 ring-border transition hover:ring-accent"
-          >
-            <div className="flex items-center justify-between gap-3">
-              <span className="font-medium">{p.name}</span>
-              <div className="flex shrink-0 items-center gap-2">
-                <RagBadge rag={p.ragStatus} percent={p.compliancePercent} />
-                <span className="text-xs text-fg-subtle">{p.code}</span>
-              </div>
-            </div>
-            {p.description && <p className="mt-1 line-clamp-2 text-sm text-fg-muted">{p.description}</p>}
-            {typeof p.openIssueCount === 'number' && (
-              <p className="mt-1 text-xs text-fg-subtle">{p.openIssueCount} open issue(s)</p>
-            )}
-          </Link>
-        ))}
-      </div>
+      {archiving && (
+        <ArchiveProjectDialog
+          open={!!archiving}
+          onOpenChange={(o) => !o && setArchiving(null)}
+          projectId={archiving.id}
+          projectCode={archiving.code}
+          projectName={archiving.name}
+          onArchived={() => {
+            setArchiving(null);
+            load();
+          }}
+        />
+      )}
     </AppShell>
   );
 }

--- a/planscape-web/app/projects/page.tsx
+++ b/planscape-web/app/projects/page.tsx
@@ -6,7 +6,16 @@ import { useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { ArchiveProjectDialog } from '@/components/ArchiveProjectDialog';
 import { RagBadge } from '@/components/RagBadge';
-import { Badge, Button, DataGrid, PageHeader, toneForStatus, type Column } from '@/components/ui';
+import {
+  Badge,
+  Button,
+  DataGrid,
+  MenuItem,
+  MenuSeparator,
+  PageHeader,
+  toneForStatus,
+  type Column,
+} from '@/components/ui';
 import { listProjects, updateProject } from '@/lib/data';
 import type { Project } from '@/lib/types';
 
@@ -141,6 +150,36 @@ export default function ProjectsPage() {
         loading={!projects && !error}
         error={error}
         onRowClick={(p) => router.push(`/projects/${p.id}`)}
+        rowMenu={(p, close) => (
+          <>
+            <MenuItem
+              onClick={() => {
+                close();
+                router.push(`/projects/${p.id}`);
+              }}
+            >
+              Open project
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                close();
+                router.push(`/projects/${p.id}/issues`);
+              }}
+            >
+              Open issues
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem
+              disabled={p.status === 'Archived'}
+              onClick={() => {
+                close();
+                setArchiving(p);
+              }}
+            >
+              Archive…
+            </MenuItem>
+          </>
+        )}
         emptyTitle="No projects yet"
         emptyDescription="Create one to start syncing models, issues and documents."
       />

--- a/planscape-web/app/settings/team/page.tsx
+++ b/planscape-web/app/settings/team/page.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+/**
+ * Firm-level team page.
+ *
+ * Two invite paths exist server-side and only one had a UI:
+ *  - `POST /api/projects/{id}/members/invite` — a seat on ONE project. Fully
+ *    wired since U4 (`/projects/{id}/members`).
+ *  - `POST /api/tenant/invite` — a person in the FIRM, independent of any
+ *    project. Had no client code anywhere. This page is its entry point.
+ *
+ * The whole of `TenantAdminController` is `[Authorize(Roles = "Owner,Admin")]`,
+ * so a Coordinator loading this page gets a 403. That is the correct answer to a
+ * legitimate request, and it renders as "you need Owner or Admin", not as a
+ * failure banner.
+ *
+ * Removing a user (`DELETE /api/tenant/users/{id}`) exists server-side and is
+ * deliberately NOT wired here — see docs/ACC_UI_SHELL_GRID_CONTRACT.md §6.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { AppShell } from '@/components/AppShell';
+import {
+  Badge,
+  Button,
+  Card,
+  DataGrid,
+  ErrorNote,
+  Input,
+  Modal,
+  PageHeader,
+  Select,
+  useToast,
+  type Column,
+} from '@/components/ui';
+import { ApiError } from '@/lib/api';
+import { getTenantDashboard, inviteTenantMember } from '@/lib/data';
+import type { QuotaExceeded, TenantDashboard, TenantUser } from '@/lib/types';
+
+// The server maps anything that isn't "Author" to "Coordinator". Offering more
+// than the two it actually meters would be a lie about what the plan counts.
+const TENANT_ROLES = ['Coordinator', 'Author'];
+
+export default function TeamPage() {
+  const { toast } = useToast();
+  const [data, setData] = useState<TenantDashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [role, setRole] = useState('Coordinator');
+  const [busy, setBusy] = useState(false);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    getTenantDashboard()
+      .then((d) => {
+        setData(d);
+        setForbidden(false);
+        setError(null);
+      })
+      .catch((e) => {
+        if (e instanceof ApiError && e.status === 403) {
+          setForbidden(true);
+          return;
+        }
+        setError(e instanceof Error ? e.message : 'Failed to load the team');
+      });
+  }, []);
+
+  useEffect(load, [load]);
+
+  async function onInvite() {
+    const addr = email.trim();
+    if (!addr) return;
+    setBusy(true);
+    setInviteError(null);
+    try {
+      await inviteTenantMember({ email: addr, displayName: displayName.trim() || addr, role });
+      toast(`${addr} invited as ${role}.`, 'success');
+      setEmail('');
+      setDisplayName('');
+      setOpen(false);
+      load();
+    } catch (e) {
+      setInviteError(inviteMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const columns: Column<TenantUser>[] = [
+    {
+      key: 'displayName',
+      header: 'Name',
+      className: 'min-w-[12rem] font-medium',
+      render: (u) => u.displayName || <span className="text-fg-subtle">—</span>,
+    },
+    { key: 'email', header: 'Email', className: 'min-w-[14rem]' },
+    {
+      key: 'role',
+      header: 'Role',
+      className: 'w-36',
+      render: (u) => (u.role ? <Badge tone="accent">{u.role}</Badge> : <span className="text-fg-subtle">—</span>),
+    },
+    {
+      key: 'iso19650Role',
+      header: 'ISO 19650',
+      className: 'w-24',
+    },
+    {
+      key: 'isActive',
+      header: 'State',
+      className: 'w-28',
+      value: (u) => (u.isActive ? 'Active' : 'Invited'),
+      // An invited user is a planted row with no password yet — showing that as
+      // "Active" would make an unfinished invite look complete.
+      render: (u) =>
+        u.isActive ? <Badge tone="success">Active</Badge> : <Badge tone="warning">Invited</Badge>,
+    },
+    {
+      key: 'lastLoginAt',
+      header: 'Last sign-in',
+      className: 'w-32',
+      render: (u) =>
+        u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString() : <span className="text-fg-subtle">Never</span>,
+    },
+  ];
+
+  if (forbidden) {
+    return (
+      <AppShell>
+        <PageHeader title="Team" />
+        <Card>
+          <p className="text-sm text-fg">You need the Owner or Admin role to manage your firm&rsquo;s team.</p>
+          <p className="mt-1 text-sm text-fg-muted">
+            Project-level membership is managed per project, under Members — that does not require Admin.
+          </p>
+        </Card>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <PageHeader
+        title="Team"
+        description={data ? `${data.tenant.name} · ${data.tenant.plan ?? 'plan unknown'}` : 'Everyone in your firm'}
+        actions={
+          <Button variant="primary" onClick={() => setOpen(true)}>
+            Invite to firm
+          </Button>
+        }
+      />
+
+      {error && (
+        <div className="mb-4">
+          <ErrorNote>{error}</ErrorNote>
+        </div>
+      )}
+
+      {data && (
+        <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Quota label="Authors" axis={data.usage.authors} />
+          <Quota label="Coordinators" axis={data.usage.coordinators} />
+          <Quota label="Projects" axis={data.usage.projects} />
+          <Quota
+            label="Storage (MB)"
+            axis={{ current: data.usage.storage.currentMb, max: data.usage.storage.maxMb }}
+          />
+        </div>
+      )}
+
+      <DataGrid<TenantUser>
+        rows={data?.users ?? null}
+        columns={columns}
+        rowId={(u) => u.id}
+        loading={!data && !error}
+        emptyTitle="No one here yet"
+        emptyDescription="Invite a colleague to the firm — they can then be added to projects."
+      />
+
+      <Modal
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) setInviteError(null);
+        }}
+        title="Invite to firm"
+        description="Firm-wide access. Add them to individual projects afterwards, under a project's Members."
+        footer={
+          <>
+            <Button onClick={() => setOpen(false)} disabled={busy}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={() => void onInvite()} disabled={busy || !email.trim()}>
+              {busy ? 'Inviting…' : 'Send invite'}
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-fg-muted">Email</span>
+            <Input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="person@firm.com"
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-fg-muted">Name</span>
+            <Input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="Optional — defaults to the email"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-fg-muted">Role</span>
+            <Select value={role} onChange={(e) => setRole(e.target.value)}>
+              {TENANT_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </Select>
+            <span className="text-xs text-fg-subtle">
+              Authors and Coordinators are capped separately by your plan.
+            </span>
+          </label>
+          {inviteError && (
+            <p role="alert" className="rounded bg-danger-subtle px-3 py-2 text-sm text-danger">
+              {inviteError}
+            </p>
+          )}
+        </div>
+      </Modal>
+    </AppShell>
+  );
+}
+
+/**
+ * Turn the three answers this endpoint actually gives into sentences. Without
+ * this, a full plan reads as the literal string "quota_exceeded" — the server's
+ * useful sentence lives in `reason`, not in `error`.
+ */
+function inviteMessage(e: unknown): string {
+  if (!(e instanceof ApiError)) return e instanceof Error ? e.message : 'Invite failed.';
+  if (e.status === 402) {
+    const q = e.body as QuotaExceeded | undefined;
+    const detail = q?.reason ? ` ${q.reason}` : '';
+    return `Your plan's seat limit is full.${detail} Upgrade your plan to invite more people.`;
+  }
+  if (e.status === 409) return 'Someone already has an account with that email.';
+  if (e.status === 403) return 'You need the Owner or Admin role to invite people to the firm.';
+  return e.message;
+}
+
+function Quota({ label, axis }: { label: string; axis: { current: number; max: number } }) {
+  // int.MaxValue is the server's "unlimited" — rendering it as 2147483647 would
+  // read as a bug.
+  const unlimited = axis.max >= 2147483647;
+  const pct = unlimited || !axis.max ? 0 : Math.min(100, Math.round((axis.current / axis.max) * 100));
+  const tone = pct >= 100 ? 'bg-danger' : pct >= 80 ? 'bg-warning' : 'bg-accent';
+  return (
+    <Card>
+      <div className="text-xs text-fg-muted">{label}</div>
+      <div className="mt-0.5 text-2xl font-semibold text-fg">
+        {axis.current}
+        <span className="text-sm font-normal text-fg-muted"> / {unlimited ? '∞' : axis.max}</span>
+      </div>
+      {!unlimited && (
+        <div className="mt-2 h-1 w-full overflow-hidden rounded bg-surface-3">
+          <div className={`h-full ${tone}`} style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/planscape-web/components/AppShell.tsx
+++ b/planscape-web/components/AppShell.tsx
@@ -191,6 +191,19 @@ export function AppShell({ children }: { children: ReactNode }) {
                     </MenuItem>
                   ))}
                   <MenuSeparator />
+                  {/* Firm-wide, deliberately NOT inside a project — inviting
+                      someone to the practice is not a project action. Owner /
+                      Admin only server-side; the page says so rather than
+                      hiding, since the token doesn't tell us the tenant role
+                      reliably enough to gate the menu on it. */}
+                  <MenuItem
+                    onClick={() => {
+                      close();
+                      router.push('/settings/team');
+                    }}
+                  >
+                    Team
+                  </MenuItem>
                   <MenuItem
                     onClick={() => {
                       close();

--- a/planscape-web/components/ArchiveProjectDialog.tsx
+++ b/planscape-web/components/ArchiveProjectDialog.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button, Input, Modal } from '@/components/ui';
+import { ApiError } from '@/lib/api';
+import { archiveProject } from '@/lib/data';
+
+/**
+ * Type-the-code confirmation for archiving a project — the GitHub
+ * "type the repository name" pattern.
+ *
+ * This deliberately mirrors what `DELETE /api/projects/{id}` already enforces
+ * server-side (`?confirmCode=<Project.Code>`), rather than shipping a weaker
+ * client confirm and letting the server's 400 be the real gate. The server check
+ * stays the backstop; this is the part the user actually reads.
+ *
+ * Archiving is a SOFT delete — say so in the dialog, because "Archive" next to a
+ * red button reads as destructive and people hesitate over the wrong thing.
+ */
+export function ArchiveProjectDialog({
+  open,
+  onOpenChange,
+  projectId,
+  projectCode,
+  projectName,
+  onArchived,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  /** The project's own `code` — this is what the user must retype. */
+  projectCode: string;
+  projectName?: string;
+  onArchived?: () => void;
+}) {
+  const [typed, setTyped] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-opening the dialog must not inherit the previous attempt's typed code or
+  // its error banner.
+  useEffect(() => {
+    if (open) {
+      setTyped('');
+      setError(null);
+    }
+  }, [open]);
+
+  // Case-insensitive + trimmed, matching the server's OrdinalIgnoreCase compare.
+  // A stricter client check would reject codes the server accepts.
+  const matches = typed.trim().toLowerCase() === (projectCode ?? '').trim().toLowerCase();
+
+  async function onConfirm() {
+    if (!matches) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await archiveProject(projectId, typed.trim());
+      onOpenChange(false);
+      onArchived?.();
+    } catch (e) {
+      // 403 is a real, expected answer — the caller is neither the project author
+      // nor a tenant admin. Name that instead of dropping a generic toast.
+      if (e instanceof ApiError && e.status === 403) {
+        setError(
+          'You do not have permission to archive this project. Only the person who created it, or a tenant Owner/Admin, can.',
+        );
+      } else if (e instanceof ApiError && e.status === 400) {
+        setError(`${e.message} The code for this project is "${projectCode}".`);
+      } else {
+        setError(e instanceof Error ? e.message : 'Archive failed.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Archive project"
+      description="Archiving is reversible — nothing is deleted."
+      footer={
+        <>
+          <Button onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void onConfirm()} disabled={!matches || busy}>
+            {busy ? 'Archiving…' : 'Archive project'}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-fg-muted">
+          {projectName ? <span className="font-medium text-fg">{projectName}</span> : 'This project'} will be marked
+          archived. Its issues, documents and models are kept and it stays visible under the archived filter — it just
+          stops counting towards active projects.
+        </p>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-fg-muted">
+            Type <span className="rounded bg-surface-3 px-1 font-mono text-fg">{projectCode}</span> to confirm
+          </span>
+          <Input
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={projectCode}
+            aria-label="Project code confirmation"
+            autoFocus
+            autoComplete="off"
+          />
+        </label>
+        {error && (
+          <p role="alert" className="rounded bg-danger-subtle px-3 py-2 text-sm text-danger">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/planscape-web/components/shell/Menu.tsx
+++ b/planscape-web/components/shell/Menu.tsx
@@ -1,6 +1,55 @@
 'use client';
 
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
+
+/**
+ * The behaviour both popups share: Escape closes and hands focus back, an
+ * outside click closes, and ↑/↓/Home/End walk the items (WAI-ARIA menu pattern).
+ *
+ * Extracted so the right-click menu added in U6 is the SAME menu as the shell's
+ * click menus rather than a second implementation that drifts. If you fix a
+ * keyboard bug, fix it here once.
+ */
+function useMenuBehaviour(
+  open: boolean,
+  wrapRef: RefObject<HTMLElement | null>,
+  close: () => void,
+  restoreFocus?: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) close();
+    }
+    function items(): HTMLElement[] {
+      return Array.from(wrapRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])') ?? []);
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        close();
+        restoreFocus?.(); // don't strand focus at the top of the page
+        return;
+      }
+      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') return;
+      const list = items();
+      if (!list.length) return;
+      e.preventDefault();
+      const at = list.indexOf(document.activeElement as HTMLElement);
+      const next =
+        e.key === 'Home' ? 0
+        : e.key === 'End' ? list.length - 1
+        : e.key === 'ArrowDown' ? (at + 1) % list.length
+        : (at - 1 + list.length) % list.length;
+      list[next]?.focus();
+    }
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open, wrapRef, close, restoreFocus]);
+}
 
 /**
  * U2 — a minimal accessible popover menu for the shell (avatar, tenant, project
@@ -27,42 +76,12 @@ export function Menu({
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointerDown(e: MouseEvent) {
-      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
-    }
-    function items(): HTMLElement[] {
-      return Array.from(wrapRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])') ?? []);
-    }
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') {
-        setOpen(false);
-        triggerRef.current?.focus(); // don't strand focus at the top of the page
-        return;
-      }
-      // U5 — arrow keys move through the menu, matching the WAI-ARIA menu
-      // pattern. Without this an open menu is only reachable by Tab, which
-      // walks straight past it into the page behind.
-      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') return;
-      const list = items();
-      if (!list.length) return;
-      e.preventDefault();
-      const at = list.indexOf(document.activeElement as HTMLElement);
-      const next =
-        e.key === 'Home' ? 0
-        : e.key === 'End' ? list.length - 1
-        : e.key === 'ArrowDown' ? (at + 1) % list.length
-        : (at - 1 + list.length) % list.length;
-      list[next]?.focus();
-    }
-    document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
+  // U5 — arrow keys move through the menu, matching the WAI-ARIA menu pattern.
+  // Without this an open menu is only reachable by Tab, which walks straight
+  // past it into the page behind.
+  const close = useRef(() => setOpen(false)).current;
+  const restore = useRef(() => triggerRef.current?.focus()).current;
+  useMenuBehaviour(open, wrapRef, close, restore);
 
   return (
     <div ref={wrapRef} className="relative">
@@ -85,6 +104,72 @@ export function Menu({
           {children(() => setOpen(false))}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * U6 — the same menu, opened at a point instead of under a trigger. Used by the
+ * DataGrid for right-click row actions.
+ *
+ * It is a panel, not a wrapper: the caller owns "where and when", because only
+ * the caller knows what was right-clicked. Rendering is unconditional — mount it
+ * when open, unmount it when closed — so focus management runs exactly once per
+ * opening.
+ *
+ * Deliberately not a portal. The grid is inside `<main>` with no clipping
+ * ancestor, and `position: fixed` already escapes the grid's `overflow-x: auto`.
+ * A portal would add a mount point for no behaviour.
+ */
+export function ContextMenuPanel({
+  x,
+  y,
+  onClose,
+  children,
+  label = 'Row actions',
+  widthClass = 'w-56',
+}: {
+  x: number;
+  y: number;
+  onClose: () => void;
+  children: ReactNode;
+  label?: string;
+  widthClass?: string;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const returnTo = useRef<HTMLElement | null>(null);
+  const [pos, setPos] = useState({ x, y });
+
+  const restore = useRef(() => returnTo.current?.focus?.()).current;
+  useMenuBehaviour(true, wrapRef, onClose, restore);
+
+  useLayoutEffect(() => {
+    returnTo.current = document.activeElement as HTMLElement | null;
+    const el = wrapRef.current;
+    if (!el) return;
+    // Clamp into the viewport: a right-click near the bottom-right otherwise
+    // opens a menu that is half off-screen and unreachable.
+    const r = el.getBoundingClientRect();
+    const pad = 8;
+    setPos({
+      x: Math.max(pad, Math.min(x, window.innerWidth - r.width - pad)),
+      y: Math.max(pad, Math.min(y, window.innerHeight - r.height - pad)),
+    });
+    el.querySelector<HTMLElement>('[role="menuitem"]:not([disabled])')?.focus();
+  }, [x, y]);
+
+  return (
+    <div
+      ref={wrapRef}
+      role="menu"
+      aria-label={label}
+      style={{ top: pos.y, left: pos.x }}
+      className={`fixed z-40 ${widthClass} animate-zoom-in overflow-hidden rounded-md border border-border bg-surface py-1 shadow-lg`}
+      // A right-click inside the menu should not open the browser's own menu on
+      // top of ours.
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {children}
     </div>
   );
 }

--- a/planscape-web/components/shell/nav.ts
+++ b/planscape-web/components/shell/nav.ts
@@ -45,6 +45,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   search: 'Search',
   settings: 'Settings',
   tokens: 'Access tokens',
+  team: 'Team',
   handoff: 'Handoff',
   new: 'New',
   live: 'Live',

--- a/planscape-web/components/ui/DataGrid.test.tsx
+++ b/planscape-web/components/ui/DataGrid.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, waitFor, within } from '@testing-library/react
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DataGrid, type Column, type DataGridProps } from './DataGrid';
+import { MenuItem } from '@/components/shell/Menu';
 import { ToastProvider } from './toast';
 
 /**
@@ -196,5 +197,63 @@ describe('DataGrid — inline edit (the contract)', () => {
     await user.type(screen.getByRole('textbox'), 'xyz');
     await user.keyboard('{Escape}');
     expect(save).not.toHaveBeenCalled();
+  });
+});
+
+describe('DataGrid — right-click row menu (U6)', () => {
+  const menu = (onOpen = vi.fn()) => ({
+    rowMenu: (r: Row, close: () => void) => (
+      <MenuItem
+        onClick={() => {
+          close();
+          onOpen(r.id);
+        }}
+      >
+        Open
+      </MenuItem>
+    ),
+  });
+
+  it('does not attach a context menu when no rowMenu is given', async () => {
+    const user = userEvent.setup();
+    grid(plain);
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Beta duct clash') });
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('opens at the right-clicked row and runs that row’s action', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    grid(plain, menu(onOpen));
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Gamma pipe route') });
+    const m = screen.getByRole('menu');
+    await user.click(within(m).getByRole('menuitem', { name: 'Open' }));
+    // The row that was right-clicked, not the first row.
+    expect(onOpen).toHaveBeenCalledWith('3');
+  });
+
+  it('closes after the action runs', async () => {
+    const user = userEvent.setup();
+    grid(plain, menu());
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Beta duct clash') });
+    await user.click(screen.getByRole('menuitem', { name: 'Open' }));
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+  });
+
+  it('Escape closes it', async () => {
+    const user = userEvent.setup();
+    grid(plain, menu());
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Beta duct clash') });
+    expect(screen.getByRole('menu')).toBeDefined();
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+  });
+
+  it('right-clicking a row does NOT also fire the row navigation', async () => {
+    const user = userEvent.setup();
+    const onRowClick = vi.fn();
+    grid(plain, { ...menu(), onRowClick });
+    await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Beta duct clash') });
+    expect(onRowClick).not.toHaveBeenCalled();
   });
 });

--- a/planscape-web/components/ui/DataGrid.tsx
+++ b/planscape-web/components/ui/DataGrid.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { cn } from '@/lib/cn';
+import { ContextMenuPanel } from '@/components/shell/Menu';
 import { EmptyState, ErrorNote, Input, Select, SkeletonRows } from './primitives';
 import { useToast } from './toast';
 
@@ -57,6 +58,14 @@ export interface DataGridProps<T> {
   filterable?: boolean;
   /** Optimistically-applied local patches so the parent needn't refetch. */
   onRowPatched?: (id: string, key: string, value: string) => void;
+  /**
+   * U6 — right-click row actions. Return `MenuItem`s; call `close` from each.
+   *
+   * These must be the actions the row ALREADY offers as buttons or links, not a
+   * separate set only discoverable by right-clicking. A right-click menu is a
+   * shortcut, and an action that exists nowhere else is not a shortcut.
+   */
+  rowMenu?: (row: T, close: () => void) => ReactNode;
 }
 
 type SortState = { key: string; dir: 'asc' | 'desc' } | null;
@@ -74,6 +83,7 @@ export function DataGrid<T>({
   selectable = false,
   filterable = true,
   onRowPatched,
+  rowMenu,
 }: DataGridProps<T>) {
   const { toast } = useToast();
   const [sort, setSort] = useState<SortState>(null);
@@ -83,6 +93,8 @@ export function DataGrid<T>({
   /** Cell overrides applied optimistically, keyed `${rowId}:${colKey}`. */
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<string | null>(null);
+  /** Which row was right-clicked, and where. Null = no context menu open. */
+  const [menuAt, setMenuAt] = useState<{ row: T; x: number; y: number } | null>(null);
 
   const valueOf = useCallback(
     (row: T, col: Column<T>): string => {
@@ -267,6 +279,14 @@ export function DataGrid<T>({
                       onRowClick && 'cursor-pointer',
                     )}
                     onClick={onRowClick ? () => onRowClick(row) : undefined}
+                    onContextMenu={
+                      rowMenu
+                        ? (e) => {
+                            e.preventDefault();
+                            setMenuAt({ row, x: e.clientX, y: e.clientY });
+                          }
+                        : undefined
+                    }
                   >
                     {selectable && (
                       <td className="px-2 py-1.5" onClick={(e) => e.stopPropagation()}>
@@ -349,6 +369,12 @@ export function DataGrid<T>({
           </table>
         )}
       </div>
+
+      {rowMenu && menuAt && (
+        <ContextMenuPanel x={menuAt.x} y={menuAt.y} onClose={() => setMenuAt(null)}>
+          {rowMenu(menuAt.row, () => setMenuAt(null))}
+        </ContextMenuPanel>
+      )}
     </div>
   );
 }

--- a/planscape-web/components/ui/index.ts
+++ b/planscape-web/components/ui/index.ts
@@ -18,4 +18,8 @@ export {
 } from './primitives';
 export { Modal, Drawer, Tabs, TabPanel } from './overlays';
 export { DataGrid, type Column, type DataGridProps } from './DataGrid';
+// Re-exported so a page building a DataGrid's `rowMenu` has one import path.
+// The menu itself stays in components/shell — it is the shell's menu, and the
+// point of U6 was to reuse it rather than grow a second one here.
+export { MenuItem, MenuLabel, MenuSeparator } from '@/components/shell/Menu';
 export { ToastProvider, useToast, type ToastTone } from './toast';

--- a/planscape-web/lib/api.test.ts
+++ b/planscape-web/lib/api.test.ts
@@ -62,6 +62,19 @@ describe('api()', () => {
     await expect(api('/api/x')).rejects.toBeInstanceOf(ApiError);
   });
 
+  it('keeps the parsed error body on the ApiError', async () => {
+    // The 402 quota refusal carries its useful sentence in `reason`; `message`
+    // resolves to the machine string "quota_exceeded", which is not something to
+    // show a person. Callers need the body to do better.
+    const f = mockFetch(402, { error: 'quota_exceeded', axis: 'Authors', reason: 'Authors cap reached (5 of 5).' });
+    vi.stubGlobal('fetch', f);
+    await expect(api('/api/tenant/invite')).rejects.toMatchObject({
+      status: 402,
+      message: 'quota_exceeded',
+      body: { reason: 'Authors cap reached (5 of 5).' },
+    });
+  });
+
   it('clears the token and throws on 401', async () => {
     setToken('tok');
     const f = mockFetch(401, {}, false);

--- a/planscape-web/lib/api.ts
+++ b/planscape-web/lib/api.ts
@@ -21,10 +21,19 @@ export function setToken(token: string | null): void {
 
 export class ApiError extends Error {
   status: number;
-  constructor(status: number, message: string) {
+  /**
+   * The parsed error body, when there was one. `message` is still the field a
+   * caller should show by default; this exists for the handful of responses that
+   * carry structured detail worth rendering differently — e.g. the 402
+   * `{ error: 'quota_exceeded', axis, current, max, reason, upgrade_url }`,
+   * whose useful sentence is `reason`, not `error`.
+   */
+  body?: unknown;
+  constructor(status: number, message: string, body?: unknown) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
+    this.body = body;
   }
 }
 
@@ -46,13 +55,15 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
 
   if (!res.ok) {
     let message = `Request failed (HTTP ${res.status})`;
+    let parsed: unknown;
     try {
       const body = await res.json();
+      parsed = body;
       message = body.message || body.error || message;
     } catch {
       /* non-JSON error body — keep the generic message */
     }
-    throw new ApiError(res.status, message);
+    throw new ApiError(res.status, message, parsed);
   }
 
   if (res.status === 204) return undefined as T;

--- a/planscape-web/lib/data.test.ts
+++ b/planscape-web/lib/data.test.ts
@@ -198,3 +198,20 @@ describe('archiveProject', () => {
     expect(calls()[0].url).toContain('confirmCode=A%26B%2F1');
   });
 });
+
+describe('tenant admin', () => {
+  it('inviteTenantMember POSTs to the tenant route, not a project route', async () => {
+    await data.inviteTenantMember({ email: 'a@b.com', displayName: 'A B', role: 'Author' });
+    const c = calls()[0];
+    expect(c.init.method).toBe('POST');
+    expect(c.url).toContain('/api/tenant/invite');
+    expect(c.url).not.toContain('/projects/');
+    expect(bodyOf(c.init)).toEqual({ email: 'a@b.com', displayName: 'A B', role: 'Author' });
+  });
+
+  it('getTenantDashboard has no tenant id in the path — the token resolves it', async () => {
+    lastBody = { tenant: { id: 't' }, usage: {}, users: [] };
+    await data.getTenantDashboard();
+    expect(calls()[0].url).toMatch(/\/api\/tenant\/dashboard$/);
+  });
+});

--- a/planscape-web/lib/data.test.ts
+++ b/planscape-web/lib/data.test.ts
@@ -182,3 +182,19 @@ describe('members + search + transmittals + photos', () => {
     expect(calls()[2].url).toContain('/photos/ph/reject');
   });
 });
+
+describe('archiveProject', () => {
+  it('DELETEs with the confirm code on the query string', async () => {
+    await data.archiveProject('p1', 'ABC-123');
+    const c = calls()[0];
+    expect(c.init.method).toBe('DELETE');
+    expect(c.url).toContain('/api/projects/p1?confirmCode=ABC-123');
+  });
+
+  it('URL-encodes a code containing reserved characters', async () => {
+    // A code is user-supplied at project creation; "A&B/1" must not truncate
+    // the query string or invent a second parameter.
+    await data.archiveProject('p1', 'A&B/1');
+    expect(calls()[0].url).toContain('confirmCode=A%26B%2F1');
+  });
+});

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -43,6 +43,27 @@ export function createProject(body: {
   return api<Project>('/api/projects', { method: 'POST', body: JSON.stringify(body) });
 }
 
+/**
+ * Archive a project — a SOFT delete. `Status` flips to `Archived`; every row is
+ * kept and the project stays visible under the archived filter. There is no hard
+ * delete on this route by design; a true purge is separate admin tooling.
+ *
+ * The server double-gates it (`ProjectsController.ArchiveProject`):
+ *  - **403** unless the caller is the project author (`CreatedById`) or a tenant
+ *    admin. That is correct behaviour, not a bug — surface it as "you don't have
+ *    permission", not as a generic failure.
+ *  - **400** unless `confirmCode` equals the project's own `Code`
+ *    (case-insensitive), with `{ message, expectedField, expectedValue }`.
+ *
+ * The client asks for the code too — see `ArchiveProjectDialog`. The 400 is the
+ * server's backstop, not the UI's confirmation step.
+ */
+export function archiveProject(id: string, confirmCode: string): Promise<void> {
+  return api<void>(`/api/projects/${id}?confirmCode=${encodeURIComponent(confirmCode)}`, {
+    method: 'DELETE',
+  });
+}
+
 // ── Issues ──
 export async function listIssues(projectId: string, status?: string): Promise<BimIssue[]> {
   const qs = status ? `?status=${encodeURIComponent(status)}` : '';

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -50,6 +50,10 @@ export function createProject(body: {
  * `seqNumPad`, `tagPrefix`, `tagSuffix` and `configJson`, none of which the
  * grid edits.
  *
+ * `documentSyncAutoEnabled` is in the list because it genuinely is a project
+ * setting this route accepts — the per-project "Auto-sync this project" toggle
+ * from the document-sync design.
+ *
  * `status` in particular stays out on purpose — writing it here would be a
  * second, unconfirmed route to `Archived`, bypassing the confirm-code gate that
  * `archiveProject` exists to honour. Note it is NOT accepting `code`: the server
@@ -59,7 +63,7 @@ export function createProject(body: {
  */
 export function updateProject(
   id: string,
-  body: { name?: string; description?: string; phase?: string },
+  body: { name?: string; description?: string; phase?: string; documentSyncAutoEnabled?: boolean },
 ): Promise<Project> {
   return api<Project>(`/api/projects/${id}`, { method: 'PUT', body: JSON.stringify(body) });
 }

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -44,6 +44,26 @@ export function createProject(body: {
 }
 
 /**
+ * Update project settings. The body is deliberately narrower than
+ * `UpdateProjectRequest`: that record also accepts `status`, `tagSeparator`,
+ * `seqNumPad`, `tagPrefix`, `tagSuffix` and `configJson`, none of which the
+ * grid edits.
+ *
+ * `status` in particular stays out on purpose — writing it here would be a
+ * second, unconfirmed route to `Archived`, bypassing the confirm-code gate that
+ * `archiveProject` exists to honour. Note it is NOT accepting `code`: the server
+ * has no write for it, and it is the archive confirmation token.
+ *
+ * Null-valued fields are "leave unchanged" server-side, so a partial body is safe.
+ */
+export function updateProject(
+  id: string,
+  body: { name?: string; description?: string; phase?: string },
+): Promise<Project> {
+  return api<Project>(`/api/projects/${id}`, { method: 'PUT', body: JSON.stringify(body) });
+}
+
+/**
  * Archive a project — a SOFT delete. `Status` flips to `Archived`; every row is
  * kept and the project stays visible under the archived filter. There is no hard
  * delete on this route by design; a true purge is separate admin tooling.

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -23,6 +23,7 @@ import type {
   SitePhoto,
   AccessToken,
   MintedAccessToken,
+  TenantDashboard,
 } from './types';
 
 // ── Projects ──
@@ -429,6 +430,44 @@ export function updateMemberRole(
 
 export function removeMember(projectId: string, memberId: string): Promise<void> {
   return api(`/api/projects/${projectId}/members/${memberId}`, { method: 'DELETE' });
+}
+
+// ── Tenant (firm-wide) administration ──
+// Every route here lives on TenantAdminController, which is
+// [Authorize(Roles = "Owner,Admin")] as a whole. A 403 from any of them means
+// "you are not an Owner or Admin", not "something went wrong" — render it that
+// way. There is no tenant id in the path: the tenant is resolved from the token
+// and the global query filter, so an admin cannot even type the wrong one.
+
+/** Plan, live usage vs limits, and the firm's user list — one payload. */
+export function getTenantDashboard(): Promise<TenantDashboard> {
+  return api<TenantDashboard>('/api/tenant/dashboard');
+}
+
+/**
+ * Invite someone to the FIRM, not to a single project — the counterpart to
+ * `inviteMember`, which adds a seat on one project. This is the path that was
+ * server-only until now: `POST /api/tenant/invite` had no client code anywhere.
+ *
+ * `role` is `"Author"` or anything else, which the server maps to
+ * `"Coordinator"` — those are the two axes the plan meters separately.
+ *
+ * Failures worth handling by hand rather than as a generic toast:
+ *  - **402** `{ error: 'quota_exceeded', axis, current, max, reason }` — the
+ *    plan's Author/Coordinator cap is full. `ApiError.body` carries the detail.
+ *  - **409** the email already belongs to a user.
+ *  - **403** the caller is not an Owner/Admin.
+ *
+ * The invited row is planted inactive with a stub password; the server's real
+ * invite-email flow is still a TODO on its side, so treat "invited" as "seat
+ * reserved", not "they got a link".
+ */
+export function inviteTenantMember(body: {
+  email: string;
+  displayName: string;
+  role: string;
+}): Promise<{ id: string; email: string; displayName: string; role: string }> {
+  return api('/api/tenant/invite', { method: 'POST', body: JSON.stringify(body) });
 }
 
 // ── Cross-project search ──

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -24,6 +24,12 @@ export interface Project {
   taggedElements?: number;
   lastSyncAt?: string | null;
   isPinned?: boolean;
+  /**
+   * Document sync — "Auto-sync this project". On by default. Off means a linked
+   * Planscape Companion stops syncing automatically but still syncs on an
+   * explicit "Sync now"; it does not unlink anything.
+   */
+  documentSyncAutoEnabled?: boolean;
   city?: string | null;
   country?: string | null;
 }

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -251,6 +251,60 @@ export interface Iso19650Role {
   label: string;
 }
 
+// ── Tenant (firm-wide) administration ──
+// Mirrors TenantAdminController, which is [Authorize(Roles = "Owner,Admin")] in
+// its entirety — every call here 403s for anyone else, and that is correct.
+
+/** A user account in the firm — distinct from ProjectMember, which is a seat on one project. */
+export interface TenantUser {
+  id: string;
+  email: string;
+  displayName?: string | null;
+  role?: string; // Owner | Admin | Coordinator | Contributor | Viewer
+  iso19650Role?: string | null;
+  lastLoginAt?: string | null;
+  /** false until an invitee sets a password — an invite plants an inactive row. */
+  isActive?: boolean;
+}
+
+export interface TenantQuotaAxis {
+  current: number;
+  max: number;
+}
+
+export interface TenantDashboard {
+  tenant: {
+    id: string;
+    name: string;
+    slug?: string;
+    contactEmail?: string | null;
+    plan?: string;
+    currency?: string;
+    billingCycle?: string;
+    trialExpiresAt?: string | null;
+    isActive?: boolean;
+    createdAt?: string;
+  };
+  usage: {
+    authors: TenantQuotaAxis;
+    coordinators: TenantQuotaAxis;
+    projects: TenantQuotaAxis;
+    storage: { currentMb: number; maxMb: number };
+    memberSeats?: number;
+  };
+  users: TenantUser[];
+}
+
+/** Shape of the 402 body from a quota refusal. */
+export interface QuotaExceeded {
+  error: 'quota_exceeded';
+  axis?: string;
+  current?: number;
+  max?: number;
+  reason?: string;
+  upgrade_url?: string;
+}
+
 // ── Cross-project search ──
 export interface SearchResult {
   type: 'tag' | 'issue' | 'document' | 'meeting';

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -1,14 +1,31 @@
+/**
+ * Mirrors both project payloads, which are NOT the same shape:
+ *  - `GET /api/projects` (list) omits `description`, `configJson` and the tag
+ *    format fields;
+ *  - `GET /api/projects/{id}` (detail) returns the full entity.
+ * Everything the list can leave out is optional here, so a grid column that
+ * silently renders `undefined` is a compile-time question rather than a
+ * runtime blank.
+ */
 export interface Project {
   id: string;
   code: string;
   name: string;
-  description: string;
+  /** Detail payload only — the list projection does not include it. */
+  description?: string;
   createdAt: string;
   phase?: string;
-  status?: string;
+  status?: string; // Active | Archived | Completed
   compliancePercent?: number;
   ragStatus?: string;
   openIssueCount?: number;
+  memberCount?: number;
+  totalElements?: number;
+  taggedElements?: number;
+  lastSyncAt?: string | null;
+  isPinned?: boolean;
+  city?: string | null;
+  country?: string | null;
 }
 
 export type IssuePriority = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';


### PR DESCRIPTION
## Summary
- Projects list becomes a real DataGrid, with the archive (soft-delete) endpoint wired up and a type-the-code confirm dialog matching the server's own confirmation gate.
- Tenant-wide invite (a Team page, separate from the existing per-project invite).
- Right-click row menus + richer columns across the existing grids.
- `planscape://` protocol actually does something now — StingLink.exe + PlanscapeLinkWatcher, docs/PLANSCAPE_PROTOCOL.md.
- Full document sync feature: DocumentSyncHub + changed-since delta (server), Planscape Companion (new standalone tray app, named-pipe IPC, autostart), the sync engine (CDE-state-gated, no OS file locks, superseded-file safety net), BCC integration (pipe client, launch-on-startup, per-project auto/manual toggle, Documents-grid badge), Companion tray polish (checked-out count, state glyphs, opt-in full history). Full design at docs/superpowers/specs/2026-07-31-document-sync-design.md and plan at docs/superpowers/plans/2026-07-31-document-sync-plan.md.
- Fix: BCC's Deliverables tab was permanently empty — `BuildCoordData` never read `deliverables.json` even though it's written and read elsewhere. Wired it in, verified the field-mapping against a real console harness before shipping (caught and fixed a lowercase-field-alias bug in the process).

## Test plan
- [x] `dotnet build` — 0 warnings / 0 errors (verified independently, not just claimed)
- [x] `dotnet test` — 515 passed / 0 failed / 9 skipped (verified independently)
- [x] `npm run build` / typecheck — clean on planscape-web
- [x] Planscape.Companion.exe run standalone (`--diagnose`) from both the build output and the deployed CompiledPlugin copy
- [ ] PENDING-HUMAN-VERIFY: everything requiring an actual Revit session — the badge, the sync strip, launch-on-startup, a real end-to-end sync against the live server. Full checklist in docs/superpowers/plans/2026-07-31-document-sync-plan.md §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)