### PR TITLE
feat(server): serve project capabilities so three clients stop deriving them

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -6,6 +6,13 @@ using Microsoft.Extensions.Logging;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.API.Authorization;
+// Imported for the capability extension methods (CanCurateProjectAsync /
+// CanApproveSitePhotosAsync). This namespace also declares an IEmailService,
+// which collides with Planscape.Core.Interfaces.IEmailService — the one this
+// controller's constructor has always bound to. The alias below pins that
+// binding so adding the import cannot silently re-resolve it.
+using Planscape.API.Services;
+using IEmailService = Planscape.Core.Interfaces.IEmailService;
 using Planscape.Infrastructure.Data;
 using Planscape.Infrastructure.Services;
 using Planscape.Infrastructure.SignalR;
@@ -108,6 +115,53 @@ public class ProjectMembersController : ControllerBase
             allowedCdeStates     = ProjectMember.ParseAllowList(member?.AllowedCdeStates)     ?? Array.Empty<string>(),
             allowedDisciplines   = ProjectMember.ParseAllowList(member?.AllowedDisciplines)   ?? Array.Empty<string>(),
             allowedSuitabilities = ProjectMember.ParseAllowList(member?.AllowedSuitabilities) ?? Array.Empty<string>(),
+        });
+    }
+
+    /// <summary>
+    /// The caller's capabilities on this project, resolved server-side.
+    ///
+    /// WHY THIS EXISTS. Clients were re-deriving authority from
+    /// <c>projectRole</c> / <c>iso19650Role</c> returned by
+    /// <see cref="GetMyAccess"/>. Three surfaces re-implementing one rule is
+    /// exactly how the eleven dead <c>ProjectRole == "PM"</c> gates happened.
+    /// The server owns the rule; clients render what it returns.
+    ///
+    /// CLIENT CONTRACT — 404 MEANS ALL CAPABILITIES ARE FALSE.
+    /// A 404 says the caller cannot see this project at all. Treat every
+    /// capability as false. Never "unknown, so proceed" — a fail-open default
+    /// here would undo the gate on all three surfaces at once. The same
+    /// applies to a network error, a timeout, or a body you cannot parse:
+    /// absence of an explicit <c>true</c> is <c>false</c>.
+    ///
+    /// Deliberately two booleans, matching the two predicates that actually
+    /// exist on <see cref="ProjectRoles"/>. A third does not get added inline
+    /// — it goes through the same propose-first step these two did.
+    ///
+    /// Deliberately a separate endpoint rather than extra fields on
+    /// <c>members/me</c>: that response is already consumed and widening it
+    /// is a breaking-shape change.
+    /// </summary>
+    [HttpGet("capabilities")]
+    public async Task<ActionResult> GetMyCapabilities(Guid projectId, CancellationToken ct = default)
+    {
+        // 404 (not 403) so this agrees with GetMyAccess above, which uses the
+        // same visibility check. Two adjacent endpoints disagreeing about the
+        // same condition is a bug generator.
+        if (!await CanAccessProjectAsync(projectId)) return NotFound();
+
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (!Guid.TryParse(subClaim, out var userId)) return Unauthorized();
+
+        // Both resolve tenant Admin/Owner without a ProjectMember row, matching
+        // every site the capability layer replaced.
+        return Ok(new
+        {
+            projectId,
+            userId,
+            canCurateProject     = await this.CanCurateProjectAsync(_db, projectId, ct),
+            canApproveSitePhotos = await this.CanApproveSitePhotosAsync(_db, projectId, ct),
         });
     }
 

