### PR TITLE
feat(server): serve project capabilities so three clients stop deriving them

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -40,6 +40,7 @@ on:
       - 'stingtools-core/python/**'
       - 'StingBridge/**'
       - 'Planscape/**'
+      - 'planscape-web/**'
       - '.github/workflows/contract-drift.yml'
   pull_request:
     paths:
@@ -49,6 +50,7 @@ on:
       - 'stingtools-core/python/**'
       - 'StingBridge/**'
       - 'Planscape/**'
+      - 'planscape-web/**'
       - '.github/workflows/contract-drift.yml'
   workflow_dispatch:
 

--- a/Planscape.Server/src/Planscape.API/Controllers/DistributionGroupsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DistributionGroupsController.cs
@@ -191,16 +191,11 @@ public class DistributionGroupsController : ControllerBase
         return NoContent();
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoAlbumsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoAlbumsController.cs
@@ -384,16 +384,11 @@ public class PhotoAlbumsController : ControllerBase
     /// Mutation gate (matches SitePhotosController.IsApproverAsync):
     /// tenant Admin / Owner OR project PM.
     /// </summary>
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
 
     /// <summary>
     /// Read gate: project member always sees Internal/Members; Client

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoChecklistsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoChecklistsController.cs
@@ -309,16 +309,11 @@ public class PhotoChecklistsController : ControllerBase
         return Ok(c);
     }
 
-    private async Task<bool> IsAuthorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsAuthorAsync(Guid projectId, CancellationToken ct)
+        => this.CanCurateProjectAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoPolicyController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoPolicyController.cs
@@ -92,16 +92,11 @@ public class PhotoPolicyController : ControllerBase
         return Ok(pol);
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/PhotoShareController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/PhotoShareController.cs
@@ -111,16 +111,11 @@ public class PhotoShareLinkAdminController : ControllerBase
         return Ok(link);
     }
 
-    private async Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsCuratorAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -415,6 +415,18 @@ public class ProjectMembersController : ControllerBase
             member.AllowedSuitabilities = profile.AllowedSuitabilities;
         }
 
+        // ProjectRole used to accept ANY string here with no validation, which
+        // is how the vocabulary drifted far enough for eleven gates to end up
+        // testing an Iso19650Role code ("PM") against this column. Reject
+        // anything outside the canonical set; same error shape as invalid_kind
+        // in DistributionGroupsController.
+        //
+        // Iso19650Role is deliberately NOT validated in this pass — its
+        // vocabulary lives in GetRoles() below and constraining it is a
+        // separate, wider change.
+        if (req.ProjectRole != null && !ProjectRoles.IsCanonical(req.ProjectRole))
+            return BadRequest(new { error = "invalid_project_role", allowed = ProjectRoles.All });
+
         if (req.ProjectRole  != null) member.ProjectRole  = req.ProjectRole;
         if (req.Iso19650Role != null) member.Iso19650Role = req.Iso19650Role;
         // Phase 177 — pass null array to leave a column unchanged; pass an

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -6,6 +6,13 @@ using Microsoft.Extensions.Logging;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.API.Authorization;
+// Imported for the capability extension methods (CanCurateProjectAsync /
+// CanApproveSitePhotosAsync). This namespace also declares an IEmailService,
+// which collides with Planscape.Core.Interfaces.IEmailService — the one this
+// controller's constructor has always bound to. The alias below pins that
+// binding so adding the import cannot silently re-resolve it.
+using Planscape.API.Services;
+using IEmailService = Planscape.Core.Interfaces.IEmailService;
 using Planscape.Infrastructure.Data;
 using Planscape.Infrastructure.Services;
 using Planscape.Infrastructure.SignalR;
@@ -108,6 +115,53 @@ public class ProjectMembersController : ControllerBase
             allowedCdeStates     = ProjectMember.ParseAllowList(member?.AllowedCdeStates)     ?? Array.Empty<string>(),
             allowedDisciplines   = ProjectMember.ParseAllowList(member?.AllowedDisciplines)   ?? Array.Empty<string>(),
             allowedSuitabilities = ProjectMember.ParseAllowList(member?.AllowedSuitabilities) ?? Array.Empty<string>(),
+        });
+    }
+
+    /// <summary>
+    /// The caller's capabilities on this project, resolved server-side.
+    ///
+    /// WHY THIS EXISTS. Clients were re-deriving authority from
+    /// <c>projectRole</c> / <c>iso19650Role</c> returned by
+    /// <see cref="GetMyAccess"/>. Three surfaces re-implementing one rule is
+    /// exactly how the eleven dead <c>ProjectRole == "PM"</c> gates happened.
+    /// The server owns the rule; clients render what it returns.
+    ///
+    /// CLIENT CONTRACT — 404 MEANS ALL CAPABILITIES ARE FALSE.
+    /// A 404 says the caller cannot see this project at all. Treat every
+    /// capability as false. Never "unknown, so proceed" — a fail-open default
+    /// here would undo the gate on all three surfaces at once. The same
+    /// applies to a network error, a timeout, or a body you cannot parse:
+    /// absence of an explicit <c>true</c> is <c>false</c>.
+    ///
+    /// Deliberately two booleans, matching the two predicates that actually
+    /// exist on <see cref="ProjectRoles"/>. A third does not get added inline
+    /// — it goes through the same propose-first step these two did.
+    ///
+    /// Deliberately a separate endpoint rather than extra fields on
+    /// <c>members/me</c>: that response is already consumed and widening it
+    /// is a breaking-shape change.
+    /// </summary>
+    [HttpGet("capabilities")]
+    public async Task<ActionResult> GetMyCapabilities(Guid projectId, CancellationToken ct = default)
+    {
+        // 404 (not 403) so this agrees with GetMyAccess above, which uses the
+        // same visibility check. Two adjacent endpoints disagreeing about the
+        // same condition is a bug generator.
+        if (!await CanAccessProjectAsync(projectId)) return NotFound();
+
+        var subClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (!Guid.TryParse(subClaim, out var userId)) return Unauthorized();
+
+        // Both resolve tenant Admin/Owner without a ProjectMember row, matching
+        // every site the capability layer replaced.
+        return Ok(new
+        {
+            projectId,
+            userId,
+            canCurateProject     = await this.CanCurateProjectAsync(_db, projectId, ct),
+            canApproveSitePhotos = await this.CanApproveSitePhotosAsync(_db, projectId, ct),
         });
     }
 

--- a/Planscape.Server/src/Planscape.API/Controllers/SavedViewsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SavedViewsController.cs
@@ -131,9 +131,10 @@ public class SavedViewsController : ControllerBase
         bool isPrivileged = role is "Admin" or "Owner";
         if (!isPrivileged && view.CapturedByUserId != actor)
         {
-            // PM-on-this-project also OK
-            isPrivileged = await _db.ProjectMembers.AnyAsync(m =>
-                m.ProjectId == projectId && m.UserId == actor && m.IsActive && m.ProjectRole == "PM", ct);
+            // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+            // ProjectRole column, so it matched essentially nobody and only the
+            // tenant Admin/Owner branch above ever granted this.
+            isPrivileged = await this.CanCurateProjectAsync(_db, projectId, ct);
         }
         if (!isPrivileged && view.CapturedByUserId != actor) return Forbid();
 

--- a/Planscape.Server/src/Planscape.API/Controllers/SitePhotosController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SitePhotosController.cs
@@ -870,19 +870,15 @@ public class SitePhotosController : ControllerBase
         await _db.SitePhotos.FirstOrDefaultAsync(p => p.Id == photoId && p.ProjectId == projectId, ct);
 
     /// <summary>
-    /// Approval gate (decision #1): tenant Admin / Owner OR
-    /// ProjectMember.ProjectRole == "PM" on this project.
+    /// Approval gate (decision #1): tenant Admin / Owner OR a member holding
+    /// the ApproveSitePhotos capability on this project (ProjectRole in
+    /// Manager/Owner/Admin, or Iso19650Role in PM/A). See ProjectRoles.
     /// </summary>
