### PR TITLE
feat(server): one capability layer to replace eleven dead "PM" gates

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -40,6 +40,7 @@ on:
       - 'stingtools-core/python/**'
       - 'StingBridge/**'
       - 'Planscape/**'
+      - 'planscape-web/**'
       - '.github/workflows/contract-drift.yml'
   pull_request:
     paths:
@@ -49,6 +50,7 @@ on:
       - 'stingtools-core/python/**'
       - 'StingBridge/**'
       - 'Planscape/**'
+      - 'planscape-web/**'
       - '.github/workflows/contract-drift.yml'
   workflow_dispatch:
 

--- a/Planscape.Server/src/Planscape.API/Controllers/DistributionGroupsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DistributionGroupsController.cs
@@ -191,16 +191,11 @@ public class DistributionGroupsController : ControllerBase
         return NoContent();
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoAlbumsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoAlbumsController.cs
@@ -384,16 +384,11 @@ public class PhotoAlbumsController : ControllerBase
     /// Mutation gate (matches SitePhotosController.IsApproverAsync):
     /// tenant Admin / Owner OR project PM.
     /// </summary>
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
 
     /// <summary>
     /// Read gate: project member always sees Internal/Members; Client

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoChecklistsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoChecklistsController.cs
@@ -309,16 +309,11 @@ public class PhotoChecklistsController : ControllerBase
         return Ok(c);
     }
 
-    private async Task<bool> IsAuthorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsAuthorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoPolicyController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoPolicyController.cs
@@ -92,16 +92,11 @@ public class PhotoPolicyController : ControllerBase
         return Ok(pol);
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoShareController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoShareController.cs
@@ -111,16 +111,11 @@ public class PhotoShareLinkAdminController : ControllerBase
         return Ok(link);
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -415,6 +415,18 @@ public class ProjectMembersController : ControllerBase
             member.AllowedSuitabilities = profile.AllowedSuitabilities;
         }
 
+        // ProjectRole used to accept ANY string here with no validation, which
+        // is how the vocabulary drifted far enough for eleven gates to end up
+        // testing an Iso19650Role code ("PM") against this column. Reject
+        // anything outside the canonical set; same error shape as invalid_kind
+        // in DistributionGroupsController.
+        //
+        // Iso19650Role is deliberately NOT validated in this pass — its
+        // vocabulary lives in GetRoles() below and constraining it is a
+        // separate, wider change.
+        if (req.ProjectRole != null && !ProjectRoles.IsCanonical(req.ProjectRole))
+            return BadRequest(new { error = "invalid_project_role", allowed = ProjectRoles.All });
+
         if (req.ProjectRole  != null) member.ProjectRole  = req.ProjectRole;
         if (req.Iso19650Role != null) member.Iso19650Role = req.Iso19650Role;
         // Phase 177 — pass null array to leave a column unchanged; pass an

--- a/Planscape.Server/src/Planscape.API/Controllers/SavedViewsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SavedViewsController.cs
@@ -131,9 +131,10 @@ public class SavedViewsController : ControllerBase
         bool isPrivileged = role is "Admin" or "Owner";
         if (!isPrivileged && view.CapturedByUserId != actor)
         {
-            // PM-on-this-project also OK
-            isPrivileged = await _db.ProjectMembers.AnyAsync(m =>
-                m.ProjectId == projectId && m.UserId == actor && m.IsActive && m.ProjectRole == "PM", ct);
+            // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+            // ProjectRole column, so it matched essentially nobody and only the
+            // tenant Admin/Owner branch above ever granted this.
+            isPrivileged = await this.CanCurateProjectAsync(_db, projectId, ct);
         }
         if (!isPrivileged && view.CapturedByUserId != actor) return Forbid();
 

--- a/Planscape.Server/src/Planscape.API/Controllers/SitePhotosController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SitePhotosController.cs
@@ -870,19 +870,15 @@ public class SitePhotosController : ControllerBase
         await _db.SitePhotos.FirstOrDefaultAsync(p => p.Id == photoId && p.ProjectId == projectId, ct);
 
     /// <summary>
-    /// Approval gate (decision #1): tenant Admin / Owner OR
-    /// ProjectMember.ProjectRole == "PM" on this project.
+    /// Approval gate (decision #1): tenant Admin / Owner OR a member holding
+    /// the ApproveSitePhotos capability on this project (ProjectRole in
+    /// Manager/Owner/Admin, or Iso19650Role in PM/A). See ProjectRoles.
     /// </summary>
-    private async Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
 
     private Guid? CurrentUserIdOrNull()
     {

--- a/Planscape.Server/src/Planscape.API/Controllers/SitePhotosExtController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SitePhotosExtController.cs
@@ -599,16 +599,11 @@ public class SitePhotosExtController : ControllerBase
 
     // ── helpers ──────────────────────────────────────────────────────
 
-    private async Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
+++ b/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
 using Planscape.Infrastructure.Authorization;
 using Planscape.Infrastructure.Data;
 
@@ -34,6 +36,59 @@ public static class ControllerProjectMembershipExtensions
             return controller.StatusCode(403, new { error = "You are not a member of this project" });
         }
         return null;