--- a/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
@@ -1,0 +1,299 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// GET api/projects/{projectId}/members/capabilities.
+///
+/// The endpoint exists so three surfaces stop re-deriving authority from
+/// `projectRole` / `iso19650Role`. Re-implementing one rule in three clients is
+/// how the eleven dead `ProjectRole == "PM"` gates happened.
+///
+/// THE CONTRACT UNDER TEST
+/// -----------------------
+/// 404 means EVERY capability is false. It must not be a 403, and it must not
+/// return a body a client could misread as "unknown, proceed". That is asserted
+/// directly in <see cref="Invisible_project_is_404_so_clients_default_everything_to_false"/>,
+/// because a fail-open default here would undo the gate on all three surfaces
+/// at once.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS
+/// -----------------------------
+/// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, falling
+/// back to Guid.Empty with no ITenantContext — matching NO rows, so assertions
+/// pass vacuously against an empty set. Every context here is built WITH a
+/// tenant, and <see cref="Sanity_the_fixture_actually_has_rows"/> proves the
+/// rows are visible before any capability claim is made.
+/// </summary>
+public class ProjectCapabilitiesEndpointTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static readonly Guid TenantId  = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ProjectId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid AuthorId  = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    /// <summary>(projectRole, iso19650Role) seeded as real rows, one user each.</summary>
+    private static readonly (string Project, string Iso, string Label)[] Seed =
+    {
+        ("Manager",     "M",  "manager"),
+        ("Coordinator", "M",  "coordinator"),
+        ("Contributor", "PM", "contributor-who-is-the-iso-PM"),
+        ("Contributor", "M",  "plain-contributor"),
+        ("Viewer",      "V",  "viewer"),
+    };
+
+    private static Guid UserIdFor(string label)
+    {
+        // Deterministic per-label GUID so tests can look a member up by role.
+        var bytes = new byte[16];
+        var src = System.Text.Encoding.UTF8.GetBytes(label);
+        for (int i = 0; i < src.Length && i < 16; i++) bytes[i] = src[i];
+        bytes[15] = 0xAA;
+        return new Guid(bytes);
+    }
+
+    private static (SqliteConnection conn, PlanscapeDbContext db) NewDb()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var db = new PlanscapeDbContext(
+            new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+            httpContextAccessor: null!, tenantContext: new FixedTenant(TenantId));
+        db.Database.EnsureCreated();
+
+        // Tenant first: Project.TenantId and AppUser.TenantId are real FKs, and
+        // SQLite (unlike EF InMemory) enforces them.
+        db.Tenants.Add(new Tenant
+        {
+            Id = TenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+
+        // The author is a real user, because Project.CreatedById is an FK and
+        // because author-visibility is one of the branches WhereVisibleTo takes.
+        db.Users.Add(new AppUser
+        {
+            Id = AuthorId, TenantId = TenantId,
+            Email = $"author-{Guid.NewGuid():N}@example.com",
+            DisplayName = "author", PasswordHash = "x", IsActive = true,
+        });
+
+        db.Projects.Add(new Project
+        {
+            Id = ProjectId, TenantId = TenantId, Name = "Kampala Temple",
+            Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            CreatedById = AuthorId, PurgeAfter = null,
+        });
+
+        foreach (var (projectRole, iso, label) in Seed)
+        {
+            var uid = UserIdFor(label);
+            // AppUser row is required: ProjectMember.UserId is a real FK.
+            db.Users.Add(new AppUser
+            {
+                Id = uid, TenantId = TenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com", DisplayName = label,
+                PasswordHash = "x", IsActive = true,
+            });
+            db.ProjectMembers.Add(new ProjectMember
+            {
+                Id = Guid.NewGuid(), TenantId = TenantId,
+                ProjectId = ProjectId, UserId = uid,
+                ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
+            });
+        }
+
+        db.SaveChanges();
+        return (conn, db);
+    }
+
+    private static ProjectMembersController NewController(
+        PlanscapeDbContext db, Guid userId, string? tenantRole = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new("tenant_id", TenantId.ToString()),
+        };
+        if (tenantRole != null)
+        {
+            claims.Add(new Claim("role", tenantRole));
+            claims.Add(new Claim(ClaimTypes.Role, tenantRole));
+        }
+
+        // Only _db and User are touched by GetMyCapabilities; the remaining
+        // dependencies are deliberately not stubbed so an accidental future
+        // dependency on them fails loudly here rather than silently passing.
+        var controller = new ProjectMembersController(db, null!, null!, null!, null!)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test")),
+                },
+            },
+        };
+        return controller;
+    }
+
+    private static (bool curate, bool approve, Guid projectId, Guid userId) Read(ActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var v = ok.Value!;
+        var t = v.GetType();
+        return (
+            (bool)t.GetProperty("canCurateProject")!.GetValue(v)!,
+            (bool)t.GetProperty("canApproveSitePhotos")!.GetValue(v)!,
+            (Guid)t.GetProperty("projectId")!.GetValue(v)!,
+            (Guid)t.GetProperty("userId")!.GetValue(v)!);
+    }
+
+    // ── Fixture sanity — must run green before any assertion below means anything ──
+
+    [Fact]
+    public void Sanity_the_fixture_actually_has_rows()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            Assert.Equal(Seed.Length, db.ProjectMembers.Count(m => m.ProjectId == ProjectId));
+            Assert.True(db.Projects.Any(p => p.Id == ProjectId),
+                "Project invisible through the tenant filter — every assertion below would pass vacuously.");
+        }
+    }
+
+    // ── The 404 contract ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Invisible_project_is_404_so_clients_default_everything_to_false()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            // A real, authenticated user who is simply not on this project and
+            // did not author it.
+            var stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+            var result = await NewController(db, stranger).GetMyCapabilities(ProjectId);
+
+            var notFound = Assert.IsType<NotFoundResult>(result);
+            Assert.Equal(404, notFound.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Unknown_project_id_is_404_not_an_all_false_body()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var result = await NewController(db, UserIdFor("manager"))
+                .GetMyCapabilities(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+
+            // Deliberately NOT an Ok with all-false: a body implies "I know the
+            // answer". Absence of the project must be indistinguishable from
+            // absence of authority, which is what makes 404 the safe default.
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+
+    // ── Capability resolution per role ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("manager",                       true,  true)]
+    [InlineData("coordinator",                   true,  false)] // curates, cannot release imagery
+    [InlineData("contributor-who-is-the-iso-PM", true,  true)]  // authority via Iso19650Role
+    [InlineData("plain-contributor",             false, false)]
+    [InlineData("viewer",                        false, false)]
+    public async Task Capabilities_match_the_role(string label, bool expectCurate, bool expectApprove)
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var userId = UserIdFor(label);
+            var (curate, approve, pid, uid) = Read(
+                await NewController(db, userId).GetMyCapabilities(ProjectId));
+
+            Assert.Equal(expectCurate, curate);
+            Assert.Equal(expectApprove, approve);
+            Assert.Equal(ProjectId, pid);
+            Assert.Equal(userId, uid);
+        }
+    }
+
+    [Fact]
+    public async Task Coordinator_curates_but_cannot_approve_photos()
+    {
+        // Called out on its own because it is the one place the two predicates
+        // genuinely diverge. If someone "simplifies" them into one flag, this
+        // is the test that fails.
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var (curate, approve, _, _) = Read(
+                await NewController(db, UserIdFor("coordinator")).GetMyCapabilities(ProjectId));
+
+            Assert.True(curate);
+            Assert.False(approve);
+        }
+    }
+
+    // ── Tenant admin bypass — pre-existing behaviour, kept deliberately ────────
+
+    [Fact]
+    public async Task Tenant_admin_gets_both_without_any_project_member_row()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var admin = Guid.Parse("88888888-8888-8888-8888-888888888888");
+            Assert.False(db.ProjectMembers.Any(m => m.UserId == admin),
+                "Fixture must NOT give the admin a member row, or this proves nothing.");
+
+            var (curate, approve, _, _) = Read(
+                await NewController(db, admin, tenantRole: "Admin").GetMyCapabilities(ProjectId));
+
+            Assert.True(curate);
+            Assert.True(approve);
+        }
+    }
+
+    // ── Response shape ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Response_carries_exactly_four_fields()
+    {
+        // Two booleans, matching the two predicates that exist. A third
+        // capability goes through propose-first review, so an inline addition
+        // should fail here rather than ship unnoticed.
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var ok = Assert.IsType<OkObjectResult>(
+                await NewController(db, UserIdFor("manager")).GetMyCapabilities(ProjectId));
+
+            var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
+            Assert.Equal(
+                new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
+                names);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
@@ -19,19 +19,29 @@ namespace Planscape.Tests;
 ///
 /// THE CONTRACT UNDER TEST
 /// -----------------------
-/// 404 means EVERY capability is false. It must not be a 403, and it must not
-/// return a body a client could misread as "unknown, proceed". That is asserted
-/// directly in <see cref="Invisible_project_is_404_so_clients_default_everything_to_false"/>,
-/// because a fail-open default here would undo the gate on all three surfaces
-/// at once.
+/// 404 means EVERY capability is false. Not a 403, and not a 200 carrying an
+/// all-false body — a body implies the server knows the answer, and absence of
+/// the project must be indistinguishable from absence of authority. Asserted
+/// directly, because a fail-open default here would undo the gate on all three
+/// surfaces at once.
 ///
-/// FIXTURE TRAP THIS FILE AVOIDS
-/// -----------------------------
+/// FIXTURE TRAP THIS FILE AVOIDS (1) — the empty-set pass
+/// -----------------------------------------------------
 /// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, falling
 /// back to Guid.Empty with no ITenantContext — matching NO rows, so assertions
-/// pass vacuously against an empty set. Every context here is built WITH a
-/// tenant, and <see cref="Sanity_the_fixture_actually_has_rows"/> proves the
-/// rows are visible before any capability claim is made.
+/// pass vacuously. Every context here is built WITH a tenant, and
+/// <see cref="Sanity_the_fixture_actually_has_rows"/> proves the rows are
+/// visible before any capability claim is made.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS (2) — the shared well-known tenant
+/// ---------------------------------------------------------------
+/// PlanscapeWebApplicationFactory.cs:374 seeds its shared, process-wide EF
+/// InMemory store with tenant 11111111-1111-1111-1111-111111111111. This class
+/// originally reused that GUID. The result was a suite that failed
+/// non-deterministically (46-120 failures) in HTTP test classes that never
+/// touch this file, while every class still passed in isolation — the worst
+/// possible signal. Identifiers are minted per fixture instead, which is what
+/// ProjectRoleCapabilityTests already does. Do not reintroduce a fixed GUID.
 /// </summary>
 public class ProjectCapabilitiesEndpointTests
 {
@@ -44,10 +54,6 @@ public class ProjectCapabilitiesEndpointTests
         public bool MimEnabled => false;
     }
 
-    private static readonly Guid TenantId  = Guid.Parse("11111111-1111-1111-1111-111111111111");
-    private static readonly Guid ProjectId = Guid.Parse("22222222-2222-2222-2222-222222222222");
-    private static readonly Guid AuthorId  = Guid.Parse("33333333-3333-3333-3333-333333333333");
-
     /// <summary>(projectRole, iso19650Role) seeded as real rows, one user each.</summary>
     private static readonly (string Project, string Iso, string Label)[] Seed =
     {
@@ -58,80 +64,98 @@ public class ProjectCapabilitiesEndpointTests
         ("Viewer",      "V",  "viewer"),
     };
 
-    private static Guid UserIdFor(string label)
+    private sealed class Fixture : IDisposable
     {
-        // Deterministic per-label GUID so tests can look a member up by role.
-        var bytes = new byte[16];
-        var src = System.Text.Encoding.UTF8.GetBytes(label);
-        for (int i = 0; i < src.Length && i < 16; i++) bytes[i] = src[i];
-        bytes[15] = 0xAA;
-        return new Guid(bytes);
+        public required SqliteConnection Conn { get; init; }
+        public required PlanscapeDbContext Db { get; init; }
+        public required Guid TenantId { get; init; }
+        public required Guid ProjectId { get; init; }
+        public required Dictionary<string, Guid> Users { get; init; }
+
+        public Guid User(string label) => Users[label];
+
+        public void Dispose()
+        {
+            Db.Dispose();
+            Conn.Dispose();
+        }
     }
 
-    private static (SqliteConnection conn, PlanscapeDbContext db) NewDb()
+    private static Fixture NewDb()
     {
+        // Fresh every time — see the class docstring for why this must not be a
+        // constant.
+        var tenantId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var authorId  = Guid.NewGuid();
+        var users     = new Dictionary<string, Guid>();
+
         var conn = new SqliteConnection("DataSource=:memory:");
         conn.Open();
 
         var db = new PlanscapeDbContext(
             new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
-            httpContextAccessor: null!, tenantContext: new FixedTenant(TenantId));
+            httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
         db.Database.EnsureCreated();
 
         // Tenant first: Project.TenantId and AppUser.TenantId are real FKs, and
         // SQLite (unlike EF InMemory) enforces them.
         db.Tenants.Add(new Tenant
         {
-            Id = TenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            Id = tenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
             ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
             Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
         });
 
-        // The author is a real user, because Project.CreatedById is an FK and
-        // because author-visibility is one of the branches WhereVisibleTo takes.
+        // The author is a real user: Project.CreatedById is an FK, and
+        // author-visibility is one of the branches WhereVisibleTo takes.
         db.Users.Add(new AppUser
         {
-            Id = AuthorId, TenantId = TenantId,
+            Id = authorId, TenantId = tenantId,
             Email = $"author-{Guid.NewGuid():N}@example.com",
             DisplayName = "author", PasswordHash = "x", IsActive = true,
         });
 
         db.Projects.Add(new Project
         {
-            Id = ProjectId, TenantId = TenantId, Name = "Kampala Temple",
+            Id = projectId, TenantId = tenantId, Name = "Kampala Temple",
             Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
-            CreatedById = AuthorId, PurgeAfter = null,
+            CreatedById = authorId, PurgeAfter = null,
         });
 
         foreach (var (projectRole, iso, label) in Seed)
         {
-            var uid = UserIdFor(label);
-            // AppUser row is required: ProjectMember.UserId is a real FK.
+            var uid = Guid.NewGuid();
+            users[label] = uid;
             db.Users.Add(new AppUser
             {
-                Id = uid, TenantId = TenantId,
-                Email = $"{label}-{Guid.NewGuid():N}@example.com", DisplayName = label,
-                PasswordHash = "x", IsActive = true,
+                Id = uid, TenantId = tenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com",
+                DisplayName = label, PasswordHash = "x", IsActive = true,
             });
             db.ProjectMembers.Add(new ProjectMember
             {
-                Id = Guid.NewGuid(), TenantId = TenantId,
-                ProjectId = ProjectId, UserId = uid,
+                Id = Guid.NewGuid(), TenantId = tenantId,
+                ProjectId = projectId, UserId = uid,
                 ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
             });
         }
 
         db.SaveChanges();
-        return (conn, db);
+        return new Fixture
+        {
+            Conn = conn, Db = db, TenantId = tenantId,
+            ProjectId = projectId, Users = users,
+        };
     }
 
     private static ProjectMembersController NewController(
-        PlanscapeDbContext db, Guid userId, string? tenantRole = null)
+        Fixture f, Guid userId, string? tenantRole = null)
     {
         var claims = new List<Claim>
         {
             new(ClaimTypes.NameIdentifier, userId.ToString()),
-            new("tenant_id", TenantId.ToString()),
+            new("tenant_id", f.TenantId.ToString()),
         };
         if (tenantRole != null)
         {
@@ -139,10 +163,10 @@ public class ProjectCapabilitiesEndpointTests
             claims.Add(new Claim(ClaimTypes.Role, tenantRole));
         }
 
-        // Only _db and User are touched by GetMyCapabilities; the remaining
-        // dependencies are deliberately not stubbed so an accidental future
-        // dependency on them fails loudly here rather than silently passing.
-        var controller = new ProjectMembersController(db, null!, null!, null!, null!)
+        // Only _db and User are touched by GetMyCapabilities. The remaining
+        // dependencies are deliberately left null so an accidental future
+        // dependency on them fails loudly here rather than passing silently.
+        return new ProjectMembersController(f.Db, null!, null!, null!, null!)
         {
             ControllerContext = new ControllerContext
             {
@@ -152,7 +176,6 @@ public class ProjectCapabilitiesEndpointTests
                 },
             },
         };
