### PR TITLE
fix(clashes): register IClashDetectionJob — controller could not be constructed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ Planscape.Server/load/tier-capacity-result.json
 
 # dotnet test --logger trx output
 TestResults/
+
+# Playwright
+planscape-web/test-results/
+planscape-web/playwright-report/

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -658,6 +658,13 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.PlatformSyncJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.AccSyncService>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.CustomFieldsPurgeJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.ProjectPurgeJob>();
+// ClashesController takes IClashDetectionJob in its constructor. It was never
+// registered, so the container could not build the controller AT ALL and every
+// endpoint on it returned 500 — the Clashes page was dead in production, and
+// the browser reported it as a CORS failure because a 500 loses its CORS
+// headers. Registered here beside the other job services.
+builder.Services.AddScoped<Planscape.Infrastructure.Services.IClashDetectionJob,
+    Planscape.Infrastructure.Services.ClashDetectionJob>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.ModelDerivativeJob>();
 // Phase 178 — Site photo workflow: redaction worker + daily digest job.
 // The pipeline is split out (PhotoPipeline/IPhotoRedactionPipeline) so

--- a/planscape-web/e2e/investigate.spec.ts
+++ b/planscape-web/e2e/investigate.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page, type ConsoleMessage } from '@playwright/test';
+
+/**
+ * Exploratory sweep, not a gate. It walks every project-scoped page as a real
+ * signed-in user and reports what a user would actually hit: console errors,
+ * failed API calls, dead-looking empty states.
+ *
+ * Auth is seeded by writing the same localStorage key the app itself uses
+ * (`planscape_token`) with a token minted from a Personal Access Token, so no
+ * password is ever typed. TEST_JWT is supplied by the runner.
+ */
+
+const JWT = process.env.TEST_JWT ?? '';
+const PROJECT = process.env.TEST_PROJECT ?? '';
+const BASE = process.env.TEST_BASE ?? 'http://localhost:3000';
+
+type Finding = { page: string; kind: string; detail: string };
+const findings: Finding[] = [];
+
+/** Noise that says nothing about the app's own health. */
+function isIgnorable(text: string) {
+  return (
+    text.includes('React DevTools') ||
+    text.includes('Fast Refresh') ||
+    text.includes('Download the React DevTools')
+  );
+}
+
+async function sweep(page: Page, path: string, label: string) {
+  const errors: string[] = [];
+  const failedRequests: string[] = [];
+
+  const onConsole = (m: ConsoleMessage) => {
+    if (m.type() !== 'error' && m.type() !== 'warning') return;
+    const t = m.text();
+    if (!isIgnorable(t)) errors.push(`${m.type()}: ${t.slice(0, 200)}`);
+  };
+  const onResponse = (r: { status: () => number; url: () => string }) => {
+    // 401 on a token that has expired mid-run would be misleading, so record
+    // the status and let the report show it rather than asserting on it.
+    if (r.status() >= 400 && r.url().includes('/api/')) {
+      failedRequests.push(`${r.status()} ${r.url().replace(/https?:\/\/[^/]+/, '')}`);
+    }
+  };
+
+  page.on('console', onConsole);
+  page.on('response', onResponse);
+
+  await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded' });
+  // Client-side data loads after hydration; give it room without being flaky.
+  await page.waitForTimeout(2500);
+
+  const bodyText = (await page.locator('body').innerText().catch(() => '')) || '';
+
+  page.off('console', onConsole);
+  page.off('response', onResponse);
+
+  for (const e of [...new Set(errors)]) findings.push({ page: label, kind: 'console', detail: e });
+  for (const r of [...new Set(failedRequests)]) findings.push({ page: label, kind: 'api', detail: r });
+
+  // A page that renders its own failure text is worth surfacing even when the
+  // network looked fine.
+  for (const phrase of ['Failed to', 'Something went wrong', 'Could not', 'Unauthorized']) {
+    if (bodyText.includes(phrase)) {
+      findings.push({ page: label, kind: 'ui-error', detail: `page text contains "${phrase}"` });
+    }
+  }
+  return bodyText;
+}
+
+test.beforeEach(async ({ page }) => {
+  test.skip(!JWT || !PROJECT, 'TEST_JWT and TEST_PROJECT must be set');
+  // Seed auth on the app origin before any app code runs.
+  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+  await page.evaluate((t) => localStorage.setItem('planscape_token', t), JWT);
+});
+
+test('sweep every project page for errors', async ({ page }) => {
+  const routes: Array<[string, string]> = [
+    ['/projects', 'Projects list'],
+    [`/projects/${PROJECT}`, 'Project overview'],
+    [`/projects/${PROJECT}/issues`, 'Issues'],
+    [`/projects/${PROJECT}/clashes`, 'Clashes'],
+    [`/projects/${PROJECT}/models`, 'Models'],
+    [`/projects/${PROJECT}/documents`, 'Documents'],
+    [`/projects/${PROJECT}/transmittals`, 'Transmittals'],
+    [`/projects/${PROJECT}/meetings`, 'Meetings'],
+    [`/projects/${PROJECT}/photos`, 'Site photos'],
+    [`/projects/${PROJECT}/members`, 'Members'],
+    [`/projects/${PROJECT}/viewer`, '3D viewer'],
+  ];
+
+  for (const [path, label] of routes) {
+    await sweep(page, path, label);
+  }
+
+  // Report as a readable block; the run is exploratory so it never fails here.
+  const byPage = new Map<string, Finding[]>();
+  for (const f of findings) {
+    if (!byPage.has(f.page)) byPage.set(f.page, []);
+    byPage.get(f.page)!.push(f);
+  }
+  let report = `\n===== SWEEP REPORT (${findings.length} findings) =====\n`;
+  for (const [pageName, fs] of byPage) {
+    report += `\n## ${pageName}\n`;
+    for (const f of fs) report += `  [${f.kind}] ${f.detail}\n`;
+  }
+  if (findings.length === 0) report += '\nNo console errors, failed API calls, or error text on any page.\n';
+  console.log(report);
+});
+
+test('projects grid: single click opens, double click edits', async ({ page }) => {
+  // The safety contract just shipped, exercised in a real browser rather than jsdom.
+  await page.goto(`${BASE}/projects`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(2500);
+
+  const nameCell = page.locator('button[title*="Double-click to edit"]').first();
+  if ((await nameCell.count()) === 0) {
+    console.log('\n[grid] no editable cell found — skipping (no projects visible?)\n');
+    return;
+  }
+
+  await nameCell.click();
+  await page.waitForTimeout(900);
+  const url = page.url();
+  console.log(`\n[grid] single click -> ${url}`);
+  expect(url, 'single click must navigate to a project, not open an editor').toMatch(/\/projects\/[0-9a-f-]{36}/);
+});
+
+test('3D viewer: full-screen control works with a real user gesture', async ({ page }) => {
+  await page.goto(`${BASE}/projects/${PROJECT}/viewer`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(3000);
+
+  const btn = page.getByRole('button', { name: /enter full screen/i });
+  await expect(btn, 'full-screen button should render on the viewer').toBeVisible();
+
+  await btn.click();
+  await page.waitForTimeout(1200);
+
+  const state = await page.evaluate(() => ({
+    native: !!document.fullscreenElement,
+    label: document.querySelector('[aria-label*="full screen" i]')?.getAttribute('aria-label') ?? null,
+  }));
+  console.log(`\n[viewer] after click -> native=${state.native} button="${state.label}"\n`);
+  // Either the native API engaged or the CSS fallback did; both flip the label.
+  expect(state.label, 'the control must switch to an exit affordance').toMatch(/exit/i);
+});

--- a/planscape-web/e2e/meeting.spec.ts
+++ b/planscape-web/e2e/meeting.spec.ts
@@ -1,0 +1,103 @@
+import { test, type Page } from '@playwright/test';
+
+/**
+ * Reproduces two reported symptoms that look like one cause:
+ *   1. starting a meeting makes the model reload and hang at "Loading model 0%"
+ *   2. the A/V join then fails with "Couldn't join — retry"
+ *
+ * The suspicion under test is that the viewer iframe is being REMOUNTED. Its
+ * src carries the auth token, so anything that changes the token (or merely the
+ * identity of the auth object the effect depends on) produces a new src, which
+ * reloads the frame — restarting the model download from 0% and tearing down an
+ * in-flight LiveKit connection. If that is what happens, both symptoms have a
+ * single fix and neither is a meeting bug.
+ */
+
+const JWT = process.env.TEST_JWT ?? '';
+const PROJECT = process.env.TEST_PROJECT ?? '';
+const BASE = process.env.TEST_BASE ?? 'http://localhost:3000';
+
+async function seedAuth(page: Page) {
+  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+  await page.evaluate((t) => localStorage.setItem('planscape_token', t), JWT);
+}
+
+test('starting a meeting: does the viewer iframe remount?', async ({ page }) => {
+  test.skip(!JWT || !PROJECT, 'TEST_JWT and TEST_PROJECT must be set');
+
+  const frameLoads: string[] = [];
+  const errors: string[] = [];
+
+  // A frame navigation IS the remount we are looking for.
+  page.on('framenavigated', (f) => {
+    if (f === page.mainFrame()) return;
+    frameLoads.push(`${new Date().toISOString().slice(11, 23)} ${f.url().slice(0, 120)}`);
+  });
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(m.text().slice(0, 220));
+  });
+
+  await seedAuth(page);
+  await page.goto(`${BASE}/projects/${PROJECT}/viewer`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(6000);
+
+  const loadsBefore = frameLoads.length;
+  console.log(`\n[baseline] iframe navigations while just sitting on the page: ${loadsBefore}`);
+  frameLoads.forEach((l) => console.log(`   ${l}`));
+
+  // Track src changes directly too — React swapping the attribute is the
+  // mechanism, whether or not a navigation event is emitted for it.
+  const srcSamples: string[] = [];
+  const sample = async () => {
+    const src = await page.locator('iframe[title="3D model"]').getAttribute('src').catch(() => null);
+    if (src && srcSamples[srcSamples.length - 1] !== src) srcSamples.push(src);
+  };
+  await sample();
+
+  // Open the Meet menu inside the viewer iframe and start/join.
+  const frame = page.frameLocator('iframe[title="3D model"]');
+  const meet = frame.locator('#btnMeet, [id*="Meet" i], button:has-text("Meet")').first();
+  if ((await meet.count()) === 0) {
+    console.log('\n[meet] no Meet control found in the iframe — cannot drive the meeting from here\n');
+  } else {
+    await meet.click({ timeout: 10_000 }).catch((e) => console.log(`[meet] click failed: ${e.message}`));
+    await page.waitForTimeout(1500);
+    await sample();
+
+    const join = frame.locator('button:has-text("Join A/V"), button:has-text("Join")').first();
+    if ((await join.count()) > 0) {
+      await join.click({ timeout: 10_000 }).catch((e) => console.log(`[join] click failed: ${e.message}`));
+      console.log('[meet] clicked Join A/V');
+    } else {
+      console.log('[meet] Join control not found after opening the menu');
+    }
+  }
+
+  await page.waitForTimeout(8000);
+  await sample();
+
+  console.log(`\n[after meet] total iframe navigations: ${frameLoads.length} (was ${loadsBefore} before clicking)`);
+  frameLoads.slice(loadsBefore).forEach((l) => console.log(`   ${l}`));
+
+  console.log(`\n[iframe src] distinct values seen: ${srcSamples.length}`);
+  srcSamples.forEach((s, i) => {
+    // The token is the part most likely to differ between samples.
+    const tok = /[?&]token=([^&]+)/.exec(s)?.[1] ?? '(none)';
+    console.log(`   #${i + 1} token=${tok.slice(0, 24)}… len=${s.length}`);
+  });
+  if (srcSamples.length > 1) {
+    console.log('\n   >>> iframe src CHANGED — that remounts the viewer and restarts the model load.');
+  }
+
+  const modelText = await page
+    .frameLocator('iframe[title="3D model"]')
+    .locator('body')
+    .innerText()
+    .catch(() => '');
+  const stuck = /Loading model/i.test(modelText);
+  console.log(`\n[model] still showing "Loading model": ${stuck}`);
+
+  console.log(`\n[console errors] ${errors.length}`);
+  [...new Set(errors)].slice(0, 12).forEach((e) => console.log(`   ${e}`));
+  console.log('');
+});

--- a/planscape-web/package-lock.json
+++ b/planscape-web/package-lock.json
@@ -26,6 +26,7 @@
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -906,6 +907,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -4042,6 +4059,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/planscape-web/package.json
+++ b/planscape-web/package.json
@@ -2,14 +2,15 @@
   "name": "planscape-web",
   "version": "0.1.0",
   "private": true,
-  "description": "Planscape online BIM coordination — browser app (auth → projects → issues → clashes → 3D viewer → real-time).",
+  "description": "Planscape online BIM coordination \u2014 browser app (auth \u2192 projects \u2192 issues \u2192 clashes \u2192 3D viewer \u2192 real-time).",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@microsoft/signalr": "8.0.7",
@@ -30,6 +31,7 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/planscape-web/playwright.config.ts
+++ b/planscape-web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E lives in e2e/ and is kept OUT of the vitest run (vitest owns lib/ and
+ * components/). These specs need a running app and a real token, so they are
+ * not part of the default `npm test` gate — run them explicitly.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.TEST_BASE ?? 'http://localhost:3000',
+    trace: 'off',
+    video: 'off',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});


### PR DESCRIPTION
## Summary
Every endpoint on `ClashesController` returned **500** in production — the Clashes page was dead. Render logs gave the exact cause:

```
System.InvalidOperationException: Unable to resolve service for type
'Planscape.Infrastructure.Services.IClashDetectionJob' while attempting to
activate 'Planscape.API.Controllers.ClashesController'
```

The service was never registered, so the container couldn't construct the controller at all.

**Why it was hard to spot:** the browser reported it as a **CORS** error, because a .NET 500 loses its CORS headers. CORS was never the problem.

## Test plan
- [x] `dotnet build` clean
- [ ] After deploy: `GET /api/projects/{id}/clashes` returns 200 (was 500)

## Follow-up
A smoke test resolving every controller from the DI container would catch this entire class of bug at boot rather than on first request.