### PR TITLE
fix(invite): emailed links used http:// and were unopenable + viewer full-screen

### DIFF
--- a/Planscape.Server/src/Planscape.API/PublicUrl.cs
+++ b/Planscape.Server/src/Planscape.API/PublicUrl.cs
@@ -23,6 +23,25 @@ public static class PublicUrl
         var configured = config["Planscape:PublicBaseUrl"];
         if (!string.IsNullOrWhiteSpace(configured))
             return configured.Trim().TrimEnd('/');
-        return $"{request.Scheme}://{request.Host}".TrimEnd('/');
+
+        // Behind a TLS-terminating proxy (Render, Cloudflare, most PaaS) the
+        // request reaches the app over PLAIN HTTP, so request.Scheme is "http"
+        // even though the public URL is https. Links built from it came out as
+        // http://…, and the host answers those with a redirect or an outright
+        // closed connection — a real invitee clicked one and got
+        // ERR_CONNECTION_CLOSED, i.e. every emailed link was dead.
+        //
+        // X-Forwarded-Proto is what the proxy sets to report the ORIGINAL
+        // scheme. Trusting it is appropriate here specifically because this
+        // value only ever builds an outward display link; it makes no
+        // authorisation decision, so a spoofed header cannot escalate anything.
+        var forwarded = request.Headers["X-Forwarded-Proto"].ToString();
+        var scheme = string.IsNullOrWhiteSpace(forwarded)
+            ? request.Scheme
+            // The header is a comma-separated list when several proxies chain;
+            // the ORIGINAL client scheme is the first entry.
+            : forwarded.Split(',')[0].Trim();
+
+        return $"{scheme}://{request.Host}".TrimEnd('/');
     }
 }

--- a/Planscape.Server/tests/Planscape.Tests/PublicUrlTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/PublicUrlTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Guards the production failure PublicUrl exists to prevent: an emailed invite
+/// link that the recipient cannot open.
+///
+/// Behind a TLS-terminating proxy (Render, Cloudflare, most PaaS) the request
+/// reaches the app over plain HTTP, so <c>request.Scheme</c> is "http" while the
+/// public URL is https. Links built from the raw scheme came out as http://…
+/// and the host answered with a closed connection — a real invitee clicked one
+/// and got ERR_CONNECTION_CLOSED, so every invite email was dead on arrival.
+/// </summary>
+public class PublicUrlTests
+{
+    private static IConfiguration Config(string? publicBaseUrl = null) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(publicBaseUrl == null
+                ? new Dictionary<string, string?>()
+                : new Dictionary<string, string?> { ["Planscape:PublicBaseUrl"] = publicBaseUrl })
+            .Build();
+
+    private static HttpRequest Request(string scheme, string host, string? forwardedProto = null)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Scheme = scheme;
+        ctx.Request.Host = new HostString(host);
+        if (forwardedProto != null) ctx.Request.Headers["X-Forwarded-Proto"] = forwardedProto;
+        return ctx.Request;
+    }
+
+    [Fact]
+    public void UsesHttps_WhenProxyReportsHttps_EvenThoughRequestArrivedOverHttp()
+    {
+        // THE regression. Render forwards to the app over http and reports the
+        // original scheme in X-Forwarded-Proto.
+        var url = Planscape.API.PublicUrl.Resolve(
+            Config(), Request("http", "planscape-api-free.onrender.com", "https"));
+
+        Assert.Equal("https://planscape-api-free.onrender.com", url);
+    }
+
+    [Fact]
+    public void TakesTheFirstProto_WhenSeveralProxiesChain()
+    {
+        // Comma-separated list; the ORIGINAL client scheme is first.
+        var url = Planscape.API.PublicUrl.Resolve(
+            Config(), Request("http", "example.com", "https, http"));
+
+        Assert.Equal("https://example.com", url);
+    }
+
+    [Fact]
+    public void FallsBackToRequestScheme_WhenThereIsNoProxyHeader()
+    {
+        // A bare local dev run must keep working with zero config.
+        var url = Planscape.API.PublicUrl.Resolve(Config(), Request("http", "localhost:5000"));
+
+        Assert.Equal("http://localhost:5000", url);
+    }
+
+    [Fact]
+    public void ConfiguredPublicBaseUrlStillWins()
+    {
+        // Explicit config outranks anything inferred — the documented behaviour
+        // for tunnels, where even the forwarded scheme/host is not the public one.
+        var url = Planscape.API.PublicUrl.Resolve(
+            Config("https://api.planscape.build"),
+            Request("http", "internal:5000", "http"));
+
+        Assert.Equal("https://api.planscape.build", url);
+    }
+}

--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { cn } from '@/lib/cn';
 import { listModels, modelFileUrl, getSceneManifest, chunkFileUrl } from '@/lib/data';
 import { API_BASE, getToken } from '@/lib/api';
 import { useAuth } from '@/lib/auth';