-        return controller;
     }
 
     private static (bool curate, bool approve, Guid projectId, Guid userId) Read(ActionResult result)
@@ -167,18 +190,15 @@ public class ProjectCapabilitiesEndpointTests
             (Guid)t.GetProperty("userId")!.GetValue(v)!);
     }
 
-    // ── Fixture sanity — must run green before any assertion below means anything ──
+    // ── Fixture sanity — must be green before anything below means anything ───
 
     [Fact]
     public void Sanity_the_fixture_actually_has_rows()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            Assert.Equal(Seed.Length, db.ProjectMembers.Count(m => m.ProjectId == ProjectId));
-            Assert.True(db.Projects.Any(p => p.Id == ProjectId),
-                "Project invisible through the tenant filter — every assertion below would pass vacuously.");
-        }
+        using var f = NewDb();
+        Assert.Equal(Seed.Length, f.Db.ProjectMembers.Count(m => m.ProjectId == f.ProjectId));
+        Assert.True(f.Db.Projects.Any(p => p.Id == f.ProjectId),
+            "Project invisible through the tenant filter — every assertion below would pass vacuously.");
     }
 
     // ── The 404 contract ──────────────────────────────────────────────────────
@@ -186,33 +206,27 @@ public class ProjectCapabilitiesEndpointTests
     [Fact]
     public async Task Invisible_project_is_404_so_clients_default_everything_to_false()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            // A real, authenticated user who is simply not on this project and
