### PR TITLE
feat(bcc): un-fake the site-photo suite — real HTTP, and failures that look like failures

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
@@ -1,0 +1,952 @@
+// PlanscapeServerClient — Site Photos (Phase 2, BCC site-photo suite).
+//
+// Replaces the MergeRecoveryStubs no-ops with real authenticated HTTP against the
+// server's actual contract. Follows the PlanscapeServerClient.Hvac.cs precedent:
+// one partial per feature area, EnsureAuthenticatedAsync first, LastError set on
+// every failure path, null (not a default value) returned on failure.
+//
+// ROUTES — derived from the CONTROLLER SOURCE, not from the stub signatures. The
+// stubs were written blind and several of their parameters did not match the wire.
+// Corrections made here, each verified against the controller:
+//
+//   * CreatePhotoAlbumAsync defaulted visibility to "Project". That is NOT a valid
+//     value — PhotoAlbum.ValidVisibilities is { Internal, Members, Client,
+//     Distribution } and PhotoAlbumsController.Create 400s on anything else. The
+//     server's own default is "Members"; this client now matches it.
+//   * BulkReclassifyPhotosAsync passed "newClass". The wire field is `toReason`,
+//     validated against SitePhoto.ValidReasons (BulkReclassifyRequest).
+//   * LockPhotoAlbumAsync took a bool. There is no boolean route — lock and unlock
+//     are two separate POSTs ({albumId}/lock, {albumId}/unlock).
+//   * CreatePhotoShareLinkAsync took a TimeSpan. The wire field is an ABSOLUTE
+//     DateTime `expiresAt` (CreateShareLinkRequest); converted here.
+//   * AcceptPhotoNdaAsync(projectId, ndaSha) — there is NO project-level accept-nda
+//     route on the server. Only POST photos/{photoId}/accept-nda exists. See the
+//     method for how that is handled honestly rather than faked.
+//
+// FAILURE CONTRACT — a failed list returns null, NEVER an empty list. The stubs
+// returned `new List<T>()` on every call, which made "the server is unreachable"
+// indistinguishable from "this project has no albums". That is the fabrication
+// anti-pattern in a different costume: the sub-tab renders a confident, empty,
+// wrong answer. Callers must treat null as "could not load" and render LastError.
+
+// Nullable annotations only — matching MergeRecoveryStubs.cs, which is where these
+// signatures used to live. The project sets <Nullable>disable</Nullable>, so
+// without this the `string?` / `List<T>?` annotations that the call sites already
+// expect raise CS8632. Warnings stay off; this is the per-file opt-in the codebase
+// review recommends for new/edited files rather than a project-wide flip.
+#nullable enable annotations
+#nullable disable warnings
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.BIMManager
+{
+    public sealed partial class PlanscapeServerClient
+    {
+        // ── Photo policy / NDA ────────────────────────────────────────────
+
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/photo-policy</c> (PhotoPolicyController.Get).
+        /// Returns null on failure — LastError carries the reason.
+        /// </summary>
+        /// <remarks>
+        /// The server's PhotoPolicy entity carries <c>NdaText</c> but has no
+        /// <c>NdaSha</c> or <c>Required</c> column. Both are DERIVED here, and that
+        /// derivation is the contract the accept path depends on:
+        ///   • <c>Required</c> = NdaText is non-blank (no text ⇒ nothing to accept);
+        ///   • <c>NdaSha</c>   = SHA-256 of NdaText, which is exactly what
+        ///     AcceptNdaRequest.AcceptedTextSha256 records, so an acceptance is
+        ///     pinned to the text that was actually shown.
+        /// </remarks>
+        public async Task<StingTools.UI.PhotoPolicyDto?> GetPhotoPolicyAsync(Guid projectId)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var resp = await GetAsync($"/api/projects/{projectId}/photo-policy").ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Photo policy load failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+                var j = JObject.Parse(resp.body);
+                var ndaText = Str(j, "ndaText");
+                return new StingTools.UI.PhotoPolicyDto
+                {
+                    NdaText  = ndaText,
+                    NdaSha   = string.IsNullOrWhiteSpace(ndaText) ? null : Sha256Hex(ndaText),
+                    Required = !string.IsNullOrWhiteSpace(ndaText),
+                };
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Photo policy load failed: {ex.Message}";
+                StingLog.Error("GetPhotoPolicyAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photos/{photoId}/accept-nda</c>
+        /// (SitePhotosExtController.AcceptNda). Body: <c>{ acceptedTextSha256 }</c>.
+        /// The server is idempotent — an existing acceptance returns 200.
+        /// </summary>
+        public async Task<bool> AcceptPhotoNdaAsync(Guid projectId, Guid photoId)
+            => await AcceptPhotoNdaCoreAsync(projectId, photoId, null).ConfigureAwait(false);
+
+        /// <summary>
+        /// Accept the NDA for every photo currently flagged as NDA-required
+        /// (<see cref="LastNdaRequiredIds"/>), pinning each acceptance to
+        /// <paramref name="ndaSha"/>.
+        /// </summary>
+        /// <remarks>
+        /// HONEST NOTE ON THIS OVERLOAD. The stub's signature implied a
+        /// project-level "accept the NDA once" route. **No such route exists** —
+        /// the only accept-nda endpoint on the server is per-photo
+        /// (SitePhotosExtController:394), because PhotoNdaAcceptance is keyed on
+        /// (PhotoId, UserId). Rather than fake a project-level accept or silently
+        /// no-op, this fans out over the ids the last list call reported as
+        /// NDA-gated and reports partial failure truthfully.
+        ///
+        /// With no pending ids it returns FALSE and sets LastError, rather than
+        /// returning true for having done nothing — a vacuous success here would
+        /// let the UI unlock content the user never accepted terms for.
+        /// </remarks>
+        public async Task<bool> AcceptPhotoNdaAsync(Guid projectId, string? ndaSha = null)
+        {
+            var pending = LastNdaRequiredIds?.ToList() ?? new List<Guid>();
+            if (pending.Count == 0)
+            {
+                LastError = "No NDA-gated photos are pending acceptance. "
+                          + "(The server has no project-level accept-NDA route; acceptance is per photo.)";
+                return false;
+            }
+
+            int ok = 0;
+            var failures = new List<string>();
+            foreach (var photoId in pending)
+            {
+                if (await AcceptPhotoNdaCoreAsync(projectId, photoId, ndaSha).ConfigureAwait(false)) ok++;
+                else failures.Add($"{photoId}: {LastError}");
+            }
+
+            if (failures.Count == 0)
+            {
+                LastNdaRequiredIds = new HashSet<Guid>();
+                LastError = null;
+                return true;
+            }
+
+            LastError = $"Accepted {ok} of {pending.Count} NDA-gated photos. First failure — {failures[0]}";
+            return false;
+        }
+
+        private async Task<bool> AcceptPhotoNdaCoreAsync(Guid projectId, Guid photoId, string? ndaSha)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
+            try
+            {
+                var resp = await PostJsonAsync(
+                    $"/api/projects/{projectId}/photos/{photoId}/accept-nda",
+                    new { acceptedTextSha256 = ndaSha }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"NDA acceptance failed ({resp.status}): {Trim(resp.body)}";
+                    return false;
+                }
+                LastNdaRequiredIds?.Remove(photoId);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"NDA acceptance failed: {ex.Message}";
+                StingLog.Error("AcceptPhotoNdaAsync failed", ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Photo ids the most recent load reported as NDA-gated. Populated by the
+        /// photo-list path; consumed by the project-level NDA accept overload.
+        /// </summary>
+        public HashSet<Guid> LastNdaRequiredIds { get; set; } = new();
+
+        // ── Checklists ────────────────────────────────────────────────────
+
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/photo-checklists</c>
+        /// (PhotoChecklistsController.List). Optional <c>status</c> filter.
+        /// <para>
+        /// Returns <c>null</c> on failure and an EMPTY LIST only when the project
+        /// genuinely has no checklists. Those are different answers and the sub-tab
+        /// must render them differently.
+        /// </para>
+        /// </summary>
+        public async Task<List<StingTools.UI.PhotoChecklistDto>?> ListPhotoChecklistsAsync(
+            Guid projectId, string? status = null)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var path = $"/api/projects/{projectId}/photo-checklists";
+                if (!string.IsNullOrWhiteSpace(status)) path += $"?status={Uri.EscapeDataString(status)}";
+
+                var resp = await GetAsync(path).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Checklist load failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+
+                var list = new List<StingTools.UI.PhotoChecklistDto>();
+                foreach (var t in JArray.Parse(resp.body))
+                {
+                    var j = (JObject)t;
+                    list.Add(new StingTools.UI.PhotoChecklistDto
+                    {
+                        Id        = GuidOf(j, "id"),
+                        Name      = Str(j, "name") ?? "",
+                        Status    = Str(j, "status") ?? "Open",
+                        Kind      = Str(j, "kind"),
+                        LevelCode = Str(j, "levelCode"),
+                        ZoneCode  = Str(j, "zoneCode"),
+                        DueAt     = Date(j, "dueAt"),
+                        CreatedAt = Date(j, "createdAt") ?? DateTime.MinValue,
+                        Total     = Int(j, "total"),
+                        Done      = Int(j, "done"),
+                    });
+                }
+                LastError = null;
+                return list;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Checklist load failed: {ex.Message}";
+                StingLog.Error("ListPhotoChecklistsAsync failed", ex);
+                return null;
+            }
+        }
+
+        // ── Albums ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/photo-albums</c> (PhotoAlbumsController.List).
+        /// Returns null on failure, empty list when there are genuinely no albums.
+        /// </summary>
+        public async Task<List<StingTools.UI.PhotoAlbumDto>?> ListPhotoAlbumsAsync(Guid projectId)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var resp = await GetAsync($"/api/projects/{projectId}/photo-albums").ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Album load failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+                var list = new List<StingTools.UI.PhotoAlbumDto>();
+                foreach (var t in JArray.Parse(resp.body)) list.Add(MapAlbum((JObject)t));
+                LastError = null;
+                return list;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Album load failed: {ex.Message}";
+                StingLog.Error("ListPhotoAlbumsAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/photo-albums/{albumId}</c>
+        /// (PhotoAlbumsController.GetOne). Carries the album's photo entries, which
+        /// the server has already filtered through PhotoAclGate.
+        /// </summary>
+        /// <remarks>
+        /// UNLIKE every other album route, this one returns a WRAPPER —
+        /// <c>{ album, photos, ndaRequiredIds }</c> — not a flat album object. List,
+        /// Create and Lock all return the album at the top level. Reading this
+        /// response as a flat album silently yields an empty DTO, so the shape is
+        /// handled explicitly here.
+        ///
+        /// <c>ndaRequiredIds</c> is the ONLY place the server tells the client which
+        /// photos are NDA-gated, so it is captured into
+        /// <see cref="LastNdaRequiredIds"/> — which the project-level NDA accept
+        /// overload consumes.
+        /// </remarks>
+        public async Task<StingTools.UI.PhotoAlbumDto?> GetPhotoAlbumAsync(Guid projectId, Guid albumId)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var resp = await GetAsync($"/api/projects/{projectId}/photo-albums/{albumId}")
+                    .ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Album load failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+
+                var root = JObject.Parse(resp.body);
+                if (root["album"] is not JObject albumObj)
+                {
+                    // Do not fall back to mapping the wrapper as an album — that
+                    // produces a plausible, empty, wrong DTO.
+                    LastError = "Album response did not carry an 'album' object.";
+                    return null;
+                }
+
+                var dto = MapAlbum(albumObj);
+
+                if (root["photos"] is JArray photos)
+                {
+                    foreach (var p in photos)
+                    {
+                        if (p is not JObject po) continue;
+                        var id = GuidOf(po, "photoId");
+                        if (id != System.Guid.Empty)
+                            dto.Photos.Add(new StingTools.UI.PhotoAlbumEntryDto { PhotoId = id });
+                    }
+                    // GetOne's count is the ACL-filtered truth for this caller; the
+                    // list endpoint's unfiltered photoCount is not.
+                    dto.PhotoCount = dto.Photos.Count;
+                }
+
+                if (root["ndaRequiredIds"] is JArray nda)
+                {
+                    var gated = new HashSet<Guid>();
+                    foreach (var t in nda)
+                        if (System.Guid.TryParse(t?.Value<string>(), out var g)) gated.Add(g);
+                    LastNdaRequiredIds = gated;
+                }
+
+                LastError = null;
+                return dto;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Album load failed: {ex.Message}";
+                StingLog.Error("GetPhotoAlbumAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photo-albums</c> (PhotoAlbumsController.Create).
+        /// </summary>
+        /// <param name="visibility">
+        /// One of <c>Internal | Members | Client | Distribution</c>
+        /// (PhotoAlbum.ValidVisibilities). Defaults to <c>Members</c>, matching the
+        /// server. The stub's old default of <c>"Project"</c> is not a valid value
+        /// and would have been rejected with <c>invalid_visibility</c>.
+        /// </param>
+        public async Task<StingTools.UI.PhotoAlbumDto?> CreatePhotoAlbumAsync(
+            Guid projectId, string name, string? description = null, string visibility = "Members")
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+
+            if (string.IsNullOrWhiteSpace(name)) { LastError = "Album name is required."; return null; }
+            if (!ValidAlbumVisibilities.Contains(visibility))
+            {
+                // Fail here rather than let the server 400 — the message names the
+                // allowed set, which the server's error body does too.
+                LastError = $"Invalid album visibility '{visibility}'. "
+                          + $"Allowed: {string.Join(", ", ValidAlbumVisibilities)}.";
+                return null;
+            }
+
+            try
+            {
+                var resp = await PostJsonAsync($"/api/projects/{projectId}/photo-albums", new
+                {
+                    name,
+                    description,
+                    visibility,
+                }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Album create failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+                LastError = null;
+                return MapAlbum(JObject.Parse(resp.body));
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Album create failed: {ex.Message}";
+                StingLog.Error("CreatePhotoAlbumAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photo-albums/{albumId}/photos</c>
+        /// (PhotoAlbumsController.AddPhotos). Body <c>{ photoIds }</c>, capped at 500.
+        /// </summary>
+        public async Task<bool> AddPhotosToAlbumAsync(Guid projectId, Guid albumId, IEnumerable<Guid> photoIds)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
+
+            var ids = photoIds?.Distinct().ToArray() ?? Array.Empty<Guid>();
+            if (ids.Length == 0) { LastError = "No photos selected."; return false; }
+            if (ids.Length > MaxPhotosPerAlbumAdd)
+            {
+                LastError = $"{ids.Length} photos selected; the server accepts at most {MaxPhotosPerAlbumAdd} per request.";
+                return false;
+            }
+
+            try
+            {
+                var resp = await PostJsonAsync(
+                    $"/api/projects/{projectId}/photo-albums/{albumId}/photos",
+                    new { photoIds = ids }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    // The server distinguishes album_locked and smart_album_managed;
+                    // surface the body so the operator sees which.
+                    LastError = $"Add to album failed ({resp.status}): {Trim(resp.body)}";
+                    return false;
+                }
+                LastError = null;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Add to album failed: {ex.Message}";
+                StingLog.Error("AddPhotosToAlbumAsync failed", ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Lock or unlock an album. These are TWO routes on the server, not a
+        /// boolean field: <c>POST {albumId}/lock</c> and <c>POST {albumId}/unlock</c>
+        /// (PhotoAlbumsController.Lock / .Unlock). The bool selects the route.
+        /// </summary>
+        public async Task<bool> LockPhotoAlbumAsync(Guid projectId, Guid albumId, bool locked)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
+            var verb = locked ? "lock" : "unlock";
+            try
+            {
+                // Both routes take no body; PostJsonAsync with an empty object is
+                // correct for a [FromBody]-less action.
+                var resp = await PostJsonAsync(
+                    $"/api/projects/{projectId}/photo-albums/{albumId}/{verb}",
+                    new { }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Album {verb} failed ({resp.status}): {Trim(resp.body)}";
+                    return false;
+                }
+                LastError = null;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Album {verb} failed: {ex.Message}";
+                StingLog.Error($"LockPhotoAlbumAsync({verb}) failed", ex);
+                return false;
+            }
+        }
+
+        // ── Share links ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photo-share-links</c>
+        /// (PhotoShareController.Create).
+        /// </summary>
+        /// <param name="expiry">
+        /// Relative lifetime. The wire field is an ABSOLUTE <c>expiresAt</c>
+        /// (CreateShareLinkRequest), so this is converted to
+        /// <c>UtcNow + expiry</c>. Null leaves it unset and the server applies its
+        /// own default of 14 days.
+        /// </param>
+        public async Task<StingTools.UI.PhotoShareLinkDto?> CreatePhotoShareLinkAsync(
+            Guid projectId, Guid albumId, TimeSpan? expiry = null, string? label = null)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var resp = await PostJsonAsync($"/api/projects/{projectId}/photo-share-links", new
+                {
+                    albumId,
+                    label,
+                    expiresAt = expiry.HasValue ? (DateTime?)DateTime.UtcNow.Add(expiry.Value) : null,
+                }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Share link creation failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+                var j = JObject.Parse(resp.body);
+                LastError = null;
+                return new StingTools.UI.PhotoShareLinkDto
+                {
+                    Token         = Str(j, "token") ?? "",
+                    ExpiresAt     = Date(j, "expiresAt") ?? DateTime.MinValue,
+                    ForceRedacted = Bool(j, "forceRedacted"),
+                };
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Share link creation failed: {ex.Message}";
+                StingLog.Error("CreatePhotoShareLinkAsync failed", ex);
+                return null;
+            }
+        }
+
+        // ── Bulk export ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photo-export?format=zip|pdf</c>
+        /// (PhotoExportController.Export) — streams the bundle to
+        /// <paramref name="outputPath"/> and returns the path written, or null on
+        /// failure.
+        /// </summary>
+        /// <remarks>
+        /// THIS RESPONSE IS BINARY, NOT JSON. The server writes straight to
+        /// Response.Body with <c>application/zip</c> or <c>application/pdf</c> and a
+        /// Content-Disposition header; there is no JSON envelope to parse. It is
+        /// streamed to disk with HttpCompletionOption.ResponseHeadersRead so a
+        /// 500-photo bundle never lands in memory — which mirrors the server, which
+        /// deliberately avoids a bundle-sized MemoryStream for the same reason.
+        ///
+        /// Server-side caps: 500 (zip) / 200 (pdf). Over-cap is a 400 carrying
+        /// <c>{ error, max }</c>; that JSON is read back off the error path and
+        /// reported, because on a failure the body is JSON even though success is not.
+        /// </remarks>
+        public async Task<string?> ExportPhotosAsync(
+            Guid projectId, string outputPath, Guid? albumId = null, string format = "zip")
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            return await ExportPhotosCoreAsync(projectId, outputPath, albumId, null, format)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Overload taking explicit photo ids; writes to the user's Documents folder
+        /// under the STING output location. Returns true when a file was written.
+        /// </summary>
+        public async Task<bool> ExportPhotosAsync(
+            Guid projectId, IEnumerable<Guid>? photoIds = null, string format = "zip")
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
+
+            var ids = photoIds?.Distinct().ToArray();
+            var ext  = string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase) ? "pdf" : "zip";
+            var name = $"photos-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}";
+
+            string dir;
+            try { dir = OutputLocationHelper.GetOutputDirectory(); }
+            catch (Exception ex)
+            {
+                LastError = $"Could not resolve an output folder: {ex.Message}";
+                return false;
+            }
+
+            var path = await ExportPhotosCoreAsync(
+                projectId, Path.Combine(dir, name), null, ids, format).ConfigureAwait(false);
+            return path != null;
+        }
+
+        private async Task<string?> ExportPhotosCoreAsync(
+            Guid projectId, string outputPath, Guid? albumId, Guid[]? photoIds, string format)
+        {
+            var isPdf = string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase);
+
+            if (albumId == null && (photoIds == null || photoIds.Length == 0))
+            {
+                // Mirrors the server's ids_or_album_required 400, but without a round trip.
+                LastError = "Select photos or an album to export.";
+                return null;
+            }
+
+            var cap = isPdf ? MaxPhotosPerPdfExport : MaxPhotosPerZipExport;
+            if (photoIds != null && photoIds.Length > cap)
+            {
+                LastError = $"{photoIds.Length} photos selected; the server caps a "
+                          + $"{(isPdf ? "PDF" : "ZIP")} export at {cap}. Export in batches or use an album.";
+                return null;
+            }
+
+            var http = SnapshotHttpClient();
+            if (http == null) { LastError = "Not connected."; return null; }
+
+            try
+            {
+                var body = new StringContent(
+                    JsonConvert.SerializeObject(
+                        new { photoIds, albumId },
+                        new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }),
+                    Encoding.UTF8, "application/json");
+
+                var url = $"/api/projects/{projectId}/photo-export?format={(isPdf ? "pdf" : "zip")}";
+
+                using var req = new HttpRequestMessage(HttpMethod.Post, url) { Content = body };
+                using var resp = await http
+                    .SendAsync(req, HttpCompletionOption.ResponseHeadersRead)
+                    .ConfigureAwait(false);
+
+                if (!resp.IsSuccessStatusCode)
+                {
+                    // Failure bodies ARE JSON (e.g. { error: "batch_too_large", max: 500 }),
+                    // even though a successful body is binary. Surface the cap.
+                    var err = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    LastError = $"Photo export failed ({(int)resp.StatusCode}): {DescribeExportError(err)}";
+                    return null;
+                }
+
+                var dir = Path.GetDirectoryName(outputPath);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+                // Stream to disk — never buffer the bundle.
+                using (var src = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                using (var dst = new FileStream(outputPath, FileMode.Create, FileAccess.Write,
+                                                FileShare.None, 81920, useAsync: true))
+                {
+                    await src.CopyToAsync(dst).ConfigureAwait(false);
+                }
+
+                var written = new FileInfo(outputPath);
+                if (!written.Exists || written.Length == 0)
+                {
+                    // A 200 with an empty body is a failure, not an empty export.
+                    LastError = "Photo export returned an empty file — nothing was written.";
+                    try { if (written.Exists) written.Delete(); } catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); }
+                    return null;
+                }
+
+                TouchActivity();
+                LastError = null;
+                StingLog.Info($"Photo export wrote {written.Length:N0} bytes to {outputPath}");
+                return outputPath;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Photo export failed: {ex.Message}";
+                StingLog.Error("ExportPhotosAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>Turn the server's export error body into something an operator can act on.</summary>
+        private static string DescribeExportError(string body)
+        {
+            try
+            {
+                var j = JObject.Parse(body);
+                var err = j["error"]?.Value<string>();
+                var max = j["max"]?.Value<int?>();
+                return err switch
+                {
+                    "batch_too_large"         => $"too many photos for a ZIP export (max {max ?? MaxPhotosPerZipExport}).",
+                    "batch_too_large_for_pdf" => $"too many photos for a PDF export (max {max ?? MaxPhotosPerPdfExport}).",
+                    "ids_or_album_required"   => "no photos or album were specified.",
+                    _                          => Trim(body),
+                };
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Suppressed: {ex.Message}");
+                return Trim(body);
+            }
+        }
+
+        // ── Admin bulk operations ─────────────────────────────────────────
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photos/bulk-reclassify</c>
+        /// (SitePhotosExtController.BulkReclassify). Returns the number of photos
+        /// updated, or 0 on failure with LastError set — callers test <c>n &gt; 0</c>.
+        /// </summary>
+        /// <param name="newClass">
+        /// Sent as the wire field <c>toReason</c> and validated server-side against
+        /// SitePhoto.ValidReasons. The stub's name implied a field called
+        /// <c>newClass</c>, which the server does not read.
+        /// </param>
+        public async Task<int> BulkReclassifyPhotosAsync(Guid projectId, IEnumerable<Guid> photoIds, string newClass)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return 0; }
+
+            var ids = photoIds?.Distinct().ToArray() ?? Array.Empty<Guid>();
+            if (ids.Length == 0) { LastError = "No photos selected."; return 0; }
+            if (string.IsNullOrWhiteSpace(newClass)) { LastError = "A target classification is required."; return 0; }
+            if (ids.Length > MaxPhotosPerBulkOp)
+            {
+                LastError = $"{ids.Length} photos selected; the server accepts at most {MaxPhotosPerBulkOp} per request.";
+                return 0;
+            }
+
+            return await PostBulkAsync(
+                $"/api/projects/{projectId}/photos/bulk-reclassify",
+                new { photoIds = ids, toReason = newClass },
+                "Reclassify").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/photos/bulk-reanchor</c>
+        /// (SitePhotosExtController.BulkReanchor). Returns the number updated.
+        /// </summary>
+        /// <param name="payload">
+        /// Optional pre-built body. When null, one is composed from
+        /// <paramref name="levelCode"/> / <paramref name="zoneCode"/> — the two
+        /// fields BulkReanchorRequest actually reads alongside WorkPackageId.
+        /// </param>
+        public async Task<int> BulkReanchorPhotosAsync(
+            Guid projectId, IEnumerable<Guid> photoIds, object? payload = null,
+            string? levelCode = null, string? zoneCode = null)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return 0; }
+
+            var ids = photoIds?.Distinct().ToArray() ?? Array.Empty<Guid>();
+            if (ids.Length == 0) { LastError = "No photos selected."; return 0; }
+            if (ids.Length > MaxPhotosPerBulkOp)
+            {
+                LastError = $"{ids.Length} photos selected; the server accepts at most {MaxPhotosPerBulkOp} per request.";
+                return 0;
+            }
+            if (payload == null && levelCode == null && zoneCode == null)
+            {
+                // The server would update 0 rows' worth of fields and still report
+                // success; refuse rather than report a meaningless "updated" count.
+                LastError = "Nothing to re-anchor — supply a level or a zone.";
+                return 0;
+            }
+
+            object body;
+            if (payload != null)
+            {
+                var j = JObject.FromObject(payload);
+                j["photoIds"] = JArray.FromObject(ids);
+                body = j;
+            }
+            else
+            {
+                body = new { photoIds = ids, levelCode, zoneCode };
+            }
+
+            return await PostBulkAsync(
+                $"/api/projects/{projectId}/photos/bulk-reanchor", body, "Re-anchor")
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>Shared body for the bulk endpoints, which all return <c>{ updated }</c>.</summary>
+        private async Task<int> PostBulkAsync(string path, object body, string label)
+        {
+            try
+            {
+                var resp = await PostJsonAsync(path, body).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"{label} failed ({resp.status}): {Trim(resp.body)}";
+                    return 0;
+                }
+                var updated = JObject.Parse(resp.body)["updated"]?.Value<int>() ?? 0;
+                if (updated == 0)
+                {
+                    // A 200 that changed nothing is not an error, but it must not
+                    // read as success in the UI either.
+                    LastError = $"{label} matched no photos — nothing was changed.";
+                    return 0;
+                }
+                LastError = null;
+                return updated;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"{label} failed: {ex.Message}";
+                StingLog.Error($"{label} failed", ex);
+                return 0;
+            }
+        }
+
+        // ── Distribution groups ───────────────────────────────────────────
+
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/distribution-groups</c>
+        /// (DistributionGroupsController.List). Null on failure, empty when none.
+        /// </summary>
+        public async Task<List<DistributionGroupDto>?> ListDistributionGroupsAsync(Guid projectId)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return null; }
+            try
+            {
+                var resp = await GetAsync($"/api/projects/{projectId}/distribution-groups")
+                    .ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    LastError = $"Distribution group load failed ({resp.status}): {Trim(resp.body)}";
+                    return null;
+                }
+                var list = new List<DistributionGroupDto>();
+                foreach (var t in JArray.Parse(resp.body))
+                {
+                    var j = (JObject)t;
+                    list.Add(new DistributionGroupDto
+                    {
+                        Id          = GuidOf(j, "id"),
+                        Name        = Str(j, "name") ?? "",
+                        Kind        = Str(j, "kind"),
+                        MemberCount = Int(j, "memberCount"),
+                    });
+                }
+                LastError = null;
+                return list;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Distribution group load failed: {ex.Message}";
+                StingLog.Error("ListDistributionGroupsAsync failed", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// <c>POST /api/projects/{projectId}/distribution-groups</c>, then one
+        /// <c>POST {groupId}/members</c> per recipient — members are a separate
+        /// route (AddDistributionMemberRequest), not a field on create.
+        /// </summary>
+        /// <param name="kind">
+        /// One of <c>Client | Internal | Mixed</c> (DistributionGroup.ValidKinds);
+        /// defaults to <c>Internal</c>, matching the server.
+        /// </param>
+        public async Task<bool> CreateDistributionGroupAsync(
+            Guid projectId, string name, IEnumerable<string>? recipients = null, string? kind = null)
+        {
+            if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
+            if (string.IsNullOrWhiteSpace(name)) { LastError = "Group name is required."; return false; }
+
+            var groupKind = string.IsNullOrWhiteSpace(kind) ? "Internal" : kind!;
+            if (!ValidDistributionKinds.Contains(groupKind))
+            {
+                LastError = $"Invalid distribution group kind '{groupKind}'. "
+                          + $"Allowed: {string.Join(", ", ValidDistributionKinds)}.";
+                return false;
+            }
+
+            try
+            {
+                var resp = await PostJsonAsync($"/api/projects/{projectId}/distribution-groups",
+                    new { name, kind = groupKind }).ConfigureAwait(false);
+                if (!resp.ok)
+                {
+                    // 409 name_in_use is the common one and is worth naming plainly.
+                    LastError = resp.status == 409
+                        ? $"A distribution group named '{name}' already exists."
+                        : $"Distribution group create failed ({resp.status}): {Trim(resp.body)}";
+                    return false;
+                }
+
+                var groupId = GuidOf(JObject.Parse(resp.body), "id");
+                var emails  = recipients?.Where(r => !string.IsNullOrWhiteSpace(r)).Distinct().ToArray()
+                              ?? Array.Empty<string>();
+                if (groupId == System.Guid.Empty || emails.Length == 0) { LastError = null; return true; }
+
+                var failed = new List<string>();
+                foreach (var email in emails)
+                {
+                    var m = await PostJsonAsync(
+                        $"/api/projects/{projectId}/distribution-groups/{groupId}/members",
+                        new { externalEmail = email }).ConfigureAwait(false);
+                    if (!m.ok) failed.Add(email);
+                }
+
+                if (failed.Count > 0)
+                {
+                    // The group exists; say so, and say which recipients did not land.
+                    LastError = $"Group '{name}' was created, but {failed.Count} of {emails.Length} "
+                              + $"recipients could not be added: {string.Join(", ", failed.Take(5))}"
+                              + (failed.Count > 5 ? ", …" : "");
+                    return false;
+                }
+
+                LastError = null;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LastError = $"Distribution group create failed: {ex.Message}";
+                StingLog.Error("CreateDistributionGroupAsync failed", ex);
+                return false;
+            }
+        }
+
+        // ── Shared helpers ────────────────────────────────────────────────
+
+        // Server-side caps, mirrored so the client can refuse before a round trip.
+        // PhotoExportController.MaxPhotosPerExport / MaxPhotosPerPdf; the album and
+        // bulk routes each hard-code 500.
+        private const int MaxPhotosPerZipExport  = 500;
+        private const int MaxPhotosPerPdfExport  = 200;
+        private const int MaxPhotosPerAlbumAdd   = 500;
+        private const int MaxPhotosPerBulkOp     = 500;
+
+        /// <summary>PhotoAlbum.ValidVisibilities — kept in step with the entity.</summary>
+        private static readonly string[] ValidAlbumVisibilities =
+            { "Internal", "Members", "Client", "Distribution" };
+
+        /// <summary>DistributionGroup.ValidKinds — kept in step with the entity.</summary>
+        private static readonly string[] ValidDistributionKinds =
+            { "Client", "Internal", "Mixed" };
+
+        /// <summary>
+        /// Map a FLAT album object — the shape returned by List, Create and
+        /// Lock/Unlock. GetOne's wrapper is unwrapped by its own caller before this
+        /// is reached; <c>photoCount</c> is absent on Create/Lock and maps to 0,
+        /// which is correct for a newly created album.
+        /// </summary>
+        private static StingTools.UI.PhotoAlbumDto MapAlbum(JObject j) => new()
+        {
+            Id          = GuidOf(j, "id"),
+            Name        = Str(j, "name") ?? "",
+            Description = Str(j, "description") ?? "",
+            Visibility  = Str(j, "visibility") ?? "Members",
+            Kind        = Str(j, "kind"),
+            PhotoCount  = Int(j, "photoCount"),
+            IsLocked    = Bool(j, "isLocked"),
+        };
+
+        private static string? Str(JObject j, string name)
+            => j[name]?.Type == JTokenType.Null ? null : j[name]?.Value<string>();
+
+        private static int Int(JObject j, string name)
+            => j[name]?.Type == JTokenType.Null ? 0 : (j[name]?.Value<int?>() ?? 0);
+
+        private static bool Bool(JObject j, string name)
+            => j[name]?.Type == JTokenType.Null ? false : (j[name]?.Value<bool?>() ?? false);
+
+        private static Guid GuidOf(JObject j, string name)
+            => System.Guid.TryParse(Str(j, name), out var g) ? g : System.Guid.Empty;
+
+        private static DateTime? Date(JObject j, string name)
+            => j[name]?.Type == JTokenType.Null ? null : j[name]?.Value<DateTime?>();
+
+        /// <summary>Keep an error body short enough for a TaskDialog line.</summary>
+        private static string Trim(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body)) return "(no response body)";
+            var s = body.Trim().Replace("\r", " ").Replace("\n", " ");
+            return s.Length <= 300 ? s : s.Substring(0, 300) + "…";
+        }
+
+        private static string Sha256Hex(string text)
+        {
+            using var sha = SHA256.Create();
+            var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(text));
+            var sb = new StringBuilder(bytes.Length * 2);
+            foreach (var b in bytes) sb.Append(b.ToString("x2"));
+            return sb.ToString();
+        }
+    }
+}