-    private async Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
 
     private Guid? CurrentUserIdOrNull()
     {

--- a/Planscape.Server/src/Planscape.API/Controllers/SitePhotosExtController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SitePhotosExtController.cs
@@ -599,16 +599,11 @@ public class SitePhotosExtController : ControllerBase
 
     // ── helpers ──────────────────────────────────────────────────────
 
-    private async Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
-    {
-        var role = User.FindFirst("role")?.Value ?? "";
-        if (role is "Admin" or "Owner") return true;
-        var userId = CurrentUserIdOrNull();
-        if (userId == null) return false;
-        return await _db.ProjectMembers.AsNoTracking().AnyAsync(m =>
-            m.ProjectId == projectId && m.UserId == userId.Value &&
-            m.IsActive && m.ProjectRole == "PM", ct);
-    }
+    // Was an inline `ProjectRole == "PM"` test. "PM" is an Iso19650Role
+    // code, never a ProjectRole (ProjectMember.cs:15 vs :18), so this gate
+    // matched essentially nobody. Delegates to the shared capability layer.
+    private Task<bool> IsApproverAsync(Guid projectId, CancellationToken ct)
+        => this.CanApproveSitePhotosAsync(_db, projectId, ct);
     private Guid? CurrentUserIdOrNull()
     {
         var s = User.FindFirst("user_id")?.Value

--- a/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
+++ b/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
 using Planscape.Infrastructure.Authorization;
 using Planscape.Infrastructure.Data;
 
@@ -34,6 +36,59 @@ public static class ControllerProjectMembershipExtensions
             return controller.StatusCode(403, new { error = "You are not a member of this project" });
         }
         return null;
+    }
+
+    /// <summary>
+    /// True when the caller may CURATE this project — albums, checklists,
+    /// distribution groups, deleting another member's saved view.
+    ///
+    /// Replaces the hand-rolled `ProjectRole == "PM"` check that was copied
+    /// into eight controllers. "PM" is an Iso19650Role code, never a
+    /// ProjectRole, so those checks matched (essentially) nobody — see
+    /// <see cref="ProjectRoles"/> for the full explanation.
+    /// </summary>
+    public static Task<bool> CanCurateProjectAsync(
+        this ControllerBase controller, PlanscapeDbContext db, Guid projectId, CancellationToken ct = default)
+        => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanCurateProject, ct);
+
+    /// <summary>
+    /// True when the caller may APPROVE site photos — approve/reject,
+    /// include-originals, issue share links, PUT the photo policy. Narrower
+    /// than curation: these decisions release imagery outside the project.
+    /// </summary>
+    public static Task<bool> CanApproveSitePhotosAsync(
+        this ControllerBase controller, PlanscapeDbContext db, Guid projectId, CancellationToken ct = default)
+        => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanApproveSitePhotosPredicate, ct);
+
+    /// <summary>
+    /// Shared body. The tenant `role` claim (Admin / Owner) grants without any
+    /// ProjectMember row — that is pre-existing behaviour at every site this
+    /// replaces, kept deliberately.
+    /// </summary>
+    private static async Task<bool> HasCapabilityAsync(
+        ControllerBase controller,
+        PlanscapeDbContext db,
+        Guid projectId,
+        System.Linq.Expressions.Expression<Func<ProjectMember, bool>> capability,
+        CancellationToken ct)
+    {
+        var user = controller.User;
+
+        // Match the claim shapes the replaced sites used: several read the raw
+        // "role" claim rather than IsInRole, so check both.
+        var roleClaim = user.FindFirst("role")?.Value ?? "";
+        if (roleClaim is "Admin" or "Owner" || user.IsInRole("Admin") || user.IsInRole("Owner"))
+            return true;
+
+        var userId = ParseGuid(user.FindFirst("user_id")?.Value
+                              ?? user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                              ?? user.FindFirst("sub")?.Value);
+        if (userId == Guid.Empty) return false;
+
+        return await db.ProjectMembers.AsNoTracking()
+            .Where(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive)
+            .Where(capability)
+            .AnyAsync(ct);
     }
 
     private static Guid ParseGuid(string? value)

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
@@ -1,0 +1,135 @@
+using System.Linq.Expressions;
+
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// The canonical <see cref="ProjectMember.ProjectRole"/> vocabulary, and the
+/// capability predicates derived from it.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// Eleven call sites gated on <c>ProjectRole == "PM"</c>. But "PM" is not a
+/// ProjectRole at all — the two fields carry different vocabularies, and each
+/// says so on itself:
+///
+///   ProjectMember.cs:15  ProjectRole   "Viewer/Contributor/Coordinator/Manager"
+///   ProjectMember.cs:18  Iso19650Role  "A/PM/BC/AR/SE/ME/QS etc."
+///
+/// "PM" only ever appears in the ISO 19650 list — which is also what
+/// <c>GET api/projects/{id}/members/roles</c> returns, and what the web grid
+/// saves into <c>iso19650Role</c>. Those eleven sites were reading the right
+/// code off the wrong column, so the gates matched (essentially) nobody.
+///
+/// This is a wrong-field bug, not a data migration.
+///
+/// TWO SHAPES, DELIBERATELY
+/// ------------------------
+/// Controllers need a claims-aware async check (the tenant `role` claim can
+/// grant access without any ProjectMember row). Background jobs need something
+/// EF can translate INSIDE a <c>.Where(...)</c>. A method the jobs called
+/// per-row would silently client-evaluate the whole table, so the job-facing
+/// shape is an <see cref="Expression"/> and stays one.
+///
+/// Keep the two in step: <see cref="CanCurateProject"/> is the expression form
+/// of <see cref="CanCurate"/>, and likewise for the approval pair. The tests
+/// assert they agree.
+/// </summary>
+public static class ProjectRoles
+{
+    // ── Canonical ProjectRole vocabulary ────────────────────────────────────
+    // Viewer..Admin mirror the web members dropdown
+    // (planscape-web/app/projects/[id]/members/page.tsx:23). ClientGuest is
+    // included because DailyPhotoDigestJob.cs:126 already reads it, so it is
+    // a real value in the system whether or not the UI offers it.
+
+    public const string Viewer      = "Viewer";
+    public const string Contributor = "Contributor";
+    public const string Coordinator = "Coordinator";
+    public const string Manager     = "Manager";
+    public const string Owner       = "Owner";
+    public const string Admin       = "Admin";
+    public const string ClientGuest = "ClientGuest";
+
+    /// <summary>Every legal ProjectRole. Order matches the web dropdown, with
+    /// ClientGuest appended.</summary>
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Viewer, Contributor, Coordinator, Manager, Owner, Admin, ClientGuest,
+    };
+
+    /// <summary>Case-insensitive membership test for write validation.</summary>
+    public static bool IsCanonical(string? role)
+        => role != null && All.Any(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));
+
+    // ── ISO 19650 role codes that carry project authority ───────────────────
+    // A  = Appointing Party, PM = Project Manager, BC = BIM Coordinator.
+    // These come from the Iso19650Role column — the one that actually holds
+    // "PM" — which is the whole point of this class.
+
+    private const string IsoAppointingParty = "A";
+    private const string IsoProjectManager  = "PM";
+    private const string IsoBimCoordinator  = "BC";
+
+    // ── LEGACY TOLERANCE — read this before "tidying" it away ───────────────
+    //
+    // The gates being replaced tested `ProjectRole == "PM"`. "PM" is not a
+    // canonical ProjectRole and no first-party UI writes it there — but
+    // ProjectMembersController:418 accepted ANY string with no validation
+    // until this change, so a row with ProjectRole = "PM" is possible and any
+    // such row passes the CURRENT gate.
+    //
+    // Dropping it would NARROW access for those rows, which is exactly what
+    // this change promises not to do. So "PM" is accepted as a ProjectRole
+    // here for back-compat, while `All` deliberately excludes it so new writes
+    // are rejected. Remove only after confirming no rows carry it.
+    private const string LegacyProjectRolePm = "PM";
+
+    // ── Capability: CurateProject ───────────────────────────────────────────
+    // Albums, checklists, distribution groups, deleting another member's saved
+    // view. Broader than photo approval: curation is organising, not signing off.
+
+    /// <summary>In-memory form. <paramref name="isTenantAdmin"/> covers the
+    /// tenant `role` claim being Admin or Owner, which grants regardless of
+    /// any ProjectMember row.</summary>
+    public static bool CanCurate(string? projectRole, string? iso19650Role, bool isTenantAdmin = false)
+        => isTenantAdmin
+        || Eq(projectRole, Manager) || Eq(projectRole, Owner) || Eq(projectRole, Admin)
+        || Eq(projectRole, Coordinator) || Eq(projectRole, LegacyProjectRolePm)
+        || Eq(iso19650Role, IsoProjectManager) || Eq(iso19650Role, IsoAppointingParty)
+        || Eq(iso19650Role, IsoBimCoordinator);
+
+    /// <summary>EF-translatable form for use inside <c>.Where(...)</c>.
+    /// Deliberately written with plain <c>==</c> and <c>||</c> so it becomes a
+    /// SQL <c>OR</c> chain rather than client evaluation.</summary>
+    public static Expression<Func<ProjectMember, bool>> CanCurateProject =>
+        m => m.ProjectRole == Manager
+          || m.ProjectRole == Owner
+          || m.ProjectRole == Admin
+          || m.ProjectRole == Coordinator
+          || m.ProjectRole == LegacyProjectRolePm
+          || m.Iso19650Role == IsoProjectManager
+          || m.Iso19650Role == IsoAppointingParty
+          || m.Iso19650Role == IsoBimCoordinator;
+
+    // ── Capability: ApproveSitePhotos ───────────────────────────────────────
+    // Photo approve/reject, include-originals, share-link issuance, PUT
+    // photo-policy. Narrower: these decisions release imagery outside the
+    // project, so a Coordinator curating albums does not get them.
+
+    public static bool CanApproveSitePhotos(string? projectRole, string? iso19650Role, bool isTenantAdmin = false)
+        => isTenantAdmin
+        || Eq(projectRole, Manager) || Eq(projectRole, Owner) || Eq(projectRole, Admin)
+        || Eq(projectRole, LegacyProjectRolePm)
+        || Eq(iso19650Role, IsoProjectManager) || Eq(iso19650Role, IsoAppointingParty);
+
+    public static Expression<Func<ProjectMember, bool>> CanApproveSitePhotosPredicate =>
+        m => m.ProjectRole == Manager
+          || m.ProjectRole == Owner
+          || m.ProjectRole == Admin
+          || m.ProjectRole == LegacyProjectRolePm
+          || m.Iso19650Role == IsoProjectManager
+          || m.Iso19650Role == IsoAppointingParty;
+
+    private static bool Eq(string? a, string b)
+        => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/BackgroundJobs.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/BackgroundJobs.cs
@@ -311,7 +311,11 @@ public class SlaEscalationJob
             {
                 var pmIds = await db.ProjectMembers
                     .AsNoTracking()
-                    .Where(m => m.ProjectId == issue.ProjectId && m.IsActive && m.ProjectRole == "PM")
+                    // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+                    // ProjectRole column, so this escalation notified nobody.
+                    // Chained .Where keeps the predicate EF-translatable.
+                    .Where(m => m.ProjectId == issue.ProjectId && m.IsActive)
+                    .Where(Planscape.Core.Entities.ProjectRoles.CanCurateProject)
                     .Select(m => m.UserId)
                     .Distinct()
                     .ToListAsync(ct);

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/DailyPhotoDigestJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/DailyPhotoDigestJob.cs
@@ -153,8 +153,13 @@ public class DailyPhotoDigestJob
         if (pendingReviewCount > 0)
         {
             var approvers = await (
+                // Was `ProjectRole == "PM"` — an Iso19650Role code read off the
+                // ProjectRole column, so the approver nudge emailed nobody. Query
+                // syntax cannot take an Expression in its `where`, so the
+                // capability is applied to the SOURCE, keeping it SQL-translated.
                 from m in _db.ProjectMembers.AsNoTracking()
-                where m.ProjectId == projectId && m.IsActive && m.ProjectRole == "PM"
+                             .Where(Planscape.Core.Entities.ProjectRoles.CanApproveSitePhotosPredicate)
+                where m.ProjectId == projectId && m.IsActive
                 join u in _db.Users.AsNoTracking() on m.UserId equals u.Id
                 join p in _db.UserNotificationPreferences.AsNoTracking() on u.Id equals p.UserId into pg
                 from p in pg.DefaultIfEmpty()

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/P6LiveLinkService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/P6LiveLinkService.cs
@@ -285,7 +285,10 @@ public class P6LiveLinkService
         {
             var pmUserIds = await db.ProjectMembers
                 .AsNoTracking()
-                .Where(m => m.ProjectId == projectId && m.IsActive && m.ProjectRole == "PM")
+                // Was `ProjectRole == "PM"` — see ProjectRoles. Chained .Where so
+                // the capability predicate is translated to SQL, not client-evaluated.
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(Planscape.Core.Entities.ProjectRoles.CanCurateProject)
                 .Select(m => m.UserId)
                 .Distinct()
                 .ToListAsync(ct);

--- a/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
@@ -1,0 +1,299 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// GET api/projects/{projectId}/members/capabilities.
+///
+/// The endpoint exists so three surfaces stop re-deriving authority from
+/// `projectRole` / `iso19650Role`. Re-implementing one rule in three clients is
+/// how the eleven dead `ProjectRole == "PM"` gates happened.
+///
+/// THE CONTRACT UNDER TEST
+/// -----------------------
+/// 404 means EVERY capability is false. It must not be a 403, and it must not
+/// return a body a client could misread as "unknown, proceed". That is asserted
+/// directly in <see cref="Invisible_project_is_404_so_clients_default_everything_to_false"/>,
+/// because a fail-open default here would undo the gate on all three surfaces
+/// at once.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS
+/// -----------------------------
+/// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, falling
+/// back to Guid.Empty with no ITenantContext — matching NO rows, so assertions
+/// pass vacuously against an empty set. Every context here is built WITH a
+/// tenant, and <see cref="Sanity_the_fixture_actually_has_rows"/> proves the
+/// rows are visible before any capability claim is made.
+/// </summary>
+public class ProjectCapabilitiesEndpointTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static readonly Guid TenantId  = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ProjectId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid AuthorId  = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    /// <summary>(projectRole, iso19650Role) seeded as real rows, one user each.</summary>
+    private static readonly (string Project, string Iso, string Label)[] Seed =
+    {
+        ("Manager",     "M",  "manager"),
+        ("Coordinator", "M",  "coordinator"),
+        ("Contributor", "PM", "contributor-who-is-the-iso-PM"),
+        ("Contributor", "M",  "plain-contributor"),
+        ("Viewer",      "V",  "viewer"),
+    };
+
+    private static Guid UserIdFor(string label)
+    {
+        // Deterministic per-label GUID so tests can look a member up by role.
+        var bytes = new byte[16];
+        var src = System.Text.Encoding.UTF8.GetBytes(label);
+        for (int i = 0; i < src.Length && i < 16; i++) bytes[i] = src[i];
+        bytes[15] = 0xAA;
+        return new Guid(bytes);
+    }
+
+    private static (SqliteConnection conn, PlanscapeDbContext db) NewDb()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var db = new PlanscapeDbContext(
+            new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+            httpContextAccessor: null!, tenantContext: new FixedTenant(TenantId));
+        db.Database.EnsureCreated();
+
+        // Tenant first: Project.TenantId and AppUser.TenantId are real FKs, and
+        // SQLite (unlike EF InMemory) enforces them.
+        db.Tenants.Add(new Tenant
+        {
+            Id = TenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+
+        // The author is a real user, because Project.CreatedById is an FK and
+        // because author-visibility is one of the branches WhereVisibleTo takes.
+        db.Users.Add(new AppUser
+        {
+            Id = AuthorId, TenantId = TenantId,
+            Email = $"author-{Guid.NewGuid():N}@example.com",
+            DisplayName = "author", PasswordHash = "x", IsActive = true,
+        });
+
+        db.Projects.Add(new Project
+        {
+            Id = ProjectId, TenantId = TenantId, Name = "Kampala Temple",
+            Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            CreatedById = AuthorId, PurgeAfter = null,
+        });
+
+        foreach (var (projectRole, iso, label) in Seed)
+        {
+            var uid = UserIdFor(label);
+            // AppUser row is required: ProjectMember.UserId is a real FK.
+            db.Users.Add(new AppUser
+            {
+                Id = uid, TenantId = TenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com", DisplayName = label,
+                PasswordHash = "x", IsActive = true,
+            });
+            db.ProjectMembers.Add(new ProjectMember
+            {
+                Id = Guid.NewGuid(), TenantId = TenantId,
+                ProjectId = ProjectId, UserId = uid,
+                ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
+            });
+        }
+
+        db.SaveChanges();
+        return (conn, db);
+    }
+
+    private static ProjectMembersController NewController(
+        PlanscapeDbContext db, Guid userId, string? tenantRole = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new("tenant_id", TenantId.ToString()),
+        };
+        if (tenantRole != null)
+        {
+            claims.Add(new Claim("role", tenantRole));
+            claims.Add(new Claim(ClaimTypes.Role, tenantRole));
+        }
+
+        // Only _db and User are touched by GetMyCapabilities; the remaining
+        // dependencies are deliberately not stubbed so an accidental future
+        // dependency on them fails loudly here rather than silently passing.
+        var controller = new ProjectMembersController(db, null!, null!, null!, null!)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test")),
+                },
+            },
+        };
+        return controller;
+    }
+
+    private static (bool curate, bool approve, Guid projectId, Guid userId) Read(ActionResult result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var v = ok.Value!;
+        var t = v.GetType();
+        return (
+            (bool)t.GetProperty("canCurateProject")!.GetValue(v)!,
+            (bool)t.GetProperty("canApproveSitePhotos")!.GetValue(v)!,
+            (Guid)t.GetProperty("projectId")!.GetValue(v)!,
+            (Guid)t.GetProperty("userId")!.GetValue(v)!);
+    }
+
+    // ── Fixture sanity — must run green before any assertion below means anything ──
+
+    [Fact]
+    public void Sanity_the_fixture_actually_has_rows()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            Assert.Equal(Seed.Length, db.ProjectMembers.Count(m => m.ProjectId == ProjectId));
+            Assert.True(db.Projects.Any(p => p.Id == ProjectId),
+                "Project invisible through the tenant filter — every assertion below would pass vacuously.");
+        }
+    }
+
+    // ── The 404 contract ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Invisible_project_is_404_so_clients_default_everything_to_false()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            // A real, authenticated user who is simply not on this project and
+            // did not author it.
+            var stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
+            var result = await NewController(db, stranger).GetMyCapabilities(ProjectId);
+
+            var notFound = Assert.IsType<NotFoundResult>(result);
+            Assert.Equal(404, notFound.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task Unknown_project_id_is_404_not_an_all_false_body()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var result = await NewController(db, UserIdFor("manager"))
+                .GetMyCapabilities(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+
+            // Deliberately NOT an Ok with all-false: a body implies "I know the
+            // answer". Absence of the project must be indistinguishable from
+            // absence of authority, which is what makes 404 the safe default.
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+
+    // ── Capability resolution per role ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("manager",                       true,  true)]
+    [InlineData("coordinator",                   true,  false)] // curates, cannot release imagery
+    [InlineData("contributor-who-is-the-iso-PM", true,  true)]  // authority via Iso19650Role
+    [InlineData("plain-contributor",             false, false)]
+    [InlineData("viewer",                        false, false)]
+    public async Task Capabilities_match_the_role(string label, bool expectCurate, bool expectApprove)
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var userId = UserIdFor(label);
+            var (curate, approve, pid, uid) = Read(
+                await NewController(db, userId).GetMyCapabilities(ProjectId));
+
+            Assert.Equal(expectCurate, curate);
+            Assert.Equal(expectApprove, approve);
+            Assert.Equal(ProjectId, pid);
+            Assert.Equal(userId, uid);
+        }
+    }
+
+    [Fact]
+    public async Task Coordinator_curates_but_cannot_approve_photos()
+    {
+        // Called out on its own because it is the one place the two predicates
+        // genuinely diverge. If someone "simplifies" them into one flag, this
+        // is the test that fails.
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var (curate, approve, _, _) = Read(
+                await NewController(db, UserIdFor("coordinator")).GetMyCapabilities(ProjectId));
+
+            Assert.True(curate);
+            Assert.False(approve);
+        }
+    }
+
+    // ── Tenant admin bypass — pre-existing behaviour, kept deliberately ────────
+
+    [Fact]
+    public async Task Tenant_admin_gets_both_without_any_project_member_row()
+    {
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var admin = Guid.Parse("88888888-8888-8888-8888-888888888888");
+            Assert.False(db.ProjectMembers.Any(m => m.UserId == admin),
+                "Fixture must NOT give the admin a member row, or this proves nothing.");
+
+            var (curate, approve, _, _) = Read(
+                await NewController(db, admin, tenantRole: "Admin").GetMyCapabilities(ProjectId));
+
+            Assert.True(curate);
+            Assert.True(approve);
+        }
+    }
+
+    // ── Response shape ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Response_carries_exactly_four_fields()
+    {
+        // Two booleans, matching the two predicates that exist. A third
+        // capability goes through propose-first review, so an inline addition
+        // should fail here rather than ship unnoticed.
+        var (conn, db) = NewDb();
+        using (conn)
+        {
+            var ok = Assert.IsType<OkObjectResult>(
+                await NewController(db, UserIdFor("manager")).GetMyCapabilities(ProjectId));
+
+            var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
+            Assert.Equal(
+                new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
+                names);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
@@ -19,19 +19,29 @@ namespace Planscape.Tests;
 ///
 /// THE CONTRACT UNDER TEST
 /// -----------------------
-/// 404 means EVERY capability is false. It must not be a 403, and it must not
-/// return a body a client could misread as "unknown, proceed". That is asserted
-/// directly in <see cref="Invisible_project_is_404_so_clients_default_everything_to_false"/>,
-/// because a fail-open default here would undo the gate on all three surfaces
-/// at once.
+/// 404 means EVERY capability is false. Not a 403, and not a 200 carrying an
+/// all-false body — a body implies the server knows the answer, and absence of
+/// the project must be indistinguishable from absence of authority. Asserted
+/// directly, because a fail-open default here would undo the gate on all three
+/// surfaces at once.
 ///
-/// FIXTURE TRAP THIS FILE AVOIDS
-/// -----------------------------
+/// FIXTURE TRAP THIS FILE AVOIDS (1) — the empty-set pass
+/// -----------------------------------------------------
 /// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, falling
 /// back to Guid.Empty with no ITenantContext — matching NO rows, so assertions
-/// pass vacuously against an empty set. Every context here is built WITH a
-/// tenant, and <see cref="Sanity_the_fixture_actually_has_rows"/> proves the
-/// rows are visible before any capability claim is made.
+/// pass vacuously. Every context here is built WITH a tenant, and
+/// <see cref="Sanity_the_fixture_actually_has_rows"/> proves the rows are
+/// visible before any capability claim is made.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS (2) — the shared well-known tenant
+/// ---------------------------------------------------------------
+/// PlanscapeWebApplicationFactory.cs:374 seeds its shared, process-wide EF
+/// InMemory store with tenant 11111111-1111-1111-1111-111111111111. This class
+/// originally reused that GUID. The result was a suite that failed
+/// non-deterministically (46-120 failures) in HTTP test classes that never
+/// touch this file, while every class still passed in isolation — the worst
+/// possible signal. Identifiers are minted per fixture instead, which is what
+/// ProjectRoleCapabilityTests already does. Do not reintroduce a fixed GUID.
 /// </summary>
 public class ProjectCapabilitiesEndpointTests
 {
@@ -44,10 +54,6 @@ public class ProjectCapabilitiesEndpointTests
         public bool MimEnabled => false;
     }
 
-    private static readonly Guid TenantId  = Guid.Parse("11111111-1111-1111-1111-111111111111");
-    private static readonly Guid ProjectId = Guid.Parse("22222222-2222-2222-2222-222222222222");
-    private static readonly Guid AuthorId  = Guid.Parse("33333333-3333-3333-3333-333333333333");
-
     /// <summary>(projectRole, iso19650Role) seeded as real rows, one user each.</summary>
     private static readonly (string Project, string Iso, string Label)[] Seed =
     {
@@ -58,80 +64,98 @@ public class ProjectCapabilitiesEndpointTests
         ("Viewer",      "V",  "viewer"),
     };
 
-    private static Guid UserIdFor(string label)
+    private sealed class Fixture : IDisposable
     {
-        // Deterministic per-label GUID so tests can look a member up by role.
-        var bytes = new byte[16];
-        var src = System.Text.Encoding.UTF8.GetBytes(label);
-        for (int i = 0; i < src.Length && i < 16; i++) bytes[i] = src[i];
-        bytes[15] = 0xAA;
-        return new Guid(bytes);
+        public required SqliteConnection Conn { get; init; }
+        public required PlanscapeDbContext Db { get; init; }
+        public required Guid TenantId { get; init; }
+        public required Guid ProjectId { get; init; }
+        public required Dictionary<string, Guid> Users { get; init; }
+
+        public Guid User(string label) => Users[label];
+
+        public void Dispose()
+        {
+            Db.Dispose();
+            Conn.Dispose();
+        }
     }
 
-    private static (SqliteConnection conn, PlanscapeDbContext db) NewDb()
+    private static Fixture NewDb()
     {
+        // Fresh every time — see the class docstring for why this must not be a
+        // constant.
+        var tenantId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var authorId  = Guid.NewGuid();
+        var users     = new Dictionary<string, Guid>();
+
         var conn = new SqliteConnection("DataSource=:memory:");
         conn.Open();
 
         var db = new PlanscapeDbContext(
             new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
-            httpContextAccessor: null!, tenantContext: new FixedTenant(TenantId));
+            httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
         db.Database.EnsureCreated();
 
         // Tenant first: Project.TenantId and AppUser.TenantId are real FKs, and
         // SQLite (unlike EF InMemory) enforces them.
         db.Tenants.Add(new Tenant
         {
-            Id = TenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            Id = tenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
             ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
             Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
         });
 
-        // The author is a real user, because Project.CreatedById is an FK and
-        // because author-visibility is one of the branches WhereVisibleTo takes.
+        // The author is a real user: Project.CreatedById is an FK, and
+        // author-visibility is one of the branches WhereVisibleTo takes.
         db.Users.Add(new AppUser
         {
-            Id = AuthorId, TenantId = TenantId,
+            Id = authorId, TenantId = tenantId,
             Email = $"author-{Guid.NewGuid():N}@example.com",
             DisplayName = "author", PasswordHash = "x", IsActive = true,
         });
 
         db.Projects.Add(new Project
         {
-            Id = ProjectId, TenantId = TenantId, Name = "Kampala Temple",
+            Id = projectId, TenantId = tenantId, Name = "Kampala Temple",
             Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
-            CreatedById = AuthorId, PurgeAfter = null,
+            CreatedById = authorId, PurgeAfter = null,
         });
 
         foreach (var (projectRole, iso, label) in Seed)
         {
-            var uid = UserIdFor(label);
-            // AppUser row is required: ProjectMember.UserId is a real FK.
+            var uid = Guid.NewGuid();
+            users[label] = uid;
             db.Users.Add(new AppUser
             {
-                Id = uid, TenantId = TenantId,
-                Email = $"{label}-{Guid.NewGuid():N}@example.com", DisplayName = label,
-                PasswordHash = "x", IsActive = true,
+                Id = uid, TenantId = tenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com",
+                DisplayName = label, PasswordHash = "x", IsActive = true,
             });
             db.ProjectMembers.Add(new ProjectMember
             {
-                Id = Guid.NewGuid(), TenantId = TenantId,
-                ProjectId = ProjectId, UserId = uid,
+                Id = Guid.NewGuid(), TenantId = tenantId,
+                ProjectId = projectId, UserId = uid,
                 ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
             });
         }
 
         db.SaveChanges();
-        return (conn, db);
+        return new Fixture
+        {
+            Conn = conn, Db = db, TenantId = tenantId,
+            ProjectId = projectId, Users = users,
+        };
     }
 
     private static ProjectMembersController NewController(
-        PlanscapeDbContext db, Guid userId, string? tenantRole = null)
+        Fixture f, Guid userId, string? tenantRole = null)
     {
         var claims = new List<Claim>
         {
             new(ClaimTypes.NameIdentifier, userId.ToString()),
-            new("tenant_id", TenantId.ToString()),
+            new("tenant_id", f.TenantId.ToString()),
         };
         if (tenantRole != null)
         {
@@ -139,10 +163,10 @@ public class ProjectCapabilitiesEndpointTests
             claims.Add(new Claim(ClaimTypes.Role, tenantRole));
         }
 
-        // Only _db and User are touched by GetMyCapabilities; the remaining
-        // dependencies are deliberately not stubbed so an accidental future
-        // dependency on them fails loudly here rather than silently passing.
-        var controller = new ProjectMembersController(db, null!, null!, null!, null!)
+        // Only _db and User are touched by GetMyCapabilities. The remaining
+        // dependencies are deliberately left null so an accidental future
+        // dependency on them fails loudly here rather than passing silently.
+        return new ProjectMembersController(f.Db, null!, null!, null!, null!)
         {
             ControllerContext = new ControllerContext
             {
@@ -152,7 +176,6 @@ public class ProjectCapabilitiesEndpointTests
                 },
             },
         };
-        return controller;
     }
 
     private static (bool curate, bool approve, Guid projectId, Guid userId) Read(ActionResult result)