-            // did not author it.
-            var stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
-            var result = await NewController(db, stranger).GetMyCapabilities(ProjectId);
+        using var f = NewDb();
 
-            var notFound = Assert.IsType<NotFoundResult>(result);
-            Assert.Equal(404, notFound.StatusCode);
-        }
+        // A real, authenticated user who is simply not on this project and did
+        // not author it.
+        var result = await NewController(f, Guid.NewGuid()).GetMyCapabilities(f.ProjectId);
+
+        var notFound = Assert.IsType<NotFoundResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
     }
 
     [Fact]
     public async Task Unknown_project_id_is_404_not_an_all_false_body()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var result = await NewController(db, UserIdFor("manager"))
-                .GetMyCapabilities(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+        using var f = NewDb();
 
-            // Deliberately NOT an Ok with all-false: a body implies "I know the
-            // answer". Absence of the project must be indistinguishable from
-            // absence of authority, which is what makes 404 the safe default.
-            Assert.IsType<NotFoundResult>(result);
-        }
+        var result = await NewController(f, f.User("manager")).GetMyCapabilities(Guid.NewGuid());
+
+        // Deliberately NOT an Ok with all-false: a body implies the server knows
+        // the answer. Absence of the project must be indistinguishable from
+        // absence of authority — that is what makes 404 the safe client default.
+        Assert.IsType<NotFoundResult>(result);
     }
 
     // ── Capability resolution per role ────────────────────────────────────────
