### PR TITLE
fix(web): pick people from the project roster, not free-text boxes

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
@@ -119,6 +119,43 @@ public class IssuesController : ControllerBase
         return Ok(new { items = issues, total, page, pageSize });
     }
 
+    /// <summary>
+    /// Fetch a single issue.
+    ///
+    /// This route was missing entirely: the collection GET, the activity and
+    /// attachment sub-routes and the PUT all existed, but there was no
+    /// `GET issues/{issueId}`, so the web app's issue detail page — its only
+    /// consumer — 404'd on load and rendered nothing but "Failed to load
+    /// issue". No test covered it, which is why it stayed invisible.
+    ///
+    /// Returns the assignee FK fields (AssigneeUserId / AssigneeEmail) as well
+    /// as the legacy display name, because a client that offers a member picker
+    /// has to be able to preselect the current assignee by id — matching on the
+    /// display name is exactly the ambiguity the picker exists to remove.
+    /// </summary>
+    [HttpGet("{issueId:guid}")]
+    public async Task<ActionResult> GetIssue(Guid projectId, Guid issueId)
+    {
+        var tenantId = GetTenantId();
+        var issue = await _db.Issues
+            .Where(i => i.Id == issueId && i.ProjectId == projectId && i.Project!.TenantId == tenantId)
+            .Select(i => new
+            {
+                i.Id, i.IssueCode, i.Type, i.Title, i.Description, i.Priority, i.Status,
+                i.Assignee, i.AssigneeEmail, i.AssigneeUserId, i.CoAssigneeUserIds,
+                i.Discipline, i.Revision, i.CreatedBy, i.CreatedAt, i.DueDate,
+                i.ResolvedAt, i.ResolvedBy, i.LinkedElementIds, i.WatcherUserIds,
+                i.ModelId, i.ModelElementGuid, i.ModelX, i.ModelY, i.ModelZ,
+                IsOverdue = i.DueDate.HasValue && i.DueDate < DateTime.UtcNow && i.Status != "CLOSED" && i.Status != "RESOLVED",
+                DaysOpen = (int)(DateTime.UtcNow - i.CreatedAt).TotalDays
+            })
+            .FirstOrDefaultAsync();
+        if (issue == null) return NotFound();
+        if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
+
+        return Ok(issue);
+    }
+
     [HttpPost]
     public async Task<ActionResult> CreateIssue(Guid projectId, [FromBody] CreateIssueRequest req)
     {

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -7532,19 +7532,7 @@
         </div>`;
       wrap.appendChild(cta);
       $('#ctaBackToProjects', cta).addEventListener('click', () => {
-        // apiBase is the JSON API's own origin (this viewer is served FROM
-        // it) — it has no /projects page, so navigating there 404s/blocks
-        // instead of showing anything useful. When this viewer is embedded
-        // in an iframe (the normal case, from planscape-web), the referrer
-        // is the web app that hosts a real /projects page — go there, and
-        // navigate the top-level tab, not just this iframe. Bare/standalone
-        // opens (no referrer) fall back to the API root as the least-bad option.
-        let target = (apiBase || '') + '/';
-        try {
-          if (document.referrer) target = new URL('/projects', document.referrer).toString();
-        } catch (_) {}
-        if (window.top && window.top !== window.self) window.top.location.href = target;
-        else location.href = target;
+        location.href = (apiBase || '') + '/projects';
       });
       // Hide the boot loader behind it so it doesn't double-spin.
       const bl = $('#bootLoader'); if (bl) bl.style.display = 'none';

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -7532,7 +7532,19 @@
         </div>`;
       wrap.appendChild(cta);
       $('#ctaBackToProjects', cta).addEventListener('click', () => {
-        location.href = (apiBase || '') + '/projects';
+        // apiBase is the JSON API's own origin (this viewer is served FROM
+        // it) — it has no /projects page, so navigating there 404s/blocks
+        // instead of showing anything useful. When this viewer is embedded
+        // in an iframe (the normal case, from planscape-web), the referrer
+        // is the web app that hosts a real /projects page — go there, and
+        // navigate the top-level tab, not just this iframe. Bare/standalone
+        // opens (no referrer) fall back to the API root as the least-bad option.
+        let target = (apiBase || '') + '/';
+        try {
+          if (document.referrer) target = new URL('/projects', document.referrer).toString();
+        } catch (_) {}
+        if (window.top && window.top !== window.self) window.top.location.href = target;
+        else location.href = target;
       });
       // Hide the boot loader behind it so it doesn't double-spin.
       const bl = $('#bootLoader'); if (bl) bl.style.display = 'none';

--- a/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
@@ -43,8 +43,15 @@ export default function IssueDetailPage() {
       // Send the FK, not a display name. The server validates it against
       // project membership and 400s otherwise, which is precisely why this
       // used to fail silently when someone typed a name by hand.
+      //
+      // Clearing is the awkward case: a null AssigneeUserId is "leave
+      // unchanged" server-side, not "unassign", so selecting Unassigned would
+      // do nothing at all. Sending an empty display name takes the server's
+      // name-only path and clears the visible assignee, which is as far as
+      // unassigning has ever gone here — UpdateIssue deliberately never clears
+      // AssigneeUserId. Truly releasing the FK needs a server change.
       const body: Partial<BimIssue> = {
-        assigneeUserId: assigneeUserId,
+        ...(assigneeUserId ? { assigneeUserId } : { assignee: '' }),
         dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
       };
       const updated = await updateIssue(projectId, issueId, body);

--- a/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/[issueId]/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { LoadingBlock } from '@/components/ui';
+import { MemberPicker } from '@/components/MemberPicker';
 import { getIssue, updateIssue, listComments, addComment } from '@/lib/data';
 import type { BimIssue, IssueComment, IssueStatus } from '@/lib/types';
 
@@ -19,7 +20,7 @@ export default function IssueDetailPage() {
   const [comments, setComments] = useState<IssueComment[]>([]);
   const [newComment, setNewComment] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [assignee, setAssignee] = useState('');
+  const [assigneeUserId, setAssigneeUserId] = useState<string | null>(null);
   const [dueDate, setDueDate] = useState('');
   const [savingAssign, setSavingAssign] = useState(false);
 
@@ -27,7 +28,7 @@ export default function IssueDetailPage() {
     getIssue(projectId, issueId)
       .then((i) => {
         setIssue(i);
-        setAssignee(i.assignee ?? '');
+        setAssigneeUserId(i.assigneeUserId ?? null);
         setDueDate(i.dueDate ? i.dueDate.slice(0, 10) : '');
       })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load issue'));
@@ -39,14 +40,20 @@ export default function IssueDetailPage() {
     setSavingAssign(true);
     setError(null);
     try {
+      // Send the FK, not a display name. The server validates it against
+      // project membership and 400s otherwise, which is precisely why this
+      // used to fail silently when someone typed a name by hand.
       const body: Partial<BimIssue> = {
-        assignee: assignee.trim(),
+        assigneeUserId: assigneeUserId,
         dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
       };
       const updated = await updateIssue(projectId, issueId, body);
       setIssue(updated);
-    } catch {
-      setError('Failed to save assignment');
+      setAssigneeUserId(updated.assigneeUserId ?? null);
+    } catch (e) {
+      // Surface the server's reason — "not an active member of this project"
+      // is actionable; "Failed to save assignment" is not.
+      setError(e instanceof Error ? e.message : 'Failed to save assignment');
     } finally {
       setSavingAssign(false);
     }
@@ -120,15 +127,16 @@ export default function IssueDetailPage() {
           </div>
 
           <div className="mt-4 flex flex-wrap items-end gap-3 rounded-lg bg-surface p-3 ring-1 ring-border">
-            <label className="block">
+            <div className="block">
               <span className="text-xs font-medium uppercase tracking-wide text-fg-subtle">Assignee</span>
-              <input
-                value={assignee}
-                onChange={(e) => setAssignee(e.target.value)}
-                placeholder="name or email"
-                className="mt-1 block w-56 rounded border border-border-strong px-2 py-1.5 text-sm"
-              />
-            </label>
+              <div className="mt-1 w-64">
+                <MemberPicker
+                  projectId={projectId}
+                  value={assigneeUserId}
+                  onChange={(v) => setAssigneeUserId(v as string | null)}
+                />
+              </div>
+            </div>
             <label className="block">
               <span className="text-xs font-medium uppercase tracking-wide text-fg-subtle">Due date</span>
               <input

--- a/planscape-web/app/projects/[id]/issues/new/page.tsx
+++ b/planscape-web/app/projects/[id]/issues/new/page.tsx
@@ -4,6 +4,7 @@ import { useState, type FormEvent } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { MemberPicker } from '@/components/MemberPicker';
 import { createIssue } from '@/lib/data';
 import type { IssuePriority } from '@/lib/types';
 
@@ -20,6 +21,7 @@ export default function NewIssuePage() {
   const [type, setType] = useState('CLASH');
   const [priority, setPriority] = useState<IssuePriority>('MEDIUM');
   const [discipline, setDiscipline] = useState('');
+  const [assigneeUserId, setAssigneeUserId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -34,6 +36,9 @@ export default function NewIssuePage() {
         type,
         priority,
         discipline: discipline.trim(),
+        // Optional at creation — an issue raised before anyone owns it is a
+        // normal state, so this stays unset rather than defaulting to self.
+        ...(assigneeUserId ? { assigneeUserId } : {}),
       });
       router.replace(`/projects/${projectId}/issues/${issue.id}`);
     } catch (err) {
@@ -103,6 +108,15 @@ export default function NewIssuePage() {
             className="w-full rounded border border-border-strong px-3 py-2 outline-none focus:border-accent"
           />
         </label>
+
+        <div className="block">
+          <span className="mb-1 block text-sm font-medium">Assignee (optional)</span>
+          <MemberPicker
+            projectId={projectId}
+            value={assigneeUserId}
+            onChange={(v) => setAssigneeUserId(v as string | null)}
+          />
+        </div>
 
         {error && <p className="rounded bg-danger-subtle px-3 py-2 text-sm text-danger">{error}</p>}
 

--- a/planscape-web/app/projects/[id]/meetings/new/page.tsx
+++ b/planscape-web/app/projects/[id]/meetings/new/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { MemberPicker } from '@/components/MemberPicker';
 import { createMeeting } from '@/lib/data';
 
 export const dynamic = 'force-dynamic';
@@ -21,6 +22,7 @@ export default function NewMeetingPage() {
   const [durationMinutes, setDurationMinutes] = useState('60');
   const [location, setLocation] = useState('');
   const [meetingUrl, setMeetingUrl] = useState('');
+  const [attendeeIds, setAttendeeIds] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -38,6 +40,10 @@ export default function NewMeetingPage() {
         durationMinutes: durationMinutes ? Number(durationMinutes) : undefined,
         location: location.trim() || undefined,
         meetingUrl: meetingUrl.trim() || undefined,
+        // Send ids only and let the server fill name/email from the account —
+        // it already does that in CreateMeeting, and echoing a display name we
+        // happen to be holding is how the two drift apart.
+        attendees: attendeeIds.length ? attendeeIds.map((userId) => ({ userId })) : undefined,
       });
       router.push(`/projects/${projectId}/meetings/${m.id}`);
     } catch (err) {
@@ -118,6 +124,19 @@ export default function NewMeetingPage() {
             className="mt-1 w-full rounded border border-border-strong px-2 py-1.5 text-sm"
           />
         </label>
+        <div className="block">
+          <span className="text-sm text-fg-muted">
+            Attendees{attendeeIds.length > 0 ? ` (${attendeeIds.length})` : ''}
+          </span>
+          <div className="mt-1">
+            <MemberPicker
+              projectId={projectId}
+              multiple
+              value={attendeeIds}
+              onChange={(v) => setAttendeeIds(v as string[])}
+            />
+          </div>
+        </div>
         <button
           type="submit"
           disabled={busy || !title.trim() || !scheduledAt}

--- a/planscape-web/app/projects/[id]/transmittals/page.tsx
+++ b/planscape-web/app/projects/[id]/transmittals/page.tsx
@@ -14,6 +14,7 @@ import {
   useToast,
   type Column,
 } from '@/components/ui';
+import { MemberPicker, memberLabel } from '@/components/MemberPicker';
 import { createTransmittal, listTransmittals, transmittalAction } from '@/lib/data';
 import type { Transmittal } from '@/lib/types';
 
@@ -42,6 +43,7 @@ export default function TransmittalsPage() {
   const [error, setError] = useState<string | null>(null);
   const [newOpen, setNewOpen] = useState(false);
   const [recipient, setRecipient] = useState('');
+  const [recipientUserId, setRecipientUserId] = useState<string | null>(null);
   const [notes, setNotes] = useState('');
   const [busy, setBusy] = useState(false);
 
@@ -64,6 +66,7 @@ export default function TransmittalsPage() {
       await createTransmittal(projectId, { recipient: recipient.trim(), notes: notes.trim() || undefined });
       toast(`Transmittal to ${recipient.trim()} created`, 'success');
       setRecipient('');
+      setRecipientUserId(null);
       setNotes('');
       setNewOpen(false);
       load();
@@ -163,10 +166,19 @@ export default function TransmittalsPage() {
         }
       >
         <div className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-1 text-sm">
             <span className="text-fg-muted">Recipient</span>
-            <Input value={recipient} onChange={(e) => setRecipient(e.target.value)} autoFocus />
-          </label>
+            <MemberPicker
+              projectId={projectId}
+              value={recipientUserId}
+              onChange={(v) => setRecipientUserId(v as string | null)}
+              // `Transmittal.recipient` is still a single string server-side, so
+              // store the canonical name/email the roster gives us rather than
+              // whatever the user might have typed.
+              onResolve={(sel) => setRecipient(sel[0] ? memberLabel(sel[0]) : '')}
+              placeholder="Select a recipient"
+            />
+          </div>
           <label className="flex flex-col gap-1 text-sm">
             <span className="text-fg-muted">Notes (optional)</span>
             <Input value={notes} onChange={(e) => setNotes(e.target.value)} />

--- a/planscape-web/components/MemberPicker.tsx
+++ b/planscape-web/components/MemberPicker.tsx
@@ -45,6 +45,14 @@ export interface MemberPickerProps {
   value: string | null | string[];
   onChange: (value: string | null | string[]) => void;
   multiple?: boolean;
+  /**
+   * Fires with the resolved member objects behind `value` whenever the
+   * selection or the roster changes. For callers whose stored field is still a
+   * string (transmittal recipient) rather than an FK — they need the canonical
+   * name/email, and this saves them fetching a second copy of the roster,
+   * which is the drift this component exists to prevent.
+   */
+  onResolve?: (selected: ProjectMember[]) => void;
   /** Shown as the empty option in single mode. */
   placeholder?: string;
   /** Hide the invite row where the caller cannot grant project access. */
@@ -64,6 +72,7 @@ export function MemberPicker({
   value,
   onChange,
   multiple = false,
+  onResolve,
   placeholder = 'Unassigned',
   allowInvite = true,
   disabled = false,
@@ -106,6 +115,19 @@ export function MemberPicker({
     : typeof value === 'string' && value
       ? [value]
       : [];
+
+  // Kept as an effect rather than folded into `toggle` so it also fires once
+  // the roster finishes loading — a caller preselecting an id it was handed
+  // still gets the resolved member without a second render pass of its own.
+  const selectedKey = selectedIds.join(',');
+  useEffect(() => {
+    if (!onResolve || members === null) return;
+    onResolve(members.filter((m) => selectedIds.includes(m.userId)));
+    // `selectedKey` stands in for `selectedIds`, which is a fresh array each
+    // render; `onResolve` is intentionally excluded so an inline arrow in the
+    // caller does not re-fire this on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [members, selectedKey]);
 
   function toggle(userId: string) {
     if (!multiple) {

--- a/planscape-web/components/MemberPicker.tsx
+++ b/planscape-web/components/MemberPicker.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Input, Select } from '@/components/ui';
+import { inviteMember, listMembers } from '@/lib/data';
+import type { ProjectMember } from '@/lib/types';
+import { cn } from '@/lib/cn';
+
+/**
+ * The one way to pick a human in this app.
+ *
+ * Before this existed, every surface that needed a person — issue assignee,
+ * transmittal recipient, meeting attendee — was a bare `<input>` you typed a
+ * name into. That is not a cosmetic problem: the server resolves an assignee
+ * against `ProjectMember` and returns 400 "not an active member of this
+ * project" for anything it cannot match, so a typo silently became a failed
+ * save. Worse, a *successful* free-text save wrote a display name with no
+ * `AssigneeUserId` behind it, which means no notification, no push, no
+ * "my issues" filter — the person was assigned in the UI's opinion only.
+ *
+ * So the roster is the source of truth and this component is the only door to
+ * it. `listMembers(projectId)` — the same call the Members page uses — is the
+ * canonical read; there is deliberately no second roster to drift from it.
+ *
+ * The escape hatch matters as much as the dropdown. Real projects need to
+ * assign work to someone who is not in the system yet, and a picker that
+ * refuses to do so just sends people back to free text somewhere else. Here,
+ * "invite by email" calls `inviteMember` and the invitee becomes a real
+ * `ProjectMember` (pending until they set a password) before being selected —
+ * so the escape hatch *ends* in the canonical roster rather than bypassing it.
+ * That is the deliberate difference from the plugin's Attendee Manager, which
+ * also carries a genuine "external guest, do not invite" concept for people
+ * who attend a meeting but must never get project access. The web app has no
+ * such concept today, and inventing one here would be a second roster by
+ * another name.
+ */
+
+export interface MemberPickerProps {
+  projectId: string;
+  /**
+   * Selected user id(s). Single mode takes a `string | null`; multi mode takes
+   * a `string[]`. Kept as ids rather than whole member objects so a parent can
+   * hold form state without caring whether the roster has loaded yet.
+   */
+  value: string | null | string[];
+  onChange: (value: string | null | string[]) => void;
+  multiple?: boolean;
+  /** Shown as the empty option in single mode. */
+  placeholder?: string;
+  /** Hide the invite row where the caller cannot grant project access. */
+  allowInvite?: boolean;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+/** `displayName` is optional on the account, so fall back rather than render "". */
+export function memberLabel(m: ProjectMember): string {
+  return m.displayName?.trim() || m.email;
+}
+
+export function MemberPicker({
+  projectId,
+  value,
+  onChange,
+  multiple = false,
+  placeholder = 'Unassigned',
+  allowInvite = true,
+  disabled = false,
+  className,
+  id,
+}: MemberPickerProps) {
+  const [members, setMembers] = useState<ProjectMember[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [inviting, setInviting] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [showInvite, setShowInvite] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(
+    () =>
+      listMembers(projectId)
+        .then((m) => {
+          setMembers(m);
+          setError(null);
+          return m;
+        })
+        .catch((e) => {
+          // A picker that silently renders zero options looks like a project
+          // with no members. Say which of the two it is.
+          setError(e instanceof Error ? e.message : 'Failed to load members');
+          setMembers([]);
+          return [] as ProjectMember[];
+        }),
+    [projectId],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const selectedIds: string[] = multiple
+    ? Array.isArray(value)
+      ? value
+      : []
+    : typeof value === 'string' && value
+      ? [value]
+      : [];
+
+  function toggle(userId: string) {
+    if (!multiple) {
+      onChange(userId || null);
+      return;
+    }
+    const next = selectedIds.includes(userId)
+      ? selectedIds.filter((v) => v !== userId)
+      : [...selectedIds, userId];
+    onChange(next);
+  }
+
+  async function onInvite() {
+    const email = inviteEmail.trim();
+    if (!email) return;
+    setInviting(true);
+    setNotice(null);
+    try {
+      await inviteMember(projectId, { email });
+      // Re-read rather than optimistically splicing: the server decides the
+      // member row id and whether this resolved to an existing account, and we
+      // need its real userId to select it.
+      const fresh = await load();
+      const added = fresh.find((m) => m.email.toLowerCase() === email.toLowerCase());
+      if (added) {
+        if (multiple) {
+          if (!selectedIds.includes(added.userId)) onChange([...selectedIds, added.userId]);
+        } else {
+          onChange(added.userId);
+        }
+        setNotice(`${memberLabel(added)} invited and selected.`);
+      } else {
+        // Invite accepted but the row is not readable back yet (pending
+        // account). Don't claim a selection that did not happen.
+        setNotice(`Invited ${email}. Select them once the invite is accepted.`);
+      }
+      setInviteEmail('');
+      setShowInvite(false);
+    } catch (e) {
+      setNotice(e instanceof Error ? e.message : 'Invite failed');
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  const loading = members === null;
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      {multiple ? (
+        <MultiSelectList
+          members={members}
+          selectedIds={selectedIds}
+          onToggle={toggle}
+          disabled={disabled}
+          loading={loading}
+        />
+      ) : (
+        <Select
+          id={id}
+          value={selectedIds[0] ?? ''}
+          disabled={disabled || loading}
+          onChange={(e) => onChange(e.target.value || null)}
+        >
+          <option value="">{loading ? 'Loading members…' : placeholder}</option>
+          {(members ?? []).map((m) => (
+            <option key={m.userId} value={m.userId}>
+              {memberLabel(m)} — {m.email}
+            </option>
+          ))}
+        </Select>
+      )}
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+      {!error && !loading && members!.length === 0 && (
+        <p className="text-xs text-fg-subtle">No project members yet.</p>
+      )}
+
+      {allowInvite && !disabled && (
+        <div className="flex flex-col gap-1.5">
+          {!showInvite ? (
+            <button
+              type="button"
+              onClick={() => setShowInvite(true)}
+              className="self-start text-xs text-fg-subtle underline-offset-2 hover:text-fg hover:underline"
+            >
+              Not a project member? Invite by email
+            </button>
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                placeholder="person@firm.com"
+                autoFocus
+                className="max-w-[16rem]"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void onInvite();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="primary"
+                disabled={inviting || !inviteEmail.trim()}
+                onClick={() => void onInvite()}
+              >
+                {inviting ? 'Inviting…' : 'Invite'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setShowInvite(false);
+                  setInviteEmail('');
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+          {notice && <p className="text-xs text-fg-muted">{notice}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Multi-select as a checkbox list, not a `<select multiple>`: ctrl-clicking to
+ * multi-select in a native listbox is a well-known usability trap, and an
+ * attendee list is read far more often than it is edited.
+ */
+function MultiSelectList({
+  members,
+  selectedIds,
+  onToggle,
+  disabled,
+  loading,
+}: {
+  members: ProjectMember[] | null;
+  selectedIds: string[];
+  onToggle: (userId: string) => void;
+  disabled: boolean;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded border border-border bg-surface px-2 py-1.5 text-sm text-fg-subtle">
+        Loading members…
+      </div>
+    );
+  }
+  if (!members || members.length === 0) return null;
+
+  return (
+    <ul className="max-h-48 overflow-y-auto rounded border border-border bg-surface">
+      {members.map((m) => {
+        const checked = selectedIds.includes(m.userId);
+        return (
+          <li key={m.userId}>
+            <label
+              className={cn(
+                'flex cursor-pointer items-center gap-2 px-2 py-1.5 text-sm hover:bg-surface-2',
+                disabled && 'cursor-not-allowed opacity-60',
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => onToggle(m.userId)}
+                className="h-3.5 w-3.5 accent-accent"
+              />
+              <span className="min-w-0 truncate text-fg">{memberLabel(m)}</span>
+              <span className="ml-auto shrink-0 truncate text-xs text-fg-subtle">{m.email}</span>
+            </label>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -272,6 +272,17 @@ export function getMeeting(projectId: string, meetingId: string): Promise<Meetin
   return api<Meeting>(`${mBase(projectId)}/${meetingId}`);
 }
 
+/** Mirrors the server's AttendeeDto. `userId` is what makes an attendee real —
+ *  it is the FK the meeting-invite push and the ICS export both key off. */
+export interface MeetingAttendeeInput {
+  userId?: string;
+  name?: string;
+  email?: string;
+  company?: string;
+  discipline?: string;
+  role?: string;
+}
+
 export interface CreateMeetingBody {
   title: string;
   meetingType?: string;
@@ -279,6 +290,8 @@ export interface CreateMeetingBody {
   durationMinutes?: number;
   location?: string;
   meetingUrl?: string;
+  /** Persisted by MeetingsController.CreateMeeting into MeetingAttendee rows. */
+  attendees?: MeetingAttendeeInput[];
 }
 
 export function createMeeting(projectId: string, body: CreateMeetingBody): Promise<Meeting> {

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -47,6 +47,13 @@ export interface BimIssue {
   status: IssueStatus;
   assignee: string;
   assigneeEmail?: string;
+  /**
+   * FK to the assigned AppUser — what the server actually enforces against
+   * project membership. `assignee` is the legacy display-name twin and is kept
+   * because plugin/mobile callers still send it; prefer this when writing, and
+   * use it to preselect a member picker on read.
+   */
+  assigneeUserId?: string | null;
   discipline: string;
   createdAt: string;
   dueDate?: string;


### PR DESCRIPTION
## Summary

Every web surface that needed a human — issue assignee, transmittal recipient — was a bare text input you typed a name into. That is not cosmetic: `IssuesController` resolves an assignee against `ProjectMember` and returns **400 "not an active member of this project"** for anything it cannot match. So a typo failed the save outright, and a *successful* free-text save wrote a display name with no `AssigneeUserId` behind it — no notification, no push, no "my issues" filter. The person was assigned in the UI's opinion only.

Adds `components/MemberPicker` as the single door to `listMembers(projectId)` — the same canonical read the Members page already uses — in single and multi modes, and wires it into every such surface.

The escape hatch matters as much as the dropdown: real projects assign work to people not yet in the system, and a picker that refuses just pushes free text elsewhere. "Invite by email" calls `inviteMember`, so the invitee becomes a real `ProjectMember` before being selected — the escape hatch *ends* in the canonical roster rather than bypassing it. (Deliberately different from the plugin's Attendee Manager, which also has a genuine "external guest, never grant access" concept; the web app has no such concept, and inventing one here would be a second roster by another name.)

### Two bugs found on the way

- **The issue detail page never loaded.** There was no `GET /api/projects/{projectId}/issues/{issueId}` at all — the collection GET, the activity/attachment sub-routes and the PUT existed, but not the single-issue read. Its only consumer 404'd on load and rendered nothing but "Failed to load issue". No test covered it, which is why it stayed invisible. Added, returning the assignee FK fields so a picker can preselect by id. **This is the only server change in this PR, and it is purely additive.**
- **Meeting attendees could not be added at all** — not at creation, not after. `CreateMeetingRequest` already accepted an `Attendees` list and persisted it; the client simply never sent one, so every browser-scheduled meeting notified nobody.

## Not done, on purpose

- Legacy free-text twins (`BimIssue.Assignee`, `Transmittal.Recipient` as a bare string) are untouched — plugin and mobile callers still send them. Deprecating them is a schema pass for after this proves out.
- `Transmittal.recipient` stays a single string; whether it should be an FK or support several recipients is a data-model question, not settled here.
- Un-assigning still only clears the display name. `UpdateIssue` deliberately never clears `AssigneeUserId`, so releasing the FK needs a server change.

## Test plan

- `npx tsc --noEmit` → **clean**
- `npm run build` → **clean**, all four touched routes compile
- `dotnet build Planscape.API -c Release` → **0 errors**
- `dotnet test Planscape.sln -c Release` → **512 passed, 10 skipped, 2 failed / 524**

Both failures were investigated and **neither is caused by this PR**:

| Test | This branch | Base, without this PR | Verdict |
|---|---|---|---|
| `Documents_TransitionState_WipToShared` | FAIL (500) | **FAIL (500) — reproduced** | Pre-existing + environmental. The runner reports `Redis unavailable at 'localhost:6379'`; the ~2 min duration is the documented retry timeout. Touches documents, not issues. |
| `Members_MemberRole_CannotAdd` | FAIL | **PASS** | Already fixed upstream by `f3f420009` ("order-dependent on shared fixture state"), which landed after this branch was cut. Base has since been merged in, so this branch now carries the fix. |

Manual, once deployed: assign an issue from the dropdown and confirm it sticks and notifies; invite a non-member by email and confirm they appear as pending; schedule a meeting with attendees and confirm `MeetingAttendee` rows exist; create a transmittal and confirm the recipient matches a roster name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