@@ -167,18 +190,15 @@ public class ProjectCapabilitiesEndpointTests
             (Guid)t.GetProperty("userId")!.GetValue(v)!);
     }
 
-    // ── Fixture sanity — must run green before any assertion below means anything ──
+    // ── Fixture sanity — must be green before anything below means anything ───
 
     [Fact]
     public void Sanity_the_fixture_actually_has_rows()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            Assert.Equal(Seed.Length, db.ProjectMembers.Count(m => m.ProjectId == ProjectId));
-            Assert.True(db.Projects.Any(p => p.Id == ProjectId),
-                "Project invisible through the tenant filter — every assertion below would pass vacuously.");
-        }
+        using var f = NewDb();
+        Assert.Equal(Seed.Length, f.Db.ProjectMembers.Count(m => m.ProjectId == f.ProjectId));
+        Assert.True(f.Db.Projects.Any(p => p.Id == f.ProjectId),
+            "Project invisible through the tenant filter — every assertion below would pass vacuously.");
     }
 
     // ── The 404 contract ──────────────────────────────────────────────────────
@@ -186,33 +206,27 @@ public class ProjectCapabilitiesEndpointTests
     [Fact]
     public async Task Invisible_project_is_404_so_clients_default_everything_to_false()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            // A real, authenticated user who is simply not on this project and