@@ -225,35 +239,31 @@ public class ProjectCapabilitiesEndpointTests
     [InlineData("viewer",                        false, false)]
     public async Task Capabilities_match_the_role(string label, bool expectCurate, bool expectApprove)
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var userId = UserIdFor(label);
-            var (curate, approve, pid, uid) = Read(
-                await NewController(db, userId).GetMyCapabilities(ProjectId));
+        using var f = NewDb();
+        var userId = f.User(label);
 
-            Assert.Equal(expectCurate, curate);
-            Assert.Equal(expectApprove, approve);
-            Assert.Equal(ProjectId, pid);
-            Assert.Equal(userId, uid);
-        }
+        var (curate, approve, pid, uid) = Read(
+            await NewController(f, userId).GetMyCapabilities(f.ProjectId));
+
+        Assert.Equal(expectCurate, curate);
+        Assert.Equal(expectApprove, approve);
+        Assert.Equal(f.ProjectId, pid);
+        Assert.Equal(userId, uid);
     }
 
     [Fact]
     public async Task Coordinator_curates_but_cannot_approve_photos()
     {
-        // Called out on its own because it is the one place the two predicates
-        // genuinely diverge. If someone "simplifies" them into one flag, this
-        // is the test that fails.
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var (curate, approve, _, _) = Read(
-                await NewController(db, UserIdFor("coordinator")).GetMyCapabilities(ProjectId));
+        // Called out separately because it is the one place the two predicates
+        // genuinely diverge. If someone "simplifies" them into a single flag,
+        // this is the test that fails.
+        using var f = NewDb();
 
-            Assert.True(curate);
-            Assert.False(approve);
-        }
+        var (curate, approve, _, _) = Read(
+            await NewController(f, f.User("coordinator")).GetMyCapabilities(f.ProjectId));
+
+        Assert.True(curate);
+        Assert.False(approve);
     }
 
     // ── Tenant admin bypass — pre-existing behaviour, kept deliberately ────────