@@ -24,8 +25,55 @@ export default function ViewerPage() {
   const wantModel = search.get('model') || undefined;
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const shellRef = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  // Native fullscreen where allowed, CSS "fill the window" where not.
+  //
+  // requestFullscreen() can be refused outright — a permissions-policy embed,
+  // an unusual browser, or a call the browser doesn't consider user-initiated —
+  // and it rejects asynchronously, so a naive implementation leaves the button
+  // looking dead with nothing in the console. The fallback matters more than
+  // usual here because the reason to go big is to stop the viewer's toolbar
+  // being clipped (which hides Meet), and that is worth solving even when the
+  // real fullscreen API is unavailable.
+  const toggleFullscreen = useCallback(() => {
+    const el = shellRef.current;
+    if (!el) return;
+    if (document.fullscreenElement) {
+      void document.exitFullscreen().catch(() => {});
+      return;
+    }
+    if (isFullscreen) {
+      setIsFullscreen(false);   // leaving the CSS fallback
+      return;
+    }
+    const req = el.requestFullscreen?.();
+    if (req) req.then(() => setIsFullscreen(true)).catch(() => setIsFullscreen(true));
+    else setIsFullscreen(true);
+  }, [isFullscreen]);
+
+  // Keep the button honest when the user exits via Esc or the browser's own UI.
+  useEffect(() => {
+    const onChange = () => {
+      if (document.fullscreenElement) setIsFullscreen(true);
+      else if (document.fullscreenEnabled) setIsFullscreen(false);
+    };
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, []);
+
+  // Esc must also leave the CSS fallback, which the browser knows nothing about.
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !document.fullscreenElement) setIsFullscreen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isFullscreen]);
 
   // The 3D viewer + meetings (camera, screen share, markup, chat) all live in
   // a legacy static bundle served by the API (wwwroot/viewer.html), embedded
@@ -195,7 +243,31 @@ export default function ViewerPage() {
         </p>
       )}
 
-      <div className="overflow-hidden rounded-lg ring-1 ring-border" style={{ height: '70vh' }}>
+      {/* The viewer carries its own dense toolbar (Measure / Section / View /
+          Clashes / Issues / Markup / Meet). At 70vh inside the app shell the
+          right-hand end of that toolbar is clipped, which silently hides
+          Meet — the entry point to the camera — so "no live meeting camera"
+          was really "the button is off-screen". Fullscreen gives the toolbar
+          the width it needs, and is worth having on a 3D viewer regardless. */}
+      <div
+        ref={shellRef}
+        className={cn(
+          'relative overflow-hidden ring-1 ring-border',
+          isFullscreen
+            ? 'fixed inset-0 z-50 h-screen w-screen rounded-none bg-surface'
+            : 'rounded-lg',
+        )}
+        style={isFullscreen ? undefined : { height: '70vh' }}
+      >
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          title={isFullscreen ? 'Exit full screen (Esc)' : 'Full screen'}
+          aria-label={isFullscreen ? 'Exit full screen' : 'Enter full screen'}
+          className="absolute right-2 top-2 z-10 rounded border border-border-strong bg-surface/90 px-2 py-1 text-xs text-fg shadow-sm backdrop-blur transition hover:bg-surface-3"
+        >
+          {isFullscreen ? '⤡ Exit full screen' : '⤢ Full screen'}
+        </button>
         {viewerSrc && (
           <iframe
             ref={iframeRef}
@@ -203,6 +275,8 @@ export default function ViewerPage() {
             title="3D model"
             className="h-full w-full border-0"
             onLoad={() => setReady(true)}
+            // camera/microphone/display-capture are what let the embedded
+            // meeting actually publish media from this cross-origin frame.
             allow="fullscreen; camera; microphone; display-capture"
           />
         )}


### PR DESCRIPTION
## Summary
- **Invite links were dead on arrival.** A real invitee clicked one and got `ERR_CONNECTION_CLOSED`. Render terminates TLS at its proxy and forwards over plain HTTP, so `request.Scheme` is `"http"` and `PublicUrl` built every outward link from it — but the host doesn't serve plain HTTP. Every invite and password-reset email was affected, no matter how correctly the mail was sent.
- `PublicUrl` now prefers `X-Forwarded-Proto` (first entry when proxies chain). Safe to trust here specifically because the value only builds an outward display link and makes no authorisation decision. Configured `Planscape:PublicBaseUrl` still wins; bare local runs are unchanged.
- **Viewer full-screen.** The viewer's toolbar is clipped at `70vh` inside the app shell, hiding its right-hand end — including **Meet**, the entry point to the meeting camera. So "no live meeting camera" was really "the button is off-screen". Includes a CSS fallback for embeds where `requestFullscreen` is refused.

## Test plan
- [x] Reproduced live: `http://…` → 301/closed, `https://…` → 200
- [x] 4 new `PublicUrlTests` — proxy https, chained proxies, no-proxy local fallback, configured-base-url precedence — all pass
- [x] `dotnet build` clean; `tsc --noEmit` clean on planscape-web
- [x] Full-screen button verified rendering in a browser (activation needs a trusted user gesture, so not machine-verifiable)
- [ ] After deploy: re-issue Becky's invite and confirm the link is `https://`

## Note
LiveKit is confirmed **configured and working** — the server minted a real LiveKit token (HTTP 200) during diagnosis. The camera issue was purely the clipped toolbar.