### PR TITLE
fix(security)!: close cross-tenant read and write on MaterialSync — BREAKING route change

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/MaterialSyncController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/MaterialSyncController.cs
@@ -1,53 +1,102 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 using Planscape.Core.DTOs;
+using Planscape.Infrastructure.Data;
 
 namespace Planscape.API.Controllers;
 
 /// <summary>
 /// I-2 — Material library snapshot endpoint.
-/// Receives a snapshot of the project's materials from the Revit
-/// plugin and stores it as a JSON blob under the server's data
-/// directory. Minimum-viable persistence — full per-row DB rows
-/// can land in a follow-up migration.
+/// Receives a snapshot of the project's materials from the Revit plugin and
+/// stores it as a JSON blob under the server's data directory.
+///
+/// SECURITY — why this controller looks different from its first version
+/// ---------------------------------------------------------------------
+/// It carried <c>[Authorize]</c> and nothing else: no <c>[ProjectAccess]</c>, no
+/// membership check, no tenant filter. It also does not use EF, so the DbContext's
+/// global tenant query filter — which silently protects most controllers that
+/// forget — could not reach it. Any authenticated user in any tenant who had a
+/// project GUID could READ another tenant's material library, and
+/// <c>PostSnapshot</c> was equally unguarded, so they could OVERWRITE it too.
+///
+/// The project id also had to move from the request BODY into the ROUTE.
+/// <see cref="ProjectAccessAttribute"/> resolves its subject from route data and
+/// deliberately no-ops when the route carries no project id ("let the action
+/// handle it"), so leaving the id in the body would have added the attribute
+/// while changing nothing — a fix that reads as protection and isn't.
+///
+/// PERSISTENCE — deliberately NOT changed here
+/// -------------------------------------------
+/// Snapshots are still files under ContentRootPath/App_Data. That has two known
+/// problems: the container filesystem is ephemeral (a Render redeploy loses every
+/// snapshot), and being outside EF is what made the tenant filter unable to help
+/// above. Moving this to a table is a persisted-storage change and needs its own
+/// decision, so it is only recorded here, not done.
 /// </summary>
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/projects/{projectId:guid}/material-sync")]
 [Authorize]
+[ProjectAccess]
 public class MaterialSyncController : ControllerBase
 {
     private readonly IWebHostEnvironment _env;
-    public MaterialSyncController(IWebHostEnvironment env) { _env = env; }
+    private readonly PlanscapeDbContext _db;
+
+    public MaterialSyncController(IWebHostEnvironment env, PlanscapeDbContext db)
+    {
+        _env = env;
+        _db = db;
+    }
 
     [HttpPost("snapshot")]
     public async Task<ActionResult<MaterialSyncResponse>> PostSnapshot(
+        Guid projectId,
         [FromBody] MaterialSyncRequest req,
         CancellationToken ct)
     {
-        if (req == null || req.ProjectId == Guid.Empty)
-            return BadRequest(new { error = "ProjectId required" });
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+        if (req == null) return BadRequest(new { error = "body_required" });
 
-        var dir = Path.Combine(_env.ContentRootPath, "App_Data", "material_snapshots");
-        Directory.CreateDirectory(dir);
-        var path = Path.Combine(dir, $"{req.ProjectId}.json");
+        // The DTO still carries ProjectId for backwards compatibility. The ROUTE
+        // is authoritative — it is what was authorised. A body that disagrees is
+        // rejected rather than silently ignored, so a caller can never believe it
+        // wrote to a project it did not.
+        if (req.ProjectId != Guid.Empty && req.ProjectId != projectId)
+            return BadRequest(new { error = "project_id_mismatch" });
+
+        var path = SnapshotPath(projectId);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        req.ProjectId = projectId;
         var json = JsonSerializer.Serialize(req, new JsonSerializerOptions { WriteIndented = false });
         await System.IO.File.WriteAllTextAsync(path, json, ct);
 
         return Ok(new MaterialSyncResponse
         {
             RowsAccepted = req.Materials?.Count ?? 0,
-            Notes = $"Snapshot stored at {path}",
+            // Was $"Snapshot stored at {path}", which handed the server's
+            // filesystem layout to any caller.
+            Notes = "Snapshot stored.",
         });
     }
 
-    [HttpGet("snapshot/{projectId:guid}")]
+    [HttpGet("snapshot")]
     public async Task<ActionResult<MaterialSyncRequest>> GetSnapshot(Guid projectId, CancellationToken ct)
     {
-        var path = Path.Combine(_env.ContentRootPath, "App_Data", "material_snapshots", $"{projectId}.json");
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
+        var path = SnapshotPath(projectId);
         if (!System.IO.File.Exists(path)) return NotFound();
         var json = await System.IO.File.ReadAllTextAsync(path, ct);
         var snap = JsonSerializer.Deserialize<MaterialSyncRequest>(json);
         return snap != null ? Ok(snap) : (ActionResult<MaterialSyncRequest>)NotFound();
     }
+
+    /// <summary>Path is derived from the ROUTE-authorised project id only —
+    /// never from caller-supplied text — so it cannot be steered outside the
+    /// snapshot directory.</summary>
+    private string SnapshotPath(Guid projectId)
+        => Path.Combine(_env.ContentRootPath, "App_Data", "material_snapshots", $"{projectId}.json");
 }

