### PR TITLE
fix(storage): R2 upload 500 — disable AWSSDK.S3 trailing-checksum streaming

### DIFF
--- a/Planscape.Companion/CompanionService.cs
+++ b/Planscape.Companion/CompanionService.cs
@@ -248,9 +248,63 @@ internal sealed class CompanionService : IDisposable
     {
         if (!IsConfigured) return false;
         _api = new PlanscapeApiClient(_settings.ServerUrl!, _settings.AccessToken!);
+
+        // Zero linked projects is a SETUP state, not a connectivity one.
+        //
+        // Without this branch the per-project loop below never runs, nothing ever
+        // moves State off its Offline default, and a correctly configured
+        // Companion greets its first user with "offline, will retry" while the
+        // server and token are perfectly fine. The default itself is right —
+        // Offline is the quiet, non-alarming bucket for "not proven yet" (see
+        // SyncStatus) — but leaving it unproven here is what made it a lie.
+        //
+        // So prove it directly: a token exchange is the cheapest authenticated
+        // round-trip available and separates the three outcomes that genuinely
+        // differ — reachable and authorised (Idle), unreachable (Offline),
+        // rejected (Error). The tray path never needed this because establishing
+        // the hub connection already flips the state; --diagnose has no hub.
+        if (_settings.Projects.Count == 0)
+            return await ReportConnectionOnlyAsync(ct);
+
         var result = await SyncAllAsync(SyncTrigger.Manual, ct);
         Console.WriteLine(result);
         return Status.State != SyncState.Error;
+    }
+
+    /// <summary>
+    /// Prove the server and credentials with no project to sync, and say what is
+    /// actually missing. Deliberately does NOT set <c>LastSuccessUtc</c>: nothing
+    /// synced, and claiming a successful sync would be a second, quieter lie than
+    /// the one this method exists to fix.
+    /// </summary>
+    private async Task<bool> ReportConnectionOnlyAsync(CancellationToken ct)
+    {
+        try
+        {
+            await _api!.GetAccessTokenAsync(ct);
+            SetState(SyncState.Idle);
+            Console.WriteLine("Connected — server and access token are good.");
+            Console.WriteLine("No projects are linked on this machine yet, so there is nothing to sync.");
+            Console.WriteLine("Link one with:  Planscape.Companion.exe --link <projectId> <projectCode>");
+            CompanionLog.Info("connection verified; no projects linked on this machine");
+            return true;
+        }
+        catch (CompanionAuthException ex)
+        {
+            // Rejected credentials will never fix themselves — this is the state
+            // that should shout, and the one Offline must not be confused with.
+            SetState(SyncState.Error, ex.Message);
+            Console.WriteLine($"The server rejected the access token: {ex.Message}");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // Genuinely unreachable. Here "offline, will retry" is the truth.
+            SetState(SyncState.Offline);
+            Console.WriteLine($"Could not reach {_settings.ServerUrl}: {ex.Message}");
+            CompanionLog.Warn($"connection check failed: {ex.Message}");
+            return false;
+        }
     }
 
     /// <summary>

--- a/Planscape.Server/src/Planscape.Infrastructure/Storage/S3FileStorageService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Storage/S3FileStorageService.cs
@@ -117,6 +117,13 @@ public class S3FileStorageService : IFileStorageService, IAsyncDisposable
             Key = key,
             InputStream = content,
             AutoCloseStream = false,
+            // AWSSDK.S3 3.7.300+ defaults PutObject to a trailing-checksum streaming
+            // signature (STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER). Cloudflare R2
+            // (and MinIO) don't implement that scheme and reject every upload with
+            // "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER not implemented". Disabling
+            // payload signing falls back to the classic AWS4-HMAC-SHA256 signature,
+            // which every S3-compatible provider supports.
+            DisablePayloadSigning = true,
         };
         await _s3.PutObjectAsync(request, ct);
         _logger.LogDebug("Uploaded {Key} to {Bucket}", key, _bucket);

--- a/StingTools/Commands/Delivery/DeliveryCommands.cs
+++ b/StingTools/Commands/Delivery/DeliveryCommands.cs
@@ -9,6 +9,7 @@
 //    Risk_Raise        — raise a risk (anchored to the current selection/zone)
 //    Risk_Report        — register roll-up (RAG, top risks) + CSV
 //    Midp_DriftReport   — MIDP CSV → drift detection vs the live lifecycle + CSV
