### PR TITLE
fix(web): make the viewer full-screen toggle icon-only

### DIFF
--- a/planscape-web/app/projects/[id]/viewer/page.tsx
+++ b/planscape-web/app/projects/[id]/viewer/page.tsx
@@ -267,14 +267,22 @@ export default function ViewerPage() {
         )}
         style={isFullscreen ? undefined : { height: '70vh' }}
       >
+        {/* Icon-only, and deliberately so. This button floats over the top-right
+            of the embedded viewer — exactly where that viewer's own toolbar ends.
+            A labelled "⤢ Full screen" / "⤡ Exit full screen" pill was wide enough
+            to cover the last toolbar entries, which is the same class of problem
+            fullscreen was added to solve. A single glyph masks ~5x less, and the
+            title/aria-label still carry the wording. Sized to match the viewer's
+            own .tbtn icon buttons (6px/8px padding, small radius). */}
         <button
           type="button"
           onClick={toggleFullscreen}
           title={isFullscreen ? 'Exit full screen (Esc)' : 'Full screen'}
           aria-label={isFullscreen ? 'Exit full screen' : 'Enter full screen'}
-          className="absolute right-2 top-2 z-10 rounded border border-border-strong bg-surface/90 px-2 py-1 text-xs text-fg shadow-sm backdrop-blur transition hover:bg-surface-3"
+          aria-pressed={isFullscreen}
+          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded border border-border-strong bg-surface/90 text-sm leading-none text-fg shadow-sm backdrop-blur transition hover:bg-surface-3"
         >
-          {isFullscreen ? '⤡ Exit full screen' : '⤢ Full screen'}
+          <span aria-hidden="true">{isFullscreen ? '⤡' : '⛶'}</span>
         </button>
         {viewerSrc && (
           <iframe


### PR DESCRIPTION
## Summary

The full-screen toggle on the project viewer page is absolutely positioned over the top-right of the embedded viewer iframe — which is precisely where the viewer's own dense toolbar (Measure / Section / View / Clashes / Issues / Markup / Meet) ends.

The labelled pill (`⤢ Full screen` / `⤡ Exit full screen`) was wide enough to cover the last toolbar entries. That is the same class of problem full screen exists to solve: the comment directly above this button records that a clipped **Meet** button was misdiagnosed as "no live meeting camera", when it was really "the button is off-screen". The fix for the clipped toolbar was itself clipping the toolbar.

Now a single glyph (`⛶` when windowed, `⤡` when full screen), sized `h-7 w-7` to match the viewer's own `.tbtn` icon buttons (`padding: 6px 8px`, small radius). The wording is preserved in `title` and `aria-label`.

Also adds `aria-pressed`, which the previous text-swap implementation never exposed — a screen-reader user had no way to know the toggle's state beyond the changing label.

## Where this lives

`planscape-web/app/projects/[id]/viewer/page.tsx` — the **Next.js web app**, not `Planscape/assets/viewer/`. This is the only full-screen implementation in the repo (`grep -rl "requestFullscreen"` matches this file and a compiled `_next` chunk). So it is outside the 7-file viewer CI gate and needs no `wwwroot` sync.

## Test plan

- `npm run typecheck` (`tsc --noEmit`) in `planscape-web` → **clean**, run on this machine.
- Not exercised in a browser — `planscape-web` needs a running API to render the viewer page, which I did not stand up.

Manual check, `/projects/{id}/viewer`:

1. The control renders as a single square glyph in the top-right of the viewer frame, no text.
2. Hovering shows "Full screen"; in full screen it shows "Exit full screen (Esc)".
3. Toggling still enters/leaves full screen, and `Esc` still exits (both paths unchanged).
4. The viewer's own toolbar is visibly less obscured — in particular **Meet** should now be reachable at the windowed 70vh size.
5. Screen reader announces the button as a toggle with a pressed state.

## Notes

- Purely presentational — no change to `toggleFullscreen`, the `fullscreenchange` listener, or the Esc handling.
- Known-broken CI: `Build & Test` / `CI Gate` fail on a Postgres service container (`role "root" does not exist`) — broken on `main`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)