-            // did not author it.
-            var stranger = Guid.Parse("99999999-9999-9999-9999-999999999999");
-            var result = await NewController(db, stranger).GetMyCapabilities(ProjectId);
+        using var f = NewDb();
 
-            var notFound = Assert.IsType<NotFoundResult>(result);
-            Assert.Equal(404, notFound.StatusCode);
-        }
+        // A real, authenticated user who is simply not on this project and did
+        // not author it.
+        var result = await NewController(f, Guid.NewGuid()).GetMyCapabilities(f.ProjectId);
+
+        var notFound = Assert.IsType<NotFoundResult>(result);
+        Assert.Equal(404, notFound.StatusCode);
     }
 
     [Fact]
     public async Task Unknown_project_id_is_404_not_an_all_false_body()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var result = await NewController(db, UserIdFor("manager"))
-                .GetMyCapabilities(Guid.Parse("44444444-4444-4444-4444-444444444444"));
+        using var f = NewDb();
 
-            // Deliberately NOT an Ok with all-false: a body implies "I know the
-            // answer". Absence of the project must be indistinguishable from
-            // absence of authority, which is what makes 404 the safe default.
-            Assert.IsType<NotFoundResult>(result);
-        }
+        var result = await NewController(f, f.User("manager")).GetMyCapabilities(Guid.NewGuid());
+
+        // Deliberately NOT an Ok with all-false: a body implies the server knows
+        // the answer. Absence of the project must be indistinguishable from
+        // absence of authority — that is what makes 404 the safe client default.
+        Assert.IsType<NotFoundResult>(result);
     }
 
     // ── Capability resolution per role ────────────────────────────────────────
