### PR TITLE
fix(viewer): stop the embedded viewer replacing itself with the old dashboard

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -114,6 +114,15 @@
     // iframe) can pass ?embed=1 to suppress the auto-redirect on 401 and
     // handle re-auth themselves.
     const embedMode     = params.get('embed') === '1';
+    // Being inside ANY iframe counts as embedded, whether or not the host
+    // remembered to pass ?embed=1 — and planscape-web does not pass it. That
+    // omission meant a single 401 sent this document to /index.html, so the
+    // old "office dashboard" page appeared INSIDE the 3D viewer panel and the
+    // model was gone. A frame must never navigate itself out from under its
+    // host; it should report the problem and let the host re-auth.
+    let inIframe = false;
+    try { inIframe = window.top !== window.self; } catch (_) { inIframe = true; } // cross-origin throws
+    const embeddedNoRedirect = embedMode || inIframe;
 
     // ── State ───────────────────────────────────────────────────────────
     const state = {
@@ -221,11 +230,13 @@
           // so a future dashboard-side `?next=` handler can pick it up.
           // Embedders pass ?embed=1 to keep the viewer mounted and
           // re-auth themselves.
-          toast('Sign-in expired — redirecting to login…', 'error');
+          toast(embeddedNoRedirect
+            ? 'Sign-in expired — reload the page to continue.'
+            : 'Sign-in expired — redirecting to login…', 'error');
           if (typeof localStorage !== 'undefined') {
             try { localStorage.removeItem('planscape_token'); } catch (_) {}
           }
-          if (!embedMode) {
+          if (!embeddedNoRedirect) {
             const next = location.pathname + location.search;
             try { sessionStorage.setItem('planscape_post_login_next', next); } catch (_) {}
             setTimeout(() => { location.href = `${apiBase}/index.html`; }, 1500);
@@ -487,9 +498,15 @@
           if (res.status === 401) {
             if (!authChallenged) {
               authChallenged = true;
-              showBootError('Sign-in expired — redirecting to login…', false);
+              // Embedded: stay put and offer a reload. Navigating the frame to
+              // the old dashboard is what replaced the 3D view with a marketing
+              // page and lost the model.
+              showBootError(embeddedNoRedirect
+                ? 'Sign-in expired — reload the page to load this model.'
+                : 'Sign-in expired — redirecting to login…',
+                embeddedNoRedirect, () => location.reload());
               try { localStorage.removeItem('planscape_token'); } catch (_) {}
-              if (!embedMode) {
+              if (!embeddedNoRedirect) {
                 // Same target as the api() helper above: dashboard's login
                 // overlay at /index.html (the bare /login path is a SPA hash).
                 const next = location.pathname + location.search;
@@ -552,7 +569,11 @@
           if (hasGeometry || !bl || bl.style.display === 'none') return;   // loaded fine
           showBootError(hostLoadRequested
             ? 'The model is taking longer than expected to load.'
-            : 'No model was loaded for this view — it may not be published yet.',
+            // Don't blame publishing: the far more common cause is that this
+            // page never sent us a model (expired sign-in, or the host's load
+            // never fired). Telling a user to re-publish a model that is
+            // already published sends them down the wrong path entirely.
+            : 'This page didn\'t send a model to the viewer — try reloading.',
             true, () => location.reload());
         }, HOST_LOAD_WATCHDOG_MS);
       }

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -114,6 +114,15 @@
     // iframe) can pass ?embed=1 to suppress the auto-redirect on 401 and
     // handle re-auth themselves.
     const embedMode     = params.get('embed') === '1';
+    // Being inside ANY iframe counts as embedded, whether or not the host
+    // remembered to pass ?embed=1 — and planscape-web does not pass it. That
+    // omission meant a single 401 sent this document to /index.html, so the
+    // old "office dashboard" page appeared INSIDE the 3D viewer panel and the
+    // model was gone. A frame must never navigate itself out from under its
+    // host; it should report the problem and let the host re-auth.
+    let inIframe = false;
+    try { inIframe = window.top !== window.self; } catch (_) { inIframe = true; } // cross-origin throws
+    const embeddedNoRedirect = embedMode || inIframe;
 
     // ── State ───────────────────────────────────────────────────────────
     const state = {
@@ -221,11 +230,13 @@
           // so a future dashboard-side `?next=` handler can pick it up.
           // Embedders pass ?embed=1 to keep the viewer mounted and
           // re-auth themselves.
-          toast('Sign-in expired — redirecting to login…', 'error');
+          toast(embeddedNoRedirect
+            ? 'Sign-in expired — reload the page to continue.'
+            : 'Sign-in expired — redirecting to login…', 'error');
           if (typeof localStorage !== 'undefined') {
             try { localStorage.removeItem('planscape_token'); } catch (_) {}
           }
-          if (!embedMode) {
+          if (!embeddedNoRedirect) {
             const next = location.pathname + location.search;
             try { sessionStorage.setItem('planscape_post_login_next', next); } catch (_) {}
             setTimeout(() => { location.href = `${apiBase}/index.html`; }, 1500);
@@ -487,9 +498,15 @@
           if (res.status === 401) {
             if (!authChallenged) {
               authChallenged = true;
-              showBootError('Sign-in expired — redirecting to login…', false);
+              // Embedded: stay put and offer a reload. Navigating the frame to
+              // the old dashboard is what replaced the 3D view with a marketing
+              // page and lost the model.
+              showBootError(embeddedNoRedirect
+                ? 'Sign-in expired — reload the page to load this model.'
+                : 'Sign-in expired — redirecting to login…',
+                embeddedNoRedirect, () => location.reload());
               try { localStorage.removeItem('planscape_token'); } catch (_) {}
-              if (!embedMode) {
+              if (!embeddedNoRedirect) {
                 // Same target as the api() helper above: dashboard's login
                 // overlay at /index.html (the bare /login path is a SPA hash).
                 const next = location.pathname + location.search;
@@ -552,7 +569,11 @@
           if (hasGeometry || !bl || bl.style.display === 'none') return;   // loaded fine
           showBootError(hostLoadRequested
             ? 'The model is taking longer than expected to load.'
-            : 'No model was loaded for this view — it may not be published yet.',
+            // Don't blame publishing: the far more common cause is that this
+            // page never sent us a model (expired sign-in, or the host's load
+            // never fired). Telling a user to re-publish a model that is
+            // already published sends them down the wrong path entirely.
+            : 'This page didn\'t send a model to the viewer — try reloading.',
             true, () => location.reload());
         }, HOST_LOAD_WATCHDOG_MS);
       }

--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -26,7 +26,15 @@ export default function ViewerPage() {
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const shellRef = useRef<HTMLDivElement>(null);
-  const [ready, setReady] = useState(false);
+  // A COUNTER, not a boolean. The iframe's onLoad fires on every load of that
+  // document — including when the viewer re-navigates itself (starting a
+  // meeting rewrites its own location). With a boolean, the second onLoad set
+  // `true` to `true`, React bailed out, the load effects below never re-ran,
+  // and the freshly-reloaded viewer was never told which model to show: it sat
+  // on an empty scene forever while the host, from its point of view, had
+  // already done its job. Incrementing re-runs the effects on every load, so
+  // the model is re-sent whenever the iframe document is new.
+  const [ready, setReady] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -274,7 +282,7 @@ export default function ViewerPage() {
             src={viewerSrc}
             title="3D model"
             className="h-full w-full border-0"
-            onLoad={() => setReady(true)}
+            onLoad={() => setReady((n) => n + 1)}
             // camera/microphone/display-capture are what let the embedded
             // meeting actually publish media from this cross-origin frame.
             allow="fullscreen; camera; microphone; display-capture"


### PR DESCRIPTION
## Summary

The 3D panel was showing the **old marketing / office dashboard page** instead of the model. Two defects combined to cause it.

### 1. The viewer navigated itself out of the host frame

On any 401 it ran `location.href = ${apiBase}/index.html`, guarded only by `?embed=1` — which **planscape-web does not pass**. The iframe's token is a snapshot in the URL that never refreshes, so once it expired every call 401'd and the viewer replaced the 3D view with `wwwroot/index.html` — "Planscape — office dashboard" (Mapbox map, pricing table, Compare/Docs/Sign in).

Being inside **any** iframe now counts as embedded, whether or not the host passed the flag. A frame must never navigate itself out from under its host. Embedded, it now reports "Sign-in expired — reload the page" with a Retry.

This also explains the `Offline` pill, the mock clash rows, and the missing model — all downstream of the same 401s.

### 2. The host never re-sent the model after an iframe reload

```jsx
const [ready, setReady] = useState(false);
onLoad={() => setReady(true)}     // fires on EVERY load of that document
useEffect(() => { if (!ready || ...) return; post({type:'load'}) }, [ready, ...])
```

`onLoad` fires again whenever the viewer re-navigates itself, but setting `true` to `true` is a no-op — React bails out and the load effects never re-run, so the reloaded viewer is never told which model to show. It's now a counter, so every iframe load re-sends the model.

### 3. The watchdog stopped blaming publishing

It said "may not be published yet", which sends people off to re-publish a model that is already published. The far more common cause is that the page never sent a model.

## Test plan

Verified in-browser against a stub API returning **CORS-visible 401s**, so the redirect path is genuinely exercised (a cross-origin network error is not enough — it never produces a readable 401):

| Scenario | Result |
|---|---|
| Standalone (top-level) | → `/index.html`, title "Planscape — office dashboard" — login flow **deliberately preserved** |
| Embedded in an iframe, identical 401s | stays on `viewer.html`, title "Planscape · Coordination viewer" |

Also: `node --check` clean, `npm run build` succeeds, Source ↔ wwwroot byte-equal gate simulated locally (all 7 files in sync).

## Note on deleting the old page

This stops that page hijacking the viewer, but does **not** delete it. `wwwroot/index.html` is still the API's root page (`app.UseDefaultFiles()` at [Program.cs:1211](Planscape.Server/src/Planscape.API/Program.cs#L1211)) and the login target for the standalone viewer, so removing it needs its own change — see the PR discussion.

Note: the `Build & Test` / `CI Gate` checks fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)