+    }
+
+    /// <summary>
+    /// True when the caller may CURATE this project — albums, checklists,
+    /// distribution groups, deleting another member's saved view.
+    ///
+    /// Replaces the hand-rolled `ProjectRole == "PM"` check that was copied
+    /// into eight controllers. "PM" is an Iso19650Role code, never a
+    /// ProjectRole, so those checks matched (essentially) nobody — see
+    /// <see cref="ProjectRoles"/> for the full explanation.
+    /// </summary>
+    public static Task<bool> CanCurateProjectAsync(
+        this ControllerBase controller, PlanscapeDbContext db, Guid projectId, CancellationToken ct = default)
+        => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanCurateProject, ct);
+
+    /// <summary>
+    /// True when the caller may APPROVE site photos — approve/reject,
+    /// include-originals, issue share links, PUT the photo policy. Narrower
+    /// than curation: these decisions release imagery outside the project.
+    /// </summary>
+    public static Task<bool> CanApproveSitePhotosAsync(
+        this ControllerBase controller, PlanscapeDbContext db, Guid projectId, CancellationToken ct = default)
+        => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanApproveSitePhotosPredicate, ct);
+
+    /// <summary>
+    /// Shared body. The tenant `role` claim (Admin / Owner) grants without any
+    /// ProjectMember row — that is pre-existing behaviour at every site this
+    /// replaces, kept deliberately.
+    /// </summary>
+    private static async Task<bool> HasCapabilityAsync(
+        ControllerBase controller,
+        PlanscapeDbContext db,
+        Guid projectId,
+        System.Linq.Expressions.Expression<Func<ProjectMember, bool>> capability,
+        CancellationToken ct)
+    {
+        var user = controller.User;
+
+        // Match the claim shapes the replaced sites used: several read the raw
+        // "role" claim rather than IsInRole, so check both.
+        var roleClaim = user.FindFirst("role")?.Value ?? "";
+        if (roleClaim is "Admin" or "Owner" || user.IsInRole("Admin") || user.IsInRole("Owner"))
+            return true;
+
+        var userId = ParseGuid(user.FindFirst("user_id")?.Value
+                              ?? user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                              ?? user.FindFirst("sub")?.Value);
+        if (userId == Guid.Empty) return false;
+
+        return await db.ProjectMembers.AsNoTracking()
+            .Where(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive)
+            .Where(capability)
+            .AnyAsync(ct);
     }
 
     private static Guid ParseGuid(string? value)

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
@@ -1,0 +1,135 @@
+using System.Linq.Expressions;
+
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// The canonical <see cref="ProjectMember.ProjectRole"/> vocabulary, and the
+/// capability predicates derived from it.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// Eleven call sites gated on <c>ProjectRole == "PM"</c>. But "PM" is not a
+/// ProjectRole at all — the two fields carry different vocabularies, and each
+/// says so on itself:
+///
+///   ProjectMember.cs:15  ProjectRole   "Viewer/Contributor/Coordinator/Manager"
+///   ProjectMember.cs:18  Iso19650Role  "A/PM/BC/AR/SE/ME/QS etc."
+///
+/// "PM" only ever appears in the ISO 19650 list — which is also what
+/// <c>GET api/projects/{id}/members/roles</c> returns, and what the web grid
+/// saves into <c>iso19650Role</c>. Those eleven sites were reading the right
+/// code off the wrong column, so the gates matched (essentially) nobody.
+///
+/// This is a wrong-field bug, not a data migration.
+///
+/// TWO SHAPES, DELIBERATELY
+/// ------------------------
+/// Controllers need a claims-aware async check (the tenant `role` claim can
+/// grant access without any ProjectMember row). Background jobs need something
+/// EF can translate INSIDE a <c>.Where(...)</c>. A method the jobs called
+/// per-row would silently client-evaluate the whole table, so the job-facing
+/// shape is an <see cref="Expression"/> and stays one.
+///
+/// Keep the two in step: <see cref="CanCurateProject"/> is the expression form
+/// of <see cref="CanCurate"/>, and likewise for the approval pair. The tests
+/// assert they agree.
+/// </summary>
+public static class ProjectRoles
+{
+    // ── Canonical ProjectRole vocabulary ────────────────────────────────────
+    // Viewer..Admin mirror the web members dropdown
+    // (planscape-web/app/projects/[id]/members/page.tsx:23). ClientGuest is
+    // included because DailyPhotoDigestJob.cs:126 already reads it, so it is
+    // a real value in the system whether or not the UI offers it.
+
+    public const string Viewer      = "Viewer";
+    public const string Contributor = "Contributor";
+    public const string Coordinator = "Coordinator";
+    public const string Manager     = "Manager";
+    public const string Owner       = "Owner";
+    public const string Admin       = "Admin";
+    public const string ClientGuest = "ClientGuest";
+
+    /// <summary>Every legal ProjectRole. Order matches the web dropdown, with
+    /// ClientGuest appended.</summary>
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Viewer, Contributor, Coordinator, Manager, Owner, Admin, ClientGuest,
+    };
+
+    /// <summary>Case-insensitive membership test for write validation.</summary>
+    public static bool IsCanonical(string? role)
+        => role != null && All.Any(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));
+
+    // ── ISO 19650 role codes that carry project authority ───────────────────
+    // A  = Appointing Party, PM = Project Manager, BC = BIM Coordinator.
+    // These come from the Iso19650Role column — the one that actually holds
+    // "PM" — which is the whole point of this class.
+
+    private const string IsoAppointingParty = "A";
+    private const string IsoProjectManager  = "PM";
+    private const string IsoBimCoordinator  = "BC";
+
+    // ── LEGACY TOLERANCE — read this before "tidying" it away ───────────────
+    //
+    // The gates being replaced tested `ProjectRole == "PM"`. "PM" is not a
+    // canonical ProjectRole and no first-party UI writes it there — but
+    // ProjectMembersController:418 accepted ANY string with no validation
+    // until this change, so a row with ProjectRole = "PM" is possible and any
+    // such row passes the CURRENT gate.
+    //
+    // Dropping it would NARROW access for those rows, which is exactly what
+    // this change promises not to do. So "PM" is accepted as a ProjectRole
+    // here for back-compat, while `All` deliberately excludes it so new writes
+    // are rejected. Remove only after confirming no rows carry it.
+    private const string LegacyProjectRolePm = "PM";
+
+    // ── Capability: CurateProject ───────────────────────────────────────────
+    // Albums, checklists, distribution groups, deleting another member's saved
+    // view. Broader than photo approval: curation is organising, not signing off.
+
+    /// <summary>In-memory form. <paramref name="isTenantAdmin"/> covers the
+    /// tenant `role` claim being Admin or Owner, which grants regardless of
+    /// any ProjectMember row.</summary>
+    public static bool CanCurate(string? projectRole, string? iso19650Role, bool isTenantAdmin = false)
+        => isTenantAdmin
+        || Eq(projectRole, Manager) || Eq(projectRole, Owner) || Eq(projectRole, Admin)
+        || Eq(projectRole, Coordinator) || Eq(projectRole, LegacyProjectRolePm)
+        || Eq(iso19650Role, IsoProjectManager) || Eq(iso19650Role, IsoAppointingParty)
+        || Eq(iso19650Role, IsoBimCoordinator);
+
+    /// <summary>EF-translatable form for use inside <c>.Where(...)</c>.
+    /// Deliberately written with plain <c>==</c> and <c>||</c> so it becomes a
+    /// SQL <c>OR</c> chain rather than client evaluation.</summary>
+    public static Expression<Func<ProjectMember, bool>> CanCurateProject =>
+        m => m.ProjectRole == Manager
+          || m.ProjectRole == Owner
+          || m.ProjectRole == Admin
+          || m.ProjectRole == Coordinator
+          || m.ProjectRole == LegacyProjectRolePm
+          || m.Iso19650Role == IsoProjectManager
+          || m.Iso19650Role == IsoAppointingParty
+          || m.Iso19650Role == IsoBimCoordinator;
+
+    // ── Capability: ApproveSitePhotos ───────────────────────────────────────
+    // Photo approve/reject, include-originals, share-link issuance, PUT
+    // photo-policy. Narrower: these decisions release imagery outside the
+    // project, so a Coordinator curating albums does not get them.
+
+    public static bool CanApproveSitePhotos(string? projectRole, string? iso19650Role, bool isTenantAdmin = false)
+        => isTenantAdmin
+        || Eq(projectRole, Manager) || Eq(projectRole, Owner) || Eq(projectRole, Admin)
+        || Eq(projectRole, LegacyProjectRolePm)
+        || Eq(iso19650Role, IsoProjectManager) || Eq(iso19650Role, IsoAppointingParty);
+
+    public static Expression<Func<ProjectMember, bool>> CanApproveSitePhotosPredicate =>
+        m => m.ProjectRole == Manager
+          || m.ProjectRole == Owner
+          || m.ProjectRole == Admin
+          || m.ProjectRole == LegacyProjectRolePm
+          || m.Iso19650Role == IsoProjectManager
+          || m.Iso19650Role == IsoAppointingParty;
+
+    private static bool Eq(string? a, string b)
+        => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/BackgroundJobs.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/BackgroundJobs.cs
@@ -311,7 +311,11 @@ public class SlaEscalationJob
             {
                 var pmIds = await db.ProjectMembers
                     .AsNoTracking()
-                    .Where(m => m.ProjectId == issue.ProjectId && m.IsActive && m.ProjectRole == "PM")
+                    // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+                    // ProjectRole column, so this escalation notified nobody.
+                    // Chained .Where keeps the predicate EF-translatable.
+                    .Where(m => m.ProjectId == issue.ProjectId && m.IsActive)
+                    .Where(Planscape.Core.Entities.ProjectRoles.CanCurateProject)
                     .Select(m => m.UserId)
                     .Distinct()
                     .ToListAsync(ct);

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/DailyPhotoDigestJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/DailyPhotoDigestJob.cs
@@ -153,8 +153,13 @@ public class DailyPhotoDigestJob
         if (pendingReviewCount > 0)
         {
             var approvers = await (
+                // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+                // ProjectRole column, so the approver nudge emailed nobody. Query
+                // syntax cannot take an Expression in its `where`, so the
+                // capability is applied to the SOURCE, keeping it SQL-translated.
                 from m in _db.ProjectMembers.AsNoTracking()
-                where m.ProjectId == projectId && m.IsActive && m.ProjectRole == "PM"
+                             .Where(Planscape.Core.Entities.ProjectRoles.CanApproveSitePhotosPredicate)
+                where m.ProjectId == projectId && m.IsActive
                 join u in _db.Users.AsNoTracking() on m.UserId equals u.Id
                 join p in _db.UserNotificationPreferences.AsNoTracking() on u.Id equals p.UserId into pg
                 from p in pg.DefaultIfEmpty()

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/P6LiveLinkService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/P6LiveLinkService.cs
@@ -285,7 +285,10 @@ public class P6LiveLinkService
         {
             var pmUserIds = await db.ProjectMembers
                 .AsNoTracking()
-                .Where(m => m.ProjectId == projectId && m.IsActive && m.ProjectRole == "PM")
+                // Was `ProjectRole == "PM"` — see ProjectRoles. Chained .Where so
+                // the capability predicate is translated to SQL, not client-evaluated.
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(Planscape.Core.Entities.ProjectRoles.CanCurateProject)
                 .Select(m => m.UserId)
                 .Distinct()
                 .ToListAsync(ct);

--- a/Planscape.Server/tests/Planscape.Tests/ProjectRoleCapabilityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectRoleCapabilityTests.cs
@@ -1,0 +1,271 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The capability layer that replaced eleven `ProjectRole == "PM"` gates.
+///
+/// WHAT WAS WRONG
+/// --------------
+/// `ProjectRole` and `Iso19650Role` carry different vocabularies, and each
+/// documents its own (ProjectMember.cs:15 and :18). "PM" only ever appears in
+/// the ISO 19650 list. Eleven sites read that code off the ProjectRole column,
+/// so the gates matched essentially nobody — a wrong-field bug, not a data
+/// migration.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS
+/// -----------------------------
+/// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, which
+/// falls back to Guid.Empty when no ITenantContext is supplied — matching NO
+/// rows. A fixture on the parameterless ctor makes every count assertion pass
+/// against an empty set. So the context here is always built with a tenant, and
+/// <see cref="Sanity_the_fixture_actually_has_rows"/> asserts non-empty before
+/// any capability claim is made.
+///
+/// SQLite, not EF InMemory: the EF-translation test below is meaningless on a
+/// provider that cannot produce SQL.
+/// </summary>
+public class ProjectRoleCapabilityTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    /// <summary>(projectRole, iso19650Role) pairs seeded as real rows.</summary>
+    private static readonly (string Project, string Iso, string Label)[] Seed =
+    {
+        ("Manager",     "M",  "manager"),
+        ("Contributor", "PM", "contributor-who-is-the-iso-PM"),
+        ("Contributor", "M",  "plain-contributor"),
+        ("Coordinator", "M",  "coordinator"),
+        ("Viewer",      "V",  "viewer"),
+    };
+
+    private static (SqliteConnection conn, Guid tenantId, Guid projectId) NewDb()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var ctx = NewContext(conn, tenantId);
+        ctx.Database.EnsureCreated();
+        ctx.Tenants.Add(new Tenant
+        {
+            Id = tenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+        ctx.Projects.Add(new Project
+        {
+            Id = projectId, TenantId = tenantId, Name = "Tower",
+            Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+        });
+
+        foreach (var (projectRole, iso, label) in Seed)
+        {
+            var userId = Guid.NewGuid();
+            ctx.Users.Add(new AppUser
+            {
+                Id = userId, TenantId = tenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com",
+                DisplayName = label, PasswordHash = "x", IsActive = true,
+            });
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenantId, ProjectId = projectId, UserId = userId,
+                ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
+            });
+        }
+        ctx.SaveChanges();
+        return (conn, tenantId, projectId);
+    }
+
+    [Fact]
+    public void Sanity_the_fixture_actually_has_rows()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            // If the tenant filter were mis-wired this would be 0 and every
+            // other test in this file would pass vacuously.
+            Assert.Equal(Seed.Length, ctx.ProjectMembers.Count(m => m.ProjectId == projectId));
+        }
+    }
+
+    // ── The EF predicate — this is the one that can silently client-evaluate ──
+
+    [Fact]
+    public void CurateProject_predicate_translates_to_SQL()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var query = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanCurateProject);
+
+            // If EF cannot translate the predicate it falls back to client
+            // evaluation, which in prod pulls the whole table per notification.
+            // The generated SQL must therefore carry the role comparison.
+            var sql = query.ToQueryString();
+            Assert.Contains("ProjectRole", sql, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Iso19650Role", sql, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void CurateProject_predicate_selects_the_right_members_from_the_database()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var rows = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanCurateProject)
+                .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+                .OrderBy(x => x)
+                .ToList();
+
+            Assert.NotEmpty(rows);                       // guards the empty-set trap
+            Assert.Equal(
+                new[] { "Contributor/PM", "Coordinator/M", "Manager/M" },
+                rows);
+        }
+    }
+
+    [Fact]
+    public void ApproveSitePhotos_predicate_is_narrower_than_curate()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var rows = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanApproveSitePhotosPredicate)
+                .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+                .OrderBy(x => x)
+                .ToList();
+
+            Assert.NotEmpty(rows);
+            // Coordinator curates but does NOT approve — that is the split.
+            Assert.Equal(new[] { "Contributor/PM", "Manager/M" }, rows);
+        }
+    }
+
+    // ── In-memory form, which must agree with the expression form ────────────
+
+    [Theory]
+    // A REAL member can now pass a gate that previously matched nobody.
+    [InlineData("Manager",     "M",  true,  true)]
+    [InlineData("Owner",       "M",  true,  true)]
+    [InlineData("Admin",       "M",  true,  true)]
+    // Curates but cannot approve — the deliberate split.
+    [InlineData("Coordinator", "M",  true,  false)]
+    // The wrong-column bug, fixed: the ISO code is read off the right field.
+    [InlineData("Contributor", "PM", true,  true)]
+    [InlineData("Contributor", "A",  true,  true)]
+    [InlineData("Contributor", "BC", true,  false)]   // BC curates, does not approve
+    // Plain members stay denied.
+    [InlineData("Contributor", "M",  false, false)]
+    [InlineData("Viewer",      "V",  false, false)]
+    [InlineData("ClientGuest", "M",  false, false)]
+    public void Capability_matrix(string projectRole, string iso, bool curate, bool approve)
+    {
+        Assert.Equal(curate,  ProjectRoles.CanCurate(projectRole, iso));
+        Assert.Equal(approve, ProjectRoles.CanApproveSitePhotos(projectRole, iso));
+    }
+
+    [Fact]
+    public void Tenant_admin_short_circuits_both_capabilities()
+    {
+        Assert.True(ProjectRoles.CanCurate("Viewer", "V", isTenantAdmin: true));
+        Assert.True(ProjectRoles.CanApproveSitePhotos("Viewer", "V", isTenantAdmin: true));
+    }
+
+    /// <summary>
+    /// The expression and the in-memory helper are two encodings of one rule.
+    /// This asserts they cannot drift, which a reader cannot verify by eye.
+    /// </summary>
+    [Fact]
+    public void Expression_and_in_memory_forms_agree_on_every_seeded_row()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var all = ctx.ProjectMembers.Where(m => m.ProjectId == projectId).ToList();
+            Assert.NotEmpty(all);
+
+            var curateSql = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId)
+                .Where(ProjectRoles.CanCurateProject)
+                .Select(m => m.UserId).ToHashSet();
+            var curateMem = all.Where(m => ProjectRoles.CanCurate(m.ProjectRole, m.Iso19650Role))
+                               .Select(m => m.UserId).ToHashSet();
+            Assert.Equal(curateMem, curateSql);
+
+            var approveSql = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId)
+                .Where(ProjectRoles.CanApproveSitePhotosPredicate)
+                .Select(m => m.UserId).ToHashSet();
+            var approveMem = all.Where(m => ProjectRoles.CanApproveSitePhotos(m.ProjectRole, m.Iso19650Role))
+                                .Select(m => m.UserId).ToHashSet();
+            Assert.Equal(approveMem, approveSql);
+        }
+    }
+
+    // ── Widening property ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The change promises nobody LOSES access. The old gate was
+    /// `ProjectRole == "PM"`; ProjectRole was unvalidated before this change, so
+    /// such a row was possible even though no UI writes it. It must still pass.
+    /// </summary>
+    [Fact]
+    public void A_legacy_row_with_ProjectRole_PM_still_passes_both_gates()
+    {
+        Assert.True(ProjectRoles.CanCurate("PM", "M"));
+        Assert.True(ProjectRoles.CanApproveSitePhotos("PM", "M"));
+    }
+
+    // ── Canonical vocabulary ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Viewer")]
+    [InlineData("Contributor")]
+    [InlineData("Coordinator")]
+    [InlineData("Manager")]
+    [InlineData("Owner")]
+    [InlineData("Admin")]
+    [InlineData("ClientGuest")]
+    [InlineData("manager")]              // case-insensitive
+    public void Canonical_roles_are_accepted(string role)
+        => Assert.True(ProjectRoles.IsCanonical(role));
+
+    [Theory]
+    [InlineData("Wizard")]
+    [InlineData("PM")]                   // an Iso19650Role code, not a ProjectRole
+    [InlineData("Author")]               // read by QuotaGuardService, never written
+    [InlineData("")]
+    [InlineData(null)]
+    public void Non_canonical_roles_are_rejected(string? role)
+        => Assert.False(ProjectRoles.IsCanonical(role));
+}