--- a/Planscape.Server/tests/Planscape.Tests/MaterialSyncAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/MaterialSyncAuthorizationTests.cs
@@ -1,0 +1,274 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Hosting;
+using Planscape.API.Controllers;
+using Planscape.Core.DTOs;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// MaterialSyncController's authorization, which did not exist.
+///
+/// THE DEFECT
+/// ----------
+/// The controller carried [Authorize] and nothing else — no [ProjectAccess], no
+/// membership check, no tenant filter — and it does not use EF, so the DbContext's
+/// global tenant query filter could not cover for it the way it silently does for
+/// most controllers that forget. Any authenticated user in ANY tenant who had a
+/// project GUID could read another tenant's material library, and PostSnapshot was
+/// equally unguarded, so they could overwrite it too. It also returned the server's
+/// filesystem path in the response.
+///
+/// WHAT THESE TESTS COVER, AND WHAT THEY DO NOT
+/// --------------------------------------------
+/// They construct the controller directly (the HandoffProvisioningSqliteTests
+/// precedent) and exercise the IN-ACTION guard, RequireProjectMemberAsync, against
+/// a real relational database with real ProjectMember rows.
+///
+/// They do NOT exercise [ProjectAccess]. That is an IAsyncActionFilter and only
+/// runs inside the MVC pipeline, which needs a booted host — and the host cannot
+/// boot against SQLite (Program.cs's schema block issues a Postgres-only
+/// information_schema query with no try/catch). So [ProjectAccess] is defence in
+/// depth here and is verified in the runtime pass, not by this file. Stated
+/// explicitly so nobody reads a green run as proof of the filter.
+///
+/// FIXTURE TRAP
+/// ------------
+/// PlanscapeDbContext's global filter is TenantId == CurrentTenantId and falls back
+/// to Guid.Empty without an ITenantContext, matching NO rows — under which a
+/// "denied" assertion passes for the wrong reason. Every context here is built with
+/// a tenant, and the happy-path test asserts on NON-EMPTY round-tripped content.
+/// </summary>
+public class MaterialSyncAuthorizationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), "matsync-tests-" + Guid.NewGuid().ToString("N"));
+
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    /// <summary>Minimal IWebHostEnvironment — only ContentRootPath is read.</summary>
+    private sealed class TempEnv : IWebHostEnvironment
+    {
+        public TempEnv(string root) { ContentRootPath = root; Directory.CreateDirectory(root); }
+        public string ContentRootPath { get; set; }
+        public string ApplicationName { get; set; } = "tests";
+        public string EnvironmentName { get; set; } = "Development";
+        public string WebRootPath { get; set; } = "";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    }
+
+    private PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(
+        SqliteConnection Conn, Guid TenantA, Guid TenantB,
+        Guid ProjectA, Guid MemberOfA, Guid OutsiderInB);
+
+    /// <summary>Two tenants, each with a project; one member in A, one in B.</summary>
+    private World NewWorld()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var tA = Guid.NewGuid(); var tB = Guid.NewGuid();
+        var pA = Guid.NewGuid();
+        var memberA = Guid.NewGuid(); var outsiderB = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tA))
+        {
+            ctx.Database.EnsureCreated();
+            foreach (var (tid, slug) in new[] { (tA, "acme"), (tB, "other") })
+                ctx.Tenants.Add(new Tenant
+                {
+                    Id = tid, Name = slug, Slug = $"{slug}-{Guid.NewGuid():N}"[..14],
+                    ContactEmail = $"{slug}@example.com", Tier = LicenseTier.Professional,
+                    Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+                });
+
+            ctx.Projects.Add(new Project
+            {
+                Id = pA, TenantId = tA, Name = "Tower A",
+                Code = $"PA-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            ctx.Users.Add(new AppUser
+            {
+                Id = memberA, TenantId = tA, Email = $"a-{Guid.NewGuid():N}@example.com",
+                DisplayName = "Member A", PasswordHash = "x", IsActive = true,
+            });
+            ctx.Users.Add(new AppUser
+            {
+                Id = outsiderB, TenantId = tB, Email = $"b-{Guid.NewGuid():N}@example.com",
+                DisplayName = "Outsider B", PasswordHash = "x", IsActive = true,
+            });
+
+            // Only Member A is on Project A. Outsider B is a perfectly valid,
+            // authenticated user — just of a different tenant.
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tA, ProjectId = pA, UserId = memberA,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+            ctx.SaveChanges();
+        }
+        return new World(conn, tA, tB, pA, memberA, outsiderB);
+    }
+
+    private MaterialSyncController NewController(World w, Guid actingUserId, Guid actingTenantId)
+    {
+        var ctrl = new MaterialSyncController(new TempEnv(_root), NewContext(w.Conn, actingTenantId));
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim("user_id", actingUserId.ToString()),
+            new Claim("sub", actingUserId.ToString()),
+            new Claim("role", "Contributor"),      // deliberately NOT Admin/Owner
+        }, "test");
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
+        };
+        return ctrl;
+    }
+
+    private static MaterialSyncRequest Snapshot(Guid projectId) => new()
+    {
+        ProjectId = projectId,
+        RevitDocPath = @"C:\models\tower.rvt",
+        Materials = { new MaterialSyncRow { Name = "Concrete C30", Class = "Concrete", Origin = "Revit" } },
+    };
+
+    // ── Cross-tenant denial ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Outsider_from_another_tenant_is_denied_on_GET()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var ctrl = NewController(w, w.OutsiderInB, w.TenantB);
+            var result = await ctrl.GetSnapshot(w.ProjectA, default);
+
+            var denied = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(403, denied.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Outsider_from_another_tenant_is_denied_on_POST()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var ctrl = NewController(w, w.OutsiderInB, w.TenantB);
+            var result = await ctrl.PostSnapshot(w.ProjectA, Snapshot(w.ProjectA), default);
+
+            var denied = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(403, denied.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task A_denied_POST_does_not_write_the_file()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var path = Path.Combine(_root, "App_Data", "material_snapshots", $"{w.ProjectA}.json");
+            Assert.False(File.Exists(path));
+
+            var ctrl = NewController(w, w.OutsiderInB, w.TenantB);
+            await ctrl.PostSnapshot(w.ProjectA, Snapshot(w.ProjectA), default);
+
+            // The original controller would have created it. Overwriting another
+            // tenant's snapshot was the more damaging half of the defect.
+            Assert.False(File.Exists(path));
+        }
+    }
+
+    // ── Member happy path ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Project_member_can_write_then_read_back_the_snapshot()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var post = await NewController(w, w.MemberOfA, w.TenantA)
+                .PostSnapshot(w.ProjectA, Snapshot(w.ProjectA), default);
+            var posted = Assert.IsType<OkObjectResult>(post.Result);
+            var body = Assert.IsType<MaterialSyncResponse>(posted.Value);
+            Assert.Equal(1, body.RowsAccepted);
+
+            var get = await NewController(w, w.MemberOfA, w.TenantA)
+                .GetSnapshot(w.ProjectA, default);
+            var got = Assert.IsType<OkObjectResult>(get.Result);
+            var snap = Assert.IsType<MaterialSyncRequest>(got.Value);
+
+            // NON-EMPTY on purpose: a guard that denied everything, or a fixture
+            // whose tenant filter matched nothing, would still satisfy a
+            // "no exception" test.
+            Assert.NotEmpty(snap.Materials);
+            Assert.Equal("Concrete C30", snap.Materials[0].Name);
+            Assert.Equal(w.ProjectA, snap.ProjectId);
+        }
+    }
+
+    // ── Information disclosure ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Response_does_not_leak_the_server_filesystem_path()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var post = await NewController(w, w.MemberOfA, w.TenantA)
+                .PostSnapshot(w.ProjectA, Snapshot(w.ProjectA), default);
+            var body = Assert.IsType<MaterialSyncResponse>(
+                Assert.IsType<OkObjectResult>(post.Result).Value);
+
+            Assert.NotNull(body.Notes);
+            Assert.DoesNotContain(_root, body.Notes!, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("App_Data", body.Notes!, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(".json", body.Notes!, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    // ── Route is authoritative over the body ─────────────────────────────────
+
+    [Fact]
+    public async Task A_body_naming_a_different_project_is_rejected_not_ignored()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var ctrl = NewController(w, w.MemberOfA, w.TenantA);
+            var mismatched = Snapshot(Guid.NewGuid());          // body != route
+
+            var result = await ctrl.PostSnapshot(w.ProjectA, mismatched, default);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+            Assert.Contains("project_id_mismatch", bad.Value!.ToString());
+        }
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* temp dir cleanup is best-effort */ }
+    }
+}