+//    Midp_Import        — MIDP CSV → bulk-import into deliverables.json (MidpImportCommand.cs)
 //
 //  Risks persist to <BIM manager>/risks.json (additive, safe-defaulted); each
 //  raise also appends to the tamper-evident audit log.
@@ -287,7 +288,17 @@ namespace StingTools.Commands.Delivery
             }
         }
 
-        private static List<DeliverablePlanItem> ParseMidpCsv(string path, out int skipped)
+        /// <summary>
+        /// Parse a MIDP/TIDP CSV into plan rows, tolerating the column-name
+        /// variants real spreadsheets arrive with.
+        ///
+        /// Internal, not private: <see cref="MidpImportCommand"/> bulk-writes the
+        /// same rows into deliverables.json and must agree with this reader about
+        /// which column is which. A second copy of the header matching is exactly
+        /// how the two would drift — the same reasoning that made
+        /// <see cref="ResolveDeliverablesPath"/> internal.
+        /// </summary>
+        internal static List<DeliverablePlanItem> ParseMidpCsv(string path, out int skipped)
         {
             skipped = 0;
             var rows = new List<DeliverablePlanItem>();

--- a/StingTools/Commands/Delivery/MidpImportCommand.cs
+++ b/StingTools/Commands/Delivery/MidpImportCommand.cs
@@ -1,0 +1,232 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MidpImportCommand.cs — bulk-import a MIDP/TIDP CSV into deliverables.json.
+//
+//  Command tag: Midp_Import
+//
+//  The gap this fills: until now the ONLY way a row reached deliverables.json
+//  was the template engine's per-deliverable issuance flow, one at a time.
+//  Midp_DriftReport reads a plan CSV but never writes — it parses transiently
+//  to compare against the live lifecycle. So onboarding a project meant issuing
+//  every deliverable by hand before the Deliverables tab showed anything.
+//
+//  This writes through DeliverableLifecycle.Persist rather than composing JSON
+//  directly, so the schema-version gate, the dedup-by-key rule and the atomic
+//  temp-file write all stay in one place.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using Planscape.Docs.Templates;
+using StingTools.Core;
+using StingTools.Core.Delivery;
+using StingTools.UI;
+
+namespace StingTools.Commands.Delivery
+{
+    /// <summary>
+    /// Import a whole MIDP/TIDP spreadsheet into the deliverables register.
+    ///
+    /// <para><b>Add-only, by design.</b> A code already in the register is left
+    /// completely untouched. <see cref="DeliverableLifecycle.Persist"/> replaces a
+    /// matched row wholesale (<c>arr[idx] = row</c>), so importing over an
+    /// existing project would silently wipe every Status, CDE state, IssuedDate
+    /// and RevisionHistory the lifecycle had accumulated — turning a re-run of a
+    /// harmless-looking import into data loss. Skipping instead makes the command
+    /// idempotent and safe to run twice, which is what someone re-importing an
+    /// updated programme will inevitably do.</para>
+    ///
+    /// <para>Updating existing rows from a revised programme is a genuinely
+    /// different operation (it has to decide, per field, whether the spreadsheet
+    /// or the lifecycle wins) and is deliberately not bundled in here.</para>
+    ///
+    /// <para><b>ReadOnly transaction:</b> this writes a JSON sidecar, never the
+    /// Revit model — the same shape as Midp_DriftReport, which writes a CSV.</para>
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class MidpImportCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                Document doc = ParameterHelpers.GetDoc(commandData);
+                if (doc == null) { message = "No active document."; return Result.Failed; }
+
+                var dlg = new Microsoft.Win32.OpenFileDialog
+                {
+                    Title = "Pick a MIDP/TIDP CSV to import (Code,Title,Discipline,Milestone,PlannedDate,RequiredSuitability)",
+                    Filter = "CSV (*.csv)|*.csv|All files (*.*)|*.*",
+                };
+                if (dlg.ShowDialog() != true) return Result.Cancelled;
+
+                // Same parser the drift report uses — one header-matching
+                // implementation, so the two commands cannot disagree about which
+                // column is the planned date.
+                var plan = MidpDriftReportCommand.ParseMidpCsv(dlg.FileName, out int skipped);
+                if (plan.Count == 0)
+                {
+                    StingResultPanel.Create("MIDP import")
+                        .AddSection("NO ROWS")
+                        .Text("No deliverable rows parsed. Expected header columns: "
+                            + "Code,Title,Discipline,Milestone,PlannedDate,RequiredSuitability.")
+                        .Text(skipped > 0 ? $"{skipped} row(s) had an unparseable date." : "")
+                        .Show();
+                    return Result.Cancelled;
+                }
+
+                var existing = LoadExistingKeys(doc);
+
+                int imported = 0, alreadyPresent = 0, failed = 0;
+                var failures = new List<string>();
+
+                foreach (var row in plan)
+                {
+                    if (existing.Contains(row.Code)) { alreadyPresent++; continue; }
+
+                    if (DeliverableLifecycle.Persist(doc, ToDeliverable(row)))
+                    {
+                        imported++;
+                        // Guard against a CSV that lists the same code twice: the
+                        // second occurrence would otherwise re-Persist and count
+                        // as a second import of one deliverable.
+                        existing.Add(row.Code);
+                    }
+                    else
+                    {
+                        // Persist logs the reason; surface the codes so the user
+                        // knows which rows to look at rather than just a count.
+                        failed++;
+                        if (failures.Count < 10) failures.Add(row.Code);
+                    }
+                }
+
+                var panel = StingResultPanel.Create("MIDP import")
+                    .SetSubtitle($"{Path.GetFileName(dlg.FileName)} → deliverables register")
+                    .AddSection("RESULT")
+                    .Metric("Imported", imported.ToString())
+                    .Metric("Already present", alreadyPresent.ToString())
+                    .Metric("Skipped (bad date)", skipped.ToString())
+                    .Metric("Failed", failed.ToString());
+
+                if (alreadyPresent > 0)
+                    panel.Text($"{alreadyPresent} row(s) already in the register were left untouched — "
+                             + "import never overwrites lifecycle state (status, CDE, revision history).");
+                if (skipped > 0)
+                    panel.Text($"{skipped} row(s) skipped: no parseable date in the planned-date column.");
+                if (failures.Count > 0)
+                    panel.Text("Failed to save: " + string.Join(", ", failures)
+                             + (failed > failures.Count ? $" (+{failed - failures.Count} more)" : "")
+                             + " — see StingTools.log.");
+                if (imported > 0)
+                    panel.Text("Open the BIM Coordination Center → DELIVERABLES to see them.");
+
+                panel.Show();
+                StingLog.Info($"Midp_Import: {imported} imported, {alreadyPresent} already present, "
+                            + $"{skipped} skipped, {failed} failed (from {Path.GetFileName(dlg.FileName)})");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("Midp_Import", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// Shape a plan row for <see cref="DeliverableLifecycle.Persist"/>, which
+        /// serialises whatever properties this object carries straight into the
+        /// file (<c>JObject.FromObject</c>).
+        ///
+        /// <para>Every field name here is one <c>BuildCoordData</c>'s reader
+        /// already looks for, so an imported row renders on the FIRST read of the
+        /// Deliverables tab rather than only after some later edit happens to
+        /// normalise it.</para>
+        ///
+        /// <para><b>DocNumber AND Code are both set, deliberately.</b>
+        /// <c>DeliverableLifecycle.DeliverableKey</c> reads
+        /// <c>(string)d.DocNumber, (string)d.Code</c> — both arguments are
+        /// evaluated, so on an anonymous type missing either one the dynamic
+        /// binder throws, its enclosing catch returns "", and Persist then
+        /// refuses the row as unkeyed. The failure is silent apart from a log
+        /// line, and it would have made every single import a no-op.</para>
+        /// </summary>
+        private static object ToDeliverable(DeliverablePlanItem row) => new
+        {
+            // Identity — both spellings, see the remarks above.
+            DocNumber = row.Code,
+            Code = row.Code,
+
+            Title = row.Title ?? "",
+            Discipline = row.Discipline ?? "",
+
+            // The CSV's Milestone column is the register's DataDrop.
+            DataDrop = row.Milestone ?? "",
+
+            // Planned, not yet issued: the required suitability IS the current
+            // suitability until something is actually produced against it.
+            Suitability = row.RequiredSuitability ?? "",
+            RequiredSuitability = row.RequiredSuitability ?? "",
+
+            // yyyy-MM-dd so BuildCoordData's DateTime.TryParse resolves it
+            // culture-independently and its IsOverdue comparison is meaningful.
+            DueDate = row.PlannedDate.ToString("yyyy-MM-dd"),
+            PlannedDate = row.PlannedDate.ToString("yyyy-MM-dd"),
+
+            // Planned work nobody has started. Drives the Deliverables tab's
+            // PENDING KPI card.
+            Status = "Pending",
+
+            // WIP is the CDE state of something planned but not yet shared — the
+            // starting point of the lifecycle's own state machine, and what BCC's
+            // "add row" button already defaults a new register row to.
+            CDE = "WIP",
+
+            // Provenance, so a later reader can tell an imported plan row from one
+            // a person created through the issuance flow.
+            Source = "midp_import",
+            ImportedAt = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+        };
+
+        /// <summary>
+        /// Codes already in the register. Read through the same resolver and the
+        /// same key rule the rest of the codebase uses, so "already present"
+        /// cannot mean something different here than it does to Persist's own
+        /// dedup or to the Deliverables tab's reader.
+        ///
+        /// An absent file is the normal first-import case, not an error.
+        /// </summary>
+        private static HashSet<string> LoadExistingKeys(Document doc)
+        {
+            var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                string path = MidpDriftReportCommand.ResolveDeliverablesPath(doc);
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return keys;
+
+                foreach (var o in JArray.Parse(File.ReadAllText(path)).OfType<JObject>())
+                {
+                    string key = DocumentIdentity.FirstNonBlank(o, DocumentIdentity.DeliverableKeys);
+                    if (!string.IsNullOrWhiteSpace(key)) keys.Add(key);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Returning an empty set here does NOT open a path to silently
+                // overwriting anything: Persist parses the very same file before
+                // it writes, so a register this cannot read is one Persist cannot
+                // read either — every row then fails its save, lands in the
+                // "Failed" count, and the existing file is left alone.
+                StingLog.Warn($"Midp_Import: could not read the existing register ({ex.Message}); "
+                            + "rows will be attempted individually and will fail if the file is unreadable.");
+            }
+            return keys;
+        }
+    }
+}

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -1309,6 +1309,8 @@ namespace StingTools.UI
                      "Roll the risk register up — RAG counts on the residual (post-mitigation) score, open-red exposure and the top risks. CSV out.", true),
                     ("MIDP Drift", "Midp_DriftReport",
                      "Load a MIDP/TIDP CSV (Code, Title, Discipline, Milestone, PlannedDate, RequiredSuitability), join it to the live deliverables lifecycle and classify each as on-track / at-risk / overdue / suitability-short. CSV out.", false),