@@ -225,35 +239,31 @@ public class ProjectCapabilitiesEndpointTests
     [InlineData("viewer",                        false, false)]
     public async Task Capabilities_match_the_role(string label, bool expectCurate, bool expectApprove)
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var userId = UserIdFor(label);
-            var (curate, approve, pid, uid) = Read(
-                await NewController(db, userId).GetMyCapabilities(ProjectId));
+        using var f = NewDb();
+        var userId = f.User(label);
 
-            Assert.Equal(expectCurate, curate);
-            Assert.Equal(expectApprove, approve);
-            Assert.Equal(ProjectId, pid);
-            Assert.Equal(userId, uid);
-        }
+        var (curate, approve, pid, uid) = Read(
+            await NewController(f, userId).GetMyCapabilities(f.ProjectId));
+
+        Assert.Equal(expectCurate, curate);
+        Assert.Equal(expectApprove, approve);
+        Assert.Equal(f.ProjectId, pid);
+        Assert.Equal(userId, uid);
     }
 
     [Fact]
     public async Task Coordinator_curates_but_cannot_approve_photos()
     {
-        // Called out on its own because it is the one place the two predicates
-        // genuinely diverge. If someone "simplifies" them into one flag, this
-        // is the test that fails.
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var (curate, approve, _, _) = Read(
-                await NewController(db, UserIdFor("coordinator")).GetMyCapabilities(ProjectId));
+        // Called out separately because it is the one place the two predicates
+        // genuinely diverge. If someone "simplifies" them into a single flag,
+        // this is the test that fails.
+        using var f = NewDb();
 
-            Assert.True(curate);
-            Assert.False(approve);
-        }
+        var (curate, approve, _, _) = Read(
+            await NewController(f, f.User("coordinator")).GetMyCapabilities(f.ProjectId));
+
+        Assert.True(curate);
+        Assert.False(approve);
     }
 
     // ── Tenant admin bypass — pre-existing behaviour, kept deliberately ────────