--- a/stingtools-core/python/tests/test_smoke.py
+++ b/stingtools-core/python/tests/test_smoke.py
@@ -834,3 +834,91 @@ if __name__ == "__main__":
     print(f"\n{len(tests)} tests run, {failures} failures "
           f"(tmp_path tests skipped — run with pytest for full coverage)")
     sys.exit(1 if failures else 0)
+
+
+# ----------------------------------------------------------------------
+# ProjectRole vocabulary parity — server constant vs web dropdown
+#
+# The ProjectRole vocabulary drifted far enough that eleven server gates ended
+# up testing an Iso19650Role code ("PM") against the ProjectRole column, and
+# nothing caught it because the two lists live in different languages in
+# different trees. These parse both sources and pin them together, in the same
+# style as test_ifc_element_to_wire_keys_match_dto: no running server, no
+# generated schema, just the source of truth on each side.
+# ----------------------------------------------------------------------
+
+def _server_project_roles() -> list[str]:
+    """Parse ProjectRoles.All out of the C# constant file."""
+    import re
+
+    repo_root = Path(__file__).resolve().parents[3]
+    src_file = (repo_root / "Planscape.Server" / "src" / "Planscape.Core"
+                / "Entities" / "ProjectRoles.cs")
+    if not src_file.exists():
+        return []  # repo layout changed; caller skips
+
+    src = src_file.read_text(encoding="utf-8")
+
+    # const string Viewer = "Viewer";  →  {Viewer: "Viewer"}
+    consts = dict(re.findall(
+        r'public\s+const\s+string\s+(\w+)\s*=\s*"([^"]+)"\s*;', src))
+
+    # The `All` initialiser lists the const NAMES, not the literals.
+    m = re.search(r'IReadOnlyList<string>\s+All\s*=\s*new\[\]\s*\{(.*?)\}',
+                  src, re.S)
+    if not m:
+        return []
+    names = [n.strip() for n in m.group(1).split(",") if n.strip()]
+    return [consts[n] for n in names if n in consts]
+
+
+def _web_project_roles() -> list[str]:
+    """Parse PROJECT_ROLES out of the Next.js members page."""
+    import re
+
+    repo_root = Path(__file__).resolve().parents[3]
+    page = (repo_root / "planscape-web" / "app" / "projects" / "[id]"
+            / "members" / "page.tsx")
+    if not page.exists():
+        return []
+
+    m = re.search(r'const\s+PROJECT_ROLES\s*=\s*\[(.*?)\]',
+                  page.read_text(encoding="utf-8"), re.S)
+    if not m:
+        return []
+    return [a or b for a, b in re.findall(r"'([^']+)'|\"([^\"]+)\"", m.group(1))]
+
+
+def test_server_project_role_vocabulary_parses():
+    """Guard the parser itself — a silent empty parse would make the parity
+    test below pass vacuously, which is the failure mode these gates have."""
+    roles = _server_project_roles()
+    if not roles:
+        return  # repo layout changed; skip rather than false-fail
+    assert "Manager" in roles, f"ProjectRoles.All parse looks wrong: {roles}"
+    assert "PM" not in roles, (
+        "'PM' must NOT be a canonical ProjectRole — it is an Iso19650Role code. "
+        "Eleven server gates were broken by exactly this confusion."
+    )
+
+
+def test_web_project_roles_are_all_accepted_by_the_server():
+    """Every role the web members dropdown offers must be one the server
+    accepts, or saving it now returns 400 invalid_project_role.
+
+    Subset, not equality: the server also accepts ClientGuest, which the web
+    deliberately does not offer (DailyPhotoDigestJob reads it, no UI writes it).
+    """
+    server = _server_project_roles()
+    web = _web_project_roles()
+    if not server or not web:
+        return  # repo layout changed; skip
+
+    assert "Manager" in web, f"PROJECT_ROLES parse looks wrong: {web}"
+
+    unknown = sorted(set(web) - set(server))
+    assert not unknown, (
+        f"planscape-web offers ProjectRole values the server rejects: {unknown}. "
+        f"Server accepts {sorted(server)}. Add them to ProjectRoles.All or "
+        f"remove them from PROJECT_ROLES."
+    )