### PR DESCRIPTION
## 🔒 SECURITY + ⚠️ BREAKING ROUTE CHANGE — cross-tenant read **and write**, live on a deployed endpoint. Prioritise for deploy.

PR-A from the sequence. Standalone, no dependencies, no feature code.

**This PR is two things, and the second one is not just a side effect of the first: it fixes a cross-tenant auth hole, AND it changes the URL of both endpoints on this controller.** Both endpoints are on `main` today and therefore deployed. Full before/after routes below.

## The defect

`MaterialSyncController` carried `[Authorize]` and **nothing else** — no `[ProjectAccess]`, no membership check, no tenant filter. It also does not use EF, so the DbContext's global tenant query filter (which silently covers most controllers that forget) **could not reach it**.

Your review was right that I under-reported it: the **write** is the worse half.

- `GET api/MaterialSync/snapshot/{projectId}` — any authenticated user in any tenant reads another tenant's material library.
- `POST api/MaterialSync/snapshot` — same, but `File.WriteAllTextAsync` **over** it.
- `Notes = $"Snapshot stored at {path}"` returned the server filesystem layout to the caller.

## Proved before fixing

A throwaway exploit test **passed** against the pre-fix controller:

```
Passed!  - Failed: 0, Passed: 1
```

asserting all three in one run: the file was created for an arbitrary project GUID with no authorisation of any kind, the response body contained `App_Data`, and the planted row (`"PWNED"`) read straight back out. That test was deleted before commit; the six real tests replace it.