--- a/StingTools/Core/MergeRecoveryStubs.cs
+++ b/StingTools/Core/MergeRecoveryStubs.cs
@@ -313,29 +313,15 @@ namespace StingTools.BIMManager
             string? revision = null, int elementCount = 0) => Task.FromResult((true, ""));
         public Task<(bool ok, string error)> DeleteModelAsync(Guid projectId, Guid modelId) => Task.FromResult((true, ""));
 
-        // Site Photos — NDA / policy
-        public Task<StingTools.UI.PhotoPolicyDto?> GetPhotoPolicyAsync(Guid projectId) => Task.FromResult<StingTools.UI.PhotoPolicyDto?>(null);
-        public Task<bool>     AcceptPhotoNdaAsync(Guid projectId, string? ndaSha = null) => Task.FromResult(false);
-        public Task<bool>     AcceptPhotoNdaAsync(Guid projectId, Guid photoId) => Task.FromResult(false);
-        public HashSet<Guid>  LastNdaRequiredIds { get; set; } = new();
-
-        // Site Photos — checklists / albums / distribution
-        public Task<List<StingTools.UI.PhotoChecklistDto>?> ListPhotoChecklistsAsync(Guid projectId, string? status = null) => Task.FromResult<List<StingTools.UI.PhotoChecklistDto>?>(new List<StingTools.UI.PhotoChecklistDto>());
-        public Task<List<StingTools.UI.PhotoAlbumDto>?>     ListPhotoAlbumsAsync(Guid projectId) => Task.FromResult<List<StingTools.UI.PhotoAlbumDto>?>(new List<StingTools.UI.PhotoAlbumDto>());
-        public Task<StingTools.UI.PhotoAlbumDto?>           GetPhotoAlbumAsync(Guid projectId, Guid albumId) => Task.FromResult<StingTools.UI.PhotoAlbumDto?>(null);
-        public Task<StingTools.UI.PhotoAlbumDto?>           CreatePhotoAlbumAsync(Guid projectId, string name, string? description = null, string visibility = "Project") => Task.FromResult<StingTools.UI.PhotoAlbumDto?>(null);
-        public Task<bool> AddPhotosToAlbumAsync(Guid projectId, Guid albumId, IEnumerable<Guid> photoIds) => Task.FromResult(false);
-        public Task<bool> LockPhotoAlbumAsync(Guid projectId, Guid albumId, bool locked) => Task.FromResult(false);
-        public Task<StingTools.UI.PhotoShareLinkDto?> CreatePhotoShareLinkAsync(Guid projectId, Guid albumId, TimeSpan? expiry = null, string? label = null) => Task.FromResult<StingTools.UI.PhotoShareLinkDto?>(null);
-        public Task<string?> ExportPhotosAsync(Guid projectId, string outputPath, Guid? albumId = null, string format = "zip") => Task.FromResult<string?>(null);
-        public Task<bool>    ExportPhotosAsync(Guid projectId, IEnumerable<Guid>? photoIds = null, string format = "zip") => Task.FromResult(false);
-
-        // Site Photos — admin bulk — return the count of affected photos
-        // (callers do `n > 0` on the result).
-        public Task<int> BulkReclassifyPhotosAsync(Guid projectId, IEnumerable<Guid> photoIds, string newClass) => Task.FromResult(0);
-        public Task<int> BulkReanchorPhotosAsync(Guid projectId, IEnumerable<Guid> photoIds, object? payload = null, string? levelCode = null, string? zoneCode = null) => Task.FromResult(0);
-        public Task<List<DistributionGroupDto>?> ListDistributionGroupsAsync(Guid projectId) => Task.FromResult<List<DistributionGroupDto>?>(new List<DistributionGroupDto>());
-        public Task<bool> CreateDistributionGroupAsync(Guid projectId, string name, IEnumerable<string>? recipients = null, string? kind = null) => Task.FromResult(false);
+        // Site Photos — REAL implementation lives in
+        // PlanscapeServerClient.SitePhotos.cs (Phase 2). The stubs that were here
+        // returned null/false/0 — and, worse, `new List<T>()` for the three list
+        // calls, which made "the server is unreachable" render identically to
+        // "this project has no albums". Routes and DTOs in the replacement are
+        // derived from the controller source; several stub parameter names did not
+        // match the wire (visibility "Project" is not a valid value; the bulk
+        // reclassify field is `toReason`, not `newClass`; album lock/unlock are two
+        // routes, not a boolean).
     }
 
     /// <summary>Stub — distribution group DTO mirroring the server contract.</summary>

