### PR TITLE
fix(viewer): stop fabricating clash data — query the real server

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -9,7 +9,13 @@
 (function () {
   'use strict';
 
-  const USE_MOCK_CLASHES = true;   // server endpoint may not exist yet
+  // Was `true` with the note "server endpoint may not exist yet". It does
+  // exist (GET /clashes, POST /clashes/run), so this flag meant the viewer
+  // NEVER asked the server and always rendered mockClashes() — fabricated
+  // pairings of real element GUIDs, indistinguishable from real findings.
+  // That is why the viewer showed 12 clashes while the server (and the web
+  // app, correctly) had none.
+  const USE_MOCK_CLASHES = false;
 
   // ── Boot guard — wait for STING_VIEWER to be ready ────────────────────
   // C3: bail with a visible error card after 30s so dependency failures
@@ -3854,7 +3860,10 @@
       if (!USE_MOCK_CLASHES && projectId) {
         data = await api(`/api/projects/${projectId}/clashes`);
       }
-      state.clashes = (Array.isArray(data) ? data : (data?.items || null)) || mockClashes();
+      // No fabrication fallback. An empty or failed response means we show
+      // nothing and say so — inventing clashes a coordinator might act on is
+      // far worse than an empty list.
+      state.clashes = Array.isArray(data) ? data : (data?.items || []);
       placeClashPins();
       renderClashes();
       updateBadges();
@@ -6336,9 +6345,19 @@
           onResize();
         });
       }
-      $('#btnRunDetect').addEventListener('click', () => {
-        toast('Running clash detection… (mock)', 'warn');
-        setTimeout(() => { state.clashes = mockClashes(); placeClashPins(); renderClashes(); toast('Clash detection complete', 'success'); }, 1200);
+      $('#btnRunDetect').addEventListener('click', async () => {
+        // Previously this invented results client-side and reported success.
+        // Run the REAL detection job on the server, then reload the roster.
+        if (!projectId) return toast('No project — cannot run detection', 'warn');
+        toast('Running clash detection…');
+        try {
+          await api(`/api/projects/${projectId}/clashes/run`, { method: 'POST' });
+          await loadClashes();
+          toast(`Clash detection complete — ${state.clashes.length} found`, 'success');
+        } catch (err) {
+          console.warn('[coord] clash detection failed', err && err.message);
+          toast('Clash detection failed — see console', 'error');
+        }
       });
       $('#btnExportCsv').addEventListener('click', exportClashesCsv);
       $('#btnExportIssues').addEventListener('click', exportIssuesCsv);

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -9,7 +9,13 @@
 (function () {
   'use strict';
 
-  const USE_MOCK_CLASHES = true;   // server endpoint may not exist yet
+  // Was `true` with the note "server endpoint may not exist yet". It does
+  // exist (GET /clashes, POST /clashes/run), so this flag meant the viewer
+  // NEVER asked the server and always rendered mockClashes() — fabricated
+  // pairings of real element GUIDs, indistinguishable from real findings.
+  // That is why the viewer showed 12 clashes while the server (and the web
+  // app, correctly) had none.
+  const USE_MOCK_CLASHES = false;
 
   // ── Boot guard — wait for STING_VIEWER to be ready ────────────────────
   // C3: bail with a visible error card after 30s so dependency failures
@@ -3854,7 +3860,10 @@
       if (!USE_MOCK_CLASHES && projectId) {
         data = await api(`/api/projects/${projectId}/clashes`);
       }
-      state.clashes = (Array.isArray(data) ? data : (data?.items || null)) || mockClashes();
+      // No fabrication fallback. An empty or failed response means we show
+      // nothing and say so — inventing clashes a coordinator might act on is
+      // far worse than an empty list.
+      state.clashes = Array.isArray(data) ? data : (data?.items || []);
       placeClashPins();
       renderClashes();
       updateBadges();
@@ -6336,9 +6345,19 @@
           onResize();
         });
       }
-      $('#btnRunDetect').addEventListener('click', () => {
-        toast('Running clash detection… (mock)', 'warn');
-        setTimeout(() => { state.clashes = mockClashes(); placeClashPins(); renderClashes(); toast('Clash detection complete', 'success'); }, 1200);
+      $('#btnRunDetect').addEventListener('click', async () => {
+        // Previously this invented results client-side and reported success.
+        // Run the REAL detection job on the server, then reload the roster.
+        if (!projectId) return toast('No project — cannot run detection', 'warn');
+        toast('Running clash detection…');
+        try {
+          await api(`/api/projects/${projectId}/clashes/run`, { method: 'POST' });
+          await loadClashes();
+          toast(`Clash detection complete — ${state.clashes.length} found`, 'success');
+        } catch (err) {
+          console.warn('[coord] clash detection failed', err && err.message);
+          toast('Clash detection failed — see console', 'error');
+        }
       });
       $('#btnExportCsv').addEventListener('click', exportClashesCsv);
       $('#btnExportIssues').addEventListener('click', exportIssuesCsv);


### PR DESCRIPTION
## Summary

The viewer reported **12 clashes** while the server — and the web app reading it — correctly reported **none**. The 12 were invented.

```js
const USE_MOCK_CLASHES = true;   // server endpoint may not exist yet
if (!USE_MOCK_CLASHES && projectId) { data = await api(...) }
```

The guard was permanently off, so **the viewer never queried the server** and always fell through to `mockClashes()` — which synthesises clashes by randomly pairing **real element GUIDs** from `state.elementMap`. The fakes therefore carried genuine element names (`Basic roof 43`, `Picture Frame`, `1200 STAIR`) with random overlap values, indistinguishable from real findings.

**A coordinator could open an issue against a clash that does not exist.**

The endpoint the comment doubted does exist (`GET /clashes`, `POST /clashes/run`); its DI break was fixed in #521.

## Changes

1. `USE_MOCK_CLASHES` → `false`, so the roster is actually fetched.
2. The `mockClashes()` fallback is removed — an empty or failed response yields an empty list, not invention.
3. **"Run clash detection" ran nothing.** It fabricated results client-side and toasted "complete". It now `POST`s `/clashes/run`, reloads, and reports the real count (or an honest failure).

This also corrects the Model overview KPI, which #528 had faithfully wired to the fabricated count.

## Test plan

- [x] `node --check` clean; `npm run build` (the Docker step) succeeds
- [x] Both fabrication call sites removed — `mockClashes()` has no remaining callers
- [x] Source ↔ wwwroot byte-equal gate simulated locally, all 7 files in sync

**Expected after deploy:** the viewer shows the same count as the web Clashes page — currently 0 — until detection is actually run. That is the correct behaviour, and the disagreement the reporter saw disappears.

Note: `Build & Test` / `CI Gate` fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)