### PR DESCRIPTION
## Phase 1 — server capability layer. No client changes, no new endpoints.

## The bug, confirmed independently

The brief asked me to confirm the wrong-field reading before building on it. It is exactly right, and the two fields document themselves:

```csharp
/// <summary>Application role within this project (Viewer/Contributor/Coordinator/Manager).</summary>
public string ProjectRole  { get; set; } = "Contributor";      // ProjectMember.cs:15

/// <summary>ISO 19650-2 role code for this project (A/PM/BC/AR/SE/ME/QS etc.).</summary>
public string Iso19650Role { get; set; } = "M";                // ProjectMember.cs:18
```

`"PM"` appears only in the ISO list — which is also what `GET api/projects/{id}/members/roles` returns (`ProjectMembersController.cs:548-569`) and what the web grid saves into `iso19650Role` (`members/page.tsx:119`). Meanwhile the web's `ProjectRole` dropdown is a different six-value list with no `PM` in it (`members/page.tsx:23`).

So eleven sites read the right code off the wrong column. **A wrong-field bug, not a data migration.**

What was closed as a result: album curation, checklists, share links, photo policy, photo approve/reject, distribution groups, saved-view deletion, the 24h PM escalation, the approver digest email, and P6 milestone pushes — all unreachable for anyone who was not a tenant Admin/Owner.