## ⚠️ Route change — BREAKING, deliberate, stated rather than silent

**The class-level `[Route]` moved.** This is the root of the change; both action routes follow from it:

```
[Route("api/[controller]")]                         ->  [Route("api/projects/{projectId:guid}/material-sync")]
```

**Every route on this controller, in full:**

| Verb | OLD (on `main`, deployed) | NEW (this PR) |
|---|---|---|
| POST | `api/MaterialSync/snapshot`<br>`projectId` in **body** (`MaterialSyncRequest.ProjectId`) | `api/projects/{projectId:guid}/material-sync/snapshot`<br>`projectId` from **route** |
| GET | `api/MaterialSync/snapshot/{projectId:guid}`<br>`projectId` in **path segment after `snapshot`** | `api/projects/{projectId:guid}/material-sync/snapshot`<br>`projectId` from **route prefix** |

Read the action attributes in the diff with the class route in mind — in isolation they are misleading:

- `GET` goes **`[HttpGet("snapshot/{projectId:guid}")]` → `[HttpGet("snapshot")]`**. The `{projectId:guid}` was not dropped; it moved *up* into the class route, which is why `GetSnapshot(Guid projectId, …)` still binds. The parameter is still route-supplied, just from the prefix.
- `POST` keeps **`[HttpPost("snapshot")]` unchanged**, but its *effective* URL changed anyway because the class route changed, and `PostSnapshot` gained a `Guid projectId` **route** parameter it did not have before. That is the reason `req.ProjectId = projectId` is safe: `projectId` is the route-authorised value, not anything the caller put in the body.

