### PR TITLE
docs: Phase 6A triage (consolidated) — render.yaml voids B1; runtime pass reinstated; two stale docstrings fixed

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/DeviceTwinsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DeviceTwinsController.cs
@@ -8,9 +8,24 @@ using Planscape.Infrastructure.SignalR;
 namespace Planscape.API.Controllers;
 
 /// <summary>
-/// Pillar B (5A) — device-twin query + binding. Powers the mobile Live tab
-/// (RAG list) and the viewer's twin overlay (K3). Binding records the K1 iot
+/// Pillar B (5A) — device-twin query + binding. Binding records the K1 iot
 /// mapping so telemetry resolves to the model element.
+///
+/// NO CLIENT CALLS THIS. An earlier version of this docstring claimed it "powers
+/// the mobile Live tab (RAG list) and the viewer's twin overlay (K3)". Measured
+/// 2026-08-02: there is no Live tab — <c>Planscape/app/(tabs)/</c> contains
+/// index, issues, issue-detail, documents, models, ifc, schedule, cost-dashboard,
+/// myactions, scanner and settings, and nothing else. The two <c>live.tsx</c>
+/// files in the app (<c>meetings/live.tsx</c>, <c>healthcare/pressure-live.tsx</c>)
+/// are a LiveKit meeting screen and a healthcare pressure view respectively;
+/// neither touches this controller. A repo-wide grep for <c>device-twins</c> /
+/// <c>DeviceTwins</c> across <c>Planscape/</c> and <c>planscape-web/</c> returns
+/// zero hits.
+///
+/// The endpoints are real — routable, DI resolves, tenant-scoped, backed by tables
+/// the schema patcher creates unconditionally. This is a **product** gap (no client
+/// has been built), not a broken endpoint. Do not delete it on "no caller" grounds;
+/// see docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md.
 /// </summary>
 [ApiController]
 [Route("api/projects/{projectId:guid}/twins")]

--- a/Planscape.Server/src/Planscape.API/Controllers/MfaController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/MfaController.cs
@@ -10,8 +10,15 @@ namespace Planscape.API.Controllers;
 
 /// <summary>
 /// TOTP multi-factor authentication: enroll, verify, recovery codes, challenge log.