## What this adds

`Planscape.Core/Entities/ProjectRoles.cs` — canonical vocabulary + two capabilities, split by blast radius:

| | grants | to |
|---|---|---|
| **CurateProject** | albums, checklists, distribution groups, deleting another member's saved view | ProjectRole in {Manager, Owner, Admin, Coordinator} or Iso19650Role in {PM, A, BC} |
| **ApproveSitePhotos** | approve/reject, include-originals, share links, PUT photo-policy | ProjectRole in {Manager, Owner, Admin} or Iso19650Role in {PM, A} |

A Coordinator curates but does **not** approve — approval releases imagery outside the project.

**Two shapes, on purpose.** Controllers get a claims-aware async helper beside `RequireProjectMemberAsync`. Jobs get a static `Expression<Func<ProjectMember,bool>>` so EF translates it *inside* `.Where()`. `DailyPhotoDigestJob` uses query syntax, which cannot take an Expression in its `where`, so the predicate is applied to the **source** — otherwise it would client-evaluate the table per digest.

Each controller helper keeps its name and signature; only the body changed. **All 36 call sites are untouched.**

## Write validation

`PUT members/{id}` accepted **any** string for `ProjectRole` (`:418`) — which is how the vocabulary drifted this far in the first place. Non-canonical values now return `400 { error: "invalid_project_role", allowed: [...] }`, matching the existing `invalid_kind` shape in `DistributionGroupsController`.

