### PR TITLE
fix(viewer): make the 3D model viewable on phones

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.css
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.css
@@ -1774,3 +1774,48 @@ tr.row-selected td { color: var(--text-primary); }
 }
 .viewport-wrap.bp-collapsed .walk-joystick { bottom: calc(32px + 66px); }
 .viewport-wrap.bp-expanded  .walk-joystick { bottom: calc(60vh + 66px); }
+
+/* ── Phones ──────────────────────────────────────────────────────────────
+   .app-shell is a three-column grid: left | canvas | right. The panels are
+   240px + 260px = 500px of fixed columns, which is WIDER THAN A PHONE, so
+   at 375px the 1fr canvas column computed to ZERO width — the model was
+   simply invisible on a phone, and the toolbar started off-screen at x=378
+   so Meet / Issues could not be reached either.
+
+   Below 700px the canvas always owns the full width, and the panels become
+   overlays that sit on top of it. Overlaying (rather than keeping them in
+   the grid) is the point: if they still took a column, opening one would
+   squeeze the 3D view back to nothing on exactly the screens that can least
+   afford it. The header toggles still open and close them as before. */
+@media (max-width: 700px) {
+  .app-shell,
+  .app-shell.left-collapsed,
+  .app-shell.right-collapsed,
+  .app-shell.left-collapsed.right-collapsed {
+    grid-template-columns: 0 1fr 0;
+  }
+
+  /* Grid items default to min-width:auto, which lets wide content push the
+     item past the viewport — that is why the header measured 500px. */
+  .header { min-width: 0; overflow-x: auto; }
+  .toolbar { flex-wrap: nowrap; }
+
+  .left-panel,
+  .right-panel {
+    position: fixed;
+    top: var(--toolbar-height);
+    bottom: 0;
+    width: min(86vw, 320px);
+    z-index: 60;
+    box-shadow: 0 0 28px rgba(0, 0, 0, 0.55);
+  }
+  .left-panel  { left: 0; }
+  .right-panel { right: 0; }
+
+  /* On a phone "collapsed" means gone, not a zero-width column. */
+  .app-shell.left-collapsed  .left-panel  { display: none; }
+  .app-shell.right-collapsed .right-panel { display: none; }
+
+  /* Drag-to-resize rails are a mouse affordance and only steal touches. */
+  .rail-handle { display: none; }
+}

--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -4440,6 +4440,18 @@
         if (s.b) $('#bottomPanel')?.classList.add('collapsed');
         if (s.l || s.r || s.b || s.lw || s.rw) onResize();
       } catch (e) {}
+      // Phones start with BOTH panels closed so the 3D view owns the screen.
+      // This deliberately overrides the persisted desktop state: those widths
+      // are restored from localStorage, and a saved "both panels open" would
+      // otherwise reproduce the zero-width-canvas bug on a phone. The header
+      // toggles still open them (as overlays — see the max-width:700px block
+      // in coordination-viewer.css), so nothing is lost, just out of the way.
+      try {
+        if (window.matchMedia && window.matchMedia('(max-width: 700px)').matches) {
+          shell.classList.add('left-collapsed', 'right-collapsed');
+          onResize();
+        }
+      } catch (e) {}
       // V2 — each rail handle: DRAG to resize the panel's width live (clamped), CLICK (no
       // drag) to collapse/expand. Width persists; the canvas + camera resize live via the
       // ortho-aware sizeRenderer so 3D framing stays correct as the viewport reclaims space.

--- a/Planscape/assets/viewer/coordination-viewer.css
+++ b/Planscape/assets/viewer/coordination-viewer.css
@@ -1774,3 +1774,48 @@ tr.row-selected td { color: var(--text-primary); }
 }
 .viewport-wrap.bp-collapsed .walk-joystick { bottom: calc(32px + 66px); }
 .viewport-wrap.bp-expanded  .walk-joystick { bottom: calc(60vh + 66px); }