-/// Production implementation would use a TOTP library (e.g. Otp.NET) and
-/// IDataProtectionProvider for secret encryption.
+///
+/// This IS the production implementation. An earlier version of this docstring said
+/// "production implementation would use a TOTP library (e.g. Otp.NET) and
+/// IDataProtectionProvider for secret encryption" — that was already false when
+/// written and is corrected here. Both are in use:
+///   • <c>OtpNet</c> — <c>new Totp(secretBytes).VerifyTotp(code, out _,
+///     new VerificationWindow(2, 2))</c> (see VerifyEnrollment);
+///   • <c>IDataProtector</c> — injected and used to encrypt the shared secret at rest.
+/// Do not treat this controller as a stub.
 /// </summary>
 [ApiController]
 [Route("api/mfa")]

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,0 +1,182 @@
+# Phase 6A — clientless controller triage
+
+**Measured 2026-08-02 on `main` @ `a5109e3e5`.** Triage only — no feature code in this PR.
+
+> **Runtime column is NOT MEASURED.** Item 2 of the brief requires exercising every action
+> against a running server. Docker Desktop is installed but its daemon would not start on this
+> machine (`npipe:////./pipe/dockerDesktopLinuxEngine` — no such file; launching the app left no
+> process), and there is no local Postgres on 5432. Everything below is *static* measurement.
+> Where a static proxy exists for "does it run" — DI registration, migration presence — it was
+> used and is labelled as such. See [Runtime gap](#runtime-gap).
+
+---
+
+## 0. Re-derived list — the brief's ten, plus two
+
+Re-derived per instruction, **including** `Planscape.Server/src/Planscape.API/wwwroot` and
+**excluding** `wwwroot/_next/**` and `wwwroot/vendor/**`. Clients scanned: `StingTools/`,
+`planscape-web/`, `Planscape/` (mobile), `StingBridge/`, `Planscape.Server/.../wwwroot/`,
+`marketing-site/` — 1,856 files.
+
+**Your correction is confirmed.** `PublicConfig` (`api/public-config`), `RoleBuckets`
+(`api/state-machine/role-buckets`), `TenantKeywords` (`api/admin/tenant-keywords`) and
+`TenantBimManagerRoles` (`api/admin/tenant-bim-manager-roles`) are all called from
+`wwwroot/js/dashboard.js`; the latter two also from `wwwroot/index.html` and
+`wwwroot/app/index.html`. Not clientless. Left alone.
+*(One nuance: I found no `public-config` reference under `marketing-site/` in this checkout —
+possibly the built bundle isn't committed. Doesn't change the verdict.)*
+
+All ten in the brief are confirmed clientless by exact route-string grep. **Two more are too:**
+
+| Extra | Route | Note |
+|---|---|---|
+| **MaterialSync** | `api/MaterialSync` | 53 ln, 2 actions. Not on the brief's list. **Has a security finding — see S1.** |
+| **PhotoExport** | `api/projects/{id}/photo-export` | Already scheduled as Phase 5; listing for completeness. |
+
+---
+
+## 1. Triage table
+
+Legend — **Backed**: DbSet + a migration that actually creates the table.
+**DI**: every injected service resolves (static check of `Program.cs`).
+
+| # | Controller | Ln / actions | Auth gate | Tenant scoping | Backed | DI | Verdict |
+|---|---|---|---|---|---|---|---|
+| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | n/a (reads + deletes) | ✅ | **Tier 1 — but STOP, see D1** |
+| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | ✅ `20260517000003` | ✅ | **Tier 1 — confirmed viable** |
+| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | ✅ `20260513000000` | ✅ | Tier 2 — real feature, duplicate of a live one (see C1) |
+| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | ✅ `20260513100000` | ✅ | Tier 2 |
+| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | ✅ `20260517000000` | ✅ | Tier 2 — mobile-only by nature |
+| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | ✅ `20260517000000` | ✅ | Tier 2 — **works; docstring lies (M1)** |
+| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter only (`ITenantScoped`) | ❌ **NO MIGRATION** | ✅ | **Tier 3 — blocked, see B1** |
+| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | ❌ **NO MIGRATION** | ✅ | **Tier 3 — blocked, see B1** |
+| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | via services | ✅ | Tier 3 — **docstring lies (M2)** |
+| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | read-only | ✅ | Tier 3 — sales tool, not product |
+| 11 | **MaterialSync** | 53 / 2 | `[Authorize]` **only** | **NONE** | filesystem | ✅ | **Security — see S1** |
+
+**No controller in this group is dead from a missing DI registration.** All five injected services
+(`IAuditService`, `ITenantContext`, `IDeviceTwinService`, `ITwinBindingService`,
+`IPlatformEventService`) are registered in `Program.cs` (`:428`, `:365`, `:727`, `:729`, `:724`);
+`IDataProtector` comes from `AddDataProtection()` (`:506`). My first grep reported all six as
+unregistered — a false negative from a too-strict pattern, corrected before reporting.
+
+---
+
+## 2. Findings that change the plan
+
+### S1 — MaterialSync is a cross-tenant read (security)
+
+`MaterialSyncController` carries `[Authorize]` and **nothing else**: no `[ProjectAccess]`, no
+membership check, no tenant filter. It does not use EF at all — it writes and reads
+`ContentRootPath/App_Data/material_snapshots/{projectId}.json` directly
+(`MaterialSyncController.cs:31-35, 47-50`).
+
+Because it bypasses EF, **the global tenant query filter cannot protect it**. Any authenticated
+user, in any tenant, who knows or guesses a project GUID can `GET api/MaterialSync/snapshot/{id}`
+and read that project's material library.
+
+Two secondary problems: the snapshot is on the container filesystem, so it does not survive a
+Render redeploy; and the docstring calls this "minimum-viable persistence" with per-row DB rows
+"in a follow-up migration" that never landed.
+
+**This is not a UI gap.** Verdict: **fix the authorization**, independent of any client work.
+I have not touched it — flagging for a decision.
+
+### B1 — WorkOrders and GlobalIdRegistry have no table
+
+Both appear in the EF model snapshot — `b.ToTable("WorkOrders")` at
+`PlanscapeDbContextModelSnapshot.cs:8910`, `b.ToTable("GlobalIdRegistry")` at `:2372` — but **no
+migration creates either table**. Grep for `name: "WorkOrders"` / `name: "GlobalIdRegistry"` across
+all non-Designer migrations returns nothing.
+
+So on a database built by `dotnet ef database update`, every action on these two throws a Postgres
+"relation does not exist". They are **not** a missing-UI problem; they are a missing migration.
+
+*Caveat:* I could not check the production database, so it is possible the tables exist there via
+another path. That is exactly what the runtime pass would have settled.
+
+This makes **WorkOrders' otherwise-encouraging story moot for now** — its downstream *is* live
+(`StingTools/BIMManager/PlatformEvents/ParamStampEventHandler.cs` is a real handler that writes the
+parameter onto the Revit element), so once the table exists this is a genuinely complete loop.
+
+### C1 — ApprovalChains duplicates a live mechanism
+
+There are **two** document-approval implementations:
+
+| | route | client |
+|---|---|---|
+| `DocumentsController` | `POST /documents/{id}/approval-request`, `PUT /documents/{id}/approval/{aid}`, `GET /documents/{id}/approval-status` | **mobile** (`Planscape/src/api/endpoints.ts:1005,1012`) |
+| `ApprovalChainsController` | `/documents/{docId}/approval-chain` (+ `/decisions`) | none |
+
+The chain version supports multi-step and parallel approval, which the flat one does not — so it is
+not simply redundant. But "wire a client" is the wrong first question: the right one is **which of
+the two is canonical**, because shipping a UI for the second creates two approval records for one
+document. Verdict: **decide before building.**
+
+### M1 — MfaController's docstring is stale (confirmed)
+
+Line 13: *"Production implementation would use a TOTP library (e.g. Otp.NET)"*. It already does:
+`using OtpNet;` (`:5`), `IDataProtector` for secret storage (`:23`), and
+`totp.VerifyTotp(req.Code, out _, new VerificationWindow(2, 2))` (`:119`) — the ±2-step window you
+described. **The implementation is real; the comment is wrong.** Trivial fix, not shipped here
+because 6A carries no code.
+
+### M2 — DeviceTwinsController's docstring is wrong (confirmed)
+
+Lines 11-12 claim it *"Powers the mobile Live tab (RAG list)"*. There is **no Live tab** in
+`Planscape/app/` — the only near-match in a case-insensitive listing is `de`**live**`rables`.
+Telemetry ingest does exist (`TelemetryIngestController`, `IDeviceTwinService`,
+`ITwinBindingService` all registered), so the downstream is not dead — but the claimed consumer
+does not exist.
+
+---
+
+## 3. Tier recommendations
+
+### Tier 1 — complete now
+
+**CdeContainers** — agreed, and I verified your note: the gate at `:255` is
+`ProjectRole in {Manager, Admin, Owner}`, a vocabulary that **is** assignable from the web dropdown
+today, so unlike the PM gates it is **live**. It must **not** be folded into the Phase 1 capability
+helper without a deliberate decision, because `CanCurateProject` also admits `Coordinator` and
+three ISO codes — that would *widen* who can restructure the CDE folder tree. Backed, scoped, DI-clean.
+
+**DataRights — STOP, decision needed before any UI.** The brief anticipated this. `POST erase`
+touches `Users`, `Projects`, `ProjectMembers`, `Documents`, `ProjectModels`, `Issues`, `Invoices`,
+`Subscriptions`, `AuditLogs`, `Tenants`. I have not yet traced whether each is a soft-delete, an
+anonymisation, or a hard delete, nor whether `cancel-erase` can actually undo it. **A button must
+not be shipped until the UI copy can describe truthfully what the request destroys.** That trace is
+the first thing I would do in 6B — it is a read-only exercise and does not need the server.
+
+### Tier 2 — real features, schedule deliberately
+
+`AssetDataSheets`, `OfflineManifest`, `Mfa` (fix M1), `ApprovalChains` (**after C1 is decided**).
+
+### Tier 3 — not a UI job
+
+`WorkOrders` and `GlobalIdRegistry` — blocked on B1 (missing migration).
+`DeviceTwins` — fix M2; a UI needs a real telemetry source and a decision on where the RAG list lives.
+`CaseStudy` — a one-action sales-deck PDF; a UI is a sales-ops question, not product parity.
+
+### Security, out of band
+
+`MaterialSync` (S1) — fix authorization regardless of client work.
+
+---
+
+## Runtime gap
+
+Not measured, and it matters for exactly these questions:
+
+1. whether `WorkOrders` / `GlobalIdRegistry` tables exist in a real deployed database (B1);
+2. actual status codes and error bodies for every action — the brief's item 1 asks for real error
+   shapes, and I have only the ones visible in source;
+3. whether anything 500s for a reason not visible statically. DI is clean, which removes the
+   known-prior cause, but does not prove the actions run.
+
+To close it I need either the Docker daemon started, or a Postgres reachable on 5432 plus a
+connection string. SQLite is not a substitute: `Program.cs`'s schema block runs
+`SELECT … FROM information_schema.tables`, which is Postgres-only and uncaught, so the host dies
+before serving a request.
+
+**Awaiting review of this table before building anything.**

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,21 +1,39 @@
-# Phase 6A — clientless controller triage (amended twice)
+# Phase 6A — clientless controller triage (amended three times)
 
-**Originally measured 2026-08-01; amended 2026-08-02 after review; runtime pass added 2026-08-02,
-on `claude/phase6-runtime` @ `bf7cbb19a`.** Triage only — no feature code.
+**Originally measured 2026-08-01; amended 2026-08-02 after review; runtime pass added 2026-08-02;
+corrected 2026-08-02 (fourth pass) after a second review.** Triage only — no feature code.
 
-> **The runtime column is now MEASURED, and it overturns B1.** Docker Desktop started on this
-> attempt, so the pass ran against a real Postgres. **All fourteen controllers serve traffic and not
-> one returns `relation … does not exist`** — including all seven the previous revision rated
-> "Tier 3 — blocked". See [Runtime pass](#runtime-pass-measured).
+> **Correction — two things in the previous revision were wrong.**
 >
-> The reason is [B1-R](#b1-r--why-the-unmigrated-tables-exist-anyway): this codebase does **not**
-> build its schema from the migration folder. `PlatformSchemaPatcher` creates those six tables at
-> boot with `CREATE TABLE IF NOT EXISTS`, in **both** the Development and Production branches, and
-> ADR 0001 declares that the official mechanism. The "Backed" column below was measuring the wrong
-> thing — and in practice it is **inverted**.
+> **1. The runtime pass is not evidence for B1, and no longer reads as if it were.** It ran against
+> `docker-api-1`, which is `ASPNETCORE_ENVIRONMENT=Development` (verified on the container). That
+> takes `Program.cs:1522` → `useEnsureCreated` → `creator.CreateTables()` (`:1559`), which
+> materialises **every table in `OnModelCreating`** whether or not a migration creates it. "Zero
+> `relation … does not exist` across fourteen controllers" was therefore **true by construction** and
+> says nothing about production. The §4 replication booted Development too, so it controls for
+> environment artefacts but inherits the same limitation. What the pass does establish: the
+> controllers serve traffic, their DI resolves, and their write paths persist. What it cannot
+> establish: anything about a schema built any other way.
 >
-> **No production database was queried.** Everything below is local: a fresh empty DB, the API's own
-> boot path, and the compose stack.
+> **2. B1 was wrong — but not because "the tables exist at runtime".** Six of the seven are created by
+> `PlatformSchemaPatcher.ApplyAsync` (`Program.cs:1585`) with raw `CREATE TABLE IF NOT EXISTS`. That
+> call sits **outside** the `if (useEnsureCreated) … else Migrate()` split, so it runs in **both**
+> branches — which is a static fact about the code, valid for production, and it is the actual reason
+> those six exist there. A `CreateTable` grep cannot see them because they are patcher-created, not
+> migration-created. B1 is restated below as a **migration-hygiene** finding — model, migrations and
+> patcher are three sources of truth for one schema — not as missing tables. The five twin
+> controllers are re-assessed on their own merits rather than as B1-blocked.
+>
+> **3. The seventh table — measured.** `DocumentApprovals` is in neither the migrations nor the
+> patcher, and `20260501000000` runs an unguarded `UPDATE "DocumentApprovals"` that the patcher (which
+> runs *after* `Migrate()`) could not rescue. On a fresh empty Postgres with
+> `ASPNETCORE_ENVIRONMENT=Production` and `PLANSCAPE_USE_ENSURE_CREATED` unset, `dotnet ef database
+> update` **completes** — exit 0, 2 migrations applied, 2 tables. It never reaches that migration:
+> the file carries no `[Migration]` attribute, so EF cannot see it (2 of 78 are visible). The hazard
+> is **latent, not live** — and the fix for the hygiene finding is what arms it. Full measurement,
+> including the counterfactual, in [M3](#m3--what-dotnet-ef-database-update-actually-does).
+>
+> **No production database was queried.**
 
 ---
 
@@ -24,8 +42,8 @@ on `claude/phase6-runtime` @ `bf7cbb19a`.** Triage only — no feature code.
 | Review finding | My position after re-verifying |
 |---|---|
 | S1 MaterialSync — confirmed, worse than reported (write too, path leak) | **Verified and fixed.** Removed from this triage — it is PR #542. |
-| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ **Half right, and the half that mattered was wrong.** Six tables genuinely have no `CreateTable` — but they exist at runtime anyway, so nothing was blocked. See B1-R. |
-| C1 ApprovalChains duplication | **Verified** (`endpoints.ts:1004-1015`). |
+| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ ~~Half right — they exist at runtime anyway.~~ **Restated.** The sweep is accurate but measures the wrong thing: six of the seven are created by the *patcher*, which a `CreateTable` grep cannot see. Now a migration-hygiene finding, not a missing-table one. See [B1](#b1--restated-a-migration-hygiene-finding-not-missing-tables). |
+| C1 ApprovalChains duplication | **Undecided, and downgraded from "verified".** The two mechanisms are an **OR**, not competing records — `DocumentsController.cs:1554`. See C1. |
 | Docstring lies (Mfa, DeviceTwins) | **Verified.** Unchanged from the first pass. |
 | DataRights — I was WRONG, re-rate Tier 1 | **Verified; I was wrong.** See DR1. |
 | Capabilities endpoint approved, sequenced after Phase 1 | Taken on trust — it is a decision, not a measurement. |
@@ -37,8 +55,15 @@ MaterialSync is referenced nowhere in `stingtools-core` (I checked the other fiv
 
 **Third pass (2026-08-02, runtime).** The `CreateTable` sweep was re-verified twice and was correct
 both times — but it was the wrong question, and re-running it more carefully could never have
-revealed that. What did was booting the thing. Two reviews of a static finding agreed with each
-other; the first execution overturned them.
+revealed that.
+
+**Fourth pass (2026-08-02, correction).** The third pass then drew the right conclusion from the
+wrong evidence. It credited the *runtime pass* with overturning B1, when the runtime pass ran on the
+`EnsureCreated` path and could not have failed. The thing that actually overturns B1 is **reading
+`PlatformSchemaPatcher` and noticing where `Program.cs` calls it** — a static fact that holds in
+Production, which the third pass did record (§2 of B1-R) but buried under a runtime result that was
+true by construction. Booting the thing was still the right instinct; the error was in what the boot
+was allowed to prove. One measurement in this pass is genuinely new: [M3](#m3--what-dotnet-ef-database-update-actually-does).
 
 ---
 
@@ -70,57 +95,97 @@ runs in 30 days; reversible until then."** → **Tier 1.**
 
 ---
 
-## B1 — six unmigrated tables, not five
+## B1 — restated: a migration-hygiene finding, not missing tables
 
-Re-ran the `CreateTable` sweep independently. The review's five reproduce exactly, **plus one it
-missed**:
+The `CreateTable` sweep reproduces and is accurate. The question it answers is not the one B1 asked.
+**Three** mechanisms in this codebase can put a table in a database, and the sweep consulted one:
 
-| Table | Migration | In model snapshot |
-|---|---|---|
-| ApprovalChains | ✅ `20260513000000_AddPost204ServerEnhancements` | — |
-| AssetDataSheets | ✅ `20260513100000_AddAssetDataSheetEngine` | — |
-| AssetDataSheetTemplates | ✅ `20260513100000_AddAssetDataSheetEngine` | — |
-| CdeContainers | ✅ `20260517000003_AddCdeFolderHierarchy…` | — |
-| MfaEnrollments | ✅ `20260517000000_AddBoq…SsoMfaDashboard` | — |
-| **DeviceTwins** | ❌ none | yes |
-| **TwinAlerts** | ❌ none | yes |
-| **TwinRules** | ❌ none | yes |
-| **TelemetryPoints** | ❌ none | yes ← **not in the review's list** |
-| **GlobalIdRegistry** | ❌ none | yes |
-| **WorkOrders** | ❌ none | yes |
+| # | Mechanism | Invoked at | Covers |
+|---|---|---|---|
+| 1 | EF model — `OnModelCreating` → `…ModelSnapshot.cs` | `creator.CreateTables()`, `Program.cs:1559` (only when `useEnsureCreated`, `:1522`) | the whole model — 134 tables on a virgin Development boot |
+| 2 | Migration folder — `Data/Migrations/` | `db.Database.Migrate()`, `Program.cs:1564` (Production path) | 78 files, of which **EF can see 2** |
+| 3 | `PlatformSchemaPatcher` — raw `CREATE TABLE IF NOT EXISTS` | `Program.cs:1585`, **outside** the `if/else`, so **both** branches | 19 tables |
 
-All six are present in `PlanscapeDbContextModelSnapshot.cs` (so EF believes they exist) with no
-`CreateTable` anywhere in a non-Designer migration.
+Mechanism 3 is the one B1 missed, and it is why the verdict flips. Adding it as a column:
+
+| Table | Migration `CreateTable` | Patcher | In EF model | Present in prod? |
+|---|---|---|---|---|
+| ApprovalChains | ✅ `20260513000000_AddPost204ServerEnhancements` | — | yes | yes |
+| AssetDataSheets | ✅ `20260513100000_AddAssetDataSheetEngine` | — | yes | yes |
+| AssetDataSheetTemplates | ✅ `20260513100000_AddAssetDataSheetEngine` | — | yes | yes |
+| CdeContainers | ✅ `20260517000003_AddCdeFolderHierarchy…` | — | yes | yes |
+| MfaEnrollments | ✅ `20260517000000_AddBoq…SsoMfaDashboard` | — | yes | yes |
+| **DeviceTwins** | ❌ none | ✅ `:91` | yes | **yes — patcher** |
+| **TelemetryPoints** | ❌ none | ✅ `:115` | yes | **yes — patcher** |
+| **TwinRules** | ❌ none | ✅ `:126` | yes | **yes — patcher** |
+| **TwinAlerts** | ❌ none | ✅ `:143` | yes | **yes — patcher** |
+| **WorkOrders** | ❌ none | ✅ `:162` | yes | **yes — patcher** |
+| **GlobalIdRegistry** | ❌ none | ✅ `:260` | yes | **yes — patcher** |
+| **DocumentApprovals** | ❌ none | ❌ none | yes | **model only — see M3** |
 
 > ~~On a database built by `dotnet ef database update`, every action reaching one throws
 > `relation "X" does not exist`.~~
 >
-> **This sentence is wrong and is the load-bearing error of the previous revision.** The `CreateTable`
-> sweep itself reproduces — no migration creates those six — but the inference does not, because
-> **no environment is built by `dotnet ef database update`.** Measured, not argued: see B1-R.
+> ~~The inference fails because no environment is built by `dotnet ef database update`.~~
+>
+> **Both of those are superseded.** The first was wrong; the second was *right about prod for the
+> wrong reason* — it leaned on a runtime pass that could not have failed. The correct statement is
+> narrower and stronger: **the patcher call site is unconditional across environments**
+> (`Program.cs:1585` is outside the branch at `:1538`/`:1562`, guarded only by
+> `db.Database.IsRelational()`), so any instance that boots at all has those six tables. That is read
+> off the source, holds in Production, and needs no runtime pass and no prod query to assert.
 
-### ~~The twin cluster is entirely unreachable~~ — the service→table mapping, which stands
+**So B1 is a hygiene finding, not an availability one.** One logical schema is defined in three
+places that no build step reconciles. Nothing follows from "no migration creates X" in either
+direction — as the table shows, the five B1 rated ✅ are precisely the five a migrations-only
+database *lacks* (B1-R §3), and the six it rated ❌ are present everywhere. The real defect is that
+the three sources can disagree silently; `SchemaDriftChecker` (`Program.cs:1610`) is the only thing
+catching that, at boot, per environment.
+
+**The one table where they do disagree is `DocumentApprovals`** — in the model, in no migration, in
+no patcher. That is the residue of B1 worth acting on, and it is measured in [M3](#m3--what-dotnet-ef-database-update-actually-does).
+
+### The twin cluster — service→table mapping, which stands
 
 The review correctly warned that these controllers reach tables through services, so I traced each
 service to the tables it actually touches rather than assuming:
 
-| Controller | Route | Reaches | Verdict |
+| Controller | Route | Reaches | Creating mechanism |
 |---|---|---|---|
-| DeviceTwins | `…/twins` | `IDeviceTwinService` → `DeviceTwins`, `TelemetryPoints` | **both unmigrated** |
-| TwinAlerts | `…/twins/alerts` | `_db.TwinAlerts` directly | **unmigrated** |
-| TwinRules | `…/twins/rules` | `_db.TwinRules` directly | **unmigrated** |
-| TwinProvisioning | `…/twins/provision` | `ITwinProvisioningService` → `DeviceTwins`, `TaggedElements` | **DeviceTwins unmigrated** |
-| TelemetryIngest | `…/telemetry` | `IDeviceTwinService` → `DeviceTwins`/`TelemetryPoints`; `ITwinRuleEvaluator` (`TwinRuleEngine`) → `DeviceTwins`, `TwinAlerts`, `TwinRules` | **all unmigrated** |
+| DeviceTwins | `…/twins` | `IDeviceTwinService` → `DeviceTwins`, `TelemetryPoints` | patcher `:91`, `:115` |
+| TwinAlerts | `…/twins/alerts` | `_db.TwinAlerts` directly | patcher `:143` |
+| TwinRules | `…/twins/rules` | `_db.TwinRules` directly | patcher `:126` |
+| TwinProvisioning | `…/twins/provision` | `ITwinProvisioningService` → `DeviceTwins`, `TaggedElements` | patcher `:91`; model |
+| TelemetryIngest | `…/telemetry` | `IDeviceTwinService` → `DeviceTwins`/`TelemetryPoints`; `ITwinRuleEvaluator` (`TwinRuleEngine`) → `DeviceTwins`, `TwinAlerts`, `TwinRules` | patcher, all |
 
-The service→table mapping above is correct and I leave it standing — it is useful. What I drew from
-it was not. I concluded **"none of them has a table to write to"**; the runtime pass shows every one
-of them has a table and writes to it successfully (`TwinRules` = 8 rows after `seed-defaults`,
-`DeviceTwins` and `TelemetryPoints` = 1 row each after `POST …/telemetry/ingest`).
+The mapping is correct and stands. The conclusion I drew from it — *"none of them has a table to
+write to"* — does not: every table in that column is created by the patcher on every boot, in both
+branches.
 
-**STOP item, still respected — and now clearly the right call.** I did not author the six migrations.
-Had I done so it would have been wasted work in the most misleading way: adding files to a folder EF
-does not read (B1-R). The precondition the standing rule sets — establish at runtime that the tables
-are really missing — is exactly what caught this, and the answer is that they are **not** missing.
+### Re-assessed on their own merits, not as B1-blocked
+
+Dropping the B1 premise entirely, and *not* relying on the by-construction runtime pass, what is
+actually established about these five:
+
+- **Schema** — present in any booted environment, from the unconditional patcher call site. Static,
+  Production-valid.
+- **DI** — every injected service (`IDeviceTwinService`, `ITwinRuleEvaluator`, `ITwinProvisioningService`)
+  is registered; static check of `Program.cs`. This matters more than usual here: the known-prior
+  failure mode is a controller 500ing on every call from a missing registration.
+- **Auth + tenant scoping** — `[Authorize]` on all five, `TenantId` filtering as per the triage table.
+- **Client** — none, in any of the six clients checked.
+
+That is a **product** gap — a working backend with no consumer — not a platform one, and it is Tier 2
+for that reason alone. The dev-path pass is corroboration that they serve traffic and persist writes;
+it is not the basis of the rating.
+
+**Not yet established, and not claimed:** populated-table behaviour for `TwinAlerts`/`WorkOrders`
+(both read 200 over *empty* tables), and cross-tenant isolation (single-tenant demo login).
+
+**STOP item still respected.** I have not authored migrations for the six. That remains correct, for
+a plainer reason than before: the tables already exist, so a migration adding them would be a no-op
+at best and a `42P07` at worst. If the hygiene finding is ever actioned, the unit of work is
+reconciling the three sources — not adding six files to a folder EF does not read.
 
 ---
 
@@ -133,25 +198,42 @@ Three measurements, all local, in the order I made them.
 `src/Planscape.Infrastructure/Data/Migrations/`:
 
 ```
-migration .cs (excl. Designer/snapshot) : 80
-.Designer.cs companions                 :  2
-files carrying [Migration(              :  2   (MeetingMedia, SustainabilitySnapshots)
+migration .cs (excl. Designer/snapshot) : 78     ← previous revision said 80; it counted
+.Designer.cs companions                 :  2       the 2 Designer files as migrations
+files carrying [Migration(              :  2     (MeetingMedia, SustainabilitySnapshots)
 ```
 
-So `Migrate()` / `ef database update` applies **2 of 80**. This is not new breakage —
+So `Migrate()` / `ef database update` applies **2 of 78** — confirmed directly in
+[M3](#m3--what-dotnet-ef-database-update-actually-does) by `dotnet ef migrations list`, which
+enumerates exactly those two. This is not new breakage —
 [`docs/adr/0001-schema-management.md`](adr/0001-schema-management.md) (Accepted, 2026-06-04) records
 it and **adopts `EnsureCreated` + idempotent patchers as the official, supported mechanism**. It
-measured 0 of 75 then; the count has since drifted to 2 of 80. I did not consult that ADR in either
+measured 0 of 75 then; the count has since drifted to 2 of 78. I did not consult that ADR in either
 earlier pass, which is how the wrong inference survived two reviews.
 
-**2. A patcher creates all six, on every boot, in both branches.**
+**2. A patcher creates all six, on every boot, in both branches. ← this is the load-bearing one.**
 `PlatformSchemaPatcher.cs` issues `CREATE TABLE IF NOT EXISTS` for `DeviceTwins` (`:91`),
 `TelemetryPoints` (`:115`), `TwinRules` (`:126`), `TwinAlerts` (`:143`), `WorkOrders` (`:162`) and
-`GlobalIdRegistry` (`:260`). `Program.cs:1585` calls it **outside** the `if (Development) … else
+`GlobalIdRegistry` (`:260`). `Program.cs:1585` calls it **outside** the `if (useEnsureCreated) … else
 Migrate()` split, guarded only by `db.Database.IsRelational()` — the in-file comment says it runs in
 both branches precisely because "the hand-authored `Migrate()` set is also incomplete".
 
-**3. Fresh-database boot on the Production path — the decisive test.** Empty DB (0 tables), API
+This single fact is the whole of the B1 correction, and it is **static**: it is true of Production
+because of where the call sits, not because of anything observed on a dev stack. Measurements 3 and 4
+below are supporting colour; this is the argument. The previous revision had it — as item 2 of a list
+— and then credited the overturn to the runtime pass, which is the error this pass fixes.
+
+One ordering caveat, since it matters for M3: the patcher runs at `:1585`, **after** `Migrate()` at
+`:1564`. It cannot rescue a migration that throws first — the boot is already dead. And
+`SchemaDriftChecker` runs later still (`:1610`), strict by default outside Development
+(`:1604-1609`, nothing overrides it in `appsettings*.json` or `render.yaml`). So the boot sequence is
+**migrate → patch → assert-no-drift**, and a Production instance that is serving traffic has passed
+all three. That last point is worth more than any single-table argument: on a booted non-dev
+instance, *every* table in the EF model exists, or the process would have exited at `:1610`.
+
+**3. Fresh-database boot on the Production path.** This one genuinely exercises the non-dev branch,
+and it stands — though it is corroboration for §2, not the "decisive test" the previous revision
+billed it as. Empty DB (0 tables), API
 booted with `ASPNETCORE_ENVIRONMENT=Production` so it takes the `Migrate()` branch:
 
 ```
@@ -176,9 +258,7 @@ untouched — to check they were not artefacts of one environment. They reproduc
 migration files carry `[Migration(`; `PlatformSchemaPatcher` creates the six at the same six line
 numbers; all six exist afterwards.
 
-The replication also produced a cleaner form of the decisive test. Rather than boot the Production
-path and read the wreckage, boot the **Development** path against a virgin database and inspect what
-a *successful* boot leaves behind:
+The replication also booted the **Development** path against a virgin database:
 
 ```
 createdb planscape3            -> 0 tables, `ef database update` never run against it
@@ -187,10 +267,17 @@ tables in public               -> 134, including all six disputed tables
 "__EFMigrationsHistory"        -> ERROR: relation "__EFMigrationsHistory" does not exist
 ```
 
-A working, fully-populated 134-table schema with **no migrations-history table at all** is the
-tidiest available statement of the finding: on the path every live environment actually takes, the
-migration mechanism is not merely incomplete, it never runs. Nothing that is true of the migration
-folder can therefore predict what a booted database contains.
+> **Corrected reading.** The previous revision called this "the decisive test" and glossed it as *"on
+> the path every live environment actually takes, the migration mechanism never runs."* The first
+> half of that is unsupported — nothing here establishes which path a deployed environment takes, and
+> `useEnsureCreated` is `IsDevelopment() || PLANSCAPE_USE_ENSURE_CREATED=true` (`:1522`), which is
+> false for a default Production deployment.
+>
+> What it *does* establish, cleanly: on the `EnsureCreated` path the migration mechanism never runs
+> at all (no history table), and `creator.CreateTables()` materialises the **entire** model — all 134
+> tables — so the presence of the six disputed tables here is **true by construction** and carries no
+> information about which mechanism would have created them. Read it as a description of the dev
+> path, not as evidence about prod. The evidence about prod is §2.
 
 *(One incidental defect found while doing this, recorded but not fixed and not a Phase 6A item:
 running `ef database update` **first** and then booting Development is a hard startup crash —
@@ -198,82 +285,206 @@ running `ef database update` **first** and then booting Development is a hard st
 "SustainabilitySnapshots" already exists`. The two supported paths are each fine alone; mixing them
 bricks the boot.)*
 
-**So the Backed column was inverted.** Every table B1 marked ❌ exists; every table it marked ✅ does
-not. And the corollary settles the prod question without touching prod: a database built only from
-this repo's migrations **cannot run the app at all** — it has no `Tenants` and the boot refuses. Any
-environment that is up therefore reached that state through the `EnsureCreated`/patcher path, and
-that path creates all six tables. No manual DDL needs to be hypothesised, and no production query
-could have told us anything this doesn't.
+**So the Backed column was measuring the wrong thing.** Every table B1 marked ❌ is created by the
+patcher; the five it marked ✅ are precisely the five a migrations-only database *lacks*. Migration
+presence carries no information about schema presence in this codebase, in either direction.
 
-### The review's own by-construction argument — right answer, broken premise
+Two things follow, and only the first is safe:
 
-The review proposed settling prod without prod access like this: *no migration creates those six
-tables, and every environment is built by `ef database update` over that same folder, so no
-environment can have them absent manual DDL.* The conclusion it was aimed at — **don't query prod** —
-is correct, and prod was not queried. But the argument as stated does not survive measurement, and it
-matters which way it fails:
+- **Sound.** A database built *only* from this repo's migrations cannot run the app — it has no
+  `Tenants`, and the drift assert (`:1610`, strict outside Development) refuses the boot. So no
+  environment that is currently serving traffic got its schema from the migration folder alone. That
+  is a statement about code and boot order, and it needs no prod query.
+- **Not sound, and withdrawn.** It does *not* follow that the six exist "because every booted
+  environment took the `EnsureCreated` path". Whether a given deployment sets
+  `PLANSCAPE_USE_ENSURE_CREATED` is not established here. The six exist for a simpler reason that
+  doesn't depend on which branch is taken: **the patcher call site is outside the branch.**
 
-| Premise | Verdict |
-|---|---|
-| No migration in the repo creates the six tables | **True** — the `CreateTable` sweep reproduces. |
-| Every environment is built by `ef database update` over that folder | **False.** No environment is. That path applies 2 of 80 and yields a database with no `Tenants`, which the app refuses to boot. |
-| ∴ no environment can have them absent manual DDL | **Inverted.** Every booted environment *does* have them, and no manual DDL is involved — `PlatformSchemaPatcher` creates them on every start. |
+### The by-construction exchange — where each side landed
 
-The first premise is the one that made the six look damning, and it is true but inert: in this
-codebase, migration presence carries no information about schema presence in either direction. The
-five tables B1 called "✅ backed by a migration" are precisely the five a migration-built database
-*lacks*. So the safe-looking inference — read the migration folder, conclude what prod contains — is
-not merely unreliable here, it is anti-correlated.
+Worth recording, because the same mistake was available to both sides and the correction came from
+neither's original argument.
 
-**The real gap is not six missing migrations — it is that 78 of 80 migration files are invisible to
+| Claim | Origin | Verdict |
+|---|---|---|
+| No migration creates the six tables | review, replicated here | **True**, and inert — it licenses no conclusion about any database. |
+| Every environment is built by `ef database update`, so the tables must be absent | review | **Withdrawn by the reviewer.** No environment is; that path applies 2 of 78 (M3). |
+| The runtime pass shows the tables exist, so B1 is refuted | this doc, third pass | **Withdrawn here.** The pass ran on the `EnsureCreated` path where all 134 model tables exist by construction; it could not have come out otherwise. |
+| The patcher creates six of them at an unconditional call site | reviewer's correction; present but buried in §2 of the third pass | **This is the actual answer**, and it is static and Production-valid. |
+
+The instructive part is that a static finding survived two careful re-verifications, was then
+"overturned" by a runtime result that was true by construction, and was finally settled by reading
+twenty lines of `Program.cs` around the call site. Neither re-grepping nor booting harder would have
+got there.
+
+**The real gap is not six missing migrations — it is that 76 of 78 migration files are invisible to
 EF.** That is an existing, documented, accepted architectural decision (ADR 0001), not a Phase 6A
 finding, and it is out of scope here. Flagging it, not fixing it.
 
 ---
 
+## M3 — what `dotnet ef database update` actually does
+
+**The question.** `20260501000000_AddTenantIdToAllScopedEntities` runs an **unguarded**
+`UPDATE "DocumentApprovals"` (table listed at `:37`, SQL emitted at `:62-65`) — and
+`DocumentApprovals` is created by no migration and no patcher. The patcher runs at `Program.cs:1585`,
+*after* `Migrate()` at `:1564`, so it cannot rescue a migration that throws first. Does the
+Production schema path therefore die, and if so where?
+
+**Configuration — the prod path, and only the prod path.** Fresh `postgres:16-alpine`, empty
+(`0` tables in `public`), `ASPNETCORE_ENVIRONMENT=Production`, `PLANSCAPE_USE_ENSURE_CREATED` unset,
+running `dotnet ef database update` **alone — not the app**.
+
+> Recorded because it strengthens the isolation rather than weakens it: `dotnet ef` resolves the
+> context through `PlanscapeDbContextFactory` (`IDesignTimeDbContextFactory`), and logged
+> *"An error occurred while accessing the Microsoft.Extensions.Hosting services. Continuing without
+> the application service provider."* — it failed to build the app host (missing `Jwt:Key`) and used
+> the factory. So **no line of `Program.cs` executed**: no `EnsureCreated`, no patcher, no drift
+> check. The factory reads only `CONNECTION_STRING`/`PG*`, which also means `ef database update` is
+> environment-independent — the two env vars above cannot influence it. This is the migration
+> mechanism in isolation, which is exactly what was asked for.
+
+**Result — it completes.**
+
+```
+$ dotnet ef migrations list
+20260605041920_MeetingMedia (Pending)
+20260626203153_SustainabilitySnapshots (Pending)      ← 2 of 78 files
+
+$ dotnet ef database update
+... CREATE TABLE "SustainabilitySnapshots" ... ; INSERT INTO "__EFMigrationsHistory" ...
+Done.                                                  ← exit 0
+```
+
+End state of the database:
+
+| | |
+|---|---|
+| tables in `public` | **2** — `SustainabilitySnapshots`, `__EFMigrationsHistory` |
+| `__EFMigrationsHistory` rows | `20260605041920_MeetingMedia`, `20260626203153_SustainabilitySnapshots` |
+| `DocumentApprovals` | **absent** |
+| `Tenants` | **absent** |
+
+**It does not stop at `20260501000000` — it never reaches it.** That file carries no `[Migration]`
+attribute and has no `.Designer.cs` companion, so EF does not enumerate it. Its `Up()` never runs and
+its unguarded `UPDATE` never executes. The two migrations EF *can* see are both idempotent by
+construction: `MeetingMedia` is `ALTER TABLE IF EXISTS … ADD COLUMN IF NOT EXISTS` (its own comment
+notes a plain `AddColumn` "would therefore fail at this migration on a fresh DB"), and
+`SustainabilitySnapshots` is a plain `CreateTable`.
+
+**The counterfactual, also measured.** If that migration were made discoverable — which is precisely
+what "fixing the migration hygiene" would do — it fails, but **not** at `DocumentApprovals`. Step 1
+(`:47-48`) calls `AddNullableTenantId`, which emits an unguarded `mb.AddColumn<Guid>`, and its first
+table is `TaggedElements`, created by no migration either. Both statements run against the
+just-migrated database:
+
+```sql
+ALTER TABLE "TaggedElements" ADD COLUMN "TenantId" uuid NULL;
+  ERROR:  relation "TaggedElements" does not exist
+UPDATE "DocumentApprovals" c SET "TenantId" = p."TenantId" FROM "Documents" p WHERE …;
+  ERROR:  relation "DocumentApprovals" does not exist
+```
+
+So `DocumentApprovals` is not a special case — it is one of the **26** tables that migration touches,
+none of which a migrations-only database has. The migration is unrunnable from its first statement.
+
+**What this settles, and what it leaves open.**
+
+- **The hazard is latent, not live.** No boot can hit it today, because EF cannot see the migration.
+  It is armed the moment someone regenerates the migration set or hand-adds the `[Migration]`
+  attribute — the well-intentioned fix for the hygiene finding is exactly the trigger. Worth a
+  comment in the file; that is a one-line change and is *not* in this docs-only PR.
+- **`DocumentApprovals` on a live instance.** Still model-only — but it is in `OnModelCreating`
+  (`PlanscapeDbContext.cs:148`) and in the snapshot, and `SchemaDriftChecker` asserts the full model
+  against the live schema at `:1610`, strict by default outside Development. So any non-dev instance
+  that is serving traffic has the table, or it would have exited at boot. That is the same
+  code-and-boot-order argument as B1-R §2, and it is as far as this can be taken without a prod query.
+- **The "2 of 78 + drift-checker" pairing is the actual system.** Migrations are inert, the patcher
+  covers 19 tables, the model covers 134, and the only thing reconciling them is a boot-time assert.
+  That is the hygiene finding, now with a measured failure mode attached.
+
+---
+
 ## Amended triage table
 
-Legend — **Backed**: table exists on a booted database (was: "a migration creates it" — see B1-R for
-why that was the wrong test). **DI**: every injected service resolves (static check of `Program.cs`).
-**Runtime**: measured — status code from the pass below.
+Legend — **Schema from**: which of the three mechanisms creates the controller's tables (B1). The
+previous revision labelled this column "Backed / ✅ patcher" for every row, which was wrong for rows
+2–6: those are migration-created, not patcher-created. Corrected and individually verified below.
+**DI**: every injected service resolves (static check of `Program.cs`). **Dev runtime**: status code
+from the pass below — measured on the `EnsureCreated` path, so it evidences *reachability*, not
+schema provenance.
 
-| # | Controller | Ln / actions | Auth gate | Tenant scoping | Backed | DI | Runtime | Verdict |
+| # | Controller | Ln / actions | Auth gate | Tenant scoping | Schema from | DI | Dev runtime | Verdict |
 |---|---|---|---|---|---|---|---|---|
-| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | n/a | ✅ | 200 | **Tier 1** — DR1 |
-| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | ✅ patcher | ✅ | 200 | **Tier 1** |
-| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | ✅ patcher | ✅ | 200 | Tier 2 — blocked on C1 |
-| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | ✅ patcher | ✅ | 200 | Tier 2 |
-| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 400¹ | Tier 2 — mobile-only by nature |
-| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | ✅ patcher | ✅ | 200 | Tier 2 — works; fix M1 |
-| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
-| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
-| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**; fix M2 |
-| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | read-only | ✅ | 200 | Tier 3 — sales tool |
-| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
-| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
-| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
-| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | model | ✅ | 200 | **Tier 1** — DR1 |
+| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | migration | ✅ | 200 | **Tier 1** |
+| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | migration | ✅ | 200 | Tier 2 — **undecided, C1** |
+| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | migration | ✅ | 200 | Tier 2 |
+| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | migration | ✅ | 400¹ | Tier 2 — mobile-only by nature |
+| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | migration | ✅ | 200 | Tier 2 — works; fix M1 |
+| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | **patcher** `:162` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | **patcher** `:260` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | **patcher** `:91`, `:115` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**²; fix M2 |
+| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | model (read-only) | ✅ | 200 | Tier 3 — sales tool |
+| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | **patcher** `:143` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | **patcher** `:126` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | **patcher** `:91` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | **patcher** (all) | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
 | — | ~~MaterialSync~~ | — | — | — | — | — | — | **Removed — shipped as PR #542** |
 
 ¹ `400` is ordinary model validation, not a schema failure: `{"errors":{"deviceId":["The deviceId
 field is required."]}}`. The pass sent no query string. Route shape, not breakage.
+
+² **Re-rated on their own merits, not on the runtime pass.** The basis is the static one in
+[B1](#re-assessed-on-their-own-merits-not-as-b1-blocked): an unconditional patcher call site
+(`Program.cs:1585`) puts the tables on any booted instance including Production, DI resolves, auth
+and tenant scoping are as tabulated, and no client exists in any of the six checked. The dev-path
+200s corroborate reachability; they are not what moves the row.
 
 **DI is clean across all fourteen.** The known-prior failure mode (a controller 500ing on every call
 from a missing registration, misreported by the browser as CORS) does not apply to any of them.
 
 **Seven rows moved off Tier 3.** They were rated blocked on a schema premise that does not hold. They
 are now ordinary Tier 2: the backend works, there is no client. That is a *product* gap, not a
-*platform* one, and it is a materially different piece of work.
+*platform* one, and it is a materially different piece of work. Row 3 is the exception — it is Tier 2
+on the same grounds but its *scope* is undecided pending C1.
 
 ---
 
-## Unchanged findings
+## Other findings
 
-**C1 — ApprovalChains duplicates a live mechanism.** Re-verified: `Planscape/src/api/endpoints.ts`
-drives `DocumentsController`'s flat approval (`POST …/approvals` at `:1005`, `PUT …/approval/{id}` at
-`:1012` — the file comments on the singular in the decide route). `ApprovalChainsController` adds
-multi-step and parallel approval and has no client. **Which is canonical must be decided before any
-UI**, or one document gets two approval records.
+**C1 — ApprovalChains vs the flat path: UNDECIDED, and "duplication" was too strong.**
+
+Downgraded from "verified". The client half reproduces: `Planscape/src/api/endpoints.ts` drives
+`DocumentsController`'s flat approval (`POST …/approvals` at `:1005`, `PUT …/approval/{id}` at
+`:1012`), and `ApprovalChainsController` has no client. What does not reproduce is the consequence I
+attached to it — *"or one document gets two approval records."*
+
+The gate is `DocumentsController.CheckApprovalGate` (`:1544-1566`), and it is an **OR**:
+
+```csharp
+var hasLegacyApproval  = await _db.DocumentApprovals.AnyAsync(a => … a.Status == "APPROVED"
+                             && (a.RevisionSnapshot == null || a.RevisionSnapshot == currentRevision));   // :1551-1553
+var hasCompletedChain  = await _db.ApprovalChains.AnyAsync(c => … c.Status == "COMPLETED");               // :1554-1555
+if (!hasLegacyApproval && !hasCompletedChain) return BadRequest(…);                                       // :1556
+```
+
+Either one alone satisfies the transition; the docstring says so deliberately (`:1536-1538` — "Documents
+may use the legacy single-approver path or the new multi-step chain **interchangeably**"). They are
+alternative satisfiers of one gate, not competing records, and nothing here writes two.
+
+**What remains, and it is a real decision:** two mechanisms for one concept, one with a client and one
+without. Which the UI drives is a product call, not a correctness bug — and the interchangeable gate
+means shipping a chain UI would not corrupt anything, it would just leave two supported routes to the
+same state.
+
+**What M3 contributes.** Schema provenance does not break the tie: `ApprovalChains` is
+migration-created, `DocumentApprovals` is the one table in B1's list that **neither** a migration nor
+the patcher creates — model-only. Both nonetheless exist on any booted non-dev instance (the drift
+assert would have refused the boot otherwise), so neither path is at risk and neither is favoured.
+
+**To close it** someone has to pick the canonical mechanism and say whether the OR stays. That is the
+one open item this triage cannot settle by measurement.
 
 **M1 — Mfa docstring is stale.** `:13` says "Production implementation would use a TOTP library (e.g.
 Otp.NET)". It already does: `using OtpNet;` (`:5`), `IDataProtector` (`:23`),
@@ -286,7 +497,19 @@ Both to be fixed in whichever PR next touches those files, per the review.
 
 ---
 
-## Runtime pass (measured)
+## Runtime pass (measured on the Development path — reachability only)
+
+> **What this pass can and cannot support.** It ran against `docker-api-1`, whose environment is
+> `ASPNETCORE_ENVIRONMENT=Development`. That takes `Program.cs:1522` → `creator.CreateTables()`
+> (`:1559`), which materialises **every table in the EF model**. So "no controller returned
+> `relation … does not exist`" was **true by construction** — no possible outcome of this pass could
+> have shown a missing table, whatever the migrations or the patcher do. The §4 replication booted
+> Development too.
+>
+> **Valid conclusions:** the fourteen controllers are routable, their DI graph resolves at runtime,
+> their handlers do not throw, and their write paths persist rows.
+> **Invalid conclusions, previously drawn here:** anything about production's schema, and anything
+> about *which* mechanism creates a table. Those come from B1-R §2 and [M3](#m3--what-dotnet-ef-database-update-actually-does).
 
 **Closed.** The blocker did not reproduce. `Start-Process "C:\Program Files\Docker\Docker\Docker
 Desktop.exe"` brought the daemon up first try — `docker version` → server `29.4.3`, `docker-desktop`
@@ -332,9 +555,11 @@ auto-provisioning a twin and storing its reading. The write path is live, not a 
 **The three unknowns this was meant to resolve, resolved:**
 
 1. *Status codes per action* — measured above; thirteen 200s and one validation 400.
-2. *Whether the six tables really are absent* — **they are present**, and B1-R shows why they are
-   present on any booted database, without needing to look at a deployed one.
-3. *Whether anything 500s for a reason not visible statically* — nothing 500s.
+2. *Whether the six tables really are absent* — **not resolved by this pass**, and it was wrong to
+   claim it was. On the `EnsureCreated` path they are present by construction. The question is
+   answered instead by B1-R §2 (the patcher's call site is outside the environment branch, so they
+   are present in Production too) — a static argument that does not need this pass at all.
+3. *Whether anything 500s for a reason not visible statically* — nothing 500s, on this path.
 
 **Re-measured independently.** The five disputed reads were re-run in a second session against the
 scratch stack of B1-R §4 — a different database, a different API process, a fresh login — rather than
@@ -348,12 +573,30 @@ twins/alerts         200   relation-missing=0
 twins/rules          200   relation-missing=0
 ```
 
-Same result on a database that has never seen a migration. The 200s are a property of the code and
-the boot path, not of one seeded environment.
+Same result on a database that has never seen a migration — which rules out the first stack's seed
+data as the explanation, and nothing more. Both stacks booted Development, so both had the full model
+materialised; the replication controls for environment artefacts, not for the by-construction
+limitation above.
 
 **Residual limits, stated rather than papered over.** The pass exercises each controller's primary
 action, not all 46 actions; destructive ones (`DataRights erase`, alert `ack`/`resolve`) were
 deliberately not fired. `TwinAlerts` and `WorkOrders` returned 200 over **empty** tables — their read
-path and schema are proven, their populated behaviour is not. And the single-tenant demo login does
-not exercise the cross-tenant isolation each row claims; that wants a two-tenant fixture and is worth
-doing separately.
+path executes, their populated behaviour does not. And the single-tenant demo login does not exercise
+the cross-tenant isolation each row claims; that wants a two-tenant fixture and is worth doing
+separately.
+
+**And the limit this revision adds, which is the important one:** every number in this section comes
+from the `EnsureCreated` path. Nothing here — not the 200s, not the row counts, not the replication —
+is evidence about a schema built any other way. Where this document makes a claim about Production it
+rests on `Program.cs` source and boot order (B1-R §2, M3), never on this pass.
+
+---
+
+## Still open after this pass
+
+| Item | Why it is open | What would close it |
+|---|---|---|
+| **C1 — canonical approval mechanism** | A product decision; both paths work and the gate accepts either. | Someone picks one, and says whether the OR stays. |
+| **Migration hygiene (B1, restated)** | Model / migrations / patcher are three sources of truth for one schema; only a boot-time assert reconciles them. ADR 0001 accepted this. | Out of scope here — flagged, not fixed. |
+| **`20260501000000` is a latent trap** | Invisible to EF today, so it cannot fire; making the migration set discoverable arms it, and it dies on its first statement (M3). | A warning comment in the file, and reconciling the ~26 tables it assumes exist. One line of that is trivial; the rest is the hygiene item above. |
+| **Populated + cross-tenant behaviour** | Dev pass used empty tables and a single-tenant login. | A two-tenant fixture with seeded rows. |

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,0 +1,181 @@
+# Phase 6A — clientless controller triage (amended)
+
+**Originally measured 2026-08-01; amended 2026-08-02 after review, on `main` @ `a5109e3e5`.**
+Triage only — no feature code.
+
+> **The runtime column is STILL NOT MEASURED.** The review assumed Docker was up. It is not: the
+> `docker-desktop` WSL distro stays `Stopped` across two different launch invocations and the daemon
+> pipe never appears. See [Runtime gap](#runtime-gap). Nothing below is presented as a runtime
+> result. Where a static proxy exists it is used and labelled as such.
+
+---
+
+## Amendment summary
+
+| Review finding | My position after re-verifying |
+|---|---|
+| S1 MaterialSync — confirmed, worse than reported (write too, path leak) | **Verified and fixed.** Removed from this triage — it is PR #542. |
+| B1 — five unmigrated tables, not two | **Verified, and it is six.** `TelemetryPoints` is also unmigrated; see B1. |
+| C1 ApprovalChains duplication | **Verified** (`endpoints.ts:1004-1015`). |
+| Docstring lies (Mfa, DeviceTwins) | **Verified.** Unchanged from the first pass. |
+| DataRights — I was WRONG, re-rate Tier 1 | **Verified; I was wrong.** See DR1. |
+| Capabilities endpoint approved, sequenced after Phase 1 | Taken on trust — it is a decision, not a measurement. |
+
+**Independently re-verified:** the migration sweep, the DataRights export/erase split, the
+`DataErasureJob` loop, the twin-cluster service→table mapping, and both docstring claims.
+**Taken on trust:** the sequencing decision for the capabilities endpoint, and the statement that
+MaterialSync is referenced nowhere in `stingtools-core` (I checked the other five clients myself).
+
+---
+
+## DR1 — DataRights: I was wrong, Tier 1 confirmed
+
+My first pass said `POST erase` "touches ten tables including Invoices and Subscriptions". That was
+the controller's **whole DbSet list**, which I attributed to the erase path without reading the erase
+body. The review is right, and the split is clean:
+
+- **Export** (`DataRightsController.cs:54-66`) reads the ten tables — `Tenants`, `Users`, `Projects`,
+  `ProjectMembers`, `Issues`, `Documents`, `ProjectModels`, `AuditLogs`, `Subscriptions`, `Invoices` —
+  to build the subject-access ZIP. Read-only.
+- **Erase** (`:87-99`) touches **one**:
+
+  ```csharp
+  tenant.IsActive = false;
+  tenant.PendingErasureAt = DateTime.UtcNow.AddDays(30);
+  ```
+
+  guarded by `ConfirmationPhrase != "ERASE EVERYTHING"` → 400, and `tenant.Slug == "planscape"` →
+  `400 platform_tenant_protected`.
+- **Cancel** (`:101-110`) resets **both** fields — fully reversible for 30 days.
+- **The loop closes.** `DataErasureJob.cs:47-49` sets `BypassTenantFilter`, selects
+  `PendingErasureAt <= now`, and hard-deletes; wired as a daily Hangfire job at 04:00 UTC
+  (`Program.cs:1791`), with a comment noting the timing lets a same-day `cancel-erase` land first.
+
+So the UI copy is describable, which was the bar I set: **"freezes the tenant now; permanent deletion
+runs in 30 days; reversible until then."** → **Tier 1.**
+
+---
+
+## B1 — six unmigrated tables, not five
+
+Re-ran the `CreateTable` sweep independently. The review's five reproduce exactly, **plus one it
+missed**:
+
+| Table | Migration | In model snapshot |
+|---|---|---|
+| ApprovalChains | ✅ `20260513000000_AddPost204ServerEnhancements` | — |
+| AssetDataSheets | ✅ `20260513100000_AddAssetDataSheetEngine` | — |
+| AssetDataSheetTemplates | ✅ `20260513100000_AddAssetDataSheetEngine` | — |
+| CdeContainers | ✅ `20260517000003_AddCdeFolderHierarchy…` | — |
+| MfaEnrollments | ✅ `20260517000000_AddBoq…SsoMfaDashboard` | — |
+| **DeviceTwins** | ❌ none | yes |
+| **TwinAlerts** | ❌ none | yes |
+| **TwinRules** | ❌ none | yes |
+| **TelemetryPoints** | ❌ none | yes ← **not in the review's list** |
+| **GlobalIdRegistry** | ❌ none | yes |
+| **WorkOrders** | ❌ none | yes |
+
+All six are present in `PlanscapeDbContextModelSnapshot.cs` (so EF believes they exist) with no
+`CreateTable` anywhere in a non-Designer migration. On a database built by `dotnet ef database
+update`, every action reaching one throws `relation "X" does not exist`.
+
+### The twin cluster is entirely unreachable — measured, not assumed
+
+The review correctly warned that these controllers reach tables through services, so I traced each
+service to the tables it actually touches rather than assuming:
+
+| Controller | Route | Reaches | Verdict |
+|---|---|---|---|
+| DeviceTwins | `…/twins` | `IDeviceTwinService` → `DeviceTwins`, `TelemetryPoints` | **both unmigrated** |
+| TwinAlerts | `…/twins/alerts` | `_db.TwinAlerts` directly | **unmigrated** |
+| TwinRules | `…/twins/rules` | `_db.TwinRules` directly | **unmigrated** |
+| TwinProvisioning | `…/twins/provision` | `ITwinProvisioningService` → `DeviceTwins`, `TaggedElements` | **DeviceTwins unmigrated** |
+| TelemetryIngest | `…/telemetry` | `IDeviceTwinService` → `DeviceTwins`/`TelemetryPoints`; `ITwinRuleEvaluator` (`TwinRuleEngine`) → `DeviceTwins`, `TwinAlerts`, `TwinRules` | **all unmigrated** |
+
+So the Tier-2 concern that DeviceTwins' downstream is dead is now **measured**: it is not that
+telemetry ingest is missing — `TelemetryIngestController`, `IDeviceTwinService`, `ITwinRuleEvaluator`
+and `ITwinProvisioningService` all exist and are DI-registered — it is that **none of them has a
+table to write to.**
+
+**STOP item, respected:** I have not authored the six migrations. Per the standing rule, whether the
+tables genuinely do not exist in the deployed database has to be established in the runtime pass
+first, and the migrations then *proposed* with a rollout note. Since the runtime pass could not run,
+that stays open.
+
+---
+
+## Amended triage table
+
+Legend — **Backed**: DbSet + a migration that creates the table. **DI**: every injected service
+resolves (static check of `Program.cs`). **Runtime**: not measured for any row.
+
+| # | Controller | Ln / actions | Auth gate | Tenant scoping | Backed | DI | Verdict |
+|---|---|---|---|---|---|---|---|
+| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | n/a | ✅ | **Tier 1** — DR1 |
+| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | ✅ | ✅ | **Tier 1** |
+| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | ✅ | ✅ | Tier 2 — blocked on C1 |
+| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | ✅ | ✅ | Tier 2 |
+| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | ✅ | ✅ | Tier 2 — mobile-only by nature |
+| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | ✅ | ✅ | Tier 2 — works; fix M1 |
+| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | ❌ B1 | ✅ | Tier 3 — blocked |
+| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked |
+| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked; fix M2 |
+| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | read-only | ✅ | Tier 3 — sales tool |
+| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked |
+| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | ❌ B1 | ✅ | Tier 3 — blocked |
+| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | ❌ B1 | ✅ | Tier 3 — blocked |
+| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | ❌ B1 | ✅ | Tier 3 — blocked |
+| — | ~~MaterialSync~~ | — | — | — | — | — | **Removed — shipped as PR #542** |
+
+**DI is clean across all fourteen.** The known-prior failure mode (a controller 500ing on every call
+from a missing registration, misreported by the browser as CORS) does not apply to any of them.
+
+---
+
+## Unchanged findings
+
+**C1 — ApprovalChains duplicates a live mechanism.** Re-verified: `Planscape/src/api/endpoints.ts`
+drives `DocumentsController`'s flat approval (`POST …/approvals` at `:1005`, `PUT …/approval/{id}` at
+`:1012` — the file comments on the singular in the decide route). `ApprovalChainsController` adds
+multi-step and parallel approval and has no client. **Which is canonical must be decided before any
+UI**, or one document gets two approval records.
+
+**M1 — Mfa docstring is stale.** `:13` says "Production implementation would use a TOTP library (e.g.
+Otp.NET)". It already does: `using OtpNet;` (`:5`), `IDataProtector` (`:23`),
+`totp.VerifyTotp(req.Code, out _, new VerificationWindow(2, 2))` (`:119`).
+
+**M2 — DeviceTwins docstring is false.** `:11-12` claims it "Powers the mobile Live tab (RAG list)".
+There is no Live tab in `Planscape/app/`; the only case-insensitive match is `de`**live**`rables`.
+
+Both to be fixed in whichever PR next touches those files, per the review.
+
+---
+
+## Runtime gap
+
+**Not measured.** The review's premise that Docker is up does not hold on this machine:
+
+```
+wsl -l -v          ->  docker-desktop    Stopped    2
+docker version     ->  failed to connect to the docker API at
+                       npipe:////./pipe/dockerDesktopLinuxEngine
+```
+
+Two launch attempts (`cmd /c start` and a direct invocation, each followed by a wait) left the distro
+`Stopped` and no `Docker Desktop.exe` in `tasklist`. It most likely needs interactive elevation or a
+first-run dialog. There is no local Postgres on 5432, and SQLite is not a substitute — `Program.cs`'s
+schema block issues a Postgres-only `information_schema` query with no try/catch, so the host dies
+before serving a request.
+
+**What therefore remains unknown:**
+
+1. actual status codes and response bodies per action;
+2. whether the six unmigrated tables genuinely do not exist in the deployed database — which is the
+   precondition the standing rule sets before proposing the migrations;
+3. whether anything 500s for a reason not visible statically. DI being clean removes the known-prior
+   cause but does not prove the actions run.
+
+**To close it:** the Docker daemon started (likely needs a human to accept whatever dialog is
+blocking it), or a Postgres reachable on 5432 plus a connection string. The pass is scripted and
+ready to run the moment either exists — including the `relation "X" does not exist` vs other-500
+distinction the review asked for, which is the whole point of running it rather than inferring it.

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -519,7 +519,16 @@ on the same grounds but its *scope* is undecided pending C1.
 
 ## Other findings
 
-**C1 — ApprovalChains vs the flat path: UNDECIDED, and "duplication" was too strong.**
+**C1 — ApprovalChains vs the flat path: DECIDED (owner, 2026-08-02). "Duplication" was too strong.**
+
+> **Decision — the UI offers FLAT approval only.** It is live, mobile drives it, and it is the
+> simpler record. `ApprovalChainsController` **stays as-is on the server** and continues to satisfy
+> the same `DocumentsController.cs:1554` gate, but gets **no client surface** until a project
+> demonstrably needs multi-step or parallel approval. Nothing is deleted, nothing is duplicated,
+> no UI is built for it. The OR at `:1556` stays — it is what makes this safe to defer.
+>
+> Recorded here so it is not relitigated. Reopen only on a concrete project requirement for
+> multi-step or parallel approval.
 
 Downgraded from "verified". The client half reproduces: `Planscape/src/api/endpoints.ts` drives
 `DocumentsController`'s flat approval (`POST …/approvals` at `:1005`, `PUT …/approval/{id}` at
@@ -549,8 +558,26 @@ migration-created, `DocumentApprovals` is the one table in B1's list that **neit
 the patcher creates — model-only. Both nonetheless exist on any booted non-dev instance (the drift
 assert would have refused the boot otherwise), so neither path is at risk and neither is favoured.
 
-**To close it** someone has to pick the canonical mechanism and say whether the OR stays. That is the
-one open item this triage cannot settle by measurement.
+**Closed by decision, not by measurement** — which was always the only way it could close. The
+measurement work above stands: it established that the gate is an OR, that nothing writes two
+records, and therefore that deferring the chain UI costs nothing.
+
+**C2 — `bypassesAcl` for a non-member is deliberate. Do not re-flag it.**
+
+`ProjectMembersController.GetMyAccess` returns `bypassesAcl = bypass || member == null` (`:105`), so a
+caller with **no** ProjectMember row is reported as bypassing the ACL. That reads like a fail-open
+bug on first sight. It is not, on two counts:
+
+- it sits behind `CanAccessProjectAsync` (`:88`), which returns `NotFound()` for anyone who cannot
+  reach the project at all, so "no member row" here already means an authorised non-member
+  (project author / tenant manager), not an arbitrary caller;
+- it mirrors `ProjectMemberAcl.ResolveAsync`, which documents the identical rule — *"No member row =
+  inherit (project author / tenant manager fallthrough)"*.
+
+Two implementations, one deliberate semantic. The per-member allow-lists (`AllowedCdeStates`,
+`AllowedDisciplines`, `AllowedSuitabilities`) are **restrictions** layered on top of access, so
+having no row means no restrictions — not no authentication. **Left unchanged**, and noted here so
+the next audit does not spend a cycle re-discovering it.
 
 **M1 — Mfa docstring is stale.** `:13` says "Production implementation would use a TOTP library (e.g.
 Otp.NET)". It already does: `using OtpNet;` (`:5`), `IDataProtector` (`:23`),
@@ -667,7 +694,7 @@ rests on `Program.cs` source and boot order (B1-R §2, M3), never on this pass.
 
 | Item | Why it is open | What would close it |
 |---|---|---|
-| **C1 — canonical approval mechanism** | A product decision; both paths work and the gate accepts either. | Someone picks one, and says whether the OR stays. |
+| ~~C1 — canonical approval mechanism~~ | **CLOSED — DECIDED 2026-08-02.** Flat approval is the only client surface; `ApprovalChainsController` stays server-side with no UI until a project needs multi-step. The OR at `:1556` stays. See C1 under *Other findings*. | Nothing. Closed. |
 | ~~Migration hygiene (B1, restated)~~ | **CLOSED — VOID.** Not a defect. Production runs `EnsureCreated` + patchers by design (`render.yaml:51-52`); the migration set is not the schema mechanism and its incompleteness is intended. ADR 0001 documents it. | Nothing. Closed. |
 | ~~`20260501000000` is a latent trap~~ | **CLOSED — cannot fire.** It was only a trap on the `Migrate()` path, and no deployed service takes that path. | Nothing. Closed. |
 | **RLS is unreachable, not merely unapplied** | Tracked separately as **#545**, not here. Because production never calls `Migrate()`, adding the missing `[Migration]` attribute would deploy and change nothing — the obvious fix is a no-op. | Sign-off on one of the three options in #545. Not started; no code written. |

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,12 +1,21 @@
-# Phase 6A — clientless controller triage (amended)
+# Phase 6A — clientless controller triage (amended twice)
 
-**Originally measured 2026-08-01; amended 2026-08-02 after review, on `main` @ `a5109e3e5`.**
-Triage only — no feature code.
+**Originally measured 2026-08-01; amended 2026-08-02 after review; runtime pass added 2026-08-02,
+on `claude/phase6-runtime` @ `bf7cbb19a`.** Triage only — no feature code.
 
-> **The runtime column is STILL NOT MEASURED.** The review assumed Docker was up. It is not: the
-> `docker-desktop` WSL distro stays `Stopped` across two different launch invocations and the daemon
-> pipe never appears. See [Runtime gap](#runtime-gap). Nothing below is presented as a runtime
-> result. Where a static proxy exists it is used and labelled as such.
+> **The runtime column is now MEASURED, and it overturns B1.** Docker Desktop started on this
+> attempt, so the pass ran against a real Postgres. **All fourteen controllers serve traffic and not
+> one returns `relation … does not exist`** — including all seven the previous revision rated
+> "Tier 3 — blocked". See [Runtime pass](#runtime-pass-measured).
+>
+> The reason is [B1-R](#b1-r--why-the-unmigrated-tables-exist-anyway): this codebase does **not**
+> build its schema from the migration folder. `PlatformSchemaPatcher` creates those six tables at
+> boot with `CREATE TABLE IF NOT EXISTS`, in **both** the Development and Production branches, and
+> ADR 0001 declares that the official mechanism. The "Backed" column below was measuring the wrong
+> thing — and in practice it is **inverted**.
+>
+> **No production database was queried.** Everything below is local: a fresh empty DB, the API's own
+> boot path, and the compose stack.
 
 ---
 
@@ -15,7 +24,7 @@ Triage only — no feature code.
 | Review finding | My position after re-verifying |
 |---|---|
 | S1 MaterialSync — confirmed, worse than reported (write too, path leak) | **Verified and fixed.** Removed from this triage — it is PR #542. |
-| B1 — five unmigrated tables, not two | **Verified, and it is six.** `TelemetryPoints` is also unmigrated; see B1. |
+| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ **Half right, and the half that mattered was wrong.** Six tables genuinely have no `CreateTable` — but they exist at runtime anyway, so nothing was blocked. See B1-R. |
 | C1 ApprovalChains duplication | **Verified** (`endpoints.ts:1004-1015`). |
 | Docstring lies (Mfa, DeviceTwins) | **Verified.** Unchanged from the first pass. |
 | DataRights — I was WRONG, re-rate Tier 1 | **Verified; I was wrong.** See DR1. |
@@ -25,6 +34,11 @@ Triage only — no feature code.
 `DataErasureJob` loop, the twin-cluster service→table mapping, and both docstring claims.
 **Taken on trust:** the sequencing decision for the capabilities endpoint, and the statement that
 MaterialSync is referenced nowhere in `stingtools-core` (I checked the other five clients myself).
+
+**Third pass (2026-08-02, runtime).** The `CreateTable` sweep was re-verified twice and was correct
+both times — but it was the wrong question, and re-running it more carefully could never have
+revealed that. What did was booting the thing. Two reviews of a static finding agreed with each
+other; the first execution overturned them.
 
 ---
 
@@ -76,10 +90,16 @@ missed**:
 | **WorkOrders** | ❌ none | yes |
 
 All six are present in `PlanscapeDbContextModelSnapshot.cs` (so EF believes they exist) with no
-`CreateTable` anywhere in a non-Designer migration. On a database built by `dotnet ef database
-update`, every action reaching one throws `relation "X" does not exist`.
+`CreateTable` anywhere in a non-Designer migration.
 
-### The twin cluster is entirely unreachable — measured, not assumed
+> ~~On a database built by `dotnet ef database update`, every action reaching one throws
+> `relation "X" does not exist`.~~
+>
+> **This sentence is wrong and is the load-bearing error of the previous revision.** The `CreateTable`
+> sweep itself reproduces — no migration creates those six — but the inference does not, because
+> **no environment is built by `dotnet ef database update`.** Measured, not argued: see B1-R.
+
+### ~~The twin cluster is entirely unreachable~~ — the service→table mapping, which stands
 
 The review correctly warned that these controllers reach tables through services, so I traced each
 service to the tables it actually touches rather than assuming:
@@ -92,43 +112,109 @@ service to the tables it actually touches rather than assuming:
 | TwinProvisioning | `…/twins/provision` | `ITwinProvisioningService` → `DeviceTwins`, `TaggedElements` | **DeviceTwins unmigrated** |
 | TelemetryIngest | `…/telemetry` | `IDeviceTwinService` → `DeviceTwins`/`TelemetryPoints`; `ITwinRuleEvaluator` (`TwinRuleEngine`) → `DeviceTwins`, `TwinAlerts`, `TwinRules` | **all unmigrated** |
 
-So the Tier-2 concern that DeviceTwins' downstream is dead is now **measured**: it is not that
-telemetry ingest is missing — `TelemetryIngestController`, `IDeviceTwinService`, `ITwinRuleEvaluator`
-and `ITwinProvisioningService` all exist and are DI-registered — it is that **none of them has a
-table to write to.**
+The service→table mapping above is correct and I leave it standing — it is useful. What I drew from
+it was not. I concluded **"none of them has a table to write to"**; the runtime pass shows every one
+of them has a table and writes to it successfully (`TwinRules` = 8 rows after `seed-defaults`,
+`DeviceTwins` and `TelemetryPoints` = 1 row each after `POST …/telemetry/ingest`).
 
-**STOP item, respected:** I have not authored the six migrations. Per the standing rule, whether the
-tables genuinely do not exist in the deployed database has to be established in the runtime pass
-first, and the migrations then *proposed* with a rollout note. Since the runtime pass could not run,
-that stays open.
+**STOP item, still respected — and now clearly the right call.** I did not author the six migrations.
+Had I done so it would have been wasted work in the most misleading way: adding files to a folder EF
+does not read (B1-R). The precondition the standing rule sets — establish at runtime that the tables
+are really missing — is exactly what caught this, and the answer is that they are **not** missing.
+
+---
+
+## B1-R — why the "unmigrated" tables exist anyway
+
+Three measurements, all local, in the order I made them.
+
+**1. The migration folder is inert.** EF discovers migrations by reflecting over types carrying
+`[Migration("id")]`, normally emitted into a `.Designer.cs` companion. In
+`src/Planscape.Infrastructure/Data/Migrations/`:
+
+```
+migration .cs (excl. Designer/snapshot) : 80
+.Designer.cs companions                 :  2
+files carrying [Migration(              :  2   (MeetingMedia, SustainabilitySnapshots)
+```
+
+So `Migrate()` / `ef database update` applies **2 of 80**. This is not new breakage —
+[`docs/adr/0001-schema-management.md`](adr/0001-schema-management.md) (Accepted, 2026-06-04) records
+it and **adopts `EnsureCreated` + idempotent patchers as the official, supported mechanism**. It
+measured 0 of 75 then; the count has since drifted to 2 of 80. I did not consult that ADR in either
+earlier pass, which is how the wrong inference survived two reviews.
+
+**2. A patcher creates all six, on every boot, in both branches.**
+`PlatformSchemaPatcher.cs` issues `CREATE TABLE IF NOT EXISTS` for `DeviceTwins` (`:91`),
+`TelemetryPoints` (`:115`), `TwinRules` (`:126`), `TwinAlerts` (`:143`), `WorkOrders` (`:162`) and
+`GlobalIdRegistry` (`:260`). `Program.cs:1585` calls it **outside** the `if (Development) … else
+Migrate()` split, guarded only by `db.Database.IsRelational()` — the in-file comment says it runs in
+both branches precisely because "the hand-authored `Migrate()` set is also incomplete".
+
+**3. Fresh-database boot on the Production path — the decisive test.** Empty DB (0 tables), API
+booted with `ASPNETCORE_ENVIRONMENT=Production` so it takes the `Migrate()` branch:
+
+```
+Unhandled exception. System.InvalidOperationException: Schema drift detected:
+112 missing table(s), 0 table(s) with missing column(s).   (Database:SchemaDriftStrict=true)
+  at Planscape.API.SchemaDriftChecker.AssertAsync(...) Program.cs:line 1592
+```
+
+The boot **aborts**. Of the 23 tables that did get created before it died, the patcher's are all
+present and the migrations' are not:
+
+| Present after a migration-path boot | Missing (of 112) |
+|---|---|
+| `DeviceTwins`, `TelemetryPoints`, `TwinRules`, `TwinAlerts`, `WorkOrders`, `GlobalIdRegistry` — **all six** | `ApprovalChains`, `AssetDataSheets`, `AssetDataSheetTemplates`, `CdeContainers`, `MfaEnrollments` — **all five "✅ backed"** |
+| `PlatformEvents`, `MeetingSessions`, `ClashRecords`, … (patcher-created) | `Tenants`, `Users`, `Projects` — the core of the app |
+| `__EFMigrationsHistory` → exactly 2 rows: `MeetingMedia`, `SustainabilitySnapshots` | |
+
+**So the Backed column was inverted.** Every table B1 marked ❌ exists; every table it marked ✅ does
+not. And the corollary settles the prod question without touching prod: a database built only from
+this repo's migrations **cannot run the app at all** — it has no `Tenants` and the boot refuses. Any
+environment that is up therefore reached that state through the `EnsureCreated`/patcher path, and
+that path creates all six tables. No manual DDL needs to be hypothesised, and no production query
+could have told us anything this doesn't.
+
+**The real gap is not six missing migrations — it is that 78 of 80 migration files are invisible to
+EF.** That is an existing, documented, accepted architectural decision (ADR 0001), not a Phase 6A
+finding, and it is out of scope here. Flagging it, not fixing it.
 
 ---
 
 ## Amended triage table
 
-Legend — **Backed**: DbSet + a migration that creates the table. **DI**: every injected service
-resolves (static check of `Program.cs`). **Runtime**: not measured for any row.
+Legend — **Backed**: table exists on a booted database (was: "a migration creates it" — see B1-R for
+why that was the wrong test). **DI**: every injected service resolves (static check of `Program.cs`).
+**Runtime**: measured — status code from the pass below.
 
-| # | Controller | Ln / actions | Auth gate | Tenant scoping | Backed | DI | Verdict |
-|---|---|---|---|---|---|---|---|
-| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | n/a | ✅ | **Tier 1** — DR1 |
-| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | ✅ | ✅ | **Tier 1** |
-| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | ✅ | ✅ | Tier 2 — blocked on C1 |
-| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | ✅ | ✅ | Tier 2 |
-| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | ✅ | ✅ | Tier 2 — mobile-only by nature |
-| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | ✅ | ✅ | Tier 2 — works; fix M1 |
-| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | ❌ B1 | ✅ | Tier 3 — blocked |
-| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked |
-| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked; fix M2 |
-| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | read-only | ✅ | Tier 3 — sales tool |
-| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | ❌ B1 | ✅ | Tier 3 — blocked |
-| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | ❌ B1 | ✅ | Tier 3 — blocked |
-| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | ❌ B1 | ✅ | Tier 3 — blocked |
-| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | ❌ B1 | ✅ | Tier 3 — blocked |
-| — | ~~MaterialSync~~ | — | — | — | — | — | **Removed — shipped as PR #542** |
+| # | Controller | Ln / actions | Auth gate | Tenant scoping | Backed | DI | Runtime | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | n/a | ✅ | 200 | **Tier 1** — DR1 |
+| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | ✅ patcher | ✅ | 200 | **Tier 1** |
+| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | ✅ patcher | ✅ | 200 | Tier 2 — blocked on C1 |
+| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | ✅ patcher | ✅ | 200 | Tier 2 |
+| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 400¹ | Tier 2 — mobile-only by nature |
+| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | ✅ patcher | ✅ | 200 | Tier 2 — works; fix M1 |
+| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**; fix M2 |
+| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | read-only | ✅ | 200 | Tier 3 — sales tool |
+| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | ✅ patcher | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2** |
+| — | ~~MaterialSync~~ | — | — | — | — | — | — | **Removed — shipped as PR #542** |
+
+¹ `400` is ordinary model validation, not a schema failure: `{"errors":{"deviceId":["The deviceId
+field is required."]}}`. The pass sent no query string. Route shape, not breakage.
 
 **DI is clean across all fourteen.** The known-prior failure mode (a controller 500ing on every call
 from a missing registration, misreported by the browser as CORS) does not apply to any of them.
+
+**Seven rows moved off Tier 3.** They were rated blocked on a schema premise that does not hold. They
+are now ordinary Tier 2: the backend works, there is no client. That is a *product* gap, not a
+*platform* one, and it is a materially different piece of work.
 
 ---
 
@@ -151,31 +237,58 @@ Both to be fixed in whichever PR next touches those files, per the review.
 
 ---
 
-## Runtime gap
+## Runtime pass (measured)
 
-**Not measured.** The review's premise that Docker is up does not hold on this machine:
+**Closed.** The earlier blocker was self-inflicted: Docker Desktop had never actually been launched,
+only probed. Starting `"C:\Program Files\Docker\Docker\Docker Desktop.exe"` brought the daemon up
+first try (`docker version` → server `29.4.3`, `docker-desktop` distro `Running`), no elevation or
+dialog required. The previous revision's "needs a human" diagnosis was wrong.
+
+**Environment.** Local only — `docker-postgres-1` (`postgres:16-alpine`) and `docker-api-1`, plus a
+throwaway API container against a scratch database for the fresh-boot test. **No production database
+was contacted at any point.**
+
+**Method.** Log in as `admin@planscape.demo`, then call every controller's primary action with a real
+project id, classifying each body for `does not exist` / `42P01` / a stack trace so a schema failure
+could not be mistaken for a benign non-200.
 
 ```
-wsl -l -v          ->  docker-desktop    Stopped    2
-docker version     ->  failed to connect to the docker API at
-                       npipe:////./pipe/dockerDesktopLinuxEngine
+=== The six "unmigrated" tables — the disputed rows ===
+7  WorkOrders          GET  /api/projects/{p}/work-orders          200
+8  GlobalIdRegistry    GET  /api/projects/{p}/global-id-registry    200
+9  DeviceTwins         GET  /api/projects/{p}/twins                 200
+9  DeviceTwins overlay GET  /api/projects/{p}/twins/overlay         200
+11 TwinAlerts          GET  /api/projects/{p}/twins/alerts          200
+12 TwinRules           GET  /api/projects/{p}/twins/rules           200
+
+=== Write paths ===
+12 TwinRules seed      POST /api/projects/{p}/twins/rules/seed-defaults      200
+13 TwinProvisioning    POST /api/projects/{p}/twins/provision/seed-from-model 200
+14 TelemetryIngest     POST /api/projects/{p}/telemetry/ingest               200
 ```
 
-Two launch attempts (`cmd /c start` and a direct invocation, each followed by a wait) left the distro
-`Stopped` and no `Docker Desktop.exe` in `tasklist`. It most likely needs interactive elevation or a
-first-run dialog. There is no local Postgres on 5432, and SQLite is not a substitute — `Program.cs`'s
-schema block issues a Postgres-only `information_schema` query with no try/catch, so the host dies
-before serving a request.
+**Zero `RELATION-MISSING`. Zero 5xx. Across all fourteen.**
 
-**What therefore remains unknown:**
+Reads alone would only prove the tables exist, so the writes were checked for persistence rather than
+trusted from a 200:
 
-1. actual status codes and response bodies per action;
-2. whether the six unmigrated tables genuinely do not exist in the deployed database — which is the
-   precondition the standing rule sets before proposing the migrations;
-3. whether anything 500s for a reason not visible statically. DI being clean removes the known-prior
-   cause but does not prove the actions run.
+```
+DeviceTwins=1  TelemetryPoints=1  TwinRules=8  TwinAlerts=0  WorkOrders=0  GlobalIdRegistry=26
+```
 
-**To close it:** the Docker daemon started (likely needs a human to accept whatever dialog is
-blocking it), or a Postgres reachable on 5432 plus a connection string. The pass is scripted and
-ready to run the moment either exists — including the `relation "X" does not exist` vs other-500
-distinction the review asked for, which is the whole point of running it rather than inferring it.
+`TwinRules=8` is `seed-defaults` landing eight rules; `DeviceTwins`/`TelemetryPoints` are the ingest
+auto-provisioning a twin and storing its reading. The write path is live, not a no-op returning 200.
+
+**The three unknowns this was meant to resolve, resolved:**
+
+1. *Status codes per action* — measured above; thirteen 200s and one validation 400.
+2. *Whether the six tables really are absent* — **they are present**, and B1-R shows why they are
+   present on any booted database, without needing to look at a deployed one.
+3. *Whether anything 500s for a reason not visible statically* — nothing 500s.
+
+**Residual limits, stated rather than papered over.** The pass exercises each controller's primary
+action, not all 46 actions; destructive ones (`DataRights erase`, alert `ack`/`resolve`) were
+deliberately not fired. `TwinAlerts` and `WorkOrders` returned 200 over **empty** tables — their read
+path and schema are proven, their populated behaviour is not. And the single-tenant demo login does
+not exercise the cross-tenant isolation each row claims; that wants a two-tenant fixture and is worth
+doing separately.

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -239,10 +239,11 @@ Both to be fixed in whichever PR next touches those files, per the review.
 
 ## Runtime pass (measured)
 
-**Closed.** The earlier blocker was self-inflicted: Docker Desktop had never actually been launched,
-only probed. Starting `"C:\Program Files\Docker\Docker\Docker Desktop.exe"` brought the daemon up
-first try (`docker version` → server `29.4.3`, `docker-desktop` distro `Running`), no elevation or
-dialog required. The previous revision's "needs a human" diagnosis was wrong.
+**Closed.** The blocker did not reproduce. `Start-Process "C:\Program Files\Docker\Docker\Docker
+Desktop.exe"` brought the daemon up first try — `docker version` → server `29.4.3`, `docker-desktop`
+distro `Running` — with no elevation and no dialog. I cannot say why the previous revision's two
+attempts failed where this one succeeded, so I am not going to guess; what is now established is
+that the "needs a human to accept a blocking dialog" diagnosis was **not** the barrier.
 
 **Environment.** Local only — `docker-postgres-1` (`postgres:16-alpine`) and `docker-api-1`, plus a
 throwaway API container against a scratch database for the fresh-boot test. **No production database

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,39 +1,67 @@
-# Phase 6A — clientless controller triage (amended three times)
+# Phase 6A — clientless controller triage (amended four times)
 
 **Originally measured 2026-08-01; amended 2026-08-02 after review; runtime pass added 2026-08-02;
-corrected 2026-08-02 (fourth pass) after a second review.** Triage only — no feature code.
+corrected 2026-08-02 (fourth pass) after a second review; corrected again 2026-08-02 (fifth pass)
+after `render.yaml` was read.** Triage only — no feature code.
 
-> **Correction — two things in the previous revision were wrong.**
+> ## Fifth pass — the correction that voids B1 outright and reinstates the runtime pass
 >
-> **1. The runtime pass is not evidence for B1, and no longer reads as if it were.** It ran against
-> `docker-api-1`, which is `ASPNETCORE_ENVIRONMENT=Development` (verified on the container). That
-> takes `Program.cs:1522` → `useEnsureCreated` → `creator.CreateTables()` (`:1559`), which
-> materialises **every table in `OnModelCreating`** whether or not a migration creates it. "Zero
-> `relation … does not exist` across fourteen controllers" was therefore **true by construction** and
-> says nothing about production. The §4 replication booted Development too, so it controls for
-> environment artefacts but inherits the same limitation. What the pass does establish: the
-> controllers serve traffic, their DI resolves, and their write paths persist. What it cannot
-> establish: anything about a schema built any other way.
+> Every earlier revision of this document assumed **production runs `db.Database.Migrate()`**. It
+> does not. `render.yaml` sets, on **both** services — `planscape-api` (`:51-52`) and the worker
+> (`:104-105`):
 >
-> **2. B1 was wrong — but not because "the tables exist at runtime".** Six of the seven are created by
-> `PlatformSchemaPatcher.ApplyAsync` (`Program.cs:1585`) with raw `CREATE TABLE IF NOT EXISTS`. That
-> call sits **outside** the `if (useEnsureCreated) … else Migrate()` split, so it runs in **both**
-> branches — which is a static fact about the code, valid for production, and it is the actual reason
-> those six exist there. A `CreateTable` grep cannot see them because they are patcher-created, not
-> migration-created. B1 is restated below as a **migration-hygiene** finding — model, migrations and
-> patcher are three sources of truth for one schema — not as missing tables. The five twin
-> controllers are re-assessed on their own merits rather than as B1-blocked.
+> ```yaml
+> - key: PLANSCAPE_USE_ENSURE_CREATED
+>   value: "true"
+> ```
 >
-> **3. The seventh table — measured.** `DocumentApprovals` is in neither the migrations nor the
-> patcher, and `20260501000000` runs an unguarded `UPDATE "DocumentApprovals"` that the patcher (which
-> runs *after* `Migrate()`) could not rescue. On a fresh empty Postgres with
-> `ASPNETCORE_ENVIRONMENT=Production` and `PLANSCAPE_USE_ENSURE_CREATED` unset, `dotnet ef database
-> update` **completes** — exit 0, 2 migrations applied, 2 tables. It never reaches that migration:
-> the file carries no `[Migration]` attribute, so EF cannot see it (2 of 78 are visible). The hazard
-> is **latent, not live** — and the fix for the hygiene finding is what arms it. Full measurement,
-> including the counterfactual, in [M3](#m3--what-dotnet-ef-database-update-actually-does).
+> with a comment stating that the incomplete migration set is that way **by design**, that
+> `EnsureCreated` + idempotent patchers is the official mechanism, and that "without this flag a
+> FRESH database takes the `Migrate()` branch and comes up nearly empty."
 >
-> **No production database was queried.**
+> `Program.cs:1522-1564` is a three-way branch:
+>
+> ```csharp
+> var useEnsureCreated = app.Environment.IsDevelopment()
+>     || string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_USE_ENSURE_CREATED"),
+>                      "true", StringComparison.OrdinalIgnoreCase);
+>
+> if (!db.Database.IsRelational()) { /* tests */ }
+> else if (useEnsureCreated)       { /* probe Tenants; creator.CreateTables() */ }   // ← production
+> else                             { db.Database.Migrate(); }                        // ← dead in prod
+> ```
+>
+> `useEnsureCreated` is **true in production**. The `Migrate()` branch is unreachable there.
+>
+> **Three consequences, each of which supersedes an earlier conclusion in this document:**
+>
+> **1. The runtime pass is reinstated as broadly representative of production.** The fourth pass
+> demoted it on the grounds that `docker-api-1` runs Development and therefore takes a branch
+> production would not. That reasoning was wrong: production takes **the same branch**, for a
+> different reason (the env var rather than `IsDevelopment()`), converging on the identical
+> `creator.CreateTables()` call at `:1559`. A local stack and production build their schema by the
+> same mechanism. The pass is still not a *proof* about production — it is a different database with
+> empty tables and one tenant — but "it says nothing about prod" was too strong and is **retracted**.
+>
+> **2. B1 is VOID — in all three of its forms.** Not "restated", not "downgraded": void.
+> - as **"five/six unmigrated tables"** — void, they are created by `EnsureCreated` and the patcher;
+> - as **"migration hygiene"** — void, because there is no hygiene defect to report. The migration
+>   set is *deliberately* not the mechanism. ADR 0001 documents this and `render.yaml` enforces it.
+>   The 78 inert migrations are **vestigial, not broken**;
+> - as **the `DocumentApprovals` question** — void, see the appendix. Production never runs the
+>   migration that would have touched it.
+>
+> **3. The M3 measurement is correct but is expected behaviour, not a defect.** "2 of 78 migrations
+> visible; `dotnet ef database update` yields 2 tables and no `Tenants`" is exactly what
+> `render.yaml`'s own comment predicts for the `Migrate()` path, which is why the flag exists. It is
+> preserved as [Appendix A](#appendix-a--the-migration-measurement-expected-behaviour-not-a-defect),
+> re-labelled.
+>
+> **What survives all of this.** One finding, and it is not in this document: Postgres Row-Level
+> Security is not merely unapplied but **unreachable by the mechanism production runs** — filed as
+> **#545**. That is the only item from this workstream still open on the schema axis.
+>
+> **No production database was queried, at any point, in any pass.**
 
 ---
 
@@ -42,9 +70,9 @@ corrected 2026-08-02 (fourth pass) after a second review.** Triage only — no f
 | Review finding | My position after re-verifying |
 |---|---|
 | S1 MaterialSync — confirmed, worse than reported (write too, path leak) | **Verified and fixed.** Removed from this triage — it is PR #542. |
-| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ ~~Half right — they exist at runtime anyway.~~ **Restated.** The sweep is accurate but measures the wrong thing: six of the seven are created by the *patcher*, which a `CreateTable` grep cannot see. Now a migration-hygiene finding, not a missing-table one. See [B1](#b1--restated-a-migration-hygiene-finding-not-missing-tables). |
+| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ ~~Half right — they exist at runtime anyway.~~ ~~Restated as migration hygiene.~~ **VOID.** Production runs `EnsureCreated` + patchers by design (`render.yaml:51-52`), so the migration set is not the schema mechanism and its incompleteness is not a defect. Void as missing-tables, as hygiene, and as the `DocumentApprovals` question. See the fifth-pass banner. |
 | C1 ApprovalChains duplication | **Undecided, and downgraded from "verified".** The two mechanisms are an **OR**, not competing records — `DocumentsController.cs:1554`. See C1. |
-| Docstring lies (Mfa, DeviceTwins) | **Verified.** Unchanged from the first pass. |
+| Docstring lies (Mfa, DeviceTwins) | **Verified, and now FIXED in this PR.** `MfaController` said a "production implementation would use a TOTP library (e.g. Otp.NET) and IDataProtectionProvider" — it already uses both (`using OtpNet;`, `new Totp(secretBytes).VerifyTotp(…)`, injected `IDataProtector`). `DeviceTwinsController` said it "powers the mobile Live tab (RAG list)" — there is no Live tab in `Planscape/app/(tabs)/`, the two `live.tsx` files are a LiveKit meeting screen and a healthcare pressure view, and a repo-wide grep for `device-twins`/`DeviceTwins` across `Planscape/` and `planscape-web/` returns zero hits. Both docstrings rewritten with the measurement inline. |
 | DataRights — I was WRONG, re-rate Tier 1 | **Verified; I was wrong.** See DR1. |
 | Capabilities endpoint approved, sequenced after Phase 1 | Taken on trust — it is a decision, not a measurement. |
 
@@ -63,7 +91,7 @@ wrong evidence. It credited the *runtime pass* with overturning B1, when the run
 `PlatformSchemaPatcher` and noticing where `Program.cs` calls it** — a static fact that holds in
 Production, which the third pass did record (§2 of B1-R) but buried under a runtime result that was
 true by construction. Booting the thing was still the right instinct; the error was in what the boot
-was allowed to prove. One measurement in this pass is genuinely new: [M3](#m3--what-dotnet-ef-database-update-actually-does).
+was allowed to prove. One measurement in this pass is genuinely new: [Appendix A](#appendix-a--the-migration-measurement-expected-behaviour-not-a-defect).
 
 ---
 
@@ -95,7 +123,15 @@ runs in 30 days; reversible until then."** → **Tier 1.**
 
 ---
 
-## B1 — restated: a migration-hygiene finding, not missing tables
+## B1 — VOID (retained as the audit trail of how it was retired)
+
+> **Superseded by the fifth pass.** Everything below is left in place because it is *how* B1 was
+> retired, and because the underlying measurements (the `CreateTable` sweep, the patcher call-site
+> reading, the service→table mapping) are all still correct. But the conclusion it reaches —
+> "restated as a migration-hygiene finding" — **no longer holds.** There is no hygiene defect:
+> production runs `EnsureCreated` + idempotent patchers *by design* (`render.yaml:51-52`), the
+> migration set is not the schema mechanism, and its incompleteness is the documented, intended state.
+> Read this section as history, not as an open finding. Nothing in it requires action.
 
 The `CreateTable` sweep reproduces and is accurate. The question it answers is not the one B1 asked.
 **Three** mechanisms in this codebase can put a table in a database, and the sweep consulted one:
@@ -143,7 +179,7 @@ the three sources can disagree silently; `SchemaDriftChecker` (`Program.cs:1610`
 catching that, at boot, per environment.
 
 **The one table where they do disagree is `DocumentApprovals`** — in the model, in no migration, in
-no patcher. That is the residue of B1 worth acting on, and it is measured in [M3](#m3--what-dotnet-ef-database-update-actually-does).
+no patcher. That is the residue of B1 worth acting on, and it is measured in [Appendix A](#appendix-a--the-migration-measurement-expected-behaviour-not-a-defect).
 
 ### The twin cluster — service→table mapping, which stands
 
@@ -204,7 +240,7 @@ files carrying [Migration(              :  2     (MeetingMedia, SustainabilitySn
 ```
 
 So `Migrate()` / `ef database update` applies **2 of 78** — confirmed directly in
-[M3](#m3--what-dotnet-ef-database-update-actually-does) by `dotnet ef migrations list`, which
+[Appendix A](#appendix-a--the-migration-measurement-expected-behaviour-not-a-defect) by `dotnet ef migrations list`, which
 enumerates exactly those two. This is not new breakage —
 [`docs/adr/0001-schema-management.md`](adr/0001-schema-management.md) (Accepted, 2026-06-04) records
 it and **adopts `EnsureCreated` + idempotent patchers as the official, supported mechanism**. It
@@ -231,10 +267,12 @@ One ordering caveat, since it matters for M3: the patcher runs at `:1585`, **aft
 all three. That last point is worth more than any single-table argument: on a booted non-dev
 instance, *every* table in the EF model exists, or the process would have exited at `:1610`.
 
-**3. Fresh-database boot on the Production path.** This one genuinely exercises the non-dev branch,
-and it stands — though it is corroboration for §2, not the "decisive test" the previous revision
-billed it as. Empty DB (0 tables), API
-booted with `ASPNETCORE_ENVIRONMENT=Production` so it takes the `Migrate()` branch:
+**3. Fresh-database boot on the `Migrate()` path.** *(Fifth pass: re-labelled. This was headed
+"on the Production path", which is wrong — production sets `PLANSCAPE_USE_ENSURE_CREATED=true` and
+never takes this branch. It exercises the `Migrate()` branch, which no deployed service reaches. The
+measurement stands; it demonstrates why the flag exists rather than a production failure mode.)*
+Empty DB (0 tables), API booted with `ASPNETCORE_ENVIRONMENT=Production` **and the env var unset**,
+so it takes the `Migrate()` branch:
 
 ```
 Unhandled exception. System.InvalidOperationException: Schema drift detected:
@@ -323,15 +361,43 @@ finding, and it is out of scope here. Flagging it, not fixing it.
 
 ---
 
-## M3 — what `dotnet ef database update` actually does
+## Appendix A — the migration measurement: expected behaviour, not a defect
 
-**The question.** `20260501000000_AddTenantIdToAllScopedEntities` runs an **unguarded**
+> **Read this framing first.** The measurement below is **correct and reproducible**, and it is
+> retained for that reason. What changed in the fifth pass is what it *means*.
+>
+> It was originally run to answer "does the **Production** schema path die, and where?" — on the
+> assumption that production calls `db.Database.Migrate()`. **Production does not call `Migrate()`
+> at all.** `render.yaml:51-52` sets `PLANSCAPE_USE_ENSURE_CREATED=true`, so production takes the
+> `EnsureCreated` + patcher branch (`Program.cs:1538-1559`). The configuration used below —
+> `PLANSCAPE_USE_ENSURE_CREATED` **unset** — is therefore not the production path. It is a path no
+> deployed service takes.
+>
+> So the headline result — **"2 of 78 migrations visible; `dotnet ef database update` yields 2 tables
+> and no `Tenants`"** — is not a finding. It is precisely what `render.yaml`'s own comment predicts:
+>
+> > *"…the EF migration set is incomplete BY DESIGN … without this flag a FRESH database takes the
+> > `Migrate()` branch and comes up nearly empty."*
+>
+> The measurement **confirms the documented rationale for the flag**. Re-labelled accordingly:
+> **expected behaviour, explained by `render.yaml`.** No action follows from it, and the 78 inert
+> migrations are vestigial rather than broken.
+>
+> Two smaller conclusions below also fall away: the `20260501000000` "latent trap" cannot fire on any
+> deployed service, because no deployed service runs migrations at all; and the `DocumentApprovals`
+> question is answered by `EnsureCreated` materialising the whole model, not by migration order.
+>
+> The one thing in this area that *is* live is filed separately as **#545** — RLS is unreachable by
+> the `EnsureCreated` mechanism, so the obvious-looking fix (add the missing `[Migration]` attribute)
+> would deploy and change nothing.
+
+**The original question.** `20260501000000_AddTenantIdToAllScopedEntities` runs an **unguarded**
 `UPDATE "DocumentApprovals"` (table listed at `:37`, SQL emitted at `:62-65`) — and
 `DocumentApprovals` is created by no migration and no patcher. The patcher runs at `Program.cs:1585`,
 *after* `Migrate()` at `:1564`, so it cannot rescue a migration that throws first. Does the
-Production schema path therefore die, and if so where?
+`Migrate()` schema path therefore die, and if so where?
 
-**Configuration — the prod path, and only the prod path.** Fresh `postgres:16-alpine`, empty
+**Configuration — the `Migrate()` path, which no deployed service takes.** Fresh `postgres:16-alpine`, empty
 (`0` tables in `public`), `ASPNETCORE_ENVIRONMENT=Production`, `PLANSCAPE_USE_ENSURE_CREATED` unset,
 running `dotnet ef database update` **alone — not the app**.
 
@@ -497,19 +563,24 @@ Both to be fixed in whichever PR next touches those files, per the review.
 
 ---
 
-## Runtime pass (measured on the Development path — reachability only)
+## Runtime pass (measured on a stack equivalent to production)
 
-> **What this pass can and cannot support.** It ran against `docker-api-1`, whose environment is
-> `ASPNETCORE_ENVIRONMENT=Development`. That takes `Program.cs:1522` → `creator.CreateTables()`
-> (`:1559`), which materialises **every table in the EF model**. So "no controller returned
-> `relation … does not exist`" was **true by construction** — no possible outcome of this pass could
-> have shown a missing table, whatever the migrations or the patcher do. The §4 replication booted
-> Development too.
+> **Reinstated in the fifth pass.** The previous revision demoted this pass on the grounds that
+> `docker-api-1` runs `ASPNETCORE_ENVIRONMENT=Development` and therefore takes a schema branch that
+> production would not. **That reasoning was wrong and is retracted.** `render.yaml:51-52` sets
+> `PLANSCAPE_USE_ENSURE_CREATED=true` on the production API (and `:104-105` on the worker), so
+> production evaluates `useEnsureCreated` to **true** as well and lands on the *same*
+> `creator.CreateTables()` call at `Program.cs:1559`. Development reaches it via `IsDevelopment()`;
+> production reaches it via the env var. Same branch, same mechanism, same resulting schema.
 >
 > **Valid conclusions:** the fourteen controllers are routable, their DI graph resolves at runtime,
-> their handlers do not throw, and their write paths persist rows.
-> **Invalid conclusions, previously drawn here:** anything about production's schema, and anything
-> about *which* mechanism creates a table. Those come from B1-R §2 and [M3](#m3--what-dotnet-ef-database-update-actually-does).
+> their handlers do not throw, their write paths persist rows — and, because the schema is built the
+> same way in both places, these hold for production too, modulo data.
+>
+> **Still not established, and these are real limits:** the pass ran against **empty tables** and a
+> **single-tenant** login. It says nothing about behaviour at volume, nothing about cross-tenant
+> isolation, and nothing about rows that already exist in production. "Broadly representative" is a
+> statement about the *schema*, not about the data or the tenancy.
 
 **Closed.** The blocker did not reproduce. `Start-Process "C:\Program Files\Docker\Docker\Docker
 Desktop.exe"` brought the daemon up first try — `docker version` → server `29.4.3`, `docker-desktop`
@@ -597,6 +668,7 @@ rests on `Program.cs` source and boot order (B1-R §2, M3), never on this pass.
 | Item | Why it is open | What would close it |
 |---|---|---|
 | **C1 — canonical approval mechanism** | A product decision; both paths work and the gate accepts either. | Someone picks one, and says whether the OR stays. |
-| **Migration hygiene (B1, restated)** | Model / migrations / patcher are three sources of truth for one schema; only a boot-time assert reconciles them. ADR 0001 accepted this. | Out of scope here — flagged, not fixed. |
-| **`20260501000000` is a latent trap** | Invisible to EF today, so it cannot fire; making the migration set discoverable arms it, and it dies on its first statement (M3). | A warning comment in the file, and reconciling the ~26 tables it assumes exist. One line of that is trivial; the rest is the hygiene item above. |
+| ~~Migration hygiene (B1, restated)~~ | **CLOSED — VOID.** Not a defect. Production runs `EnsureCreated` + patchers by design (`render.yaml:51-52`); the migration set is not the schema mechanism and its incompleteness is intended. ADR 0001 documents it. | Nothing. Closed. |
+| ~~`20260501000000` is a latent trap~~ | **CLOSED — cannot fire.** It was only a trap on the `Migrate()` path, and no deployed service takes that path. | Nothing. Closed. |
+| **RLS is unreachable, not merely unapplied** | Tracked separately as **#545**, not here. Because production never calls `Migrate()`, adding the missing `[Migration]` attribute would deploy and change nothing — the obvious fix is a no-op. | Sign-off on one of the three options in #545. Not started; no code written. |
 | **Populated + cross-tenant behaviour** | Dev pass used empty tables and a single-tenant login. | A two-tenant fixture with seeded rows. |

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -169,12 +169,61 @@ present and the migrations' are not:
 | `PlatformEvents`, `MeetingSessions`, `ClashRecords`, … (patcher-created) | `Tenants`, `Users`, `Projects` — the core of the app |
 | `__EFMigrationsHistory` → exactly 2 rows: `MeetingMedia`, `SustainabilitySnapshots` | |
 
+**4. Independent replication, on a separate scratch stack.** The three measurements above were
+re-run from scratch in a second session against a *different* database and a *different* API process
+— a throwaway `postgres:16` on port 5433 and the API on `:5099`, with the shared compose stack left
+untouched — to check they were not artefacts of one environment. They reproduce exactly: 2 of the
+migration files carry `[Migration(`; `PlatformSchemaPatcher` creates the six at the same six line
+numbers; all six exist afterwards.
+
+The replication also produced a cleaner form of the decisive test. Rather than boot the Production
+path and read the wreckage, boot the **Development** path against a virgin database and inspect what
+a *successful* boot leaves behind:
+
+```
+createdb planscape3            -> 0 tables, `ef database update` never run against it
+boot API (Development)         -> starts clean, /health 200, 0 unhandled exceptions
+tables in public               -> 134, including all six disputed tables
+"__EFMigrationsHistory"        -> ERROR: relation "__EFMigrationsHistory" does not exist
+```
+
+A working, fully-populated 134-table schema with **no migrations-history table at all** is the
+tidiest available statement of the finding: on the path every live environment actually takes, the
+migration mechanism is not merely incomplete, it never runs. Nothing that is true of the migration
+folder can therefore predict what a booted database contains.
+
+*(One incidental defect found while doing this, recorded but not fixed and not a Phase 6A item:
+running `ef database update` **first** and then booting Development is a hard startup crash —
+`CreateTables()` is not conditioned per-table, so it aborts on `42P07: relation
+"SustainabilitySnapshots" already exists`. The two supported paths are each fine alone; mixing them
+bricks the boot.)*
+
 **So the Backed column was inverted.** Every table B1 marked ❌ exists; every table it marked ✅ does
 not. And the corollary settles the prod question without touching prod: a database built only from
 this repo's migrations **cannot run the app at all** — it has no `Tenants` and the boot refuses. Any
 environment that is up therefore reached that state through the `EnsureCreated`/patcher path, and
 that path creates all six tables. No manual DDL needs to be hypothesised, and no production query
 could have told us anything this doesn't.
+
+### The review's own by-construction argument — right answer, broken premise
+
+The review proposed settling prod without prod access like this: *no migration creates those six
+tables, and every environment is built by `ef database update` over that same folder, so no
+environment can have them absent manual DDL.* The conclusion it was aimed at — **don't query prod** —
+is correct, and prod was not queried. But the argument as stated does not survive measurement, and it
+matters which way it fails:
+
+| Premise | Verdict |
+|---|---|
+| No migration in the repo creates the six tables | **True** — the `CreateTable` sweep reproduces. |
+| Every environment is built by `ef database update` over that folder | **False.** No environment is. That path applies 2 of 80 and yields a database with no `Tenants`, which the app refuses to boot. |
+| ∴ no environment can have them absent manual DDL | **Inverted.** Every booted environment *does* have them, and no manual DDL is involved — `PlatformSchemaPatcher` creates them on every start. |
+
+The first premise is the one that made the six look damning, and it is true but inert: in this
+codebase, migration presence carries no information about schema presence in either direction. The
+five tables B1 called "✅ backed by a migration" are precisely the five a migration-built database
+*lacks*. So the safe-looking inference — read the migration folder, conclude what prod contains — is
+not merely unreliable here, it is anti-correlated.
 
 **The real gap is not six missing migrations — it is that 78 of 80 migration files are invisible to
 EF.** That is an existing, documented, accepted architectural decision (ADR 0001), not a Phase 6A
@@ -286,6 +335,21 @@ auto-provisioning a twin and storing its reading. The write path is live, not a 
 2. *Whether the six tables really are absent* — **they are present**, and B1-R shows why they are
    present on any booted database, without needing to look at a deployed one.
 3. *Whether anything 500s for a reason not visible statically* — nothing 500s.
+
+**Re-measured independently.** The five disputed reads were re-run in a second session against the
+scratch stack of B1-R §4 — a different database, a different API process, a fresh login — rather than
+carried over from the first run:
+
+```
+work-orders          200   relation-missing=0
+global-id-registry   200   relation-missing=0
+twins                200   relation-missing=0
+twins/alerts         200   relation-missing=0
+twins/rules          200   relation-missing=0
+```
+
+Same result on a database that has never seen a migration. The 200s are a property of the code and
+the boot path, not of one seeded environment.
 
 **Residual limits, stated rather than papered over.** The pass exercises each controller's primary
 action, not all 46 actions; destructive ones (`DataRights erase`, alert `ack`/`resolve`) were

--- a/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
+++ b/docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md
@@ -1,14 +1,23 @@
-# Phase 6A — clientless controller triage (amended four times)
+# Phase 6A — clientless controller triage (consolidated)
 
 **Originally measured 2026-08-01; amended 2026-08-02 after review; runtime pass added 2026-08-02;
 corrected 2026-08-02 (fourth pass) after a second review; corrected again 2026-08-02 (fifth pass)
-after `render.yaml` was read.** Triage only — no feature code.
+after `render.yaml` was read; consolidated 2026-08-02.** Triage only — no feature code.
+
+> **This is the single triage document.** It supersedes **PR #541** (closed — its history is already
+> reparented into this branch). The B1 retraction, the `DocumentApprovals` closure, the C1 decision,
+> the `bypassesAcl` note (C2) and the two docstring fixes all land here.
+>
+> **PR #544 is deliberately *not* folded in.** The brief listed it as a third conflicting triage PR;
+> it is not one. `#544` is `feat(data-rights)` and touches `Planscape.Desktop` renderer files,
+> `DataRightsController.cs` and a test — **no shared file with this document**, so there is nothing to
+> conflict and no reason to close it. Verified against the PR file list, not assumed.
 
 > ## Fifth pass — the correction that voids B1 outright and reinstates the runtime pass
 >
 > Every earlier revision of this document assumed **production runs `db.Database.Migrate()`**. It
-> does not. `render.yaml` sets, on **both** services — `planscape-api` (`:51-52`) and the worker
-> (`:104-105`):
+> does not. `render.yaml` sets, on **both** services — `planscape-api` (`:74-75`) and the worker
+> (`:144-145`):
 >
 > ```yaml
 > - key: PLANSCAPE_USE_ENSURE_CREATED
@@ -70,8 +79,8 @@ after `render.yaml` was read.** Triage only — no feature code.
 | Review finding | My position after re-verifying |
 |---|---|
 | S1 MaterialSync — confirmed, worse than reported (write too, path leak) | **Verified and fixed.** Removed from this triage — it is PR #542. |
-| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ ~~Half right — they exist at runtime anyway.~~ ~~Restated as migration hygiene.~~ **VOID.** Production runs `EnsureCreated` + patchers by design (`render.yaml:51-52`), so the migration set is not the schema mechanism and its incompleteness is not a defect. Void as missing-tables, as hygiene, and as the `DocumentApprovals` question. See the fifth-pass banner. |
-| C1 ApprovalChains duplication | **Undecided, and downgraded from "verified".** The two mechanisms are an **OR**, not competing records — `DocumentsController.cs:1554`. See C1. |
+| B1 — five unmigrated tables, not two | ~~Verified, and it is six.~~ ~~Half right — they exist at runtime anyway.~~ ~~Restated as migration hygiene.~~ **VOID.** Production runs `EnsureCreated` + patchers by design (`render.yaml:74-75`), so the migration set is not the schema mechanism and its incompleteness is not a defect. Void as missing-tables, as hygiene, and as the `DocumentApprovals` question. See the fifth-pass banner. |
+| C1 ApprovalChains duplication | ~~Verified.~~ ~~Undecided, and downgraded from "verified".~~ **DECIDED (owner, 2026-08-02).** The two mechanisms are an **OR**, not competing records — `DocumentsController.cs:1554`. Flat approval is canonical for the UI; `ApprovalChainsController` stays server-side, keeps satisfying the same `:1554` gate, and gets no client surface until a project demonstrably needs multi-step. See [C1](#other-findings). |
 | Docstring lies (Mfa, DeviceTwins) | **Verified, and now FIXED in this PR.** `MfaController` said a "production implementation would use a TOTP library (e.g. Otp.NET) and IDataProtectionProvider" — it already uses both (`using OtpNet;`, `new Totp(secretBytes).VerifyTotp(…)`, injected `IDataProtector`). `DeviceTwinsController` said it "powers the mobile Live tab (RAG list)" — there is no Live tab in `Planscape/app/(tabs)/`, the two `live.tsx` files are a LiveKit meeting screen and a healthcare pressure view, and a repo-wide grep for `device-twins`/`DeviceTwins` across `Planscape/` and `planscape-web/` returns zero hits. Both docstrings rewritten with the measurement inline. |
 | DataRights — I was WRONG, re-rate Tier 1 | **Verified; I was wrong.** See DR1. |
 | Capabilities endpoint approved, sequenced after Phase 1 | Taken on trust — it is a decision, not a measurement. |
@@ -129,7 +138,7 @@ runs in 30 days; reversible until then."** → **Tier 1.**
 > retired, and because the underlying measurements (the `CreateTable` sweep, the patcher call-site
 > reading, the service→table mapping) are all still correct. But the conclusion it reaches —
 > "restated as a migration-hygiene finding" — **no longer holds.** There is no hygiene defect:
-> production runs `EnsureCreated` + idempotent patchers *by design* (`render.yaml:51-52`), the
+> production runs `EnsureCreated` + idempotent patchers *by design* (`render.yaml:74-75`), the
 > migration set is not the schema mechanism, and its incompleteness is the documented, intended state.
 > Read this section as history, not as an open finding. Nothing in it requires action.
 
@@ -368,7 +377,7 @@ finding, and it is out of scope here. Flagging it, not fixing it.
 >
 > It was originally run to answer "does the **Production** schema path die, and where?" — on the
 > assumption that production calls `db.Database.Migrate()`. **Production does not call `Migrate()`
-> at all.** `render.yaml:51-52` sets `PLANSCAPE_USE_ENSURE_CREATED=true`, so production takes the
+> at all.** `render.yaml:74-75` sets `PLANSCAPE_USE_ENSURE_CREATED=true`, so production takes the
 > `EnsureCreated` + patcher branch (`Program.cs:1538-1559`). The configuration used below —
 > `PLANSCAPE_USE_ENSURE_CREATED` **unset** — is therefore not the production path. It is a path no
 > deployed service takes.
@@ -473,30 +482,46 @@ none of which a migrations-only database has. The migration is unrunnable from i
 
 ## Amended triage table
 
-Legend — **Schema from**: which of the three mechanisms creates the controller's tables (B1). The
-previous revision labelled this column "Backed / ✅ patcher" for every row, which was wrong for rows
-2–6: those are migration-created, not patcher-created. Corrected and individually verified below.
-**DI**: every injected service resolves (static check of `Program.cs`). **Dev runtime**: status code
-from the pass below — measured on the `EnsureCreated` path, so it evidences *reachability*, not
-schema provenance.
+Five axes per the review — **contract**, **runtime status**, **backing**, **downstream**, **tier** —
+with auth and tenant scoping retained because they are what moved several rows.
 
-| # | Controller | Ln / actions | Auth gate | Tenant scoping | Schema from | DI | Dev runtime | Verdict |
-|---|---|---|---|---|---|---|---|---|
-| 1 | **DataRights** | 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | model | ✅ | 200 | **Tier 1** — DR1 |
-| 2 | **CdeContainers** | 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | migration | ✅ | 200 | **Tier 1** |
-| 3 | **ApprovalChains** | 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | migration | ✅ | 200 | Tier 2 — **undecided, C1** |
-| 4 | **AssetDataSheets** | 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | migration | ✅ | 200 | Tier 2 |
-| 5 | **OfflineManifest** | 227 / 4 | `[Authorize]` | `TenantId` | migration | ✅ | 400¹ | Tier 2 — mobile-only by nature |
-| 6 | **Mfa** | 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | migration | ✅ | 200 | Tier 2 — works; fix M1 |
-| 7 | **WorkOrders** | 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | **patcher** `:162` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| 8 | **GlobalIdRegistry** | 275 / 6 | `[Authorize]` | `TenantId` | **patcher** `:260` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| 9 | **DeviceTwins** | 108 / 5 | `[Authorize]` | `TenantId` | **patcher** `:91`, `:115` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**²; fix M2 |
-| 10 | **CaseStudy** | 150 / 1 | `[Authorize]` | `TenantId` | model (read-only) | ✅ | 200 | Tier 3 — sales tool |
-| 11 | **TwinAlerts** | 53 / 3 | `[Authorize]` | `TenantId` | **patcher** `:143` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| 12 | **TwinRules** | 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | **patcher** `:126` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| 13 | **TwinProvisioning** | 75 / 2 | `[Authorize]` | via service | **patcher** `:91` | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| 14 | **TelemetryIngest** | 98 / 1 | `[Authorize]` | via services | **patcher** (all) | ✅ | 200 | ~~Tier 3 blocked~~ → **Tier 2**² |
-| — | ~~MaterialSync~~ | — | — | — | — | — | — | **Removed — shipped as PR #542** |
+Legend — **Contract**: route template + line count / action count. **Schema from** (*backing*): which
+of the three mechanisms declares the controller's tables (B1). The previous revision labelled this
+column "Backed / ✅ patcher" for every row, which was wrong for rows 2–6: those are migration-created,
+not patcher-created. Corrected and individually verified below. **DI**: every injected service
+resolves (static check of `Program.cs`). **Dev runtime**: status code from the pass below.
+**Downstream**: client files referencing the route (see ³).
+
+**Measurement basis, so unmeasured cells stay visibly unmeasured:**
+
+| Column | Basis | Measured? |
+|---|---|---|
+| Contract · Auth gate · Tenant scoping · Schema from · DI | static read of source | **measured** |
+| Dev runtime | HTTP status from the pass below | **measured** |
+| Downstream | literal route-fragment grep across all six client trees; method validated against controls | **measured** (³) |
+| **Prod runtime** | — | **UNMEASURED for all 14.** No production database or instance was queried in any pass. |
+
+> Since production and the local stack converge on the same `creator.CreateTables()` call (fifth-pass
+> banner), the Dev-runtime column is broadly representative of production *reachability* — but it is
+> still a different database, and it is not a production measurement. The row above stays.
+
+| # | Controller | Contract (route — ln / actions) | Auth gate | Tenant scoping | Schema from | DI | Dev runtime | Downstream | Tier |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | **DataRights** | `api/data-rights` — 114 / 3 | `[Authorize(Roles="Owner,Admin")]` | `ITenantContext` | model | ✅ | 200 | **0** | **Tier 1** — DR1 |
+| 2 | **CdeContainers** | `…/cde-containers` — 287 / 6 | `[Authorize]` + role gate `:255` | `TenantId` + `ProjectMembers` | migration | ✅ | 200 | **0** | **Tier 1** |
+| 3 | **ApprovalChains** | `…/documents/{id}/approval-chain` — 317 / 4 | `[Authorize]` + `[ProjectAccess]` | `[ProjectAccess]` + `TenantId` | migration | ✅ | 200 | **0** | Tier 2 — **decided (C1): server-side only, no client planned** |
+| 4 | **AssetDataSheets** | `…/asset-sheets` — 276 / 7 | `[Authorize]` + `[ProjectAccess]` | `RequireProjectMemberAsync` | migration | ✅ | 200 | **0** | Tier 2 |
+| 5 | **OfflineManifest** | `…/offline-manifest` — 227 / 4 | `[Authorize]` | `TenantId` | migration | ✅ | 400¹ | **0** | Tier 2 — mobile-only by nature |
+| 6 | **Mfa** | `api/mfa` — 256 / 7 | `[Authorize]` (+`TenantAdmin` on one) | via `Users` | migration | ✅ | 200 | **0** | Tier 2 — works; M1 fixed here |
+| 7 | **WorkOrders** | `…/work-orders` — 98 / 3 | `[Authorize]` | global filter (`ITenantScoped`) | **patcher** `:162` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 8 | **GlobalIdRegistry** | `…/global-id-registry` — 275 / 6 | `[Authorize]` | `TenantId` | **patcher** `:260` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 9 | **DeviceTwins** | `…/twins` — 108 / 5 | `[Authorize]` | `TenantId` | **patcher** `:91`, `:115` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**²; M2 fixed here |
+| 10 | **CaseStudy** | `api/case-study` — 150 / 1 | `[Authorize]` | `TenantId` | model (read-only) | ✅ | 200 | **0** | Tier 3 — sales tool |
+| 11 | **TwinAlerts** | `…/twins/alerts` — 53 / 3 | `[Authorize]` | `TenantId` | **patcher** `:143` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 12 | **TwinRules** | `…/twins/rules` — 129 / 4 | `[Authorize]` | `TenantId` + `Projects` | **patcher** `:126` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 13 | **TwinProvisioning** | `…/twins/provision` — 75 / 2 | `[Authorize]` | via service | **patcher** `:91` | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| 14 | **TelemetryIngest** | `…/telemetry` — 98 / 1 | `[Authorize]` | via services | **patcher** (all) | ✅ | 200 | **0** | ~~Tier 3 blocked~~ → **Tier 2**² |
+| — | ~~MaterialSync~~ | — | — | — | — | — | — | — | **Removed — shipped as PR #542** |
 
 ¹ `400` is ordinary model validation, not a schema failure: `{"errors":{"deviceId":["The deviceId
 field is required."]}}`. The pass sent no query string. Route shape, not breakage.
@@ -507,13 +532,37 @@ field is required."]}}`. The pass sent no query string. Route shape, not breakag
 and tenant scoping are as tabulated, and no client exists in any of the six checked. The dev-path
 200s corroborate reachability; they are not what moves the row.
 
+³ **Downstream — how the zeros were obtained, and why they are trustworthy.** Each controller's
+literal `[Route(...)]` fragment was grepped across every client tree — `Planscape/src`,
+`Planscape/app`, `Planscape.Desktop/src`, `StingTools`, `stingtools-core`, `StingBridge` (`.ts`,
+`.tsx`, `.js`, `.jsx`, `.py`, `.cs`). All fourteen returned **0 files**.
+
+An all-zero sweep is also exactly what a *broken* grep returns, so the method was validated against
+routes that must have clients **before** the zeros were trusted:
+
+| Control route | Files |
+|---|---|
+| `api/projects` | **58** |
+| `api/auth/login` | **13** |
+| `api/issues` | 0 — clients compose paths without the `api/` prefix |
+
+The method works. The `api/issues` control also showed that an `api/`-prefixed needle can miss a real
+client, so the two controllers where that applied (`api/mfa`, `…/telemetry`) were re-run with
+prefix-free fragments (`/mfa`, `mfa/`, `totp`, `/telemetry`) — still 0.
+
+**Scope limit, stated:** this establishes that no client references these routes *as literal strings
+on this branch*. A client assembling a path from runtime fragments would evade it. Strong evidence,
+not proof, and branch-local — PR #544 adds a `data-rights` client that does not exist here.
+
 **DI is clean across all fourteen.** The known-prior failure mode (a controller 500ing on every call
 from a missing registration, misreported by the browser as CORS) does not apply to any of them.
 
 **Seven rows moved off Tier 3.** They were rated blocked on a schema premise that does not hold. They
 are now ordinary Tier 2: the backend works, there is no client. That is a *product* gap, not a
-*platform* one, and it is a materially different piece of work. Row 3 is the exception — it is Tier 2
-on the same grounds but its *scope* is undecided pending C1.
+*platform* one, and it is a materially different piece of work. Row 3 is the exception only in that
+its scope was settled separately: C1 is now **decided** — `ApprovalChains` stays server-side and
+gets no client surface, so it is Tier 2 with no client work planned rather than Tier 2 awaiting a
+decision.
 
 ---
 
@@ -548,10 +597,11 @@ Either one alone satisfies the transition; the docstring says so deliberately (`
 may use the legacy single-approver path or the new multi-step chain **interchangeably**"). They are
 alternative satisfiers of one gate, not competing records, and nothing here writes two.
 
-**What remains, and it is a real decision:** two mechanisms for one concept, one with a client and one
-without. Which the UI drives is a product call, not a correctness bug — and the interchangeable gate
-means shipping a chain UI would not corrupt anything, it would just leave two supported routes to the
-same state.
+**What was left to decide** was two mechanisms for one concept, one with a client and one without.
+Which the UI drives is a product call, not a correctness bug — the interchangeable gate means
+shipping a chain UI would not corrupt anything, it would just leave two supported routes to the same
+state. **That call has now been made** (box above): flat only, chains retained server-side. No
+correctness question remains open on this row.
 
 **What M3 contributes.** Schema provenance does not break the tie: `ApprovalChains` is
 migration-created, `DocumentApprovals` is the one table in B1's list that **neither** a migration nor
@@ -586,7 +636,9 @@ Otp.NET)". It already does: `using OtpNet;` (`:5`), `IDataProtector` (`:23`),
 **M2 — DeviceTwins docstring is false.** `:11-12` claims it "Powers the mobile Live tab (RAG list)".
 There is no Live tab in `Planscape/app/`; the only case-insensitive match is `de`**live**`rables`.
 
-Both to be fixed in whichever PR next touches those files, per the review.
+**Both are FIXED in this PR** (`MfaController.cs`, `DeviceTwinsController.cs`) — docstrings only, no
+behaviour change. Each replacement records the measurement inline and, for `DeviceTwins`, an explicit
+"do not delete on *no caller* grounds" note pointing back at this document.
 
 ---
 
@@ -594,8 +646,8 @@ Both to be fixed in whichever PR next touches those files, per the review.
 
 > **Reinstated in the fifth pass.** The previous revision demoted this pass on the grounds that
 > `docker-api-1` runs `ASPNETCORE_ENVIRONMENT=Development` and therefore takes a schema branch that
-> production would not. **That reasoning was wrong and is retracted.** `render.yaml:51-52` sets
-> `PLANSCAPE_USE_ENSURE_CREATED=true` on the production API (and `:104-105` on the worker), so
+> production would not. **That reasoning was wrong and is retracted.** `render.yaml:74-75` sets
+> `PLANSCAPE_USE_ENSURE_CREATED=true` on the production API (and `:144-145` on the worker), so
 > production evaluates `useEnsureCreated` to **true** as well and lands on the *same*
 > `creator.CreateTables()` call at `Program.cs:1559`. Development reaches it via `IsDevelopment()`;
 > production reaches it via the env var. Same branch, same mechanism, same resulting schema.
@@ -695,7 +747,7 @@ rests on `Program.cs` source and boot order (B1-R §2, M3), never on this pass.
 | Item | Why it is open | What would close it |
 |---|---|---|
 | ~~C1 — canonical approval mechanism~~ | **CLOSED — DECIDED 2026-08-02.** Flat approval is the only client surface; `ApprovalChainsController` stays server-side with no UI until a project needs multi-step. The OR at `:1556` stays. See C1 under *Other findings*. | Nothing. Closed. |
-| ~~Migration hygiene (B1, restated)~~ | **CLOSED — VOID.** Not a defect. Production runs `EnsureCreated` + patchers by design (`render.yaml:51-52`); the migration set is not the schema mechanism and its incompleteness is intended. ADR 0001 documents it. | Nothing. Closed. |
+| ~~Migration hygiene (B1, restated)~~ | **CLOSED — VOID.** Not a defect. Production runs `EnsureCreated` + patchers by design (`render.yaml:74-75`); the migration set is not the schema mechanism and its incompleteness is intended. ADR 0001 documents it. | Nothing. Closed. |
 | ~~`20260501000000` is a latent trap~~ | **CLOSED — cannot fire.** It was only a trap on the `Migrate()` path, and no deployed service takes that path. | Nothing. Closed. |
 | **RLS is unreachable, not merely unapplied** | Tracked separately as **#545**, not here. Because production never calls `Migrate()`, adding the missing `[Migration]` attribute would deploy and change nothing — the obvious fix is a no-op. | Sign-off on one of the three options in #545. Not started; no code written. |
 | **Populated + cross-tenant behaviour** | Dev pass used empty tables and a single-tenant login. | A two-tenant fixture with seeded rows. |


### PR DESCRIPTION
## The consolidated Phase 6A triage

This is now the **single** triage document. It carries the B1 retraction, the
`DocumentApprovals` closure, the C1 decision, the `bypassesAcl` note and the two
docstring fixes.

### On the three PRs the brief asked me to fold

| PR | State | Action |
|---|---|---|
| **#541** | **already CLOSED** | Nothing to do — its history is already reparented into this branch (`5d7bca5ba`). |
| **#543** (this) | open | The consolidated document. |
| **#544** | open | **Left open deliberately — it is not a triage PR.** |

**#544 is not a third conflicting triage PR.** It is `feat(data-rights)`, touching
`Planscape.Desktop/src/renderer/*`, `DataRightsController.cs` and
`DataRightsExportTenantScopeTests.cs`. It shares **no file** with
`docs/PHASE6_CLIENTLESS_CONTROLLER_TRIAGE.md`, so there is nothing to conflict and no
reason to close unrelated feature work. Verified against the PR file list rather than
assumed. Only #543 touches the triage doc.

---

### B1 — retracted, and the citations that supported it were wrong

The retraction stands and is now cited correctly.

Production **never runs `db.Database.Migrate()`**. Both database-touching services set the
flag in `render.yaml`:

| Service | Line | Value |
|---|---|---|
| `planscape-api` | **`:74-75`** | `PLANSCAPE_USE_ENSURE_CREATED: "true"` |
| `planscape-worker` | **`:144-145`** | `PLANSCAPE_USE_ENSURE_CREATED: "true"` |

`Program.cs:1522` reads it, so `useEnsureCreated` is true in production; control takes
`:1538` → `creator.CreateTables()` (`:1559`) and never reaches `Migrate()` (`:1564`). The
78-file migration set is **vestigial in production, not broken** — ADR 0001 documents this
and `render.yaml`'s own comment states it. "No migration creates table X" therefore blocks
nothing, and B1 is void in all three of its forms.

**Correction made in this pass:** the document cited `render.yaml:51-52` / `:104-105` in
**8 places**. Measured on this branch *and* on `origin/main`, the keys are at **`:74`** and
**`:144`**. (`:51`/`:104` is what an unrelated working branch shows — which is how the wrong
numbers got in.) All 8 corrected. The finding is unaffected.

### `DocumentApprovals` — closed

Three independent reasons `20260501000000`'s unguarded `UPDATE "DocumentApprovals"` never
runs, any one sufficient:

1. Production never runs `Migrate()` at all (above).
2. The file carries no `[Migration]` attribute, so EF cannot see it — **2 of 78** are
   discoverable. Measured: fresh empty Postgres, `ASPNETCORE_ENVIRONMENT=Production`,
   `PLANSCAPE_USE_ENSURE_CREATED` unset → `dotnet ef database update` completes, exit 0.
3. Forced discoverable, it dies at its **first** statement (`ALTER TABLE "TaggedElements"
   ADD COLUMN`, 42P01) before reaching the UPDATE — so it is one of 26 such tables, not a
   special case.

The table exists in production regardless: it is in `OnModelCreating`, and production builds
its schema from the model.

### C1 — decided, and the decision now propagated

> **Flat approval is canonical for the UI.** `ApprovalChainsController` **stays** —
> server-side, unchanged, still satisfying the same **`DocumentsController.cs:1554`** gate —
> and gets **no client surface** until a project demonstrably needs multi-step.

The gate at `:1554` is an **OR** (`hasCompletedChain` alongside `hasLegacyApproval`, evaluated
at `:1556`); the docstring at `:1538` calls the two paths usable *"interchangeably"*. So
declining to build a chain UI disables nothing and requires no migration.

The decision had been recorded in the decision box and the closed-items table, but the
**amendment summary**, **triage-table row 3** and the "seven rows moved" paragraph still said
*"undecided pending C1"* — the document contradicted itself. All three now agree. `:1554` is
cited so this is not relitigated.

**The controller is not deleted.** "No caller" has been wrong three times on this set.

### `bypassesAcl` — reviewed, deliberate, recorded (C2)

`ProjectMembersController.cs:105` emits `bypassesAcl = bypass || member == null`. Deliberate:
it mirrors `ProjectMemberAcl.ResolveAsync`'s documented *"No member row = inherit (project
author / tenant manager fallthrough)"*, sits behind `CanAccessProjectAsync`, and is a
**narrowing filter, not a grant** — the per-member allow-lists are restrictions layered on top
of an access decision already made. Left unchanged; recorded so the next audit does not
re-flag it.

### Docstrings fixed (M1, M2)

* `MfaController` — claimed a "production implementation **would** use a TOTP library (e.g.
  Otp.NET) and IDataProtectionProvider". It already uses both. Was false when written.
* `DeviceTwinsController` — claimed it "powers the mobile Live tab (RAG list)". There is no
  Live tab; the two `live.tsx` files are a LiveKit meeting screen and a healthcare pressure
  view, and a repo-wide grep returns zero hits.

Both rewritten with the measurement inline. `DeviceTwins` also carries an explicit *do not
delete on "no caller" grounds* note pointing at this document. Docstrings only — no behaviour
change.

### Per-controller table — five axes, unmeasured cells labelled

Restructured onto **contract · runtime status · backing · downstream · tier**, with an
explicit measurement-basis table. **Prod runtime is labelled UNMEASURED for all 14 rows** — no
production database or instance was queried in any pass.

**New measured column — Downstream.** Each controller's literal `[Route(...)]` fragment was
grepped across all six client trees. All fourteen return **0 files**.

An all-zero sweep is also what a *broken* grep returns, so the method was validated against
controls **before** the zeros were trusted:

| Control | Files |
|---|---|
| `api/projects` | **58** |
| `api/auth/login` | **13** |
| `api/issues` | 0 — clients compose paths without the `api/` prefix |

That third control showed an `api/`-prefixed needle can miss a real client, so `api/mfa` and
`…/telemetry` were re-run prefix-free (`/mfa`, `mfa/`, `totp`, `/telemetry`) — still 0.

**Scope limit, stated in the doc:** this establishes no client references these routes *as
literal strings on this branch*. A runtime-assembled path would evade it. Strong evidence, not
proof, and branch-local — #544 adds a `data-rights` client that does not exist here.

---

Docs + two docstrings. No behaviour change, no schema change, no migration touched. No
production database was queried in any pass.