`Iso19650Role` is deliberately **not** validated here — that is a wider change.

## The widening claim — one correction to the brief

The brief said to state this change is purely widening, and to stop and report if any gate would narrow. **One would have**, so I handled it rather than shipping the narrowing:

`ProjectRole` was **unvalidated until this commit**, so a row with `ProjectRole = "PM"` is possible even though no UI writes it — and such a row **passes the current gate**. Dropping `"PM"` from the accepted ProjectRole set would have revoked access from exactly those rows.

So `"PM"` is retained as an explicit, commented legacy tolerance in the capability check, while being deliberately **absent** from `ProjectRoles.All` so new writes are refused. A test pins it.

With that in place, widening is verified rather than asserted:

| | before | after |
|---|---|---|
| tenant branch | `role is "Admin" or "Owner"` | same **plus** `IsInRole("Admin"/"Owner")` — wider |
| user-id claims | `user_id` then `NameIdentifier` then `sub` | **identical** chain (checked in all 4 controllers) |
| role match | `ProjectRole == "PM"` | superset, incl. legacy `"PM"` |

No user can lose access at any of the eleven sites.

## Tests — RED then GREEN

Proved RED by temporarily restoring the pre-fix semantics:

```
Capability_matrix(Manager,     M,  curate: True, approve: True)  [FAIL]
Capability_matrix(Owner,       M,  ...)                          [FAIL]
Capability_matrix(Admin,       M,  ...)                          [FAIL]
Capability_matrix(Coordinator, M,  curate: True, approve: False) [FAIL]
Capability_matrix(Contributor, PM, ...)                          [FAIL]   <- the wrong-column bug
Capability_matrix(Contributor, A,  ...)                          [FAIL]
Capability_matrix(Contributor, BC, ...)                          [FAIL]
CurateProject_predicate_selects_the_right_members_from_the_database [FAIL]
ApproveSitePhotos_predicate_is_narrower_than_curate                 [FAIL]

Failed: 9, Passed: 21, Total: 30
```