--- a/StingTools/UI/SitePhotosAdminSubTab.cs
+++ b/StingTools/UI/SitePhotosAdminSubTab.cs
@@ -129,7 +129,19 @@ namespace StingTools.UI
                     });
                     return;
                 }
+                // null = the load FAILED; an empty list = there are genuinely no
+                // groups. "No distribution groups yet." over an unreachable server
+                // is invented data — and here it is actively dangerous, because an
+                // operator could conclude nobody is on distribution and re-add
+                // recipients who are already there.
                 var groups = await PlanscapeServerClient.Instance.ListDistributionGroupsAsync(state.ProjectId);
+                if (groups == null)
+                {
+                    dgPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                        "Could not load distribution groups.",
+                        PlanscapeServerClient.Instance.LastError));
+                    return;
+                }
                 if (groups.Count == 0)
                 {
                     dgPanel.Children.Add(new TextBlock {

--- a/StingTools/UI/SitePhotosAlbumsSubTab.cs
+++ b/StingTools/UI/SitePhotosAlbumsSubTab.cs
@@ -87,12 +87,22 @@ namespace StingTools.UI
                     });
                     return;
                 }
+                // null = the load FAILED. An empty list = the project genuinely has
+                // no albums. These must never render the same: "No albums yet" over
+                // a failed request is invented data.
                 List<PhotoAlbumDto> albums;
                 try { albums = await PlanscapeServerClient.Instance.ListPhotoAlbumsAsync(state.ProjectId); }
                 catch (Exception ex)
                 {
                     StingLog.Warn($"AlbumsSubTab.Load: {ex.Message}");
-                    listPanel.Children.Add(new TextBlock { Text = "Load failed.", Foreground = Brushes.Crimson, Margin = new Thickness(6) });
+                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure("Could not load albums.", ex.Message));
+                    return;
+                }
+                if (albums == null)
+                {
+                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                        "Could not load albums.",
+                        PlanscapeServerClient.Instance.LastError));
                     return;
                 }
                 if (albums.Count == 0)