+                    ("Import MIDP", "Midp_Import",
+                     "Bulk-import a MIDP/TIDP CSV into the deliverables register so the Coordination Center's DELIVERABLES tab is populated for a new project. Add-only: codes already in the register are left untouched, so re-running never overwrites lifecycle state.", false),
                 }));
 
             sp.Children.Add(BuildActionGroup("Measurement Standard",

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -3626,6 +3626,7 @@ namespace StingTools.UI
                     case "Risk_Raise":                  RunCommand<Commands.Delivery.RiskRaiseCommand>(app); break;
                     case "Risk_Report":                 RunCommand<Commands.Delivery.RiskReportCommand>(app); break;
                     case "Midp_DriftReport":            RunCommand<Commands.Delivery.MidpDriftReportCommand>(app); break;
+                    case "Midp_Import":                 RunCommand<Commands.Delivery.MidpImportCommand>(app); break;
 
                     // Phase 184h — P6 multi-standard
                     case "Cost_SetMeasurementStandard": RunCommand<Commands.Cost.CostSetMeasurementStandardCommand>(app); break;

--- a/docs/seed_test_midp.csv
+++ b/docs/seed_test_midp.csv
@@ -1,0 +1,4 @@
+Code,Title,Discipline,Milestone,PlannedDate,RequiredSuitability
+A-101,Floor Plan L01,A,DD2,2026-08-05,S2
+M-201,HVAC Schematic,M,DD2,2026-08-15,S1
+E-301,Electrical Riser,E,DD1,2026-07-20,S4

--- a/docs/superpowers/plans/2026-07-31-document-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-31-document-sync-plan.md
@@ -413,3 +413,49 @@ The behaviour behind them is proven (§4e); what nobody has seen is the tray.
     and tells the user the exact `--history` command instead. Confirm that message
     is accurate and useful; when the register gains a document id (§4d), this is
     the call site to finish.
+
+### MIDP bulk import (`Midp_Import`) — the end-to-end Deliverables-tab proof
+
+Commit `c4d3f3e3f` made BCC *read* `deliverables.json`; `Midp_Import` is the first
+command that bulk-*writes* one. Together they are what finally proves the
+Deliverables tab, but only a real Revit session can run them.
+
+**What IS already machine-verified** (a Revit-free harness against the real,
+unmodified `DocumentIdentity.cs`, the same technique `c4d3f3e3f` used):
+the imported row's serialised shape satisfies every candidate list
+`BuildCoordData`'s reader checks — Code, Name, Discipline, DataDrop, Status,
+Suitability, CDE, DueDate — so a freshly-imported row renders on the FIRST read;
+`IsOverdue` computes true for the deliberately-past seed row and false for a
+future one; and `Type`/`Owner` are correctly absent rather than invented. The
+harness also pinned the `DeliverableKey` trap (below). **What it cannot prove is
+where the file lands and whether the tab shows it.**
+
+27. **Import the seed file.** Open a real project, BIM tab → Cost/Delivery panel →
+    **Import MIDP**, and pick `docs/seed_test_midp.csv` (3 rows; `E-301`'s
+    2026-07-20 date is deliberately in the past).
+    Expect: **Imported 3 · Already present 0 · Skipped 0 · Failed 0.**
+    *If it reports `Failed 3`, read `StingTools.log` — `Persist` refusing rows as
+    unkeyed is the one failure mode this command was most exposed to.*
+28. **The file landed where the reader looks.** Confirm
+    `<project root>\_data\_BIM_COORD\deliverables.json` now exists and holds three
+    objects, each with **both** `DocNumber` and `Code`, plus `Status: "Pending"`
+    and `CDE: "WIP"`. The write path (`DeliverableLifecycle.DeliverablesPath`) and
+    the read path (`MidpDriftReportCommand.ResolveDeliverablesPath`) were traced to
+    the same location by inspection — this step is what confirms it on a real
+    project, which is the single most likely thing to be wrong.
+29. **The tab finally populates.** Open the BIM Coordination Center →
+    **DELIVERABLES**. Expect three rows; KPI cards reading **TOTAL 3 · PENDING 3 ·
+    OVERDUE 1**; the `E-301` row highlighted red (the register's existing
+    overdue row style); and the DATA DROP breakdown showing DD1 = 1, DD2 = 2.
+30. **Re-import is safe.** Run **Import MIDP** on the same file again.
+    Expect **Imported 0 · Already present 3**, and — the point of the check —
+    confirm any lifecycle state you set in between (issue one deliverable first,
+    so its Status/CDE/RevisionHistory change) is **still intact afterwards**.
+    Import is add-only precisely so a second run cannot wipe that; `Persist`
+    replaces a matched row wholesale, so a naive implementation would have.
+31. **Bad rows are counted, not silently dropped.** Add a row with an unparseable
+    date to a copy of the CSV and import it: it must appear in **Skipped**, with
+    the other rows still importing.
+32. **The drift report now has something to join to.** Run **MIDP Drift** against
+    the same CSV afterwards — with the register populated it should report the
+    rows as planned-and-not-issued rather than finding nothing to join.


### PR DESCRIPTION
## Summary
- `Amazon.S3.AmazonS3Exception: STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER not implemented` — confirmed live via Render logs on `planscape-api-free` after wiring real Cloudflare R2 credentials for the first time.
- `AWSSDK.S3` 3.7.300+ defaults `PutObject` to a trailing-checksum streaming signature that R2 (and MinIO) don't implement.
- `PutObjectRequest.DisablePayloadSigning = true` falls back to classic `AWS4-HMAC-SHA256` signing, which every S3-compatible provider supports. Only call site in the codebase.

## Test plan
- [x] `dotnet build` on `Planscape.Infrastructure` — clean, 0 errors/0 warnings
- [ ] Once merged + deployed, re-run live document upload + model publish against `planscape-api-free` to confirm the 500 is gone