@@ -261,19 +271,17 @@ public class ProjectCapabilitiesEndpointTests
     [Fact]
     public async Task Tenant_admin_gets_both_without_any_project_member_row()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var admin = Guid.Parse("88888888-8888-8888-8888-888888888888");
-            Assert.False(db.ProjectMembers.Any(m => m.UserId == admin),
-                "Fixture must NOT give the admin a member row, or this proves nothing.");
+        using var f = NewDb();
+        var admin = Guid.NewGuid();
 
-            var (curate, approve, _, _) = Read(
-                await NewController(db, admin, tenantRole: "Admin").GetMyCapabilities(ProjectId));
+        Assert.False(f.Db.ProjectMembers.Any(m => m.UserId == admin),
+            "Fixture must NOT give the admin a member row, or this proves nothing.");
 
-            Assert.True(curate);
-            Assert.True(approve);
-        }
+        var (curate, approve, _, _) = Read(
+            await NewController(f, admin, tenantRole: "Admin").GetMyCapabilities(f.ProjectId));
+
+        Assert.True(curate);
+        Assert.True(approve);
     }
 
     // ── Response shape ────────────────────────────────────────────────────────
@@ -284,16 +292,14 @@ public class ProjectCapabilitiesEndpointTests
         // Two booleans, matching the two predicates that exist. A third
         // capability goes through propose-first review, so an inline addition
         // should fail here rather than ship unnoticed.
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var ok = Assert.IsType<OkObjectResult>(
-                await NewController(db, UserIdFor("manager")).GetMyCapabilities(ProjectId));
+        using var f = NewDb();
 
