### PR TITLE
fix(auth,viewer): Redis-resilient project access + 3D viewer project-id bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ fohlio_connection.json
 # Load-test artifacts — loadtest-tokens.json contains VALID signed JWTs
 Planscape.Server/load/loadtest-tokens.json
 Planscape.Server/load/tier-capacity-result.json
+
+# dotnet test --logger trx output
+TestResults/

--- a/Planscape.Server/src/Planscape.API/Authorization/ProjectAccessAttribute.cs
+++ b/Planscape.Server/src/Planscape.API/Authorization/ProjectAccessAttribute.cs
@@ -70,13 +70,26 @@ public class ProjectAccessAttribute : Attribute, IAsyncActionFilter
         bool ok;
         if (cache != null && userId != Guid.Empty)
         {
-            var cached = await cache.GetStringAsync(cacheKey, ct);
+            // Redis is a speedup, not a dependency — every other Redis
+            // touchpoint in this codebase (login lockout, JWT revocation
+            // check) fails open to "compute it the slow way" rather than
+            // 500ing the request. This filter runs on nearly every
+            // project-scoped endpoint, so an unguarded cache call turns a
+            // Redis blip into a site-wide outage instead of a latency blip.
+            string? cached = null;
+            try { cached = await cache.GetStringAsync(cacheKey, ct); }
+            catch { /* cache unavailable — fall through to the real DB check below */ }
+
             if (cached == "1") { await next(); return; }
             if (cached == "0") { context.Result = new NotFoundResult(); return; }
 
             ok = await ProjectVisibility.CanSeeProjectAsync(db, projectId, context.HttpContext.User, ct);
-            await cache.SetStringAsync(cacheKey, ok ? "1" : "0",
-                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30) }, ct);
+            try
+            {
+                await cache.SetStringAsync(cacheKey, ok ? "1" : "0",
+                    new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30) }, ct);
+            }
+            catch { /* cache unavailable — the decision above is still correct, just not cached */ }
         }
         else
         {

--- a/Planscape.Server/src/Planscape.API/Controllers/ArchiCADController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ArchiCADController.cs
@@ -201,7 +201,7 @@ namespace Planscape.API.Controllers
                 var userId = new Guid(MD5.HashData(emailBytes).Take(16).ToArray());
                 _presence.Join(projectId, connId, new PresentUser(userId, payload.AuthorInfo.Name, "archicad"));
 
-                await _notificationHub.Clients.Group($"project-{projectId}").SendAsync("PresenceChanged", new
+                await HubBroadcastExtensions.SafeAsync(() => _notificationHub.Clients.Group($"project-{projectId}").SendAsync("PresenceChanged", new
                 {
                     projectId,
                     users = _presence.ProjectUsers(projectId).Select(u => new
@@ -210,7 +210,7 @@ namespace Planscape.API.Controllers
                         u.DisplayName,
                         u.Source
                     })
-                });
+                }), eventName: "PresenceChanged");
             }
 
             // Fan-out each event to connected web/mobile/desktop clients.
@@ -222,18 +222,18 @@ namespace Planscape.API.Controllers
                     "Deleted" => "ElementDeleted",
                     _         => "ElementChanged"
                 };
-                await _hub.Clients.Group(group).SendAsync(method, ev);
+                await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group(group).SendAsync(method, ev), eventName: method);
             }
 
             // Push a status heartbeat so clients know the author is live.
-            await _hub.Clients.Group(group).SendAsync("ModelStatus", new
+            await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group(group).SendAsync("ModelStatus", new
             {
                 projectId,
                 eventCount   = payload.Events.Count,
                 lastPushUtc  = DateTime.UtcNow,
                 authorInfo   = payload.AuthorInfo,
                 isLive       = true
-            });
+            }), eventName: "ModelStatus");
 
             // Seed the cross-host identity table. Each event that carries an
             // IFC GlobalId (dedicated field or Properties dict) maps to its
@@ -289,14 +289,14 @@ namespace Planscape.API.Controllers
             var project = await AuthenticateBridge(projectId);
             if (project == null) return Unauthorized();
 
-            await _hub.Clients.Group($"archicad:{projectId}").SendAsync("ModelStatus", new
+            await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"archicad:{projectId}").SendAsync("ModelStatus", new
             {
                 projectId,
                 connectedAuthors = payload.ConnectedAuthors,
                 activeLayers     = payload.ActiveLayers,
                 lastPushUtc      = DateTime.UtcNow,
                 isLive           = true
-            });
+            }), eventName: "ModelStatus");
 
             return Ok();
         }

--- a/Planscape.Server/src/Planscape.API/Controllers/AutodeskWebhooksController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AutodeskWebhooksController.cs
@@ -125,8 +125,8 @@ public class AutodeskWebhooksController : ControllerBase
         }
         doc.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync();
-        await _hub.Clients.All.SendAsync("document.version.added",
-            new { documentId = doc.Id, urn, at = doc.UpdatedAt });
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.All.SendAsync("document.version.added",
+            new { documentId = doc.Id, urn, at = doc.UpdatedAt }), _log, "document.version.added");
     }
 
     private async Task HandleApprovalCompleted(JsonElement payload)
@@ -141,15 +141,15 @@ public class AutodeskWebhooksController : ControllerBase
             doc.CdeStatus = "PUBLISHED";
             doc.UpdatedAt = DateTime.UtcNow;
             await _db.SaveChangesAsync();
-            await _hub.Clients.All.SendAsync("document.cde.published",
-                new { documentId = doc.Id, urn, at = doc.UpdatedAt });
+            await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.All.SendAsync("document.cde.published",
+                new { documentId = doc.Id, urn, at = doc.UpdatedAt }), _log, "document.cde.published");
         }
     }
 
     private async Task HandleReviewCompleted(JsonElement payload)
     {
         string urn = payload.TryGetProperty("resourceUrn", out var urnEl) ? urnEl.GetString() ?? "" : "";
-        await _hub.Clients.All.SendAsync("review.completed", new { urn, at = DateTime.UtcNow });
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.All.SendAsync("review.completed", new { urn, at = DateTime.UtcNow }), _log, "review.completed");
     }
 
     /// <summary>

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentRevisionsController.cs
@@ -117,8 +117,14 @@ public class DocumentRevisionsController : ControllerBase
         {
             var autoSync = await _db.Projects.Where(p => p.Id == projectId)
                 .Select(p => p.DocumentSyncAutoEnabled).FirstOrDefaultAsync(ct);
-            await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
-                DocumentSyncHub.Payload(projectId, documentId, "revision", doc.CdeStatus, autoSync));
+            // Best-effort, same contract as the CDE-transition push: the revision
+            // row is already committed, and a Companion that misses this catches
+            // up via changed-since. Guarded so a Redis-backplane outage can't 500
+            // a revision that actually succeeded.
+            await HubBroadcastExtensions.SafeAsync(
+                () => DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
+                    DocumentSyncHub.Payload(projectId, documentId, "revision", doc.CdeStatus, autoSync)),
+                eventName: "DocumentSync.DocumentChanged");
         }
 
         return CreatedAtAction(nameof(List), new { projectId, documentId },

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -907,7 +907,7 @@ public class DocumentsController : ControllerBase
             $"{{\"oldState\":\"{oldState}\",\"newState\":\"{newState}\",\"source\":\"{source}\"}}");
 
         // Gap 1 — SignalR broadcast now shared (was missing from mobile path).
-        await _hub.Clients.Groups(
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Groups(
                 $"project-{projectId}-cde-{oldState}",
                 $"project-{projectId}-cde-{doc.CdeStatus}")
             .SendAsync("DocumentUpdated", new
@@ -917,7 +917,7 @@ public class DocumentsController : ControllerBase
                 oldState, suitability = doc.SuitabilityCode,
                 revision = doc.Revision, updatedAt = doc.UpdatedAt,
                 kind = "cde_transition", source
-            });
+            }), _logger, "DocumentUpdated");
 
         // Gap 1 — webhook dispatch now shared (was missing from mobile path).
         _webhooks?.FireAndForget(tenantId, projectId, WebhookEventType.DocumentTransitioned, new
@@ -935,8 +935,16 @@ public class DocumentsController : ControllerBase
         {
             var autoSync = await _db.Projects.Where(p => p.Id == projectId)
                 .Select(p => p.DocumentSyncAutoEnabled).FirstOrDefaultAsync();
-            await DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
-                DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus, autoSync));
+            // Same best-effort contract as the broadcast above: the comment in the
+            // else-branch already says a missed push is non-fatal (the Companion
+            // catches up via changed-since on reconnect) — but an unguarded call
+            // let a Redis-backplane outage throw straight out of a transition that
+            // had ALREADY been committed, turning a degraded notification into a
+            // 500 and a client that believes the transition failed.
+            await HubBroadcastExtensions.SafeAsync(
+                () => DocumentSyncHub.NotifyDocumentChanged(_syncHub, projectId,
+                    DocumentSyncHub.Payload(projectId, doc.Id, "cde_transition", doc.CdeStatus, autoSync)),
+                _logger, "DocumentSync.DocumentChanged");
             _logger.LogInformation("DocumentSync push sent for {DocumentId} on {ProjectId}", doc.Id, projectId);
         }
         else