So both endpoints move; neither old URL survives. `api/MaterialSync/*` returns **404** after this merges.

**Why it was forced, not stylistic.** `ProjectAccessAttribute` resolves its subject from *route data* and deliberately no-ops when the route carries no project id — "No project in the route — let the action handle it" (`ProjectAccessAttribute.cs:39-47`, verified: it calls `await next(); return;`). Adding `[ProjectAccess]` while leaving the id in the body would have **looked** like protection and changed nothing. That is precisely the failure mode this whole exercise is about, so I moved it.

**Risk assessment: nil, but assert it, don't assume it.** Re-verified by exact-string grep for `api/MaterialSync`, `MaterialSync/snapshot` and `MaterialSync` across `StingTools/`, `planscape-web/`, `Planscape/`, `StingBridge/`, `marketing-site/` and `stingtools-core/` — **zero callers**, and zero references in any `.md`, `.json` or `.yml` either (no docs, no OpenAPI fixture, no CI config pins the old path). Nothing in this repo breaks. Flagged prominently anyway because it is a contract change to a deployed endpoint, and any out-of-repo or hand-rolled caller (Postman collection, curl script, a fork) **will** break and must be repointed.

The DTO keeps `ProjectId` for compatibility. The **route is authoritative**; a body that disagrees is rejected with `400 project_id_mismatch` rather than ignored, so a caller can never believe it wrote to a project it did not.

## Not changed, per your item (c)

Snapshots are still files under `ContentRootPath/App_Data`. Two known problems, recorded in the class comment rather than acted on:

1. the container filesystem is ephemeral — a Render redeploy loses every snapshot;
2. being outside EF is exactly what put this data beyond the tenant filter's reach.

Moving it into a table is a persisted-storage change and needs its own decision. Not done here.

## Tests — 6, green

| test | asserts |
|---|---|
| `Outsider_from_another_tenant_is_denied_on_GET` | 403 |
| `Outsider_from_another_tenant_is_denied_on_POST` | 403 |
| `A_denied_POST_does_not_write_the_file` | file absent after the denied call |
| `Project_member_can_write_then_read_back_the_snapshot` | 200 + **NON-EMPTY** round-trip (`Materials[0].Name == "Concrete C30"`) |
| `Response_does_not_leak_the_server_filesystem_path` | no temp root, no `App_Data`, no `.json` in `Notes` |
| `A_body_naming_a_different_project_is_rejected_not_ignored` | `400 project_id_mismatch` |

`Passed! - Failed: 0, Passed: 6`

**Fixture-trap guard**, as you flagged: the DbContext's filter falls back to `Guid.Empty` without an `ITenantContext`, under which a "denied" assertion passes for the wrong reason. Every context is built with a tenant, and the happy path asserts on non-empty round-tripped content, not merely on absence of an exception.

## What these tests do NOT cover — stated so a green run isn't over-read

They construct the controller directly (the `HandoffProvisioningSqliteTests` precedent) and therefore exercise **`RequireProjectMemberAsync`**, the in-action guard. They do **not** exercise `[ProjectAccess]` — that is an `IAsyncActionFilter` and only runs inside the MVC pipeline, which needs a booted host, and the host cannot boot against SQLite (`Program.cs`'s schema block issues a Postgres-only `information_schema` query with no try/catch). `[ProjectAccess]` is defence in depth here; verifying it belongs to the runtime pass.

They also do not exercise **routing** — constructing the controller directly bypasses the route table entirely, so the new URLs are asserted by reading the attributes, not by a request. Confirming the new paths resolve (and that the old ones 404) belongs to the same runtime pass.

## Independence

Branched from `origin/main`, not from #540. It briefly used `ProjectRoles.Contributor` from the Phase 1 branch; caught at compile and replaced with the literal so this PR stands alone and can be deployed without waiting on the capability layer.

## Notes

Known-broken CI: "Build & Test / CI Gate" fails on a Postgres container (`role "root" does not exist`) — pre-existing on `main`, unrelated. Verified locally: `dotnet build` succeeded, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
