### PR TITLE
fix(viewer): stop the heartbeat polling an endpoint it can never reach

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
+++ b/Planscape.Server/src/Planscape.API/wwwroot/coordination-viewer.js
@@ -7609,14 +7609,21 @@
       let alive = true;
       async function ping() {
         try {
-          const res = await fetch(`${apiBase}/health`, { method: 'GET', cache: 'no-store' });
-          // ANY http response means the API answered us, which is all this
-          // pill claims. /health is deliberately locked down in production
-          // (private-range client IP + X-Health-Token, Program.cs), so a
-          // browser ALWAYS gets 403 — `res.ok` left the pill stuck on
-          // "Offline" against a perfectly healthy server, and spammed a 403
-          // into the console every 15 seconds. Only a network-level failure
-          // (the catch below) actually means offline.
+          // /health/live, NOT /health.
+          //
+          // /health is deliberately locked down in production — it needs a
+          // private-range client IP AND a matching X-Health-Token header
+          // (Program.cs:1409-1418). A browser satisfies neither, so it got a
+          // 403 every single time. The previous code worked around that by
+          // treating any HTTP response as "reachable", which kept the pill
+          // honest but still put a failed request in the console every 15s —
+          // ~240 an hour, burying real errors.
+          //
+          // /health/live is AllowAnonymous, returns 200 with no DB hit
+          // (Program.cs:1375), and exists for exactly this kind of ping.
+          const res = await fetch(`${apiBase}/health/live`, { method: 'GET', cache: 'no-store' });
+          // Any HTTP response still means the API answered, which is all this
+          // pill claims; only a network-level failure (catch) means offline.
           setOnline(true);
           alive = true;
         } catch (_) {

--- a/Planscape/assets/viewer/coordination-viewer.js
+++ b/Planscape/assets/viewer/coordination-viewer.js
@@ -7609,14 +7609,21 @@
       let alive = true;
       async function ping() {
         try {
-          const res = await fetch(`${apiBase}/health`, { method: 'GET', cache: 'no-store' });
-          // ANY http response means the API answered us, which is all this
-          // pill claims. /health is deliberately locked down in production
-          // (private-range client IP + X-Health-Token, Program.cs), so a
-          // browser ALWAYS gets 403 — `res.ok` left the pill stuck on
-          // "Offline" against a perfectly healthy server, and spammed a 403
-          // into the console every 15 seconds. Only a network-level failure
-          // (the catch below) actually means offline.
+          // /health/live, NOT /health.
+          //
+          // /health is deliberately locked down in production — it needs a
+          // private-range client IP AND a matching X-Health-Token header
+          // (Program.cs:1409-1418). A browser satisfies neither, so it got a
+          // 403 every single time. The previous code worked around that by
+          // treating any HTTP response as "reachable", which kept the pill
+          // honest but still put a failed request in the console every 15s —
+          // ~240 an hour, burying real errors.
+          //
+          // /health/live is AllowAnonymous, returns 200 with no DB hit
+          // (Program.cs:1375), and exists for exactly this kind of ping.
+          const res = await fetch(`${apiBase}/health/live`, { method: 'GET', cache: 'no-store' });
+          // Any HTTP response still means the API answered, which is all this
+          // pill claims; only a network-level failure (catch) means offline.
           setOnline(true);
           alive = true;
         } catch (_) {


### PR DESCRIPTION
## Summary

The Live/Offline pill pinged `${apiBase}/health` every 15 seconds. In production that endpoint requires **both** a private-range client IP **and** a matching `X-Health-Token` header:

```csharp
var allowed = env.IsDevelopment() ? isPrivate : isPrivate && tokenOk;   // Program.cs:1414-1418
if (!allowed) return Results.Json(new { status = "forbidden" }, statusCode: 403);
```

A browser satisfies neither, so it is **403-by-design** — ~240 failed requests an hour, burying real errors in the console.

The previous code already knew this: it treated *any* HTTP response as "reachable" so the pill stayed honest against a healthy server. That fixed the pill and left the noise, because the request still fails at the network layer regardless of how the JS interprets it.

## Fix

Point the ping at **`/health/live`** — `AllowAnonymous`, returns 200, no DB hit (`Program.cs:1375`), and its own comment says it exists for orchestrator and mobile pings. It's also already excluded from the OpenTelemetry sampler (`Program.cs:1154`), so a 15s poll doesn't eat the tracing budget.

Semantics for the pill are unchanged: any response means the API answered; only a network-level failure (the `catch`) means offline.

## Verification

Headless Edge/CDP against a stub that 403s `/health` and 200s `/health/live`:

| | before | after |
|---|---|---|
| health endpoints requested | `/health` | `["/health/live"]` |
| health-related console errors | one per 15s | **0** |
| session pill | `Live` | `Live` |

Build clean; all **7 gated files byte-identical** across both locations.

## Notes

- `/health` itself is untouched — it remains the locked-down full diagnostic for orchestrators with the token.
- Known-broken CI: `Build & Test` / `CI Gate` fail on a Postgres service container (`role "root" does not exist`) — broken on `main`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)