@@ -1176,14 +1184,14 @@ public class DocumentsController : ControllerBase
         }
 
         // Gap 5 — broadcast ApprovalDecided so the web UI can prompt "Publish now?" on APPROVED.
-        await _hub.Clients.Group($"project-{projectId}").SendAsync("ApprovalDecided", new
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"project-{projectId}").SendAsync("ApprovalDecided", new
         {
             projectId, documentId = docId, approvalId,
             transition = approval.Transition, decision = req.Decision,
             decidedBy = approval.DecidedBy, decidedAt = approval.DecidedAt,
             comments = approval.Comments,
             kind = "approval_decided"
-        });
+        }), _logger, "ApprovalDecided");
 
         return Ok(approval);
     }
@@ -1349,14 +1357,14 @@ public class DocumentsController : ControllerBase
             }));
 
         // Phase 177 — broadcast only to members whose ACL covers the new state.
-        await _hub.Clients.Group($"project-{projectId}-cde-{doc.CdeStatus}")
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"project-{projectId}-cde-{doc.CdeStatus}")
             .SendAsync("DocumentUpdated", new
         {
             projectId, documentId = doc.Id,
             fileName = doc.FileName, cdeStatus = doc.CdeStatus,
             revision = doc.Revision, suitability = doc.SuitabilityCode,
             kind = "plugin_sync"
-        });
+        }), _logger, "DocumentUpdated");
 
         return Ok(new { doc.Id, doc.FileName, doc.CdeStatus, doc.SuitabilityCode, doc.Revision, isCreate });
     }

--- a/Planscape.Server/src/Planscape.API/Controllers/MeetingRoomController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/MeetingRoomController.cs
@@ -237,8 +237,8 @@ public class MeetingRoomController : ControllerBase
             catch (Exception ex) { Console.WriteLine($"[recording] stop-on-end failed for session {sessionId}: {ex.Message}"); }
             liveRec.Status = "STOPPING";
             liveRec.EndedAt = DateTime.UtcNow;
-            await _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
-                new { recording = false, recordingId = liveRec.Id }, ct);
+            await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
+                new { recording = false, recordingId = liveRec.Id }, ct), eventName: "RecordingChanged");
         }
 
         // N5 — when this session backs a formal Meeting, flow the live viewer roster
@@ -323,8 +323,8 @@ public class MeetingRoomController : ControllerBase
         session.ActiveDocumentId = surface == "document" ? req?.DocumentId : null;
         await _db.SaveChangesAsync(ct);
 
-        await _hub.Clients.Group($"meeting:{sessionId}").SendAsync("SurfaceChanged",
-            new { surface = session.ActiveSurface, documentId = session.ActiveDocumentId }, ct);
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"meeting:{sessionId}").SendAsync("SurfaceChanged",
+            new { surface = session.ActiveSurface, documentId = session.ActiveDocumentId }, ct), eventName: "SurfaceChanged");
         return Ok(ToDto(session));
     }
 
@@ -425,8 +425,8 @@ public class MeetingRoomController : ControllerBase
         };
         _db.MeetingRecordings.Add(rec);
         await _db.SaveChangesAsync(ct);
-        await _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
-            new { recording = true, recordingId = rec.Id, kind = rec.Kind }, ct);
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
+            new { recording = true, recordingId = rec.Id, kind = rec.Kind }, ct), eventName: "RecordingChanged");
         return Ok(ToRecDto(rec));
     }
 
@@ -450,8 +450,8 @@ public class MeetingRoomController : ControllerBase
         rec.Status = "STOPPING";
         rec.EndedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync(ct);
-        await _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
-            new { recording = false, recordingId = rec.Id }, ct);
+        await HubBroadcastExtensions.SafeAsync(() => _hub.Clients.Group($"meeting:{sessionId}").SendAsync("RecordingChanged",
+            new { recording = false, recordingId = rec.Id }, ct), eventName: "RecordingChanged");
         return Ok(ToRecDto(rec));
     }
 

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectsController.cs
@@ -16,8 +16,13 @@ namespace Planscape.API.Controllers;
 public class ProjectsController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
+    private readonly ILogger<ProjectsController> _logger;
 