@@ -261,19 +271,17 @@ public class ProjectCapabilitiesEndpointTests
     [Fact]
     public async Task Tenant_admin_gets_both_without_any_project_member_row()
     {
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var admin = Guid.Parse("88888888-8888-8888-8888-888888888888");
-            Assert.False(db.ProjectMembers.Any(m => m.UserId == admin),
-                "Fixture must NOT give the admin a member row, or this proves nothing.");
+        using var f = NewDb();
+        var admin = Guid.NewGuid();
 
-            var (curate, approve, _, _) = Read(
-                await NewController(db, admin, tenantRole: "Admin").GetMyCapabilities(ProjectId));
+        Assert.False(f.Db.ProjectMembers.Any(m => m.UserId == admin),
+            "Fixture must NOT give the admin a member row, or this proves nothing.");
 
-            Assert.True(curate);
-            Assert.True(approve);
-        }
+        var (curate, approve, _, _) = Read(
+            await NewController(f, admin, tenantRole: "Admin").GetMyCapabilities(f.ProjectId));
+
+        Assert.True(curate);
+        Assert.True(approve);
     }
 
     // ── Response shape ────────────────────────────────────────────────────────
@@ -284,16 +292,14 @@ public class ProjectCapabilitiesEndpointTests
         // Two booleans, matching the two predicates that exist. A third
         // capability goes through propose-first review, so an inline addition
         // should fail here rather than ship unnoticed.
-        var (conn, db) = NewDb();
-        using (conn)
-        {
-            var ok = Assert.IsType<OkObjectResult>(
-                await NewController(db, UserIdFor("manager")).GetMyCapabilities(ProjectId));
+        using var f = NewDb();
 
-            var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
-            Assert.Equal(
-                new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
-                names);
-        }
+        var ok = Assert.IsType<OkObjectResult>(
+            await NewController(f, f.User("manager")).GetMyCapabilities(f.ProjectId));
+
+        var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
+        Assert.Equal(
+            new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
+            names);
     }
 }