Then GREEN with the real implementation: **30/30 passed.**

The two that matter most: `Manager` is a *real* member passing a previously-dead gate, and `Contributor` + `Iso19650Role=PM` proves the wrong-column read is fixed.

**Fixture-trap guards** (the brief flagged this, and it is real):
- every context is built with an `ITenantContext` — the parameterless ctor makes `CurrentTenantId` fall back to `Guid.Empty`, matching **no rows**, so assertions would pass against an empty set;
- `Sanity_the_fixture_actually_has_rows` asserts non-empty **before** any capability claim;
- `CurateProject_predicate_translates_to_SQL` asserts the generated SQL contains the role columns — a predicate that client-evaluates would otherwise pass this suite while pulling the whole table in prod;
- `Expression_and_in_memory_forms_agree_on_every_seeded_row` pins the two encodings together, which no reader can verify by eye.

## Parity gate

Extended the existing `contract-drift` mechanism rather than inventing one — same style as `test_ifc_element_to_wire_keys_match_dto`: parse both sources, no running server, no generated schema.

- `test_web_project_roles_are_all_accepted_by_the_server` — every value in the web `PROJECT_ROLES` must be in `ProjectRoles.All`. Subset, not equality, because the server also accepts `ClientGuest` (read by `DailyPhotoDigestJob.cs:126`) which the web deliberately does not offer.
- `test_server_project_role_vocabulary_parses` — guards the parser itself, and asserts `"PM"` is **never** canonical. A silent empty parse would make the parity test pass vacuously, which is the exact failure mode these gates suffer from.

