### PR TITLE
fix(viewer): dock the A/V bar clear of the nav controls, tray and minimap

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/livekit-av.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/livekit-av.js
@@ -105,8 +105,13 @@
   window.addEventListener("sting:meetLayout", function (e) {
     var mode = (e.detail && e.detail.mode) || "pip";
     var bar = document.getElementById("lkBar"); if (!bar) return;
-    if (mode === "sidebar") { bar.style.left = "auto"; bar.style.right = "12px"; bar.style.transform = "none"; }
-    else { bar.style.left = "50%"; bar.style.right = "auto"; bar.style.transform = "translateX(-50%)"; }
+    // Every mode now docks right. Bottom-centre put the Join button straight
+    // on top of the nav-controls cluster (Orbit / Pan / Walk / Fit …) and the
+    // level strip, so the two fought for the same pixels and the button was
+    // unclickable in places. Right is the only bottom edge with nothing
+    // competing for it once we clear the minimap.
+    bar.style.left = "auto"; bar.style.right = "12px"; bar.style.transform = "none";
+    positionBarAboveTray(bar);
   });
   // N2 — the host started/stopped recording (MeetingHub RecordingChanged); show the
   // consent "● REC" indicator to EVERYONE.
@@ -948,6 +953,15 @@
         var r = bp.getBoundingClientRect();
         if (r.height > 0 && r.top < window.innerHeight) {
           offset = Math.round(window.innerHeight - r.top) + 16;
+        }
+      }
+      // The bar docks bottom-RIGHT, which is exactly where the minimap lives.
+      // Stack above it rather than on it.
+      var mm = document.getElementById("minimap");
+      if (mm) {
+        var m = mm.getBoundingClientRect();
+        if (m.height > 0 && m.right > window.innerWidth - 260) {
+          offset = Math.max(offset, Math.round(window.innerHeight - m.top) + 16);
         }
       }
     } catch (e) {}

--- a/Planscape.Server/tests/Planscape.Tests/ProjectMemberInviteVisibilityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectMemberInviteVisibilityTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Reported: "I added another project member but it removed itself and could
+/// not reflect in the platform — it couldn't get saved."
+///
+/// The invite endpoint returns 200 and calls SaveChangesAsync, so the row
+/// commits. The question is whether the member is then VISIBLE to the very
+/// next list call. Anything that writes the row outside the reader's tenant
+/// scope — ProjectMember is ITenantScoped and the read has a global
+/// TenantId == CurrentTenantId filter — produces exactly the reported
+/// symptom: saved, returns success, never appears again.
+///
+/// This drives the real round-trip (invite -> list) through the real
+/// container so the answer is measured rather than theorised.
+/// </summary>
+public class ProjectMemberInviteVisibilityTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public ProjectMemberInviteVisibilityTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    [Fact]
+    public async Task InvitedMember_AppearsInTheMemberList()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var email = $"invitee-{Guid.NewGuid():N}@example.com";
+
+        var invite = await client.PostAsJsonAsync(
+            $"/api/projects/{TestData.ProjectId}/members/invite",
+            new { email, projectRole = "Contributor", iso19650Role = "M" });
+
+        var inviteBody = await invite.Content.ReadAsStringAsync();
+        Assert.True(invite.IsSuccessStatusCode,
+            $"invite failed: {(int)invite.StatusCode} {inviteBody}");
+
+        // The exact call the members page makes immediately after inviting.
+        var list = await client.GetAsync($"/api/projects/{TestData.ProjectId}/members");
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+
+        var members = await list.Content.ReadFromJsonAsync<JsonElement>();
+        var emails = members.EnumerateArray()
+            .Select(m => m.TryGetProperty("email", out var e) ? e.GetString() : null)
+            .Where(e => e != null)
+            .ToList();
+
+        Assert.True(emails.Contains(email),
+            $"invited '{email}' is missing from the list — saved but invisible. " +
+            $"list returned: {string.Join(", ", emails)}");
+    }
+}

--- a/Planscape/assets/viewer/livekit-av.js
+++ b/Planscape/assets/viewer/livekit-av.js
@@ -105,8 +105,13 @@
   window.addEventListener("sting:meetLayout", function (e) {
     var mode = (e.detail && e.detail.mode) || "pip";
     var bar = document.getElementById("lkBar"); if (!bar) return;
-    if (mode === "sidebar") { bar.style.left = "auto"; bar.style.right = "12px"; bar.style.transform = "none"; }
-    else { bar.style.left = "50%"; bar.style.right = "auto"; bar.style.transform = "translateX(-50%)"; }
+    // Every mode now docks right. Bottom-centre put the Join button straight
+    // on top of the nav-controls cluster (Orbit / Pan / Walk / Fit …) and the
+    // level strip, so the two fought for the same pixels and the button was
+    // unclickable in places. Right is the only bottom edge with nothing
+    // competing for it once we clear the minimap.
+    bar.style.left = "auto"; bar.style.right = "12px"; bar.style.transform = "none";
+    positionBarAboveTray(bar);
   });
   // N2 — the host started/stopped recording (MeetingHub RecordingChanged); show the
   // consent "● REC" indicator to EVERYONE.
@@ -948,6 +953,15 @@
         var r = bp.getBoundingClientRect();
         if (r.height > 0 && r.top < window.innerHeight) {
           offset = Math.round(window.innerHeight - r.top) + 16;
+        }
+      }
+      // The bar docks bottom-RIGHT, which is exactly where the minimap lives.
+      // Stack above it rather than on it.
+      var mm = document.getElementById("minimap");
+      if (mm) {
+        var m = mm.getBoundingClientRect();
+        if (m.height > 0 && m.right > window.innerWidth - 260) {
+          offset = Math.max(offset, Math.round(window.innerHeight - m.top) + 16);
         }
       }
     } catch (e) {}


### PR DESCRIPTION
## Summary

Two defects put the **Join A/V** control where it couldn't be used.

**1. Occlusion.** The bar was `position:absolute; bottom:12px; z-index:14` — *below* the clash/issues tray. Windowed you got a half-cut "Join A/V"; in full screen with the tray open it vanished entirely, which read as "the join button is missing". Now `position:fixed` (so full screen behaves) at `z-index:1200`, floated above the tray the way the rest of the bottom-anchored UI already does, tracking tray resizes via `ResizeObserver` and capped at half the viewport height.

**2. Collision.** A `sting:meetLayout` handler re-centred the bar on every layout event (default `pip`), dropping it straight onto the nav-controls cluster (Orbit / Pan / Walk / Fit) and the level strip.

That second one is also **why the right-align in my previous commit silently didn't take** — the inline style was correct, then overwritten at runtime. Every mode now docks right, and the vertical offset clears the minimap, which shares that corner.

## Test plan

Verified in-browser with the tray expanded (1280×800), overlap tested against each competing element:

```
join rect {l:1152, t:523, r:1258, b:558}
navControls false · levelStrip false · minimap false · bottomTray false
fully on screen: true
```

## Also: the "member removes itself" report

Adds `ProjectMemberInviteVisibilityTests`, driving **invite → list** through the real container — the exact round-trip the members page performs.

**It passes.** So that round-trip is not broken in isolation: the row commits, and it is visible to the very next list call under a normal tenant context. Four theories are now eliminated (`IsActive` default, missing `SaveChanges`, the `AppUser` filter, and tenant scoping in the happy path).

The test is committed so nobody re-investigates the same ground. Reproducing the real failure still needs the server-side evidence from the moment it happened — the `[invite] sent project=… to=…` log line, or the invite request's response.

Note: the `Build & Test` / `CI Gate` checks fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)