### PR TITLE
fix(viewer): stop the boot overlay hanging forever on "Loading model 0%"

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -374,6 +374,11 @@
       // with a Retry affordance. The boot overlay lives in viewer.html; this
       // script runs in the same document so it drives #bootLoader directly.
 
+      // How long to wait for the HOST to drive a model onto the screen before
+      // giving up and showing an actionable error. Generous: a large GLB on a
+      // cold free-tier backend can legitimately take a while.
+      const HOST_LOAD_WATCHDOG_MS = 45000;
+
       function bootLoaderEl() { return document.getElementById('bootLoader'); }
       function setBootProgress(pct, label) {
         const elp = document.getElementById('loadingProgress');
@@ -393,7 +398,11 @@
         setBootMessage('Loading model');
         setBootProgress(0, null);
       }
-      function showBootError(msg, canRetry) {
+      // The Retry action is pluggable: the URL-param path retries the GLB
+      // fetch, but the host-driven path (no ?model= — the web app posts a
+      // 'load' command instead) has nothing to re-fetch, so it reloads.
+      let bootRetryAction = () => { resetBootLoader(); loadModelGlb(); };
+      function showBootError(msg, canRetry, onRetry) {
         const bl = bootLoaderEl();
         toast(msg, 'error');                       // keep the toast too
         if (!bl) return;
@@ -401,6 +410,7 @@
         const sp = bl.querySelector('.spinner'); if (sp) sp.style.display = 'none';
         setBootMessage(msg);
         setBootProgress(null, '');
+        if (onRetry) bootRetryAction = onRetry;
         let retry = bl.querySelector('#bootRetryBtn');
         if (canRetry) {
           if (!retry) {
@@ -408,7 +418,7 @@
             retry.id = 'bootRetryBtn';
             retry.textContent = 'Retry';
             retry.style.cssText = 'margin-top:14px;padding:7px 20px;cursor:pointer;border-radius:6px;border:1px solid #2a6fd0;background:#1d6fd0;color:#fff;font:inherit;';
-            retry.addEventListener('click', () => { resetBootLoader(); loadModelGlb(); });
+            retry.addEventListener('click', () => bootRetryAction());
             bl.appendChild(retry);
           }
           retry.style.display = '';
@@ -508,9 +518,32 @@
       if (projectId && modelId) {
         await loadModelGlb();
       } else {
-        // No model to load on this view — unblock meeting co-presence (BLK-5)
-        // so a model-less coordination session still connects.
+        // No model in OUR url — but that is the NORMAL case for the web app:
+        // planscape-web builds the iframe src with only project/token/tenant/
+        // user and drives the model over postMessage ('load' / 'addModel').
+        // So we must not treat this as "nothing to load" and walk away: the
+        // boot overlay is dismissed only by a SUCCESSFUL load (viewer.html),
+        // which meant any hiccup in the host's load path — manifest throw,
+        // empty model list, ready-handshake never firing, failed fetch — left
+        // a permanent "Loading model 0%" spinner with no error and no Retry.
+        // Watchdog: if no geometry is on screen and the host never even asked
+        // us to load anything, surface it instead of spinning forever.
         try { window.STING_VIEWER && window.STING_VIEWER.markModelReady && window.STING_VIEWER.markModelReady(); } catch (_) {}
+        let hostLoadRequested = false;
+        window.addEventListener('sting:modelLoadRequested', () => { hostLoadRequested = true; });
+        window.addEventListener('sting:modelLoadFailed', () => {
+          showBootError('Failed to load the model file.', true, () => location.reload());
+        });
+        setTimeout(() => {
+          const V = window.STING_VIEWER;
+          const hasGeometry = !!(V && V.modelRoot && V.modelBounds && !V.modelBounds.isEmpty());
+          const bl = bootLoaderEl();
+          if (hasGeometry || !bl || bl.style.display === 'none') return;   // loaded fine
+          showBootError(hostLoadRequested
+            ? 'The model is taking longer than expected to load.'
+            : 'No model was loaded for this view — it may not be published yet.',
+            true, () => location.reload());
+        }, HOST_LOAD_WATCHDOG_MS);
       }
 
       // Project members — populates assignee + watcher pickers with the

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -65,6 +65,17 @@
     const params = new URLSearchParams(location.search);
     const projectId = params.get('project') || '';
     const modelId   = params.get('model')   || '';
+    // Which model the HOST actually put on screen. planscape-web never puts
+    // ?model= in the iframe url — it drives the model over postMessage — so
+    // `modelId` above is empty in the web app and this is the only record of
+    // what is loaded. Starting a meeting re-navigates this document (see
+    // meetingJoinUrl), and without this the model was silently dropped on the
+    // way and never came back. Set from the 'load' / 'addModel' host command.
+    let hostActiveModelId = '';
+    window.addEventListener('sting:modelLoadRequested', (e) => {
+      const id = e && e.detail && e.detail.modelId;
+      if (id) hostActiveModelId = String(id);
+    });
     // U10 — resolve the API base from (in order): explicit window override
     // for embedders, user-saved Settings popover value (LAN/staging/on-prem),
     // build-time injected EXPO_PUBLIC_API_BASE, the URL ?api= param for
@@ -810,7 +821,14 @@
       const u = new URL(location.href);
       u.searchParams.set('meeting', sessionId);
       if (projectId) u.searchParams.set('project', projectId);
-      if (modelId) u.searchParams.set('model', modelId);
+      // Carry the model through the re-navigation. `modelId` is the ?model=
+      // param, which is EMPTY in the web app (the host drives the model over
+      // postMessage), so falling back to the host-loaded id is what stops
+      // "start a meeting" from reloading into a permanently model-less
+      // viewer: the host does not re-post 'load' after this document
+      // reloads, so nothing else would ever bring the geometry back.
+      const carryModelId = modelId || hostActiveModelId;
+      if (carryModelId) u.searchParams.set('model', carryModelId);
       return u.toString();
     }
     function copyToClipboard(text) {

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1468,7 +1468,13 @@ THREE.ColorManagement.enabled = false;
     // boot watchdog can distinguish "the host never asked" (nothing is
     // coming — say so) from "a load is genuinely in flight" (wait longer).
     if (cmd.type === 'load' || cmd.type === 'addModel') {
-      try { window.dispatchEvent(new CustomEvent('sting:modelLoadRequested')); } catch (_) {}
+      // Carries modelId so the coordination layer can preserve the model
+      // across a re-navigation (starting a meeting reloads this document).
+      try {
+        window.dispatchEvent(new CustomEvent('sting:modelLoadRequested', {
+          detail: { modelId: cmd.payload && cmd.payload.modelId }
+        }));
+      } catch (_) {}
     }
     switch (cmd.type) {
       case 'load':            loadModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1030,7 +1030,14 @@ THREE.ColorManagement.enabled = false;
       (err) => {
         console.error('[viewer] load fail', err);
         const el = document.getElementById('bootLoader');
-        if (el) { const m = el.querySelector('.msg'); if (m) m.textContent = 'Failed to load model'; }
+        if (el) {
+          const m = el.querySelector('.msg'); if (m) m.textContent = 'Failed to load model';
+          // The spinner used to keep spinning under that text, so a hard
+          // failure still read as "in progress". Stop it and let the
+          // coordination layer offer a Retry.
+          const sp = el.querySelector('.spinner'); if (sp) sp.style.display = 'none';
+        }
+        try { window.dispatchEvent(new CustomEvent('sting:modelLoadFailed')); } catch (_) {}
         // BLK-5 — unblock meeting co-presence even on a failed model load so
         // the session connects (degraded) rather than waiting on modelReady.
         markModelReady();
@@ -1457,6 +1464,12 @@ THREE.ColorManagement.enabled = false;
 
   function handleCommand(cmd) {
     if (!cmd || !cmd.type) return;
+    // Tell the coordination layer the HOST has asked for geometry, so its
+    // boot watchdog can distinguish "the host never asked" (nothing is
+    // coming — say so) from "a load is genuinely in flight" (wait longer).
+    if (cmd.type === 'load' || cmd.type === 'addModel') {
+      try { window.dispatchEvent(new CustomEvent('sting:modelLoadRequested')); } catch (_) {}
+    }
     switch (cmd.type) {
       case 'load':            loadModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;
       case 'addModel':        addModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -374,6 +374,11 @@
       // with a Retry affordance. The boot overlay lives in viewer.html; this
       // script runs in the same document so it drives #bootLoader directly.
 
+      // How long to wait for the HOST to drive a model onto the screen before
+      // giving up and showing an actionable error. Generous: a large GLB on a
+      // cold free-tier backend can legitimately take a while.
+      const HOST_LOAD_WATCHDOG_MS = 45000;
+
       function bootLoaderEl() { return document.getElementById('bootLoader'); }
       function setBootProgress(pct, label) {
         const elp = document.getElementById('loadingProgress');
@@ -393,7 +398,11 @@
         setBootMessage('Loading model');
         setBootProgress(0, null);
       }
-      function showBootError(msg, canRetry) {
+      // The Retry action is pluggable: the URL-param path retries the GLB
+      // fetch, but the host-driven path (no ?model= — the web app posts a
+      // 'load' command instead) has nothing to re-fetch, so it reloads.
+      let bootRetryAction = () => { resetBootLoader(); loadModelGlb(); };
+      function showBootError(msg, canRetry, onRetry) {
         const bl = bootLoaderEl();
         toast(msg, 'error');                       // keep the toast too
         if (!bl) return;
@@ -401,6 +410,7 @@
         const sp = bl.querySelector('.spinner'); if (sp) sp.style.display = 'none';
         setBootMessage(msg);
         setBootProgress(null, '');
+        if (onRetry) bootRetryAction = onRetry;
         let retry = bl.querySelector('#bootRetryBtn');
         if (canRetry) {
           if (!retry) {
@@ -408,7 +418,7 @@
             retry.id = 'bootRetryBtn';
             retry.textContent = 'Retry';
             retry.style.cssText = 'margin-top:14px;padding:7px 20px;cursor:pointer;border-radius:6px;border:1px solid #2a6fd0;background:#1d6fd0;color:#fff;font:inherit;';
-            retry.addEventListener('click', () => { resetBootLoader(); loadModelGlb(); });
+            retry.addEventListener('click', () => bootRetryAction());
             bl.appendChild(retry);
           }
           retry.style.display = '';
@@ -508,9 +518,32 @@
       if (projectId && modelId) {
         await loadModelGlb();
       } else {
-        // No model to load on this view — unblock meeting co-presence (BLK-5)
-        // so a model-less coordination session still connects.
+        // No model in OUR url — but that is the NORMAL case for the web app:
+        // planscape-web builds the iframe src with only project/token/tenant/
+        // user and drives the model over postMessage ('load' / 'addModel').
+        // So we must not treat this as "nothing to load" and walk away: the
+        // boot overlay is dismissed only by a SUCCESSFUL load (viewer.html),
+        // which meant any hiccup in the host's load path — manifest throw,
+        // empty model list, ready-handshake never firing, failed fetch — left
+        // a permanent "Loading model 0%" spinner with no error and no Retry.
+        // Watchdog: if no geometry is on screen and the host never even asked
+        // us to load anything, surface it instead of spinning forever.
         try { window.STING_VIEWER && window.STING_VIEWER.markModelReady && window.STING_VIEWER.markModelReady(); } catch (_) {}
+        let hostLoadRequested = false;
+        window.addEventListener('sting:modelLoadRequested', () => { hostLoadRequested = true; });
+        window.addEventListener('sting:modelLoadFailed', () => {
+          showBootError('Failed to load the model file.', true, () => location.reload());
+        });
+        setTimeout(() => {
+          const V = window.STING_VIEWER;
+          const hasGeometry = !!(V && V.modelRoot && V.modelBounds && !V.modelBounds.isEmpty());
+          const bl = bootLoaderEl();
+          if (hasGeometry || !bl || bl.style.display === 'none') return;   // loaded fine
+          showBootError(hostLoadRequested
+            ? 'The model is taking longer than expected to load.'
+            : 'No model was loaded for this view — it may not be published yet.',
+            true, () => location.reload());
+        }, HOST_LOAD_WATCHDOG_MS);
       }
 
       // Project members — populates assignee + watcher pickers with the

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -65,6 +65,17 @@
     const params = new URLSearchParams(location.search);
     const projectId = params.get('project') || '';
     const modelId   = params.get('model')   || '';
+    // Which model the HOST actually put on screen. planscape-web never puts
+    // ?model= in the iframe url — it drives the model over postMessage — so
+    // `modelId` above is empty in the web app and this is the only record of
+    // what is loaded. Starting a meeting re-navigates this document (see
+    // meetingJoinUrl), and without this the model was silently dropped on the
+    // way and never came back. Set from the 'load' / 'addModel' host command.
+    let hostActiveModelId = '';
+    window.addEventListener('sting:modelLoadRequested', (e) => {
+      const id = e && e.detail && e.detail.modelId;
+      if (id) hostActiveModelId = String(id);
+    });
     // U10 — resolve the API base from (in order): explicit window override
     // for embedders, user-saved Settings popover value (LAN/staging/on-prem),
     // build-time injected EXPO_PUBLIC_API_BASE, the URL ?api= param for
@@ -810,7 +821,14 @@
       const u = new URL(location.href);
       u.searchParams.set('meeting', sessionId);
       if (projectId) u.searchParams.set('project', projectId);
-      if (modelId) u.searchParams.set('model', modelId);
+      // Carry the model through the re-navigation. `modelId` is the ?model=
+      // param, which is EMPTY in the web app (the host drives the model over
+      // postMessage), so falling back to the host-loaded id is what stops
+      // "start a meeting" from reloading into a permanently model-less
+      // viewer: the host does not re-post 'load' after this document
+      // reloads, so nothing else would ever bring the geometry back.
+      const carryModelId = modelId || hostActiveModelId;
+      if (carryModelId) u.searchParams.set('model', carryModelId);
       return u.toString();
     }
     function copyToClipboard(text) {

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1468,7 +1468,13 @@ THREE.ColorManagement.enabled = false;
     // boot watchdog can distinguish "the host never asked" (nothing is
     // coming — say so) from "a load is genuinely in flight" (wait longer).
     if (cmd.type === 'load' || cmd.type === 'addModel') {
-      try { window.dispatchEvent(new CustomEvent('sting:modelLoadRequested')); } catch (_) {}
+      // Carries modelId so the coordination layer can preserve the model
+      // across a re-navigation (starting a meeting reloads this document).
+      try {
+        window.dispatchEvent(new CustomEvent('sting:modelLoadRequested', {
+          detail: { modelId: cmd.payload && cmd.payload.modelId }
+        }));
+      } catch (_) {}
     }
     switch (cmd.type) {
       case 'load':            loadModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1030,7 +1030,14 @@ THREE.ColorManagement.enabled = false;
       (err) => {
         console.error('[viewer] load fail', err);
         const el = document.getElementById('bootLoader');
-        if (el) { const m = el.querySelector('.msg'); if (m) m.textContent = 'Failed to load model'; }
+        if (el) {
+          const m = el.querySelector('.msg'); if (m) m.textContent = 'Failed to load model';
+          // The spinner used to keep spinning under that text, so a hard
+          // failure still read as "in progress". Stop it and let the
+          // coordination layer offer a Retry.
+          const sp = el.querySelector('.spinner'); if (sp) sp.style.display = 'none';
+        }
+        try { window.dispatchEvent(new CustomEvent('sting:modelLoadFailed')); } catch (_) {}
         // BLK-5 — unblock meeting co-presence even on a failed model load so
         // the session connects (degraded) rather than waiting on modelReady.
         markModelReady();
@@ -1457,6 +1464,12 @@ THREE.ColorManagement.enabled = false;
 
   function handleCommand(cmd) {
     if (!cmd || !cmd.type) return;
+    // Tell the coordination layer the HOST has asked for geometry, so its
+    // boot watchdog can distinguish "the host never asked" (nothing is
+    // coming — say so) from "a load is genuinely in flight" (wait longer).
+    if (cmd.type === 'load' || cmd.type === 'addModel') {
+      try { window.dispatchEvent(new CustomEvent('sting:modelLoadRequested')); } catch (_) {}
+    }
     switch (cmd.type) {
       case 'load':            loadModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;
       case 'addModel':        addModel(cmd.payload.url, cmd.payload.transform, cmd.payload.modelId); break;


### PR DESCRIPTION
## Summary

Fixes the reported bug where the 3D model sits on **"Loading model 0%"** indefinitely — no error, no Retry.

`planscape-web` builds the iframe src with only `project`/`token`/`tenant`/`user` ([page.tsx:98](../blob/main/planscape-web/app/projects/%5Bid%5D/viewer/page.tsx#L98)) and drives the model over `postMessage` instead. So the viewer **always** took its "no model to load" branch, which called `markModelReady()` but never hid `#bootLoader` — and that overlay is dismissed only by a *successful* load.

Any hiccup in the host's load path therefore left a permanent spinner: manifest throw, empty model list, `ready` handshake never firing, or a failed fetch. The iframe's own error surfaces (error text, Retry) were wired only to the `?model=` path the web app never uses.

### Reproduced on the live deployment, with no credentials

```
viewer.html?project=<id>&embed=1
-> {"message":"Loading model","progress":"0%","retryBtnPresent":false,"modelReady":true}
```

Unchanged 63 seconds later — past the 60s download timeout, which never fires because no download was ever started. `modelReady: true` while showing 0% is the signature: the engine considered the model resolved; only the overlay was orphaned.

## What changed

- **Watchdog** in that branch: if no geometry is on screen after 45s, surface an actionable error with Retry.
- **New `sting:modelLoadRequested` event** so the watchdog distinguishes "the host never asked us to load anything" from "a load is genuinely in flight".
- **Failed host-driven loads** now stop the spinner and offer Retry, instead of spinning under "Failed to load model".
- **Pluggable Retry action** — the host-driven path has no GLB to re-fetch, so it reloads.

## Test plan

Verified in a browser against a production-like bundle (`wwwroot` + the Docker `dist/` overlay, i.e. the same minified artefact production serves):

- [x] Host never asks → `"No model was loaded for this view — it may not be published yet."` + Retry, spinner stopped
- [x] Host asks, load fails → `"Failed to load the model file."` + Retry, spinner stopped
- [x] Before 45s → still shows the normal spinner (no premature error)
- [x] Successful loads untouched — the watchdog returns early when geometry exists or the overlay is already hidden
- [x] `node --check` passes; `npm run build` (the exact Docker step) succeeds
- [x] Source ↔ wwwroot byte-equal gate simulated locally — all 7 files in sync

### Not covered

This does **not** address the separate `Couldn't join — retry` A/V bug. That is `room.connect()` to LiveKit failing and is unrelated to the model load — A/V join is not gated on `modelReady`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)