Verified the parsers return real data:
```
server: ['Viewer','Contributor','Coordinator','Manager','Owner','Admin','ClientGuest']
web   : ['Viewer','Contributor','Coordinator','Manager','Owner','Admin']
```

Also added `planscape-web/**` to the workflow triggers — it was missing, so a change to the web dropdown would not have run this gate.

## Post-change grep

Zero `ProjectRole == "PM"` in executable code. Survivors are exactly the non-PM ones the brief said to leave: `CdeContainers:255`, `WeeklyDigestJob:48`, `TenantAdmin:51`, `CoordinatorWorkloadJob:39`, `QuotaGuardService:76`, plus `BackgroundJobs:278` (Owner/Admin) and `DailyPhotoDigestJob:126` (ClientGuest).

## STOP-and-ask — the capabilities endpoint

Not built, as instructed. Proposing it:

**`GET api/projects/{projectId}/members/capabilities` returning `{ curateProject: bool, approveSitePhotos: bool }`**

The three clients currently have no way to learn what the caller may do, so each must attempt-then-report a 403. That works but means every surface shows an action, lets the user click it, and only then explains — and each surface has to render that 403 consistently for parity to hold.

One endpoint would let all three disable or hide the action identically, which is what parity rule (c) actually asks for. It reads only data the caller already has access to, so it leaks nothing.

**Until you decide**, the parity rule for Phases 2-5 stands as written: attempt the action, render the server's 403 as a specific human message ("Only a project manager can curate albums") on all three surfaces. Never a silent no-op, never a toast claiming success.

## Separate finding — NOT touched, as instructed

`QuotaGuardService.cs:76-77` counts the billing **Authors** seat axis as `ProjectRole == "Author"`, and nothing in the codebase ever assigns `"Author"`, so that axis reads 0 forever; `Coordinators` counts `!= "Author"`, i.e. every member including the project owner. Left completely alone per the brief. A characterisation test pinning the current behaviour already exists in #538 (`QuotaSeatCountingTests`) if you want the numbers.

Worth noting one interaction: `"Author"` is **not** in the canonical vocabulary this PR introduces, so `PUT members/{id}` will now reject it. Nothing wrote it before and no UI offers it, so this changes no behaviour — but if the seat fix later wants `"Author"` as a real role, it must be added to `ProjectRoles.All` at that point.

## Verification status

- `dotnet build Planscape.API` -> **succeeded, 0 errors** (7 pre-existing warnings).
- `ProjectRoleCapabilityTests` -> **30/30**, RED-then-GREEN evidence above.
- Python parity tests -> **2/2**.
- Full server suite -> reported in a follow-up comment; the run exceeds the tool timeout.
- **Not verified:** no endpoint was exercised against a running server in this phase, because Phase 1 changes no routes or response shapes — only who passes an existing gate. Phase 2 onward will do live exercise as the method requires.

## Notes

Known-broken CI: "Build & Test / CI Gate" fails on a Postgres container (`role "root" does not exist`) — pre-existing on `main`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
