### PR TITLE
fix(viewer): fetch the element map in the web app, and stop the false "Offline"

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -363,16 +363,48 @@
       }
       renderModels();
 
-      // Element map
-      if (projectId && modelId) {
-        const map = await api(`/api/projects/${projectId}/models/${modelId}/element-map`);
-        if (map) {
-          state.elementMap = map;
-          if (V && V.scene) {
-            // forward to original viewer command so it can populate userData links
-            handleHostCommand({ type: 'elementMap', payload: { map } });
-          }
+      // Element map. This used to be gated on `modelId` — the ?model= param —
+      // which planscape-web NEVER sets, because it drives the model over
+      // postMessage instead. So in the web app the map was simply never
+      // fetched: state.elementMap stayed empty and the Model overview read
+      // "0 Elements / 0% Tagged / 0% Compliance" next to a model that had
+      // just rendered 562 meshes. The model tree, discipline chips, level
+      // bands and the properties panel all read the same map, so they were
+      // starved too. Fetch for whichever model we know about, from either
+      // source, and re-fetch when the host later tells us what it loaded.
+      await loadElementMap(modelId || hostActiveModelId);
+      window.addEventListener('sting:modelLoadRequested', (e) => {
+        const id = e && e.detail && e.detail.modelId;
+        if (id && id !== state.elementMapModelId) loadElementMap(String(id));
+      });
+
+      async function loadElementMap(mid) {
+        if (!projectId || !mid || mid === state.elementMapModelId) return;
+        let map = null;
+        try {
+          map = await api(`/api/projects/${projectId}/models/${mid}/element-map`);
+        } catch (err) {
+          // A model published as pure geometry has no map — that is a normal
+          // state, not a failure. Leave the KPIs at zero and say nothing.
+          console.warn('[coord] element-map unavailable', err && err.message);
+          return;
         }
+        if (!map || !Object.keys(map).length) return;
+        state.elementMap = map;
+        state.elementMapModelId = mid;
+        if (V && V.scene) {
+          // forward to original viewer command so it can populate userData links
+          handleHostCommand({ type: 'elementMap', payload: { map } });
+        }
+        // The map can now land AFTER these were first built (the host tells us
+        // the model id asynchronously), so refresh everything that reads it.
+        try { buildModelTree(); } catch (_) {}
+        try { buildDisciplineChips(); } catch (_) {}
+        try { buildLevelStrip(); } catch (_) {}
+        // Only refresh the overview when nothing is selected — otherwise this
+        // would wipe the element card the user is reading.
+        const selCount = (state.selectedElementGuids && state.selectedElementGuids.size) || 0;
+        if (!selCount && !state.selectedElementGuid) { try { renderProperties(null); } catch (_) {} }
       }
       buildModelTree();
       buildDisciplineChips();
@@ -7535,8 +7567,15 @@
       async function ping() {
         try {
           const res = await fetch(`${apiBase}/health`, { method: 'GET', cache: 'no-store' });
-          setOnline(res.ok);
-          alive = res.ok;
+          // ANY http response means the API answered us, which is all this
+          // pill claims. /health is deliberately locked down in production
+          // (private-range client IP + X-Health-Token, Program.cs), so a
+          // browser ALWAYS gets 403 — `res.ok` left the pill stuck on
+          // "Offline" against a perfectly healthy server, and spammed a 403
+          // into the console every 15 seconds. Only a network-level failure
+          // (the catch below) actually means offline.
+          setOnline(true);
+          alive = true;
         } catch (_) {
           setOnline(false);
           alive = false;

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -363,16 +363,48 @@
       }
       renderModels();
 
-      // Element map
-      if (projectId && modelId) {
-        const map = await api(`/api/projects/${projectId}/models/${modelId}/element-map`);
-        if (map) {
-          state.elementMap = map;
-          if (V && V.scene) {
-            // forward to original viewer command so it can populate userData links
-            handleHostCommand({ type: 'elementMap', payload: { map } });
-          }
+      // Element map. This used to be gated on `modelId` — the ?model= param —
+      // which planscape-web NEVER sets, because it drives the model over
+      // postMessage instead. So in the web app the map was simply never
+      // fetched: state.elementMap stayed empty and the Model overview read
+      // "0 Elements / 0% Tagged / 0% Compliance" next to a model that had
+      // just rendered 562 meshes. The model tree, discipline chips, level
+      // bands and the properties panel all read the same map, so they were
+      // starved too. Fetch for whichever model we know about, from either
+      // source, and re-fetch when the host later tells us what it loaded.
+      await loadElementMap(modelId || hostActiveModelId);
+      window.addEventListener('sting:modelLoadRequested', (e) => {
+        const id = e && e.detail && e.detail.modelId;
+        if (id && id !== state.elementMapModelId) loadElementMap(String(id));
+      });
+
+      async function loadElementMap(mid) {
+        if (!projectId || !mid || mid === state.elementMapModelId) return;
+        let map = null;
+        try {
+          map = await api(`/api/projects/${projectId}/models/${mid}/element-map`);
+        } catch (err) {
+          // A model published as pure geometry has no map — that is a normal
+          // state, not a failure. Leave the KPIs at zero and say nothing.
+          console.warn('[coord] element-map unavailable', err && err.message);
+          return;
         }
+        if (!map || !Object.keys(map).length) return;
+        state.elementMap = map;
+        state.elementMapModelId = mid;
+        if (V && V.scene) {
+          // forward to original viewer command so it can populate userData links
+          handleHostCommand({ type: 'elementMap', payload: { map } });
+        }
+        // The map can now land AFTER these were first built (the host tells us
+        // the model id asynchronously), so refresh everything that reads it.
+        try { buildModelTree(); } catch (_) {}
+        try { buildDisciplineChips(); } catch (_) {}
+        try { buildLevelStrip(); } catch (_) {}
+        // Only refresh the overview when nothing is selected — otherwise this
+        // would wipe the element card the user is reading.
+        const selCount = (state.selectedElementGuids && state.selectedElementGuids.size) || 0;
+        if (!selCount && !state.selectedElementGuid) { try { renderProperties(null); } catch (_) {} }
       }
       buildModelTree();
       buildDisciplineChips();
@@ -7535,8 +7567,15 @@
       async function ping() {
         try {
           const res = await fetch(`${apiBase}/health`, { method: 'GET', cache: 'no-store' });
-          setOnline(res.ok);
-          alive = res.ok;
+          // ANY http response means the API answered us, which is all this
+          // pill claims. /health is deliberately locked down in production
+          // (private-range client IP + X-Health-Token, Program.cs), so a
+          // browser ALWAYS gets 403 — `res.ok` left the pill stuck on
+          // "Offline" against a perfectly healthy server, and spammed a 403
+          // into the console every 15 seconds. Only a network-level failure
+          // (the catch below) actually means offline.
+          setOnline(true);
+          alive = true;
         } catch (_) {
           setOnline(false);
           alive = false;


### PR DESCRIPTION
## Summary

Two independent defects, both visible on every web-app load.

### 1. "0 Elements / 0% Tagged / 0% Compliance" beside a fully rendered model

```js
if (projectId && modelId) { const map = await api(`.../models/${modelId}/element-map`); }
```

The element-map fetch was gated on `modelId` — the `?model=` URL param — which **planscape-web never sets**, because it drives the model over `postMessage` instead. So in the web app the map was simply never requested.

`state.elementMap` stayed empty and everything that reads it was starved: the overview KPIs, the model tree, discipline chips, level bands, and the properties panel. The reporter's console showed the model loading fine (`elementCount: 562`, `mesh→meta resolver: 562/562`) while the panel read `0 ELEMENTS`.

Now it fetches for whichever model id we know about from **either** source, and re-fetches when the host tells us what it loaded (`sting:modelLoadRequested` carries the id). Because the map can now arrive *after* those panels were first built, they're rebuilt when it lands — except the properties card when something is selected, which would wipe what the user is reading.

A model published as pure geometry legitimately has no map; that path is caught and left silent rather than treated as an error.

### 2. The session pill was stuck on "Offline" against a healthy server

It pinged `/health` and used `res.ok` — but `/health` is deliberately locked down in production (private-range client IP + `X-Health-Token`, [Program.cs:1408](Planscape.Server/src/Planscape.API/Program.cs#L1408)), so a **browser always gets 403**. The pill could never read Live, and it spammed a 403 into the console every 15 seconds (dozens visible in the reporter's DevTools).

Any HTTP response means the API answered, which is all this pill claims. Only a network-level failure is really offline.

## Test plan

Verified in-browser against a stub serving 403 on `/health`:

| Scenario | Pill |
|---|---|
| `/health` returns 403 | **Live** |
| server killed (real network failure) | **Offline** |

Also: `node --check` clean, `npm run build` succeeds, Source ↔ wwwroot byte-equal gate simulated locally (all 7 files in sync).

## Caveat on the KPI

This makes the viewer **ask** for the element map — it never did in the web app. Whether the numbers become non-zero depends on whether that model was published with element metadata. If the map is empty server-side, the KPIs stay at 0, and that's a publish/tag-sync question rather than a viewer bug.

Note: the `Build & Test` / `CI Gate` checks fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)