--- a/Planscape.Server/tests/Planscape.Tests/ProjectRoleCapabilityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectRoleCapabilityTests.cs
@@ -1,0 +1,271 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The capability layer that replaced eleven `ProjectRole == "PM"` gates.
+///
+/// WHAT WAS WRONG
+/// --------------
+/// `ProjectRole` and `Iso19650Role` carry different vocabularies, and each
+/// documents its own (ProjectMember.cs:15 and :18). "PM" only ever appears in
+/// the ISO 19650 list. Eleven sites read that code off the ProjectRole column,
+/// so the gates matched essentially nobody — a wrong-field bug, not a data
+/// migration.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS
+/// -----------------------------
+/// PlanscapeDbContext's global filter is `TenantId == CurrentTenantId`, which
+/// falls back to Guid.Empty when no ITenantContext is supplied — matching NO
+/// rows. A fixture on the parameterless ctor makes every count assertion pass
+/// against an empty set. So the context here is always built with a tenant, and
+/// <see cref="Sanity_the_fixture_actually_has_rows"/> asserts non-empty before
+/// any capability claim is made.
+///
+/// SQLite, not EF InMemory: the EF-translation test below is meaningless on a
+/// provider that cannot produce SQL.
+/// </summary>
+public class ProjectRoleCapabilityTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    /// <summary>(projectRole, iso19650Role) pairs seeded as real rows.</summary>
+    private static readonly (string Project, string Iso, string Label)[] Seed =
+    {
+        ("Manager",     "M",  "manager"),
+        ("Contributor", "PM", "contributor-who-is-the-iso-PM"),
+        ("Contributor", "M",  "plain-contributor"),
+        ("Coordinator", "M",  "coordinator"),
+        ("Viewer",      "V",  "viewer"),
+    };
+
+    private static (SqliteConnection conn, Guid tenantId, Guid projectId) NewDb()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        using var ctx = NewContext(conn, tenantId);
+        ctx.Database.EnsureCreated();
+        ctx.Tenants.Add(new Tenant
+        {
+            Id = tenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+        ctx.Projects.Add(new Project
+        {
+            Id = projectId, TenantId = tenantId, Name = "Tower",
+            Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+        });
+
+        foreach (var (projectRole, iso, label) in Seed)
+        {
+            var userId = Guid.NewGuid();
+            ctx.Users.Add(new AppUser
+            {
+                Id = userId, TenantId = tenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com",
+                DisplayName = label, PasswordHash = "x", IsActive = true,
+            });
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenantId, ProjectId = projectId, UserId = userId,
+                ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
+            });
+        }
+        ctx.SaveChanges();
+        return (conn, tenantId, projectId);
+    }
+
+    [Fact]
+    public void Sanity_the_fixture_actually_has_rows()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            // If the tenant filter were mis-wired this would be 0 and every
+            // other test in this file would pass vacuously.
+            Assert.Equal(Seed.Length, ctx.ProjectMembers.Count(m => m.ProjectId == projectId));
+        }
+    }
+
+    // ── The EF predicate — this is the one that can silently client-evaluate ──
+
+    [Fact]
+    public void CurateProject_predicate_translates_to_SQL()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var query = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanCurateProject);
+
+            // If EF cannot translate the predicate it falls back to client
+            // evaluation, which in prod pulls the whole table per notification.
+            // The generated SQL must therefore carry the role comparison.
+            var sql = query.ToQueryString();
+            Assert.Contains("ProjectRole", sql, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Iso19650Role", sql, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void CurateProject_predicate_selects_the_right_members_from_the_database()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var rows = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanCurateProject)
+                .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+                .OrderBy(x => x)
+                .ToList();
+
+            Assert.NotEmpty(rows);                       // guards the empty-set trap
+            Assert.Equal(
+                new[] { "Contributor/PM", "Coordinator/M", "Manager/M" },
+                rows);
+        }
+    }
+
+    [Fact]
+    public void ApproveSitePhotos_predicate_is_narrower_than_curate()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var rows = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId && m.IsActive)
+                .Where(ProjectRoles.CanApproveSitePhotosPredicate)
+                .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+                .OrderBy(x => x)
+                .ToList();
+
+            Assert.NotEmpty(rows);
+            // Coordinator curates but does NOT approve — that is the split.
+            Assert.Equal(new[] { "Contributor/PM", "Manager/M" }, rows);
+        }
+    }
+
+    // ── In-memory form, which must agree with the expression form ────────────
+
+    [Theory]
+    // A REAL member can now pass a gate that previously matched nobody.
+    [InlineData("Manager",     "M",  true,  true)]
+    [InlineData("Owner",       "M",  true,  true)]
+    [InlineData("Admin",       "M",  true,  true)]
+    // Curates but cannot approve — the deliberate split.
+    [InlineData("Coordinator", "M",  true,  false)]
+    // The wrong-column bug, fixed: the ISO code is read off the right field.
+    [InlineData("Contributor", "PM", true,  true)]
+    [InlineData("Contributor", "A",  true,  true)]
+    [InlineData("Contributor", "BC", true,  false)]   // BC curates, does not approve
+    // Plain members stay denied.
+    [InlineData("Contributor", "M",  false, false)]
+    [InlineData("Viewer",      "V",  false, false)]
+    [InlineData("ClientGuest", "M",  false, false)]
+    public void Capability_matrix(string projectRole, string iso, bool curate, bool approve)
+    {
+        Assert.Equal(curate,  ProjectRoles.CanCurate(projectRole, iso));
+        Assert.Equal(approve, ProjectRoles.CanApproveSitePhotos(projectRole, iso));
+    }
+
+    [Fact]
+    public void Tenant_admin_short_circuits_both_capabilities()
+    {
+        Assert.True(ProjectRoles.CanCurate("Viewer", "V", isTenantAdmin: true));
+        Assert.True(ProjectRoles.CanApproveSitePhotos("Viewer", "V", isTenantAdmin: true));
+    }
+
+    /// <summary>
+    /// The expression and the in-memory helper are two encodings of one rule.
+    /// This asserts they cannot drift, which a reader cannot verify by eye.
+    /// </summary>
+    [Fact]
+    public void Expression_and_in_memory_forms_agree_on_every_seeded_row()
+    {
+        var (conn, tenantId, projectId) = NewDb();
+        using (conn)
+        {
+            using var ctx = NewContext(conn, tenantId);
+            var all = ctx.ProjectMembers.Where(m => m.ProjectId == projectId).ToList();
+            Assert.NotEmpty(all);
+
+            var curateSql = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId)
+                .Where(ProjectRoles.CanCurateProject)
+                .Select(m => m.UserId).ToHashSet();
+            var curateMem = all.Where(m => ProjectRoles.CanCurate(m.ProjectRole, m.Iso19650Role))
+                               .Select(m => m.UserId).ToHashSet();
+            Assert.Equal(curateMem, curateSql);
+
+            var approveSql = ctx.ProjectMembers
+                .Where(m => m.ProjectId == projectId)
+                .Where(ProjectRoles.CanApproveSitePhotosPredicate)
+                .Select(m => m.UserId).ToHashSet();
+            var approveMem = all.Where(m => ProjectRoles.CanApproveSitePhotos(m.ProjectRole, m.Iso19650Role))
+                                .Select(m => m.UserId).ToHashSet();
+            Assert.Equal(approveMem, approveSql);
+        }
+    }
+
+    // ── Widening property ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The change promises nobody LOSES access. The old gate was
+    /// `ProjectRole == "PM"`; ProjectRole was unvalidated before this change, so
+    /// such a row was possible even though no UI writes it. It must still pass.
+    /// </summary>
+    [Fact]
+    public void A_legacy_row_with_ProjectRole_PM_still_passes_both_gates()
+    {
+        Assert.True(ProjectRoles.CanCurate("PM", "M"));
+        Assert.True(ProjectRoles.CanApproveSitePhotos("PM", "M"));
+    }
+
+    // ── Canonical vocabulary ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Viewer")]
+    [InlineData("Contributor")]
+    [InlineData("Coordinator")]
+    [InlineData("Manager")]
+    [InlineData("Owner")]
+    [InlineData("Admin")]
+    [InlineData("ClientGuest")]
+    [InlineData("manager")]              // case-insensitive
+    public void Canonical_roles_are_accepted(string role)
+        => Assert.True(ProjectRoles.IsCanonical(role));
+
+    [Theory]
+    [InlineData("Wizard")]
+    [InlineData("PM")]                   // an Iso19650Role code, not a ProjectRole
+    [InlineData("Author")]               // read by QuotaGuardService, never written
+    [InlineData("")]
+    [InlineData(null)]
+    public void Non_canonical_roles_are_rejected(string? role)
+        => Assert.False(ProjectRoles.IsCanonical(role));
+}

--- a/stingtools-core/python/tests/test_smoke.py
+++ b/stingtools-core/python/tests/test_smoke.py
@@ -834,3 +834,91 @@ if __name__ == "__main__":
     print(f"\n{len(tests)} tests run, {failures} failures "
           f"(tmp_path tests skipped — run with pytest for full coverage)")
     sys.exit(1 if failures else 0)