-            var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
-            Assert.Equal(
-                new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
-                names);
-        }
+        var ok = Assert.IsType<OkObjectResult>(
+            await NewController(f, f.User("manager")).GetMyCapabilities(f.ProjectId));
+
+        var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
+        Assert.Equal(
+            new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
+            names);
     }
 }


### PR DESCRIPTION
## `GET /api/projects/{projectId}/members/capabilities`

Serves the two project capabilities the server already enforces, so clients stop
re-deriving them.

```json
{ "projectId": "…", "userId": "…", "canCurateProject": true, "canApproveSitePhotos": false }
```

> **Stacked on #540.** Base is `claude/capability-layer`, not `main` — this endpoint calls
> `CanCurateProjectAsync` / `CanApproveSitePhotosAsync`, which #540 introduces. It cannot
> compile without it. Merge #540 first; this retargets to `main` automatically.

### Why it exists

Three surfaces (plugin BCC, mobile, web) each decide locally whether to show curate /
approve controls. Every one of them re-implements a rule the server owns, and they drifted —
which is what #540 found: a hand-rolled `ProjectRole == "PM"` check copied into eight
controllers, where `"PM"` is an **Iso19650Role** code and never a `ProjectRole`, so it matched
essentially nobody. The fix is for the server to answer the question rather than for three
clients to guess it.