+
+/* ── Phones ──────────────────────────────────────────────────────────────
+   .app-shell is a three-column grid: left | canvas | right. The panels are
+   240px + 260px = 500px of fixed columns, which is WIDER THAN A PHONE, so
+   at 375px the 1fr canvas column computed to ZERO width — the model was
+   simply invisible on a phone, and the toolbar started off-screen at x=378
+   so Meet / Issues could not be reached either.
+
+   Below 700px the canvas always owns the full width, and the panels become
+   overlays that sit on top of it. Overlaying (rather than keeping them in
+   the grid) is the point: if they still took a column, opening one would
+   squeeze the 3D view back to nothing on exactly the screens that can least
+   afford it. The header toggles still open and close them as before. */
+@media (max-width: 700px) {
+  .app-shell,
+  .app-shell.left-collapsed,
+  .app-shell.right-collapsed,
+  .app-shell.left-collapsed.right-collapsed {
+    grid-template-columns: 0 1fr 0;
+  }
+
+  /* Grid items default to min-width:auto, which lets wide content push the
+     item past the viewport — that is why the header measured 500px. */
+  .header { min-width: 0; overflow-x: auto; }
+  .toolbar { flex-wrap: nowrap; }
+
+  .left-panel,
+  .right-panel {
+    position: fixed;
+    top: var(--toolbar-height);
+    bottom: 0;
+    width: min(86vw, 320px);
+    z-index: 60;
+    box-shadow: 0 0 28px rgba(0, 0, 0, 0.55);
+  }
+  .left-panel  { left: 0; }
+  .right-panel { right: 0; }
+
+  /* On a phone "collapsed" means gone, not a zero-width column. */
+  .app-shell.left-collapsed  .left-panel  { display: none; }
+  .app-shell.right-collapsed .right-panel { display: none; }
+
+  /* Drag-to-resize rails are a mouse affordance and only steal touches. */
+  .rail-handle { display: none; }
+}

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -4440,6 +4440,18 @@
         if (s.b) $('#bottomPanel')?.classList.add('collapsed');
         if (s.l || s.r || s.b || s.lw || s.rw) onResize();
       } catch (e) {}
+      // Phones start with BOTH panels closed so the 3D view owns the screen.
+      // This deliberately overrides the persisted desktop state: those widths
+      // are restored from localStorage, and a saved "both panels open" would
+      // otherwise reproduce the zero-width-canvas bug on a phone. The header
+      // toggles still open them (as overlays — see the max-width:700px block
+      // in coordination-viewer.css), so nothing is lost, just out of the way.
+      try {
+        if (window.matchMedia && window.matchMedia('(max-width: 700px)').matches) {
+          shell.classList.add('left-collapsed', 'right-collapsed');
+          onResize();
+        }
+      } catch (e) {}
       // V2 — each rail handle: DRAG to resize the panel's width live (clamped), CLICK (no
       // drag) to collapse/expand. Width persists; the canvas + camera resize live via the
       // ortho-aware sizeRenderer so 3D framing stays correct as the viewport reclaims space.


### PR DESCRIPTION
## Summary

Members could not view models on their phones **regardless of permissions** — the 3D canvas was literally zero pixels wide.

`.app-shell` is a three-column grid (`left | canvas | right`). The panels are `240px + 260px = 500px` of **fixed** columns, which is wider than a phone viewport, so the `1fr` canvas column computed to zero.

Measured on the live deployment at 375×812:

```
canvasWrap {w: 0}              <- the 3D view, invisible
toolbar    {w: 907, x: 378}    <- starts off-screen; Meet / Issues unreachable
header     {w: 500}
```

## What changed

A `max-width: 700px` breakpoint where:

- The canvas always owns the full width.
- Panels become `position: fixed` overlays. **Overlaying rather than keeping them in the grid is the point** — if they still took a column, opening one would squeeze the 3D view back to nothing on exactly the screens that can least afford it.
- Phones start with both panels closed. This deliberately overrides the persisted desktop state, since a saved "both panels open" would otherwise reproduce the zero-width canvas.
- The header scrolls horizontally instead of running off-screen (grid items default to `min-width: auto`, which is why it measured 500px).
- Drag-to-resize rails are hidden — a mouse affordance that only steals touches.

## Test plan

Verified in-browser, fresh load at **375×812**:

- [x] canvas **375px** (was 0), header 375px, no horizontal overflow, panels hidden
- [x] opening the left panel → overlays at 320px, canvas **stays 375px**
- [x] renderer canvas confirmed via `STING_VIEWER.renderer.domElement` — 375×764 CSS, 750×1528 buffer (2× DPR)

Desktop regression, fresh load at **1280×800**:

- [x] grid `280px 700px 300px`, panels `position: static`, canvas 700px, no forced collapse

Also: `node --check` clean, `npm run build` (the Docker step) succeeds, Source ↔ wwwroot byte-equal gate simulated locally — all 7 files in sync.

## Scope

This fixes **mobile web only**. The React Native app bundles its own copy of `viewer.html` via `Asset.fromModule`, so app users need a new EAS build — `expo-updates` is not installed, so there is no OTA path.

Note: the `Build & Test` / `CI Gate` checks fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)