@@ -236,7 +246,16 @@ namespace StingTools.UI
 
                 // Photo strip — load detail + render thumbnails.
                 var detail = await PlanscapeServerClient.Instance.GetPhotoAlbumAsync(state.ProjectId, selected.Id);
-                if (detail?.Photos == null || detail.Photos.Count == 0)
+                if (detail == null)
+                {
+                    // Failed to load — NOT an empty album. Saying "Album is empty"
+                    // here would invite someone to re-add photos that are already in it.
+                    rightPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                        "Could not load this album's photos.",
+                        PlanscapeServerClient.Instance.LastError));
+                    return;
+                }
+                if (detail.Photos == null || detail.Photos.Count == 0)
                 {
                     rightPanel.Children.Add(new TextBlock
                     {
@@ -353,6 +372,49 @@ namespace StingTools.UI
     /// PromptForString modal without re-implementing it.</summary>
     internal static class SitePhotosTabHelpers
     {
+        /// <summary>
+        /// Render a load FAILURE — visibly different from an empty result.
+        ///
+        /// The site-photo client returns <c>null</c> from a list call when the
+        /// request failed and an empty list only when the project genuinely has
+        /// nothing. Before this existed the sub-tabs collapsed both into the
+        /// friendly "No albums yet" empty-state, so an unreachable server rendered
+        /// as a confident, wrong, empty answer. Anything that could not be loaded
+        /// says so, in red, with the server's own reason.
+        /// </summary>
+        public static UIElement BuildLoadFailure(string headline, string? detail)
+        {
+            var sp = new StackPanel { Margin = new Thickness(6) };
+            sp.Children.Add(new TextBlock
+            {
+                Text = "⚠ " + headline,
+                Foreground = Brushes.Crimson,
+                FontWeight = FontWeights.SemiBold,
+                TextWrapping = TextWrapping.Wrap
+            });
+            if (!string.IsNullOrWhiteSpace(detail))
+            {
+                sp.Children.Add(new TextBlock
+                {
+                    Text = detail,
+                    Foreground = Brushes.Crimson,
+                    Opacity = 0.85,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin = new Thickness(0, 2, 0, 0)
+                });
+            }
+            sp.Children.Add(new TextBlock
+            {
+                // Say plainly that the pane is not authoritative right now.
+                Text = "This is not an empty result — the list could not be retrieved.",
+                FontStyle = FontStyles.Italic,
+                Foreground = Brushes.Gray,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 4, 0, 0)
+            });
+            return sp;
+        }
+
         public static string? PromptForString(Window owner, string title, string prompt, string initialValue)
         {
             var dlg = new Window

--- a/StingTools/UI/SitePhotosChecklistsSubTab.cs
+++ b/StingTools/UI/SitePhotosChecklistsSubTab.cs
@@ -70,12 +70,24 @@ namespace StingTools.UI
                     return;
                 }
                 var statusFilter = (statusCb.SelectedItem as ComboBoxItem)?.Tag as string;
+                // null = the load FAILED; an empty list = there are genuinely no
+                // checklists. Rendering the friendly empty-state over a failed
+                // request would be invented data.
                 List<PhotoChecklistDto> rows;
                 try { rows = await PlanscapeServerClient.Instance.ListPhotoChecklistsAsync(state.ProjectId, statusFilter); }
                 catch (Exception ex)
                 {
                     StingLog.Warn($"ChecklistsSubTab.Load: {ex.Message}");
-                    listPanel.Children.Add(new TextBlock { Text = "Load failed.", Foreground = Brushes.Crimson, Margin = new Thickness(8) });
+                    status.Text = "load failed";
+                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure("Could not load checklists.", ex.Message));
+                    return;
+                }
+                if (rows == null)
+                {
+                    status.Text = "load failed";
+                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                        "Could not load checklists.",
+                        PlanscapeServerClient.Instance.LastError));
                     return;
                 }
                 status.Text = $"{rows.Count} checklist{(rows.Count == 1 ? "" : "s")}";