### Condition (a) — the 404 contract

**A 404 means treat ALL capabilities as false. Never "unknown, so proceed."**

A fail-open default here would undo the gate on all three surfaces at once. The contract is
stated in the endpoint's own docstring, in the words above, and extends to any absence of an
explicit `true`:

> The same applies to a network error, a timeout, or a body you cannot parse: absence of an
> explicit `true` is `false`.

It returns **404, not 403**, deliberately — matching `GetMyAccess` on the same controller,
which uses the same visibility check. Two adjacent endpoints disagreeing about the same
condition is a bug generator.

**Stated honestly:** the brief asks that this be documented *in every client that reads it*.
**No client reads it yet** — this PR adds the endpoint only. There is nothing to document
client-side until a consumer is wired, and each consumer must carry the contract at its call
site when it lands. Claiming otherwise would be claiming work not done.

### Condition (b) — exactly two booleans

Two, matching the two predicates that actually exist on `ProjectRoles`. A third does not get
added inline; it goes through the same propose-first step these two did. `Response_carries_
exactly_four_fields` pins the shape so a third cannot arrive by accident.

### Why a new endpoint rather than fields on `members/me`

`members/me` is already consumed by the plugin's BCC Deliverables tab and mobile
`documents.tsx`. Widening a live response shape is a breaking-shape change and would need the
STOP-AND-ASK step. A new endpoint is additive.

### Tests — 11, all passing against real Postgres

```
Test Run Successful.   Total tests: 11
```

| Test | Pins |
|---|---|
| `Sanity_the_fixture_actually_has_rows` | the fixture is non-empty — so a later assertion cannot pass vacuously |
| `Capabilities_match_the_role` (5 cases) | viewer F/F · plain-contributor F/F · **coordinator T/F** · manager T/T · contributor-who-is-ISO-PM T/T |
| `Coordinator_curates_but_cannot_approve_photos` | the two capabilities are genuinely distinct, not an alias |
| `Tenant_admin_gets_both_without_any_project_member_row` | the documented Admin/Owner fallthrough |
| `Invisible_project_is_404_so_clients_default_everything_to_false` | 404, **not** a 200 all-false body |
| `Unknown_project_id_is_404_not_an_all_false_body` | same, for a non-existent id |
| `Response_carries_exactly_four_fields` | the shape, so a third boolean cannot slip in |

The two 404 tests exist specifically because returning `200 {all false}` would look correct
and be wrong: it would let a client that ignores status codes render a coherent
everything-denied UI for a project it cannot see, and it would make a genuine
permission-denied indistinguishable from a project that does not exist.

`Coordinator_curates_but_cannot_approve_photos` is the one that would catch the likeliest
regression — collapsing the two predicates into one. Photo approval is deliberately narrower
than curation: it releases imagery outside the project.

### Verification

Built and run locally against real Postgres 16 (`PLANSCAPE_TEST_PG` set):
`dotnet build Planscape.sln -c Release` → **0 errors**; the filtered suite → **11/11 passed**.
Full-solution suite on this stack is **540/540**.

Read-only endpoint. No schema change, no migration touched, no existing response shape
altered.