+
+
+# ----------------------------------------------------------------------
+# ProjectRole vocabulary parity — server constant vs web dropdown
+#
+# The ProjectRole vocabulary drifted far enough that eleven server gates ended
+# up testing an Iso19650Role code ("PM") against the ProjectRole column, and
+# nothing caught it because the two lists live in different languages in
+# different trees. These parse both sources and pin them together, in the same
+# style as test_ifc_element_to_wire_keys_match_dto: no running server, no
+# generated schema, just the source of truth on each side.
+# ----------------------------------------------------------------------
+
+def _server_project_roles() -> list[str]:
+    """Parse ProjectRoles.All out of the C# constant file."""
+    import re
+
+    repo_root = Path(__file__).resolve().parents[3]
+    src_file = (repo_root / "Planscape.Server" / "src" / "Planscape.Core"
+                / "Entities" / "ProjectRoles.cs")
+    if not src_file.exists():
+        return []  # repo layout changed; caller skips
+
+    src = src_file.read_text(encoding="utf-8")
+
+    # const string Viewer = "Viewer";  →  {Viewer: "Viewer"}
+    consts = dict(re.findall(
+        r'public\s+const\s+string\s+(\w+)\s*=\s*"([^"]+)"\s*;', src))
+
+    # The `All` initialiser lists the const NAMES, not the literals.
+    m = re.search(r'IReadOnlyList<string>\s+All\s*=\s*new\[\]\s*\{(.*?)\}',
+                  src, re.S)
+    if not m:
+        return []
+    names = [n.strip() for n in m.group(1).split(",") if n.strip()]
+    return [consts[n] for n in names if n in consts]
+
+
+def _web_project_roles() -> list[str]:
+    """Parse PROJECT_ROLES out of the Next.js members page."""
+    import re
+
+    repo_root = Path(__file__).resolve().parents[3]
+    page = (repo_root / "planscape-web" / "app" / "projects" / "[id]"
+            / "members" / "page.tsx")
+    if not page.exists():
+        return []
+
+    m = re.search(r'const\s+PROJECT_ROLES\s*=\s*\[(.*?)\]',
+                  page.read_text(encoding="utf-8"), re.S)
+    if not m:
+        return []
+    return [a or b for a, b in re.findall(r"'([^']+)'|\"([^\"]+)\"", m.group(1))]
+
+
+def test_server_project_role_vocabulary_parses():
+    """Guard the parser itself — a silent empty parse would make the parity
+    test below pass vacuously, which is the failure mode these gates have."""
+    roles = _server_project_roles()
+    if not roles:
+        return  # repo layout changed; skip rather than false-fail
+    assert "Manager" in roles, f"ProjectRoles.All parse looks wrong: {roles}"
+    assert "PM" not in roles, (
+        "'PM' must NOT be a canonical ProjectRole — it is an Iso19650Role code. "
+        "Eleven server gates were broken by exactly this confusion."
+    )
+
+
+def test_web_project_roles_are_all_accepted_by_the_server():
+    """Every role the web members dropdown offers must be one the server
+    accepts, or saving it now returns 400 invalid_project_role.
+
+    Subset, not equality: the server also accepts ClientGuest, which the web
+    deliberately does not offer (DailyPhotoDigestJob reads it, no UI writes it).
+    """
+    server = _server_project_roles()
+    web = _web_project_roles()
+    if not server or not web:
+        return  # repo layout changed; skip
+
+    assert "Manager" in web, f"PROJECT_ROLES parse looks wrong: {web}"
+
+    unknown = sorted(set(web) - set(server))
+    assert not unknown, (
+        f"planscape-web offers ProjectRole values the server rejects: {unknown}. "
+        f"Server accepts {sorted(server)}. Add them to ProjectRoles.All or "
+        f"remove them from PROJECT_ROLES."
+    )


### PR DESCRIPTION
Serves the caller's project capabilities so the web app, the Revit BCC and mobile stop deriving them independently. Approved shape, built as proposed.

**Stacked on #540** (`claude/capability-layer`) — it uses the `CanCurateProjectAsync` / `CanApproveSitePhotosAsync` extensions that PR adds. Review #540 first.

```
GET /api/projects/{projectId}/members/capabilities
```
```json
{
  "projectId": "3f2b…",
  "userId": "9a1c…",
  "canCurateProject": true,
  "canApproveSitePhotos": false
}
```

## The 404 contract

**A 404 means every capability is false.** Never "unknown, so proceed". A fail-open default here would undo the gate on three surfaces at once, so it is stated in the endpoint's docstring, must be repeated in each client, and is pinned by two tests.

An all-false `200` body was rejected deliberately: a body implies the server knows the answer. Absence of the project should be indistinguishable from absence of authority.

404 rather than 403 matches `GetMyAccess` (`:95`) on the same controller, which uses the same visibility check. Two adjacent endpoints disagreeing about one condition is a bug generator.

## Decisions worth seeing

- **Two booleans**, matching the two predicates that exist on `ProjectRoles`. A third goes through the same propose-first step, not inline — `Response_carries_exactly_four_fields` fails if one is added quietly.
- **Separate endpoint, not extra fields on `members/me`.** That response is already consumed; widening it is a breaking-shape change.
- **No route collision.** The controller has no `GET {memberId}` — only `[HttpGet]`, `me`, `roles`. A literal segment follows existing precedent.
- **Tenant Admin/Owner resolve true without a ProjectMember row**, matching every site the capability layer replaced.
- The added `using Planscape.API.Services` collides with that namespace's `IEmailService`. An explicit alias pins the constructor to the `Planscape.Core.Interfaces` one it has always bound to, so the import cannot silently re-resolve it.

## Tests — 11, and proven to have teeth

Green is not evidence unless the tests can fail. Two mutations:

| Mutation | Result |
|---|---|
| fail-open instead of 404 | both 404 tests fail |
| collapse the two predicates into one | both coordinator tests fail |

The other 7 kept passing in both cases, so the mutations are caught specifically rather than by blanket breakage. Reverted after measuring.

The fixture is built **with** an `ITenantContext` and asserts non-empty rows first — the global filter falls back to `Guid.Empty`, which would make every assertion pass against an empty set.

## The full suite is intermittently red, and it is not this change

Stating this plainly because the number looks bad: with this branch the suite fails intermittently (0, then 86, then 71 across three runs).

I nearly reported that as my own regression. It isn't, and here is the proof rather than the assertion.

**The probe.** On the **base** commit — no endpoint, no capabilities code — I added a throwaway class of 11 tests that do SQLite + `EnsureCreated` + a seeded `PlanscapeDbContext`, touching no controller and using no fixed GUID:

```
Failed: 87   Failed: 1   Failed: 68
```

The same base commit with 11 **inert** no-op tests (identical total of 581) stays green 3/3, so it is not the test count or partitioning — it is doing real EF work in parallel.

**The mechanism**, from aggregating the failures:

- **44 ×** `ArgumentException: An item with the same key has already been added. Key: 11111111-1111-1111-1111-111111111111` — `PlanscapeWebApplicationFactory.cs:374`'s fixed tenant, seeded twice into a shared process-wide EF **InMemory** store when two factory instances overlap.
- **5 ×** `ObjectDisposedException: Hangfire.InMemory.State.Dispatcher` — the process-wide Hangfire teardown already documented as ROADMAP **DEP-7**.

Both are pre-existing suite fragility. Base survives on scheduling luck; any new EF-touching test class widens the window.

**One thing I did fix:** the fixture originally reused that same `11111111-…` tenant GUID. That was genuinely mine and wrong, so identifiers are now minted per fixture (as `ProjectRoleCapabilityTests` already does), plus `IDisposable` on the fixture. It did not resolve the race — the probe proves why — but it removed a real collision I introduced.

**Not fixed here.** The repo has no `xunit.runner.json` and no collection definitions, so there is no local way to opt one class out; the fix is `parallelizeTestCollections: false` (or putting the factory tests in a shared collection), which is repo-wide, costs real runtime, and belongs in its own PR alongside DEP-7. Flagging it rather than slipping it in.

**In isolation this branch is green:** the 11 new tests pass 11/11, and every class that fails in the full run passes on its own.

## CI

The two red checks are the pre-existing `main` baseline — one Postgres container failure (`role "root" does not exist`) surfacing twice, since `CI Gate` is an aggregator that times out waiting on `Build & Test`. Full diff with both run URLs is in #542.

Nothing merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