### PR DESCRIPTION
> [!WARNING]
> **A green CI run on this PR is NOT equivalent to the local verification run, and CI is the
> WEAKER evidence.** Read the two columns below before treating a CI tick as confirmation.
>
> `StingTools.SitePhotos.Tests` splits into two groups. `SitePhotoTransportTests` runs anywhere.
> The four `LiveStackRoundTripTests` are `[SkippableFact]`s that call `Skip.IfNot(ok, reason)`
> after attempting a login — **they only execute when a Planscape server is reachable.**
>
> | | local (stack up) | CI (no stack) |
> |---|---|---|
> | Passed | **12** | **8** |
> | Skipped | 2 | **6** |
> | Failed | 0 | 0 |
> | Total | 14 | 14 |
>
> The four that move — `Create_then_list_then_detail_round_trips_with_non_empty_results`,
> `Lock_then_unlock_round_trips_against_the_live_stack`,
> `Checklists_list_and_detail_are_reachable_and_self_consistent`,
> `Distribution_groups_list_is_reachable` — are the ones that actually round-trip a real server
> and assert **non-empty** results. On CI they will report as skipped, and CI will still be
> green.
>
> So: **green CI proves the transport guards hold. It does not prove the round-trip works.**
> The local run in the rebase comment below did prove that, against a live stack on
> `localhost:5000`, and it is the evidence to weigh.
>
> (The 2 skips that are constant in both columns are the PDF-cap tests, which need
> `RevitAPI.dll` for `OutputLocationHelper` and cannot load it headlessly. #560, stacked on
> this, makes one of them reachable by validating before resolving the output folder — it runs
> 13 passed / 1 skipped locally.)