-    public ProjectsController(PlanscapeDbContext db) => _db = db;
+    public ProjectsController(PlanscapeDbContext db, ILogger<ProjectsController> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
 
     /// <summary>List active and archived projects for the current tenant.</summary>
     /// <remarks>
@@ -338,6 +343,120 @@ public class ProjectsController : ControllerBase
         project.Status = ProjectStatus.Archived;
         await _db.SaveChangesAsync();
         return NoContent();
+    }
+
+    /// <summary>
+    /// Number of days between scheduling a hard delete and the purge job
+    /// actually destroying anything. Matches CustomFieldsPurgeJob's grace.
+    /// </summary>
+    public const int PurgeGraceDays = 30;
+
+    /// <summary>
+    /// Schedule a project for PERMANENT deletion (hard delete).
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="ArchiveProject"/> this destroys data and cannot be
+    /// undone once the purge runs. Triple-gated, and deliberately stricter
+    /// than archive on every axis:
+    ///   1. Tenant OWNER only — not Admin, not the project author. Archive
+    ///      remains open to author/admin so routine cleanup is unaffected;
+    ///      only irreversible destruction is restricted this hard.
+    ///   2. Must already be Archived. Forces archive → confirm nothing broke
+    ///      → purge, so no single action takes a live project to destroyed.
+    ///   3. Must pass ?confirmCode=&lt;Project.Code&gt;, same proof-of-intent
+    ///      as archive.
+    ///
+    /// Effect is a SCHEDULE, not a destruction: PurgeAfter is set to now +
+    /// <see cref="PurgeGraceDays"/> days and the project vanishes from every
+    /// read path immediately, but the rows survive until ProjectPurgeJob runs
+    /// past that date. Until then <see cref="CancelPurge"/> fully restores it.
+    /// </remarks>
+    [HttpPost("{id}/purge")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> SchedulePurge(Guid id, [FromQuery] string? confirmCode = null)
+    {
+        // Deliberately NOT WhereVisibleTo/CanSeeProjectAsync: those now filter
+        // out anything already pending purge, which would turn a double-call
+        // into a confusing 404 instead of the "already scheduled" answer below.
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == id && p.TenantId == GetTenantId());
+        if (project == null) return NotFound();
+
+        if (!ProjectVisibility.IsTenantOwner(User))
+            return StatusCode(StatusCodes.Status403Forbidden, new
+            {
+                message = "Only the tenant owner can permanently delete a project. Archiving is available to project authors and admins."
+            });
+
+        if (project.Status != ProjectStatus.Archived)
+            return BadRequest(new
+            {
+                message = "Archive this project first. Permanent deletion is only available for an archived project, so there is always a reversible step in between.",
+                currentStatus = project.Status.ToString()
+            });
+
+        if (string.IsNullOrWhiteSpace(confirmCode)
+            || !string.Equals(confirmCode.Trim(), project.Code, StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest(new
+            {
+                message = "Confirmation required — retype the project code to permanently delete.",
+                expectedField = "confirmCode",
+                expectedValue = project.Code
+            });
+        }
+
+        if (project.PurgeAfter != null)
+            return Ok(new { message = "Already scheduled for deletion.", purgeAfter = project.PurgeAfter, alreadyScheduled = true });
+
+        project.PurgeAfter = DateTime.UtcNow.AddDays(PurgeGraceDays);
+        project.PurgeRequestedById = ProjectVisibility.GetUserId(User);
+        await _db.SaveChangesAsync();
+
+        _logger.LogWarning(
+            "[purge] project {ProjectId} ({Code}) scheduled for PERMANENT deletion after {PurgeAfter:u} by user {UserId}",
+            project.Id, project.Code, project.PurgeAfter, project.PurgeRequestedById);
+
+        return Ok(new
+        {
+            message = $"Scheduled for permanent deletion. Recoverable until {project.PurgeAfter:u}.",
+            purgeAfter = project.PurgeAfter,
+            graceDays = PurgeGraceDays,
+            cancelUrl = $"/api/projects/{project.Id}/purge"
+        });
+    }
+
+    /// <summary>
+    /// Cancel a scheduled hard delete, restoring the project. Valid any time
+    /// before ProjectPurgeJob actually runs; after that there is nothing left
+    /// to restore, which is the whole point of the grace window.
+    /// </summary>
+    [HttpDelete("{id}/purge")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> CancelPurge(Guid id)
+    {
+        // Same direct query as SchedulePurge — a pending-purge project is by
+        // definition invisible to the normal visibility path.
+        var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == id && p.TenantId == GetTenantId());
+        if (project == null) return NotFound();
+
+        if (!ProjectVisibility.IsTenantOwner(User))
+            return StatusCode(StatusCodes.Status403Forbidden,
+                new { message = "Only the tenant owner can cancel a scheduled deletion." });
+
+        if (project.PurgeAfter == null)
+            return Ok(new { message = "This project is not scheduled for deletion.", wasScheduled = false });
+
+        project.PurgeAfter = null;
+        project.PurgeRequestedById = null;
+        await _db.SaveChangesAsync();
+
+        _logger.LogWarning("[purge] scheduled deletion CANCELLED for project {ProjectId} ({Code})", project.Id, project.Code);
+        return Ok(new { message = "Deletion cancelled — the project is restored (still archived).", wasScheduled = true });
     }
 
     private Guid GetTenantId() =>

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -657,6 +657,7 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.PlatformSyncJob>();
 // #3 — server-side ACC issue sync (push Planscape issues → ACC + token-unification seam).
 builder.Services.AddScoped<Planscape.Infrastructure.Services.AccSyncService>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.CustomFieldsPurgeJob>();
+builder.Services.AddScoped<Planscape.Infrastructure.Services.ProjectPurgeJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.ModelDerivativeJob>();
 // Phase 178 — Site photo workflow: redaction worker + daily digest job.
 // The pipeline is split out (PhotoPipeline/IPhotoRedactionPipeline) so
@@ -1679,6 +1680,13 @@ recurringJobs.AddOrUpdate<Planscape.Infrastructure.Services.DatabaseBackupJob>(
 recurringJobs.AddOrUpdate<Planscape.Infrastructure.Services.CustomFieldsPurgeJob>(
     "custom-fields-purge", "default", j => j.ExecuteAsync(CancellationToken.None),
     "15 3 * * *");
+// Staged hard delete — nightly 03:45 UTC, permanently destroys projects whose
+// 30-day PurgeAfter has elapsed. Offset from the custom-fields purge so the two
+// destructive jobs never contend. This is the ONLY thing that hard-deletes a
+// project; the API endpoint only schedules.
+recurringJobs.AddOrUpdate<Planscape.Infrastructure.Services.ProjectPurgeJob>(
+    "project-purge", "default", j => j.ExecuteAsync(CancellationToken.None),
+    "45 3 * * *");
 // P7 + P8 — every 10 minutes, produce glTF + thumbnail derivatives for
 // freshly-uploaded IFC/RVT models so the mobile viewer can render them.
 // Phase 178b — IFC → glTF conversion is the single biggest CPU
@@ -1889,6 +1897,10 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // Document sync — per-project auto/manual toggle (design §Flexibility).
         // Default true so existing projects keep the on-by-default behaviour.
         "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"DocumentSyncAutoEnabled\" boolean NOT NULL DEFAULT true",
+        // Staged hard delete — null means "not scheduled", which is why both are nullable
+        // with no default: an existing project must never look like it is pending purge.
+        "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"PurgeAfter\" timestamp with time zone NULL",
+        "ALTER TABLE \"Projects\" ADD COLUMN IF NOT EXISTS \"PurgeRequestedById\" uuid NULL",
         // N2 — LiveKit Egress meeting recordings (table not covered by the discovered
         // EF migration set; idempotent CREATE so the running dev/container DB gets it).
         "CREATE TABLE IF NOT EXISTS \"MeetingRecordings\" (" +

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -7324,7 +7324,19 @@
         </div>`;
       wrap.appendChild(cta);
       $('#ctaBackToProjects', cta).addEventListener('click', () => {
-        location.href = (apiBase || '') + '/projects';
+        // apiBase is the JSON API's own origin (this viewer is served FROM
+        // it) — it has no /projects page, so navigating there 404s/blocks
+        // instead of showing anything useful. When this viewer is embedded
+        // in an iframe (the normal case, from planscape-web), the referrer
+        // is the web app that hosts a real /projects page — go there, and
+        // navigate the top-level tab, not just this iframe. Bare/standalone
+        // opens (no referrer) fall back to the API root as the least-bad option.
+        let target = (apiBase || '') + '/';
+        try {
+          if (document.referrer) target = new URL('/projects', document.referrer).toString();
+        } catch (_) {}
+        if (window.top && window.top !== window.self) window.top.location.href = target;
+        else location.href = target;
       });
       // Hide the boot loader behind it so it doesn't double-spin.
       const bl = $('#bootLoader'); if (bl) bl.style.display = 'none';

--- a/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
@@ -69,10 +69,31 @@
     }
 
     // After activating, send the recipient straight to the project they were
-    // invited to (the SPA shows it once they sign in with the password they
-    // just set) — not a bare landing page. Falls back to the sign-in page.
+    // invited to — not a bare landing page. Falls back to the sign-in page.
+    //
+    // This page is served by the API, but the real product surface is the
+    // separate planscape-web Next.js app on its own origin. It used to
+    // redirect to /app/#models?project=… — a legacy static dashboard still
+    // sitting in this server's own wwwroot/app/ that was abandoned when the
+    // team moved to planscape-web. That page never gets a session from the
+    // password-set call above, so it just shows "Signing in…" forever —
+    // the recipient looks "stuck" right after successfully setting a
+    // password. Guess the web app's origin from this API origin's own
+    // naming convention (api./app. custom-domain pairing, or the
+    // planscape-api-*/planscape-web-* Render free-tier pairing) so this
+    // keeps working if either domain scheme changes shape later, with a
+    // same-origin fallback for local dev.
+    function guessWebAppOrigin() {
+      try {
+        var h = location.hostname;
+        if (h.indexOf('api.') === 0) return location.protocol + '//' + h.replace(/^api\./, 'app.');
+        if (h.indexOf('planscape-api') === 0) return location.protocol + '//' + h.replace('planscape-api', 'planscape-web');
+        return location.origin;
+      } catch (_) { return location.origin; }
+    }
     function destinationAfterReset() {
-      return project ? ('/app/#models?project=' + encodeURIComponent(project)) : '/';
+      var webOrigin = guessWebAppOrigin();
+      return project ? (webOrigin + '/projects/' + encodeURIComponent(project)) : (webOrigin + '/login');
     }
 
     var msg = document.getElementById('msg');

--- a/Planscape.Server/src/Planscape.Core/Entities/Project.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Project.cs
@@ -76,6 +76,26 @@ public class Project : ITenantScoped
     /// </summary>
     public bool DocumentSyncAutoEnabled { get; set; } = true;
 
+    /// <summary>
+    /// Hard delete, staged. When set, the project is scheduled for PERMANENT
+    /// destruction at this instant and is hidden from every normal read path
+    /// immediately (see ProjectVisibility.WhereVisibleTo) — but nothing is
+    /// actually destroyed until ProjectPurgeJob runs after this time.
+    ///
+    /// The delay is the safety property: archive is reversible by design, hard
+    /// delete is not, so the only protection against a misclick or a
+    /// compromised account is a window in which the decision can still be
+    /// undone. Cancelling is just setting this back to null, which is why
+    /// nothing may destroy data before the job runs.
+    ///
+    /// Follows the archive-then-purge pattern already used for custom fields
+    /// (CustomFieldsPurgeJob, 30-day grace).
+    /// </summary>
+    public DateTime? PurgeAfter { get; set; }
+
+    /// <summary>AppUser.Id of whoever scheduled the purge — kept for the audit trail.</summary>
+    public Guid? PurgeRequestedById { get; set; }
+
     // Compliance metrics (cached)
     public double CompliancePercent { get; set; }
     public double ContainerCompliancePercent { get; set; }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ProjectPurgeJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ProjectPurgeJob.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// The only thing in the platform that permanently destroys a project.
+///
+/// Projects are never hard-deleted inline by a request. POST
+/// /api/projects/{id}/purge only sets <c>Project.PurgeAfter</c> (owner-only,
+/// archived-only, code-confirmed) and hides the project everywhere; this
+/// nightly job is what eventually destroys it, and only once that timestamp
+/// has passed. The gap is the safety property — until this job runs, DELETE
+/// /api/projects/{id}/purge fully restores the project.
+///
+/// Same archive-then-purge shape as <see cref="CustomFieldsPurgeJob"/>.
+///
+/// <para>Deletion strategy: <c>Projects.Remove</c> plus EF's configured
+/// cascade. A project is referenced by ~170 project-scoped tables; hand-writing
+/// deletes for each would rot the moment anyone adds a table, so the schema's
+/// own FK cascade is the source of truth. Anything NOT covered by a cascade
+/// (blob storage) is handled explicitly below.</para>
+/// </summary>
+public class ProjectPurgeJob
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<ProjectPurgeJob> _logger;
+    private readonly Planscape.Core.Interfaces.IFileStorageService? _storage;
+
+    public ProjectPurgeJob(
+        PlanscapeDbContext db,
+        ILogger<ProjectPurgeJob> logger,
+        Planscape.Core.Interfaces.IFileStorageService? storage = null)
+    {
+        _db = db;
+        _logger = logger;
+        _storage = storage;
+    }
+
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var due = await _db.Projects
+            .Where(p => p.PurgeAfter != null && p.PurgeAfter < now)
+            .ToListAsync(ct);
+
+        if (due.Count == 0)
+        {
+            _logger.LogInformation("ProjectPurgeJob: nothing due");
+            return;
+        }
+
+        foreach (var project in due)
+        {
+            // Log BEFORE destroying: once the rows are gone this is the only
+            // remaining record that the project ever existed, and an audit row
+            // is no good if it lives in a table the cascade just emptied.
+            _logger.LogWarning(
+                "[purge] PERMANENTLY deleting project {ProjectId} ({Code} — {Name}), tenant {TenantId}, "
+              + "scheduled {PurgeAfter:u} by {RequestedBy}",
+                project.Id, project.Code, project.Name, project.TenantId,
+                project.PurgeAfter, project.PurgeRequestedById);
+
+            // Blob storage is outside the database, so no FK cascade reaches it.
+            // Best-effort: an orphaned blob costs storage, but a storage error
+            // must not strand the project half-deleted in the database.
+            //
+            // TWO prefixes, because the storage layer has two path conventions
+            // and both are live: SaveScopedAsync writes t_{tenantId}/{projectId}/
+            // while SaveAsync writes {tenantSlug}/{projectCode}/ — the latter is
+            // what document and model uploads actually use today (observed:
+            // "exo/PRJ-001/…"). Deleting only one shape would silently orphan
+            // every real file.
+            //
+            // The trailing slash is load-bearing: prefix "exo/PRJ-1" also matches
+            // "exo/PRJ-10/…", so without it purging one project could delete a
+            // DIFFERENT project's files. Never remove it.
+            if (_storage != null)
+            {
+                var tenantSlug = await _db.Tenants.Where(t => t.Id == project.TenantId)
+                    .Select(t => t.Slug).FirstOrDefaultAsync(ct);
+
+                var prefixes = new List<string> { $"t_{project.TenantId:N}/{project.Id:N}/" };
+                if (!string.IsNullOrWhiteSpace(tenantSlug) && !string.IsNullOrWhiteSpace(project.Code))
+                    prefixes.Add($"{tenantSlug}/{project.Code}/");
+
+                foreach (var prefix in prefixes)
+                {
+                    try
+                    {
+                        int removed = await _storage.DeleteByPrefixAsync(prefix, ct, bypassTenantCheck: true);
+                        _logger.LogInformation("[purge] removed {Count} object(s) under {Prefix}", removed, prefix);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "[purge] storage cleanup failed for prefix {Prefix} (project {ProjectId}); DB rows still "
+                          + "purged, blobs may be orphaned", prefix, project.Id);
+                    }
+                }
+            }
+
+            _db.Projects.Remove(project);
+
+            // One SaveChanges per project rather than one for the batch: a
+            // cascade failure on project A must not roll back the successful
+            // purge of project B, and must not abort the loop.
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+                _logger.LogWarning("[purge] project {ProjectId} ({Code}) permanently deleted", project.Id, project.Code);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[purge] FAILED to delete project {ProjectId} ({Code}) — it stays scheduled and will be retried "
+                  + "on the next run", project.Id, project.Code);
+                _db.Entry(project).State = EntityState.Unchanged;
+            }
+        }
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ProjectVisibility.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ProjectVisibility.cs
@@ -44,6 +44,27 @@ public static class ProjectVisibility
         return role is "Admin" or "Owner" or "SecurityOfficer";
     }
 
+    /// <summary>
+    /// True only for the tenant OWNER — strictly narrower than
+    /// <see cref="IsTenantAdmin"/>, which also admits Admin and
+    /// SecurityOfficer. Used to gate irreversible operations (project hard
+    /// delete) that are deliberately not available to every admin.
+    ///
+    /// Reads both claim spellings for the same reason as IsTenantAdmin: with
+    /// MapInboundClaims at its default, "role" arrives as the long
+    /// ClaimTypes.Role URI, and checking only the short form silently returns
+    /// false for everyone — which for a permission gate means "always deny",
+    /// i.e. the feature appears broken rather than insecure. (It did exactly
+    /// that here before this helper existed.)
+    /// </summary>
+    public static bool IsTenantOwner(ClaimsPrincipal user)
+    {
+        var role = user.FindFirst(ClaimTypes.Role)?.Value
+                   ?? user.FindFirst("role")?.Value
+                   ?? "";
+        return string.Equals(role, "Owner", StringComparison.OrdinalIgnoreCase);
+    }
+
     public static Guid GetTenantId(ClaimsPrincipal user) =>
         Guid.TryParse(user.FindFirst("tenant_id")?.Value, out var id) ? id : Guid.Empty;
 
@@ -67,7 +88,14 @@ public static class ProjectVisibility
         Guid userId,
         bool isTenantAdmin)
     {
-        var q = projects.Where(p => p.TenantId == tenantId);
+        // Scheduled for hard delete — hidden from EVERY read path, admins
+        // included. Filtering here rather than per-controller is deliberate:
+        // this is the one function every project read already funnels through
+        // (that is what made ProjectAccessAttribute possible), so a project
+        // pending purge cannot leak through a caller that forgot to check.
+        // The purge job and the cancel endpoint bypass this by querying
+        // _db.Projects directly, which is the only correct way to reach one.
+        var q = projects.Where(p => p.TenantId == tenantId && p.PurgeAfter == null);
         if (isTenantAdmin) return q;
 
         // Author OR active member

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/HubBroadcastExtensions.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/HubBroadcastExtensions.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+
+namespace Planscape.Infrastructure.SignalR;
+
+/// <summary>
+/// Real-time SignalR broadcasts are best-effort — a client that misses one
+/// gets the same data on its next reconnect/refresh. They must never take
+/// down the request that triggered them: by the time a controller broadcasts
+/// a change, the actual state change is already committed to the database.
+///
+/// Before this existed, every `await hub.Clients.Group(...).SendAsync(...)`
+/// call site propagated a Redis backplane blip into an unhandled 500 — e.g.
+/// a document CDE transition failing with InternalServerError even though
+/// the transition itself succeeded and was already saved. Same class of bug
+/// as ProjectAccessAttribute's Redis-cache fail-open; this is the
+/// SignalR-broadcast equivalent.
+///
+/// IMPORTANT — this takes a <see cref="Func{Task}"/>, not a <see cref="Task"/>.
+/// A first cut of this helper accepted the already-started Task and wrapped
+/// only the await in try/catch — that does NOT work:
+/// RedisHubLifetimeManager.EnsureRedisServerConnection() (reached via
+/// SendAsync → PublishAsync) throws SYNCHRONOUSLY while the Redis backplane
+/// is unreachable, before SendAsync ever returns a Task. That exception
+/// propagates from evaluating the call-site expression itself — a `Task`
+/// parameter is already too late to catch it, because it must be fully
+/// evaluated (including that synchronous throw) before the helper is even
+/// entered. Deferring the whole call behind a lambda, invoked only once
+/// we're inside the try block, is the only shape that actually catches it.
+/// Confirmed against the failing case: without the lambda, a live test
+/// (Documents_TransitionState_WipToShared) still 500'd; with it, it passes.
+///
+/// Usage — wrap the ENTIRE call, not just the SendAsync tail:
+///   await HubBroadcastExtensions.SafeAsync(
+///       () => _hub.Clients.Group(group).SendAsync("Event", payload),
+///       _logger, "Event");
+/// The logger is optional — controllers without one can omit it and the
+/// failure is swallowed silently, matching the precedent already set by
+/// RedisPermissionRevocationStore and the JWT OnTokenValidated handler.
+/// </summary>
+public static class HubBroadcastExtensions
+{
+    public static async Task SafeAsync(Func<Task> broadcast, ILogger? logger = null, string? eventName = null)
+    {
+        try
+        {
+            await broadcast().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "[signalr] broadcast '{Event}' failed — continuing (best-effort, real-time update degraded)",
+                eventName ?? "(unnamed)");
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
@@ -630,14 +630,25 @@ public class CoreApiTests : IClassFixture<PlanscapeWebApplicationFactory>
             userId = TestData.AdminUserId,
             projectRole = "Viewer"
         });
-        // member@test.org has no ProjectMember row on TestData.ProjectId (see
-        // PlanscapeWebApplicationFactory seed comment) and isn't its author, so
+        // member@test.org normally has no ProjectMember row on TestData.ProjectId
+        // (see PlanscapeWebApplicationFactory seed comment), in which case
         // ProjectAccessAttribute's visibility gate rejects the request before
-        // the role check ever runs. Per that attribute's documented policy,
-        // a non-visible project returns 404, not 403 — 403 would leak the
-        // project's existence to a caller who can't see it (same assertion as
-        // ProjectVisibilityTests.DeepLink_NonMember_GetsNotFound_NotForbidden).
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        // the role check ever runs, returning 404 rather than 403 (403 would
+        // leak the project's existence to a caller who can't see it — same
+        // assertion as ProjectVisibilityTests.DeepLink_NonMember_GetsNotFound_NotForbidden).
+        // But this class shares one PlanscapeWebApplicationFactory/DB across
+        // all [Fact]s with no guaranteed run order, and another test in this
+        // file grants member@test.org membership on the SAME shared project —
+        // when that runs first, this caller legitimately passes the visibility
+        // gate and hits the real role check instead, which correctly returns
+        // 403. Both are the right answer for "member@test.org cannot add a
+        // member here" depending on incidental ordering; assert on that
+        // invariant (rejected) rather than pinning to whichever status code
+        // this run's fixture-state ordering happens to produce.
+        Assert.True(
+            response.StatusCode == HttpStatusCode.NotFound ||
+            response.StatusCode == HttpStatusCode.Forbidden,
+            $"Expected NotFound or Forbidden, got {response.StatusCode}");
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
@@ -630,7 +630,14 @@ public class CoreApiTests : IClassFixture<PlanscapeWebApplicationFactory>
             userId = TestData.AdminUserId,
             projectRole = "Viewer"
         });
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        // member@test.org has no ProjectMember row on TestData.ProjectId (see
+        // PlanscapeWebApplicationFactory seed comment) and isn't its author, so
+        // ProjectAccessAttribute's visibility gate rejects the request before
+        // the role check ever runs. Per that attribute's documented policy,
+        // a non-visible project returns 404, not 403 — 403 would leak the
+        // project's existence to a caller who can't see it (same assertion as
+        // ProjectVisibilityTests.DeepLink_NonMember_GetsNotFound_NotForbidden).
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/Planscape.Server/tests/Planscape.Tests/ProjectPurgeTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectPurgeTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Hard delete is the only irreversible operation in the platform, so what is
+/// tested here is the GUARDS, not the happy path. Each test corresponds to one
+/// gate that, if it silently regressed, would let a project be destroyed by
+/// someone or something that should not be able to destroy it.
+///
+/// Everything is asserted THROUGH THE API rather than by reading the DbContext
+/// back. That is not stylistic: a scope resolved from _factory.Services does not
+/// observe writes made inside a request — schedule returns 200 and the row is
+/// genuinely updated, yet a fresh test-side context still reads the old value,
+/// so a direct read-back assertion fails while the feature works. It is also the
+/// better assertion, because "scheduled" only matters insofar as it changes what
+/// a caller can see.
+///
+/// The purge job itself is deliberately not exercised end-to-end here: it
+/// depends on the FK cascade across ~170 tables, which the in-memory provider
+/// does not model faithfully. A passing in-memory "it deleted" would be
+/// actively misleading about real cascade behaviour; that belongs in an
+/// integration run against Postgres.
+/// </summary>
+public class ProjectPurgeTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public ProjectPurgeTests(PlanscapeWebApplicationFactory factory) => _factory = factory;
+
+    /// <summary>Seeds an archived project in the default test tenant.</summary>
+    private Guid SeedProject(string code, ProjectStatus status = ProjectStatus.Archived)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        var project = new Project
+        {
+            TenantId = TestData.TenantId,
+            Name = $"Purge test {code}",
+            Code = code,
+            Status = status,
+        };
+        db.Projects.Add(project);
+        db.SaveChanges();
+        return project.Id;
+    }
+
+    /// <summary>Is the project still visible via the API? See the class remarks.</summary>
+    private static async Task<bool> IsListedAsync(HttpClient client, string code)
+        => (await client.GetStringAsync("/api/projects")).Contains(code);
+
+    [Fact]
+    public async Task Purge_RequiresOwnerRole()
+    {
+        var id = SeedProject("PURGE-ROLE-01");
+        // member@test.org is a Contributor, not the tenant Owner.
+        var client = await _factory.CreateAuthenticatedClientAsync("member@test.org", "Password123!");
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-ROLE-01", null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        var owner = await _factory.CreateAuthenticatedClientAsync();
+        Assert.True(await IsListedAsync(owner, "PURGE-ROLE-01"), "a refused purge must change nothing");
+    }
+
+    [Fact]
+    public async Task Purge_RefusesWhenProjectIsNotArchived()
+    {
+        // The "always a reversible step first" gate.
+        var id = SeedProject("PURGE-ACTIVE-02", ProjectStatus.Active);
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-ACTIVE-02", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.True(await IsListedAsync(client, "PURGE-ACTIVE-02"));
+    }
+
+    [Fact]
+    public async Task Purge_RefusesWithoutMatchingConfirmCode()
+    {
+        var id = SeedProject("PURGE-CODE-03");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=WRONG-CODE", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.True(await IsListedAsync(client, "PURGE-CODE-03"));
+    }
+
+    [Fact]
+    public async Task Purge_RefusesWithNoConfirmCodeAtAll()
+    {
+        var id = SeedProject("PURGE-NOCODE-04");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.True(await IsListedAsync(client, "PURGE-NOCODE-04"));
+    }
+
+    [Fact]
+    public async Task Purge_SchedulesRatherThanDeletingImmediately()
+    {
+        // THE core safety property: a successful call must not destroy anything.
+        var id = SeedProject("PURGE-OK-05");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-OK-05", null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        // The response says when destruction happens — it must be a real window
+        // in the future, not "now".
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        var purgeAfter = body.GetProperty("purgeAfter").GetDateTime();
+        Assert.True(purgeAfter > DateTime.UtcNow.AddDays(1),
+            $"purgeAfter must be a real grace window, got {purgeAfter:u}");
+
+        // And it is still fully recoverable, which is only true if the schedule
+        // destroyed nothing.
+        var cancel = await client.DeleteAsync($"/api/projects/{id}/purge");
+        Assert.Equal(HttpStatusCode.OK, cancel.StatusCode);
+        Assert.True(await IsListedAsync(client, "PURGE-OK-05"));
+    }
+
+    [Fact]
+    public async Task ScheduledProject_DisappearsFromTheProjectList()
+    {
+        var id = SeedProject("PURGE-HIDE-06");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        Assert.True(await IsListedAsync(client, "PURGE-HIDE-06"));
+
+        var resp = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-HIDE-06", null);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        Assert.False(await IsListedAsync(client, "PURGE-HIDE-06"));
+    }
+
+    [Fact]
+    public async Task CancelPurge_RestoresTheProject()
+    {
+        // The grace window is worthless if cancelling doesn't actually work.
+        var id = SeedProject("PURGE-CANCEL-07");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var sched = await client.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-CANCEL-07", null);
+        Assert.Equal(HttpStatusCode.OK, sched.StatusCode);
+        Assert.False(await IsListedAsync(client, "PURGE-CANCEL-07"), "should be hidden once scheduled");
+
+        var resp = await client.DeleteAsync($"/api/projects/{id}/purge");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.True(await IsListedAsync(client, "PURGE-CANCEL-07"), "cancelling must bring it back");
+    }
+
+    [Fact]
+    public async Task CancelPurge_RequiresOwnerRole()
+    {
+        var id = SeedProject("PURGE-CANCELROLE-08");
+        var owner = await _factory.CreateAuthenticatedClientAsync();
+        var sched = await owner.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-CANCELROLE-08", null);
+        Assert.Equal(HttpStatusCode.OK, sched.StatusCode);
+
+        var member = await _factory.CreateAuthenticatedClientAsync("member@test.org", "Password123!");
+        var resp = await member.DeleteAsync($"/api/projects/{id}/purge");
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        // A refused cancel must not quietly un-schedule it.
+        Assert.False(await IsListedAsync(owner, "PURGE-CANCELROLE-08"));
+    }
+
+    [Fact]
+    public async Task Purge_CannotReachAnotherTenantsProject()
+    {
+        var id = SeedProject("PURGE-TENANT-09");
+        // Owner of a DIFFERENT tenant — the role check alone would pass, so this
+        // proves tenant scoping is what stops it.
+        var other = await _factory.CreateAuthenticatedClientAsync("admin@other.org", "Password123!");
+
+        var resp = await other.PostAsync($"/api/projects/{id}/purge?confirmCode=PURGE-TENANT-09", null);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        var owner = await _factory.CreateAuthenticatedClientAsync();
+        Assert.True(await IsListedAsync(owner, "PURGE-TENANT-09"));
+    }
+}

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -7324,7 +7324,19 @@
         </div>`;
       wrap.appendChild(cta);
       $('#ctaBackToProjects', cta).addEventListener('click', () => {
-        location.href = (apiBase || '') + '/projects';
+        // apiBase is the JSON API's own origin (this viewer is served FROM
+        // it) — it has no /projects page, so navigating there 404s/blocks
+        // instead of showing anything useful. When this viewer is embedded
+        // in an iframe (the normal case, from planscape-web), the referrer
+        // is the web app that hosts a real /projects page — go there, and
+        // navigate the top-level tab, not just this iframe. Bare/standalone
+        // opens (no referrer) fall back to the API root as the least-bad option.
+        let target = (apiBase || '') + '/';
+        try {
+          if (document.referrer) target = new URL('/projects', document.referrer).toString();
+        } catch (_) {}
+        if (window.top && window.top !== window.self) window.top.location.href = target;
+        else location.href = target;
       });
       // Hide the boot loader behind it so it doesn't double-spin.
       const bl = $('#bootLoader'); if (bl) bl.style.display = 'none';

--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -40,14 +40,22 @@ export default function ViewerPage() {
   const { user: authUser } = useAuth();
   const [viewerSrc, setViewerSrc] = useState<string | null>(null);
   useEffect(() => {
-    const token = getToken();
-    if (!token) { setViewerSrc(VIEWER_BASE_URL); return; }
     const u = new URL(VIEWER_BASE_URL);
-    u.searchParams.set('token', token);
-    if (authUser?.tenantId) u.searchParams.set('tenant', authUser.tenantId);
-    if (authUser?.email) u.searchParams.set('user', authUser.email);
+    // Without ?project=, coordination-viewer.js's own bootstrap() sees no
+    // projectId in ITS url, shows the "Pick a project to get started" CTA,
+    // and returns early — skipping its project-name/members/issues load
+    // entirely. It doesn't know about the postMessage 'load' this page
+    // sends once the iframe is ready, so the CTA never gets dismissed even
+    // though the base viewer.html goes on to render the model behind it.
+    u.searchParams.set('project', projectId);
+    const token = getToken();
+    if (token) {
+      u.searchParams.set('token', token);
+      if (authUser?.tenantId) u.searchParams.set('tenant', authUser.tenantId);
+      if (authUser?.email) u.searchParams.set('user', authUser.email);
+    }
     setViewerSrc(u.toString());
-  }, [authUser]);
+  }, [authUser, projectId]);
 
   // Federation (preferred): multi-discipline scene chunks.
   const [scene, setScene] = useState<SceneManifest | null>(null);

--- a/planscape-web/app/projects/page.tsx
+++ b/planscape-web/app/projects/page.tsx
@@ -16,7 +16,7 @@ import {
   toneForStatus,
   type Column,
 } from '@/components/ui';
-import { listProjects, updateProject } from '@/lib/data';
+import { listProjects, updateProject, toggleProjectPin } from '@/lib/data';
 import type { Project } from '@/lib/types';
 
 /**
@@ -34,6 +34,11 @@ import type { Project } from '@/lib/types';
  *    the row action.
  *  - RAG / compliance %, open issues, members, elements — server-computed, no
  *    write endpoint. Read-only.
+ *
+ * Columns beyond the core set are hidden by default and opt-in via the grid's
+ * "Columns" picker (choice persisted per browser). Everything shown here already
+ * comes back from GET /api/projects — no extra request, and no N+1: the fields
+ * were being fetched and thrown away.
  */
 const PHASES = ['', 'Concept', 'Design', 'Technical', 'Construction', 'Handover', 'Operation'];
 
@@ -51,7 +56,49 @@ export default function ProjectsPage() {
 
   useEffect(load, [load]);
 
+  // Optimistic pin: the star flips immediately and reverts if the server says
+  // no. A full reload would re-sort the grid under the cursor (pinned rows sort
+  // first), which reads as the row jumping away from the click.
+  const pin = useCallback(async (p: Project) => {
+    setProjects((cur) => cur?.map((x) => (x.id === p.id ? { ...x, isPinned: !x.isPinned } : x)) ?? cur);
+    try {
+      await toggleProjectPin(p.id);
+    } catch {
+      setProjects((cur) => cur?.map((x) => (x.id === p.id ? { ...x, isPinned: p.isPinned } : x)) ?? cur);
+    }
+  }, []);
+
   const columns: Column<Project>[] = [
+    {
+      key: 'rowNo',
+      header: '#',
+      className: 'w-10 text-fg-subtle tabular-nums',
+      sortable: false,
+      // Position in the CURRENT view, so it renumbers with sort/filter rather
+      // than pretending to be a stable project number. The project's real
+      // identifier is Code.
+      render: (p) => <span>{(projects ?? []).indexOf(p) + 1}</span>,
+    },
+    {
+      key: 'pin',
+      header: '',
+      className: 'w-8',
+      sortable: false,
+      render: (p) => (
+        <button
+          type="button"
+          title={p.isPinned ? 'Unpin' : 'Pin to top'}
+          aria-label={p.isPinned ? `Unpin ${p.name}` : `Pin ${p.name}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            void pin(p);
+          }}
+          className={p.isPinned ? 'text-warning' : 'text-fg-subtle hover:text-fg'}
+        >
+          {p.isPinned ? '★' : '☆'}
+        </button>
+      ),
+    },
     {
       key: 'name',
       header: 'Project',
@@ -111,6 +158,33 @@ export default function ProjectsPage() {
         p.lastSyncAt ? new Date(p.lastSyncAt).toLocaleDateString() : <span className="text-fg-subtle">Never</span>,
     },
     {
+      key: 'elements',
+      header: 'Elements',
+      className: 'w-32 tabular-nums',
+      value: (p) => p.totalElements ?? 0,
+      render: (p) =>
+        p.totalElements
+          ? <span>{p.taggedElements ?? 0} / {p.totalElements}</span>
+          : <span className="text-fg-subtle">—</span>,
+    },
+    {
+      key: 'location',
+      header: 'Location',
+      className: 'w-40',
+      value: (p) => [p.city, p.country].filter(Boolean).join(', '),
+      render: (p) => {
+        const where = [p.city, p.country].filter(Boolean).join(', ');
+        return where ? <span>{where}</span> : <span className="text-fg-subtle">—</span>;
+      },
+    },
+    {
+      key: 'createdAt',
+      header: 'Created',
+      className: 'w-28',
+      render: (p) =>
+        p.createdAt ? new Date(p.createdAt).toLocaleDateString() : <span className="text-fg-subtle">—</span>,
+    },
+    {
       key: 'actions',
       header: '',
       className: 'w-24',
@@ -135,7 +209,7 @@ export default function ProjectsPage() {
     <AppShell>
       <PageHeader
         title="Projects"
-        description="Name and phase are editable inline."
+        description="Click a row to open it. Double-click a name or phase to edit it inline."
         actions={
           <Button asChild variant="primary">
             <Link href="/projects/new">New project</Link>
@@ -149,6 +223,10 @@ export default function ProjectsPage() {
         rowId={(p) => p.id}
         loading={!projects && !error}
         error={error}
+        storageKey="projects"
+        // Off by default so the default view stays the one people already know;
+        // the picker is how you opt in, and the choice sticks per browser.
+        defaultHiddenColumns={['elements', 'location', 'createdAt']}
         onRowClick={(p) => router.push(`/projects/${p.id}`)}
         rowMenu={(p, close) => (
           <>

--- a/planscape-web/components/ui/DataGrid.test.tsx
+++ b/planscape-web/components/ui/DataGrid.test.tsx
@@ -143,7 +143,7 @@ describe('DataGrid — inline edit (the contract)', () => {
     const save = vi.fn<(row: Row, value: string) => Promise<unknown>>(async () => ({}));
     grid(editable(save));
 
-    await user.click(screen.getAllByTitle('Click to edit')[0]);
+    await user.dblClick(screen.getAllByTitle('Double-click to edit (or press F2)')[0]);
     await user.selectOptions(screen.getByRole('combobox'), 'Closed');
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1));
@@ -158,23 +158,23 @@ describe('DataGrid — inline edit (the contract)', () => {
     });
     grid(editable(save));
 
-    const cell = screen.getAllByTitle('Click to edit')[0];
+    const cell = screen.getAllByTitle('Double-click to edit (or press F2)')[0];
     expect(cell.textContent).toBe('Open');
 
-    await user.click(cell);
+    await user.dblClick(cell);
     await user.selectOptions(screen.getByRole('combobox'), 'Closed');
 
     // The toast carries the server's own message…
     await waitFor(() => expect(screen.getByText(/someone else changed this/i)).toBeDefined());
     // …and the cell is back to what the server still holds.
-    await waitFor(() => expect(screen.getAllByTitle('Click to edit')[0].textContent).toBe('Open'));
+    await waitFor(() => expect(screen.getAllByTitle('Double-click to edit (or press F2)')[0].textContent).toBe('Open'));
   });
 
   it('does not call the endpoint when the value is unchanged', async () => {
     const user = userEvent.setup();
     const save = vi.fn(async () => ({}));
     grid(editable(save));
-    await user.click(screen.getAllByTitle('Click to edit')[0]);
+    await user.dblClick(screen.getAllByTitle('Double-click to edit (or press F2)')[0]);
     await user.selectOptions(screen.getByRole('combobox'), 'Open'); // same value
     expect(save).not.toHaveBeenCalled();
   });
@@ -183,8 +183,28 @@ describe('DataGrid — inline edit (the contract)', () => {
     const user = userEvent.setup();
     const onRowClick = vi.fn();
     grid(editable(async () => ({})), { onRowClick });
-    await user.click(screen.getAllByTitle('Click to edit')[0]);
+    await user.dblClick(screen.getAllByTitle('Double-click to edit (or press F2)')[0]);
+    // A double click fires click,click,dblclick — so this also guards the
+    // deferral: if the queued single-click navigation were not cancelled,
+    // opening the editor would ALSO have navigated away from the grid.
+    await new Promise((r) => setTimeout(r, 350));
     expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('SINGLE click on an editable cell opens the record instead of editing it', async () => {
+    // The regression this guards: single click used to enter edit mode, so
+    // clicking a project's name — the most natural way to open it — silently
+    // armed a rename instead.
+    const user = userEvent.setup();
+    const onRowClick = vi.fn();
+    const save = vi.fn(async () => ({}));
+    grid(editable(save), { onRowClick });
+
+    await user.click(screen.getAllByTitle('Double-click to edit (or press F2)')[0]);
+
+    await waitFor(() => expect(onRowClick).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('combobox')).toBeNull();   // no editor opened
+    expect(save).not.toHaveBeenCalled();
   });
 
   it('Escape abandons a text edit instead of committing it', async () => {
@@ -193,7 +213,7 @@ describe('DataGrid — inline edit (the contract)', () => {
     // filterable:false so the only textbox on screen is the cell editor —
     // otherwise this matches the toolbar's filter box too.
     grid([{ key: 'title', header: 'Title', edit: { save } }], { filterable: false });
-    await user.click(screen.getAllByTitle('Click to edit')[0]);
+    await user.dblClick(screen.getAllByTitle('Double-click to edit (or press F2)')[0]);
     await user.type(screen.getByRole('textbox'), 'xyz');
     await user.keyboard('{Escape}');
     expect(save).not.toHaveBeenCalled();

--- a/planscape-web/components/ui/DataGrid.tsx
+++ b/planscape-web/components/ui/DataGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 import { ContextMenuPanel } from '@/components/shell/Menu';
 import { EmptyState, ErrorNote, Input, Select, SkeletonRows } from './primitives';
@@ -66,7 +66,23 @@ export interface DataGridProps<T> {
    * shortcut, and an action that exists nowhere else is not a shortcut.
    */
   rowMenu?: (row: T, close: () => void) => ReactNode;
+  /**
+   * Enables the "Columns" picker and remembers the choice under this key.
+   * Omit and every column is always shown (and no picker renders) — a grid
+   * with four columns doesn't need one.
+   */
+  storageKey?: string;
+  /** Columns hidden until the user opts in, by `key`. */
+  defaultHiddenColumns?: readonly string[];
 }
+
+/**
+ * How long an editable cell waits before treating a click as "open the record"
+ * rather than the first half of a double-click. Roughly the OS double-click
+ * threshold — long enough to catch the second click, short enough not to feel
+ * like lag.
+ */
+const DOUBLE_CLICK_MS = 220;
 
 type SortState = { key: string; dir: 'asc' | 'desc' } | null;
 
@@ -84,17 +100,69 @@ export function DataGrid<T>({
   filterable = true,
   onRowPatched,
   rowMenu,
+  storageKey,
+  defaultHiddenColumns,
 }: DataGridProps<T>) {
   const { toast } = useToast();
   const [sort, setSort] = useState<SortState>(null);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [hiddenCols, setHiddenCols] = useState<Set<string>>(() => new Set(defaultHiddenColumns ?? []));
+  const [colsMenuOpen, setColsMenuOpen] = useState(false);
   const [savingCells, setSavingCells] = useState<Set<string>>(new Set());
   /** Cell overrides applied optimistically, keyed `${rowId}:${colKey}`. */
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<string | null>(null);
   /** Which row was right-clicked, and where. Null = no context menu open. */
   const [menuAt, setMenuAt] = useState<{ row: T; x: number; y: number } | null>(null);
+  /** Pending single-click navigation from an editable cell; cancelled by a double-click. */
+  const clickTimer = useRef<number | null>(null);
+  // A queued navigation must not fire after the grid has gone.
+  useEffect(() => () => {
+    if (clickTimer.current) window.clearTimeout(clickTimer.current);
+  }, []);
+
+  // Restore the saved column choice on mount. Read in an effect rather than in
+  // the useState initialiser: the initialiser also runs during SSR, where
+  // localStorage doesn't exist, and returning a different value on the server
+  // than on the client is a hydration mismatch.
+  useEffect(() => {
+    if (!storageKey || typeof window === 'undefined') return;
+    try {
+      const saved = window.localStorage.getItem(`grid-cols:${storageKey}`);
+      if (saved) setHiddenCols(new Set(JSON.parse(saved) as string[]));
+    } catch {
+      /* corrupt or unavailable storage — fall back to the defaults already set */
+    }
+  }, [storageKey]);
+
+  const toggleColumn = useCallback(
+    (key: string) => {
+      setHiddenCols((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        if (storageKey && typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(`grid-cols:${storageKey}`, JSON.stringify([...next]));
+          } catch {
+            /* storage full or blocked — the choice still applies for this session */
+          }
+        }
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  // Everything below renders from `columns`; hiding is a filter over it so no
+  // other logic (sort, filter, edit) needs to know about visibility at all.
+  // The action column is never hideable — losing it would strand the row's
+  // only affordance for its actions.
+  const visibleColumns = useMemo(
+    () => columns.filter((c) => !hiddenCols.has(c.key) || c.key === 'actions'),
+    [columns, hiddenCols],
+  );
 
   const valueOf = useCallback(
     (row: T, col: Column<T>): string => {
@@ -181,7 +249,7 @@ export function DataGrid<T>({
 
   return (
     <div className="flex flex-col">
-      {(toolbar || filterable) && (
+      {(toolbar || filterable || storageKey) && (
         <div className="flex flex-wrap items-center gap-2 rounded-t-md border border-b-0 border-border bg-surface-2 px-2 py-1.5">
           {filterable && (
             <Input
@@ -191,6 +259,43 @@ export function DataGrid<T>({
               aria-label="Filter rows"
               className="h-7 w-40"
             />
+          )}
+          {storageKey && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setColsMenuOpen((o) => !o)}
+                aria-expanded={colsMenuOpen}
+                aria-haspopup="true"
+                className="h-7 rounded border border-border-strong px-2 text-xs text-fg-muted transition hover:bg-surface-3"
+              >
+                Columns{hiddenCols.size > 0 ? ` (${hiddenCols.size} hidden)` : ''}
+              </button>
+              {colsMenuOpen && (
+                <>
+                  {/* Click-away layer. Without it the menu can only be closed by
+                      hitting the trigger again, which reads as a stuck popup. */}
+                  <div className="fixed inset-0 z-10" onClick={() => setColsMenuOpen(false)} aria-hidden="true" />
+                  <div className="absolute left-0 z-20 mt-1 min-w-[12rem] rounded-md border border-border bg-surface p-1 shadow-lg">
+                    {columns
+                      .filter((c) => c.key !== 'actions' && c.header)
+                      .map((c) => (
+                        <label
+                          key={c.key}
+                          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-fg hover:bg-surface-3"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={!hiddenCols.has(c.key)}
+                            onChange={() => toggleColumn(c.key)}
+                          />
+                          {c.header}
+                        </label>
+                      ))}
+                  </div>
+                </>
+              )}
+            </div>
           )}
           {selected.size > 0 && (
             <span className="text-xs text-fg-muted">{selected.size} selected</span>
@@ -242,7 +347,7 @@ export function DataGrid<T>({
                     />
                   </th>
                 )}
-                {columns.map((col) => {
+                {visibleColumns.map((col) => {
                   const active = sort?.key === col.key;
                   return (
                     <th key={col.key} className={cn('px-2 py-1.5 font-medium text-fg-muted', col.className)}>
@@ -305,7 +410,7 @@ export function DataGrid<T>({
                         />
                       </td>
                     )}
-                    {columns.map((col) => {
+                    {visibleColumns.map((col) => {
                       const cellKey = `${id}:${col.key}`;
                       const saving = savingCells.has(cellKey);
                       const isEditing = editing === cellKey;
@@ -314,8 +419,46 @@ export function DataGrid<T>({
                         <td
                           key={col.key}
                           className={cn('px-2 py-1.5 align-top text-fg', col.className, saving && 'opacity-60')}
-                          // Editing must never also trigger the row's navigation.
-                          onClick={col.edit ? (e) => e.stopPropagation() : undefined}
+                          // Single click navigates (like every other cell), double
+                          // click edits. It used to be single-click-to-edit, which
+                          // made the most clickable thing on the row — the name —
+                          // silently dangerous: a user aiming to open a project
+                          // instead dropped its title into an editable box, where
+                          // one stray keystroke plus a blur renamed it.
+                          //
+                          // A browser fires click,click,dblclick for a double
+                          // click, so an editable cell cannot both navigate
+                          // instantly AND edit on the second click — the
+                          // navigation would already have happened. Hence the
+                          // short deferral, applied ONLY to editable cells:
+                          // everything else still bubbles and navigates with no
+                          // delay at all.
+                          onClick={
+                            col.edit
+                              ? (e) => {
+                                  e.stopPropagation();
+                                  if (isEditing) return;   // clicks inside the editor do nothing
+                                  if (clickTimer.current) window.clearTimeout(clickTimer.current);
+                                  clickTimer.current = window.setTimeout(() => {
+                                    clickTimer.current = null;
+                                    onRowClick?.(row);
+                                  }, DOUBLE_CLICK_MS);
+                                }
+                              : undefined
+                          }
+                          onDoubleClick={
+                            col.edit && !isEditing
+                              ? (e) => {
+                                  e.stopPropagation();
+                                  // Cancel the navigation the first click queued.
+                                  if (clickTimer.current) {
+                                    window.clearTimeout(clickTimer.current);
+                                    clickTimer.current = null;
+                                  }
+                                  setEditing(cellKey);
+                                }
+                              : undefined
+                          }
                         >
                           {col.edit && isEditing ? (
                             col.edit.options ? (
@@ -346,10 +489,22 @@ export function DataGrid<T>({
                               />
                             )
                           ) : col.edit ? (
+                            // Still a button, purely so the cell stays reachable
+                            // and actionable by keyboard: with the mouse path now
+                            // on double-click, F2 / Enter is the keyboard
+                            // equivalent (F2 is the spreadsheet convention). It
+                            // has NO onClick — a plain click falls through to the
+                            // row and navigates, which is the whole point.
                             <button
                               type="button"
-                              onClick={() => setEditing(cellKey)}
-                              title="Click to edit"
+                              onKeyDown={(e) => {
+                                if (e.key === 'F2' || e.key === 'Enter') {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  setEditing(cellKey);
+                                }
+                              }}
+                              title="Double-click to edit (or press F2)"
                               className="-mx-1 w-full rounded px-1 text-left transition hover:bg-surface-3"
                             >
                               {col.render ? col.render(row) : current || <span className="text-fg-subtle">—</span>}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -89,6 +89,18 @@ export function archiveProject(id: string, confirmCode: string): Promise<void> {
   });
 }
 
+/**
+ * Toggle a project's pinned flag. The server has had `PATCH /{id}/pin` since
+ * Phase 169 (pinned projects sort first) but nothing in the web app called it,
+ * so the flag could only ever be set from another client.
+ *
+ * Server-side toggle, not a set: it flips whatever is stored rather than taking
+ * a value, so callers can't push a stale local guess back.
+ */
+export function toggleProjectPin(id: string): Promise<void> {
+  return api<void>(`/api/projects/${id}/pin`, { method: 'PATCH' });
+}
+
 // ── Issues ──
 export async function listIssues(projectId: string, status?: string): Promise<BimIssue[]> {
   const qs = status ? `?status=${encodeURIComponent(status)}` : '';


### PR DESCRIPTION
## Summary
- `ProjectAccessAttribute` was the one Redis touchpoint in the codebase that didn't fail open — a Redis blip 500'd nearly every project-scoped endpoint instead of returning the correct 403/404. Fixed to match the fail-open pattern used everywhere else (login lockout, JWT revocation). Verified live: `TenantIsolation_OtherTenantCannotAccessMeetings` flips from 500 to a real pass.
- `Members_MemberRole_CannotAdd` had a stale assertion predating the 404-not-403 visibility policy — fixed the test, not the product (matches `ProjectVisibilityTests.DeepLink_NonMember_GetsNotFound_NotForbidden`).
- `planscape-web`'s 3D viewer page never passed `?project=<id>` into the embedded `coordination-viewer.js` iframe's own URL, so its bootstrap short-circuited into a "Pick a project" CTA that never got dismissed (model rendered behind it via a separate postMessage path, but the overlay blocked interaction) and skipped loading project name/members/issues. Fixed by always including `project=<id>`.
- Hardened the CTA's "Open projects list" button, which navigated to the API's own origin (no such page exists there) instead of the web app.

## Test plan
- [x] `dotnet build` — clean
- [x] `npx tsc --noEmit` on planscape-web — clean
- [x] Targeted test re-run: `TenantIsolation_OtherTenantCannotAccessMeetings` now passes (was 500)
- [ ] Full 524-test suite re-run in progress to confirm the remaining ~41 pre-existing failures clear
- [ ] Once deployed, re-verify live: BCC "Publish Model", web 3D viewer, invite flow