### PR TITLE
fix(server): register IClashAutomationService so /clashes stops 500ing

### DIFF
--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -665,6 +665,13 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.ProjectPurgeJob>();
 // headers. Registered here beside the other job services.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.IClashDetectionJob,
     Planscape.Infrastructure.Services.ClashDetectionJob>();
+// ...and ClashDetectionJob in turn takes IClashAutomationService, which was
+// still unregistered — so the container failed one level DEEPER and every
+// endpoint kept returning the same 500 ("Unable to resolve service for type
+// IClashAutomationService while attempting to activate ClashDetectionJob").
+// Scoped, not Singleton: it holds a scoped PlanscapeDbContext.
+builder.Services.AddScoped<Planscape.Infrastructure.Services.IClashAutomationService,
+    Planscape.Infrastructure.Services.ClashAutomationService>();
 builder.Services.AddScoped<Planscape.Infrastructure.Services.ModelDerivativeJob>();
 // Phase 178 — Site photo workflow: redaction worker + daily digest job.
 // The pipeline is split out (PhotoPipeline/IPhotoRedactionPipeline) so

--- a/Planscape.Server/tests/Planscape.Tests/ClashServiceResolutionTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ClashServiceResolutionTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Regression guard for a DI break that reached production TWICE.
+///
+/// ClashesController takes IClashDetectionJob. That was unregistered, so the
+/// container could not build the controller and every /clashes endpoint
+/// returned 500 (which the browser mis-reported as CORS, because an ASP.NET
+/// 500 loses its CORS headers). The first fix registered IClashDetectionJob
+/// — but ClashDetectionJob itself takes IClashAutomationService, which was
+/// still unregistered, so the container failed one level DEEPER and the
+/// endpoint kept returning the same 500:
+///
+///   System.InvalidOperationException: Unable to resolve service for type
+///   'IClashAutomationService' while attempting to activate 'ClashDetectionJob'.
+///
+/// A compile never catches this — the graph is only proven at RESOLVE time.
+/// Resolving the root walks the WHOLE chain (job → automation service → db +
+/// notifications + webhooks), so any future link that goes missing fails here
+/// instead of in production.
+/// </summary>
+public class ClashServiceResolutionTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public ClashServiceResolutionTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    [Fact]
+    public void ClashDetectionJob_ResolvesWithItsWholeDependencyChain()
+    {
+        using var scope = _factory.Services.CreateScope();
+
+        var job = scope.ServiceProvider.GetRequiredService<IClashDetectionJob>();
+
+        Assert.NotNull(job);
+    }
+
+    [Fact]
+    public void ClashAutomationService_IsRegistered()
+    {
+        using var scope = _factory.Services.CreateScope();
+
+        var automation = scope.ServiceProvider.GetRequiredService<IClashAutomationService>();
+
+        Assert.NotNull(automation);
+    }
+}


### PR DESCRIPTION
## Summary

`/api/projects/{id}/clashes` returns 500 on production. The live Render logs show a DI failure, not an auth or CORS problem:

```
System.InvalidOperationException: Unable to resolve service for type
'Planscape.Infrastructure.Services.IClashAutomationService' while attempting
to activate 'Planscape.Infrastructure.Services.ClashDetectionJob'.
HTTP GET /api/projects/.../clashes responded 500 in 3.8840 ms
```

`ClashesController` takes `IClashDetectionJob`. A previous fix registered that interface — but `ClashDetectionJob` itself takes `IClashAutomationService`, which was still unregistered, so the container failed **one level deeper** and the endpoint kept returning the same 500. This registers it.

`AddScoped`, not `AddSingleton`: `ClashAutomationService` holds a scoped `PlanscapeDbContext`. Its other two dependencies (`INotificationService`, `OutboundWebhookDispatcher`) are already registered, so the chain is now complete.

### Why it survived a round of fixing

The client masks it: `coordination-viewer.js` catches the failure and falls back to `mockClashes()`. The panel shows mock rows while the overview shows 0 real clashes, and no error ever reaches the user.

## Test plan

- [x] Adds `ClashServiceResolutionTests` — a compile cannot catch a DI break, so it resolves the root and walks the whole chain.
- [x] Verified **red** before the fix: `Failed: 2, Passed: 0`
- [x] Verified **green** after: `Failed: 0, Passed: 2`
- [x] `dotnet build Planscape.API` — 0 errors (warnings pre-existing: NU1603, CS0618)

Note: the `Build & Test` / `CI Gate` checks fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)