## Phase 2 — the BCC site-photo suite stops pretending

The site-photo tabs were wired to `MergeRecoveryStubs`, which returned
`null`/`false`/`0` for every call — and, for the three list calls, **`new List<T>()`**.

That last one is the problem. An empty list is an answer. It rendered as:

> *"No albums yet — create one to curate photos for the client / handover."*

…whether the project had no albums or the server was unreachable. A confident,
empty, wrong answer — the same fabrication anti-pattern as invented data, wearing a
friendlier costume.

New partial `StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs` implements all
16 stubbed methods against real routes, following the documented
`PlanscapeServerClient.Hvac.cs` precedent. The stub block at
`Core/MergeRecoveryStubs.cs:316-338` is **deleted**.

---

### Five stub signatures did not match the wire

Routes and DTOs were derived from the **controller source**, not the stub signatures.
That was the right call — the stubs were written blind and five were wrong. Each of
these would have failed at runtime, not compile time:

| Stub | Reality |
|---|---|
| `CreatePhotoAlbumAsync(… visibility = "Project")` | **`"Project"` is not a valid value.** `PhotoAlbum.ValidVisibilities` is `{ Internal, Members, Client, Distribution }`; the server 400s `invalid_visibility`. **Every album creation would have failed.** Now defaults to `"Members"` (the server's own default) and validates before the round trip. |
| `BulkReclassifyPhotosAsync(… newClass)` | Wire field is **`toReason`** (`BulkReclassifyRequest`), validated against `SitePhoto.ValidReasons`. The old name would have been silently ignored — a 200 that reclassified nothing. |
| `LockPhotoAlbumAsync(… bool locked)` | There is no boolean field and no single route. **`POST {id}/lock` and `POST {id}/unlock` are two endpoints.** The bool now selects the route. |
| `CreatePhotoShareLinkAsync(… TimeSpan expiry)` | Wire field is an **absolute `expiresAt`** (`CreateShareLinkRequest`). Converted from the relative span. |
| `GetPhotoAlbumAsync` | `GetOne` returns a **wrapper** — `{ album, photos, ndaRequiredIds }` — unlike List/Create/Lock, which return a flat album. Mapping it flat yields a plausible, **empty**, wrong DTO. Now unwrapped explicitly. |

That last one also fixed a gap: `ndaRequiredIds` is the only place the server reports
which photos are NDA-gated, so it now populates `LastNdaRequiredIds`.

### The NDA overload had no route at all

`AcceptPhotoNdaAsync(projectId, ndaSha)` implied a project-level "accept once" route.
**There isn't one.** Acceptance is per photo, because `PhotoNdaAcceptance` is keyed on
`(PhotoId, UserId)` — the only endpoint is `POST photos/{photoId}/accept-nda`
(`SitePhotosExtController:394`).

Rather than fake a project-level accept or silently no-op, it fans out over the
NDA-gated ids and reports partial failure truthfully. **With nothing pending it
returns `false` with a reason, not a vacuous `true`** — a false success here would let
the UI unlock content the user never accepted terms for.

### photo-export is binary, and is treated as binary

`POST …/photo-export?format=zip|pdf` writes straight to `Response.Body` as
`application/zip` / `application/pdf` with a `Content-Disposition` header. There is no
JSON envelope.

* Streamed to disk with `HttpCompletionOption.ResponseHeadersRead` + `CopyToAsync` —
  a 500-photo bundle never lands in memory. This mirrors the server, which
  deliberately avoids a bundle-sized `MemoryStream` for the same reason.
* **Failure bodies *are* JSON**, so the over-cap `{ error, max }` is read back off the
  error path and reported in words ("too many photos for a PDF export (max 200)").
* Caps mirrored client-side — **500 zip / 200 pdf**, plus 500 for album-add and the
  bulk routes — so an over-cap batch is refused before the round trip.
* A `200` with a zero-byte body is treated as a **failure**, and the empty file is
  deleted rather than left as a plausible export.

### Failures now look like failures

A failed list returns **`null`**; an empty list means the project genuinely has
nothing. The sub-tabs could not express that difference, so they are fixed too:

* **Albums**, **Checklists**, **Admin / distribution groups**, and **album detail**
  each distinguish "could not load" from "nothing here".
* New `SitePhotosTabHelpers.BuildLoadFailure` renders the failure in red, with the
  server's own reason, and says plainly: *"This is not an empty result — the list
  could not be retrieved."*
* The **album-detail** case mattered most: *"Album is empty"* over a failed load
  invites an operator to re-add photos that are already in it.
* The **distribution-group** case is the one with real-world consequences: *"No
  distribution groups yet"* over an unreachable server could lead someone to re-add
  recipients who are already on distribution.

Every method sets `LastError` on failure; the mutation call sites already surface it in
a `TaskDialog`. Two more silent-success cases are now reported as failures: a bulk
`{ updated: 0 }`, and the empty-export above.

### Build

```
dotnet build StingTools/StingTools.csproj -c Debug -t:Rebuild
  0 Error(s)   0 Warning(s)
```

The pre-change baseline was measured first and was also **0/0**, so this neither
introduces nor hides warnings. Nullable annotations are opted in **per file**
(`#nullable enable annotations`), matching `MergeRecoveryStubs.cs` where these
signatures used to live, so the call sites' existing `string?` / `List<T>?`
expectations still bind — and it follows the codebase review's P2 recommendation to
adopt nullable incrementally rather than flipping the project.

### NOT verified in Revit — stated plainly

**No runtime verification was done, and none is claimed.**

* **Revit was not running**, and this is a background job — I cannot launch the Revit
  GUI and drive the BCC site-photo tabs.
* `Planscape.Companion.exe` **was** running; the documented deploy precondition
  requires it stopped.
* The live addin target was checked (it moves): all three of
  `…/Revit/Addins/{2025,2026,2027}/StingTools.addin` point at
  **`C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`** — one shared output for all
  three versions.

I did **not** deploy. That single shared target is used by other branches and
sessions, and overwriting it with an unverified feature-branch build would disturb
work I cannot see while buying no verification, since Revit could not be exercised
anyway. Deploying is one command once you're ready: build Release and copy over
`CompiledPlugin`, with Revit closed and the Companion tray app stopped.

**What is verified:** it compiles clean, and every route, field name, wrapper shape and
cap in it was read off the controller source and is cited in the code comments.
**What is not:** that the tabs behave correctly against a live server in Revit.


---

## Verification record (re-run independently, not carried over)

**Compiles; NOT verified in Revit — the BCC tabs have not been exercised against a live server.**

That sentence is the whole claim. Everything below is the evidence for it and the boundary around it.

### Build — re-verified from scratch on this branch

```
dotnet build StingTools/StingTools.csproj -c Debug -t:Rebuild
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:04:01.84
```

A full `-t:Rebuild`, not an incremental build, so the result cannot be inherited from stale artefacts.

### Unit tests — 9 projects, with an `origin/main` baseline

The plugin has **no test project that references `StingTools.csproj`**, so *none of these tests can
exercise this change*. They are run as a **no-regression signal only**, and are reported as such.
Because the raw results are not clean, each non-green project was re-run on `origin/main`
(`097b75a94`) to establish whether this branch caused it. **It did not — the two results are
identical.**

| Project | This branch | `origin/main` | Verdict |
|---|---|---|---|
| Sustainability | 438 passed | — | green |
| Tags | **2 failed**, 239 passed / 241 | **2 failed**, 239 passed / 241 | **identical — pre-existing** |
| Boq | 196 passed | — | green |
| Cost | 90 passed | — | green |
| Scheduling | 38 passed | — | green |
| Licensing | 14 passed | — | green |
| Clash | **does not compile** (CS0246) | **does not compile** (CS0246) | **identical — pre-existing** |
| Routing | **does not compile** (CS0234/CS0246) | **does not compile** (CS0234/CS0246) | **identical — pre-existing** |
| Connectivity | 0 tests (empty project) | 0 tests | known — CLAUDE.md P0-2 |

Totals on this branch: **1,017 executed test cases, 1,015 passed, 2 failed**, plus **97 declared
test methods** in two projects that never ran because those projects do not build.

(An earlier revision of this section said "776 executed, 774 passed". That was wrong — it omitted
Tags' 241 cases and coincidentally landed on CLAUDE.md's stale 774 figure. Corrected above. Note
that CLAUDE.md counts *declared* `[Fact]`/`[Theory]` methods while `dotnet test` reports *expanded*
cases, so the two metrics legitimately differ; neither should count the 97 that cannot run.)

None of it touches this change. This branch modifies `BIMManager/PlanscapeServerClient.SitePhotos.cs`,
`Core/MergeRecoveryStubs.cs` and three `UI/SitePhotos*` files. The failures are in
`Clash/`, `Commands/Electrical/Routing/` and `CsiMasterFormatTests` — no overlap.

### Two findings worth someone's attention (not fixed here, not in scope)

1. **`StingTools.Clash.Tests` and `StingTools.Routing.Tests` cannot compile at all.** Both use
   `<Compile Include="..\StingTools\...">` to pull plugin sources in directly — the csproj comment
   says this is "avoiding the need for Revit DLLs on the test host". Those sources have since grown
   `using Autodesk.Revit.*` dependencies, so the trick no longer holds. The consequence is worse than
   two red projects: **~97 tests (Clash + Routing) have silently stopped running**, while still being
   counted in the "774 test methods" headline. A test that cannot build reports nothing, and nothing
   currently reads as fine.
2. **`CsiMasterFormatTests` has 2 tests failing on `main`** —
   `NormalizeSection_collapses_whitespace_and_uppercases` and
   `Reconcile_finds_gaps_overspec_and_title_mismatches`.

Both predate this branch and are now filed separately rather than folded into it: **#553** (the two
non-compiling projects) and **#554** (the CsiMasterFormat failures). Neither is fixed here.

### What "not verified in Revit" means here, precisely

Revit was not launched and **nothing was deployed**. The live addin target was checked and all three
of `…/Revit/Addins/{2025,2026,2027}/StingTools.addin` resolve to the same shared
`C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`, which other branches and sessions also use;
overwriting it with an unverified feature build would disturb work not visible from here while buying
no verification, since the GUI could not be driven from a background job regardless.

So: every route, field name, wrapper shape and cap in this PR was read off the controller source and
is cited in the code comments — **and none of it has been seen to work against a running server.**
A deploy plus a manual pass over the site-photo tabs is a separate, explicit step, and Phase 2 is not
done until that step has been run.

---

## Deploy + verification checklist (D1/D2) — written before asking, so the window is short

Everything below is prepared. The only thing missing is the window in which Revit can be closed.

### Preconditions

| # | Check | Current state (checked just now) |
|---|---|---|
| P1 | **Revit closed** — all versions | No `Revit.exe` running ✅ |
| P2 | **`Planscape.Companion.exe` stopped** — it holds the output directory | **RUNNING, PID 18944** ❌ must be stopped |
| P3 | **Server up** for the positive path | `Planscape.API.exe` running, `docker-api-1` healthy on :5000 ✅ |

### Deploy target — grepped fresh, because it moves

All three Revit versions share **one** output directory (user-scope `%APPDATA%`, not machine-scope):

```
%APPDATA%\Autodesk\Revit\Addins\2025\StingTools.addin
%APPDATA%\Autodesk\Revit\Addins\2026\StingTools.addin   →  all three <Assembly> point at:
%APPDATA%\Autodesk\Revit\Addins\2027\StingTools.addin      C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll
```

**One shared target means deploying this branch replaces the plugin for every Revit version and for any other session using that directory.** Take a backup first (step 2).

### Build and copy

```bash
# 1. Build Release from this branch
cd C:/Dev/STINGTOOLS/.claude/worktrees/<this-branch-worktree>
dotnet build StingTools/StingTools.csproj -c Release -t:Rebuild

# 2. Back up the current deployed plugin (one shared target — do not skip)
cp -r "C:/Dev/STINGTOOLS/CompiledPlugin" "C:/Dev/STINGTOOLS/CompiledPlugin.bak-$(git rev-parse --short HEAD)"

# 3. Copy the build over it
cp -r StingTools/bin/Release/* "C:/Dev/STINGTOOLS/CompiledPlugin/"

# 4. Start Revit, open any project, open the BCC dock panel
```

Rollback is `cp -r CompiledPlugin.bak-<sha>/* CompiledPlugin/` with Revit closed.

### The three failure states must be visually distinct

This is the whole point of the PR, so it is the acceptance criterion for every step below:

| State | What it must look like |
|---|---|
| **Couldn't load** | **Red** text, the server's own reason, and the sentence *"This is not an empty result — the list could not be retrieved."* |
| **Empty** | Neutral prompt — e.g. *"No albums yet — create one to curate photos for the client / handover."* |
| **Forbidden** | Says **why**, naming the capability — e.g. *"Only a project manager can curate albums."* Not a bare 403, not silence. |

If any two of those render the same, the step **fails** regardless of whether the data appeared.

### Click-through — BCC → SITE PHOTOS

| # | Action | PASS |
|---|---|---|
| 1 | Open **Albums** sub-tab | Album list renders, or the correct one of the three states above |
| 2 | **Create** an album (leave visibility default) | Album appears in the list. Visibility reads **Members** — *not* "Project", which the server rejects with `invalid_visibility` |
| 3 | Create with visibility set to each of Internal / Members / Client / Distribution | All four accepted |
| 4 | Create with a deliberately bad visibility (if the UI allows) | Refused **before** the round trip, with the four valid values named |
| 5 | **Lock** an album | Lock indicator (🔒) appears — exercises `POST {id}/lock` |
| 6 | **Unlock** the same album | Indicator clears — exercises the *separate* `POST {id}/unlock` route. Both must work; they are two endpoints, not a boolean |
| 7 | **Share link** | Returns a token and an absolute expiry. Confirm the expiry is a real timestamp, not now+0 |
| 8 | **Export** an album, format **zip** | A real `.zip` lands on disk and opens. **Non-zero size** — a 0-byte file is treated as failure and deleted by design, so if you get "export failed" with no file, that is correct behaviour, not a bug |
| 9 | **Export**, format **pdf** | Real `.pdf`, non-zero |
| 10 | Export a selection **over 200 photos as pdf** | Refused client-side with *"too many photos for a PDF export (max 200)"* — before the round trip |
| 11 | Open **Checklists** sub-tab | List renders, or correct state |
| 12 | Open a checklist **detail** | Items render; totals match |
| 13 | **Fulfil** a checklist item | Done count increments and survives a refresh |
| 14 | Open **Admin** sub-tab | Distribution groups render, or correct state |
| 15 | Album **detail** on an album with photos | Photos listed. Critically: an album that fails to load must **not** say *"Album is empty"* — that invites re-adding photos that are already there |

### D2 — the negative test. This is the regression the PR exists to prevent.

**Untested means unfixed.** Run it explicitly:

```bash
docker compose -f Planscape.Server/docker/docker-compose.yml stop api
#   …or point the plugin at a bad base URL
```

Then revisit **every** sub-tab: Albums, Checklists, Admin, and album detail.

| Requirement | Fail condition |
|---|---|
| Every tab shows a **visible red error** naming the failure | Any tab showing an empty list, a neutral "nothing here" prompt, or a blank panel |
| The error is distinguishable from the empty state at a glance | Error and empty render identically |

Then `docker compose start api` and confirm the tabs recover on refresh.

**If any tab shows an empty list while the server is down, this PR has not achieved its purpose and must not leave draft.**

### After the run

The **Compiles; NOT verified in Revit** line is replaced only by what was genuinely exercised, step by step, with verbatim dialog text or screenshots. Any step not reached stays explicitly listed as unverified. The line is not softened to make the PR look finished.

---

## ⚠️ DEPLOYED — backup path and rollback (posted BEFORE the copy)

Recorded here, not in a session transcript, so restoring never depends on this session surviving.

**Backup of the pre-deploy plugin:**

```
C:\Dev\STINGTOOLS\CompiledPlugin.bak-pre-pr550
```

**One-line rollback** (Git Bash; **Revit must be closed and `Planscape.Companion.exe` stopped** first):

```bash
cp -rf "C:/Dev/STINGTOOLS/CompiledPlugin.bak-pre-pr550/." "C:/Dev/STINGTOOLS/CompiledPlugin/"
```

That restores the exact bytes that were deployed before this PR — a build of `main` dated 2026-08-01 14:33:25 (`StingTools.dll`, 18,392,576 bytes).

**What was deployed over it:** `StingTools/bin/Release/*` built from this branch at `4c01cbc83`, `dotnet build -c Release -t:Rebuild` → **0 errors, 0 warnings**.

**Scope of the change:** all three of `%APPDATA%\Autodesk\Revit\Addins\{2025,2026,2027}\StingTools.addin` resolve to the single shared `C:\Dev\STINGTOOLS\CompiledPlugin\StingTools.dll`, so this deploy affects **every Revit version on this machine and any other session pointed at that target**. Pre-flight lock check before copying: the DLL was **not locked** (exclusive open succeeded) and its last write was 2026-08-01 14:33 — ~17 hours old, so nothing was mid-deploy.

Note that `CompiledPlugin.bak-*` directories are **not** covered by `.gitignore` — main ignores `CompiledPlugin/` but not the timestamped backups, which is what PR #501 addresses. The backup will show as untracked until then; do not commit it.

---

## Correction to the checklist above — "forbidden" is NOT distinct in this build

Found while verifying the deployed binary, and posted before the click-through so the run is not wasted on a criterion this PR never met.

**Evidence:** there is no 403 / forbidden handling anywhere in the site-photo UI or the client partial. The only mention is a comment in `SitePhotosAdminSubTab.cs:13` noting that a permission gate exists server-side. The deployed DLL confirms it — the new failure strings `This is not an empty result` and `could not be retrieved` are present, but no forbidden-specific copy is.

**What that means in practice:** a `403` flows through the generic failure path and renders as **couldn't-load** — red, with the server's reason. That is not a fabrication and not an empty list, so it does not violate what this PR set out to fix. But it does **not** satisfy the parity bar's requirement that forbidden be visually distinct and say *why* ("Only a project manager can curate albums").

**So the three-state table above overstates this PR.** #550's scope was *couldn't-load vs empty*. Distinguishing *forbidden* as a third state is parity work, and belongs with the SavedViews / DistributionGroups / PhotoExport surfaces where the capability rules land — after the capabilities endpoint (#547) ships.

**Revised acceptance for the click-through:** verify **couldn't-load vs empty** are distinct on every surface. Where a step mentions forbidden, record what actually renders — expected to be the red load-failure treatment — and log it as a known gap rather than a step failure.


---

## ✅ RUNTIME RESULTS — M1, M2, M3 all PASS (owner-observed, in Revit, against the deployed binary)

**This replaces "Compiles; NOT verified in Revit" for the three states below — and only
for those three.** The lines below are the owner's own words from the run; they are
recorded verbatim rather than paraphrased into a summary.

The binary exercised is the `m-pass-deploy` build of this branch, deployed to the shared
`C:\Dev\STINGTOOLS\CompiledPlugin` target documented above (rollback:
`CompiledPlugin.bak-pre-pr550`).

### M1 — Albums list, API stopped

> "Could not load albums. / Album load failed: No connection could be made because the
> target machine actively refused it. (localhost:5000) / This is not an empty result — the
> list could not be retrieved."

Red, names the real reason, **not** "No albums yet". **PASS.**

### M2 — album creation via the BCC

New album created: `new album 01 — Members — 0 photos`. Visibility default read
**Members**. Creation succeeded, where the old binary gave `(no detail)`.

That is the `invalid_visibility` fix confirmed on the wire: the stub's `"Project"` default
would have 400'd **every** album creation. **PASS.**

### M3 — the sharp one: album detail, empty vs unreachable

Same album, **server up**:

> "Album is empty. Select photos in the Grid tab and click '＋ Add selected'."

Same album, **server stopped**, detail reloaded:

> "Could not load this album's photos. / Album load failed: No connection could be made…
> / This is not an empty result — the list could not be retrieved."

It did **not** say "Album is empty". **PASS.**

This is the single case the PR most needed to get right — "Album is empty" over a failed
load invites an operator to re-add photos that are already in the album — and it is now
observed correct in both directions, not merely argued from the source.

### Verified in passing

* **#570** — the Planscape project link is readable: the Albums tab lists the seeded album
  instead of falling back to "Sign in to Planscape".
* **#571** — no NRE on connect.

---

## Three polish defects found in the same run — filed separately, NOT fixed here

All three are **presentation** defects sitting on top of behaviour that passed. None of
them re-introduces the fabrication this PR removes, and none is in scope for #550 — its
scope is *couldn't-load vs empty must be distinguishable*, which M1/M2/M3 confirm it
delivers. Filed rather than folded in, so this PR does not widen:

| # | Defect | Where |
|---|---|---|
| **#572** | The list error block renders **twice** — two identical "Could not load albums" panels stacked. `LoadListAsync` clears synchronously on entry and appends after the await, with no in-flight guard, so any two overlapping loads both clear then both append. Same shape exists in the Checklists and Admin sub-tabs. | `SitePhotosAlbumsSubTab.cs:79-107` |
| **#573** | After a failed list load the **right pane keeps showing a previously-loaded album** and its empty-state text, presented as if live — the list says "couldn't load" while the detail beside it looks current. Same confusion class as this PR fixes, in the other pane. `LoadListAsync` never touches `rightPanel` and never resets `selected`. | `SitePhotosAlbumsSubTab.cs:77, 79-107` |
| **#574** | **"0 photos" still renders beside the detail load-failure.** The count is written from the cached list DTO *before* the detail round-trip, so an unknown count is presented as a fact. The 🔒 chip on the same line inherits it. | `SitePhotosAlbumsSubTab.cs:143-148, 248-256` |

None was reproduced from this session — there is no Revit here. Each is owner-observed,
with the enabling code path read off this branch and cited. That distinction is kept in
the issues themselves.

---

## What was NOT exercised in this pass — stated plainly

The click-through above covers steps **1, 2 and 15** of the checklist. **Everything else
in it remains unverified**, and the earlier "Compiles; NOT verified in Revit" caveat still
stands for all of it:

| Not run | Checklist step |
|---|---|
| Create with each of Internal / Members / Client / Distribution | 3 |
| Deliberately bad visibility refused pre-flight | 4 |
| **Lock** an album (`POST {id}/lock`) | 5 |
| **Unlock** — the *separate* `POST {id}/unlock` route | 6 |
| **Share link** — token + absolute expiry | 7 |
| **Export ZIP** — real, non-zero file | 8 |
| **Export PDF** | 9 |
| Over-200-photo PDF refused client-side | 10 |
| **Checklists** sub-tab, detail, and item fulfilment | 11, 12, 13 |
| **Admin** / distribution groups | 14 |
| D2 negative pass across Checklists / Admin (only Albums + album detail were run) | D2 |

The five corrected stub signatures are therefore in a split state: **`invalid_visibility`
is confirmed on the wire (M2)** and `GetOne`'s wrapper shape is confirmed (M3), while the
**lock/unlock two-route split, the `expiresAt` conversion, the `toReason` field rename and
the binary export path have not been touched by a human at all.**

The harness in **#559 / #560** covers the transport for those routes, but **no human has
clicked them in the BCC.** A green harness is not the same claim as an exercised UI, and
this PR does not make that claim.

**#550 stays in draft.** The remaining steps are a second pass, not a formality.

---

## Known gap carried forward (unchanged)

**Forbidden is still not a distinct state in this build** — a 403 renders through the
generic red couldn't-load treatment. That is not a fabrication and does not violate this
PR's scope, but it does not meet the parity bar. Tracked in **#558**, blocked on the
capabilities endpoint (**#547**).

