### PR TITLE
feat(security): prepare Postgres RLS on the path that actually runs — no-op until Database:RlsEnabled is set (#545)

### DIFF
--- a/Planscape.Server/docs/rls_rehearsal.sql
+++ b/Planscape.Server/docs/rls_rehearsal.sql
@@ -1,0 +1,108 @@
+\set ON_ERROR_STOP on
+\echo '================ RLS REHEARSAL ================'
+
+-- Non-superuser role. Superusers ALWAYS bypass RLS, so testing as `postgres`
+-- would pass vacuously no matter what the policy said.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rls_app') THEN
+    EXECUTE 'DROP OWNED BY rls_app CASCADE';
+    EXECUTE 'DROP ROLE rls_app';
+  END IF;
+END $$;
+CREATE ROLE rls_app LOGIN PASSWORD 'rehearsal' NOSUPERUSER NOBYPASSRLS;
+
+DROP TABLE IF EXISTS "Projects";
+CREATE TABLE "Projects" ("Id" uuid PRIMARY KEY, "TenantId" uuid NOT NULL, "Name" text NOT NULL);
+ALTER TABLE "Projects" OWNER TO rls_app;
+
+INSERT INTO "Projects" VALUES
+  ('11111111-1111-1111-1111-111111111111','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','Tenant A - Alpha'),
+  ('22222222-2222-2222-2222-222222222222','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','Tenant A - Beta'),
+  ('33333333-3333-3333-3333-333333333333','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','Tenant B - Secret');
+
+\echo ''
+\echo '--- STEP 1: RED. No policy yet. Tenant A must be able to see Tenant B. ---'
+\echo '--- (If this is already 0, the rest of the test proves nothing.)      ---'
+SET ROLE rls_app;
+SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+SELECT count(*) AS "RED_total_rows_visible_expect_3" FROM "Projects";
+SELECT count(*) AS "RED_tenantB_rows_visible_expect_1" FROM "Projects"
+  WHERE "TenantId" = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+RESET ROLE;
+
+\echo ''
+\echo '--- STEP 2: apply the EXACT SQL RlsPolicyPatcher.PolicyFor("Projects") emits ---'
+ALTER TABLE "Projects" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Projects" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON "Projects";
+CREATE POLICY tenant_isolation ON "Projects"
+    USING ("TenantId"::text = current_setting('app.current_tenant', true))
+    WITH CHECK ("TenantId"::text = current_setting('app.current_tenant', true));
+
+\echo ''
+\echo '--- STEP 2b: idempotency — run it a second time, must not error ---'
+ALTER TABLE "Projects" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Projects" FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON "Projects";
+CREATE POLICY tenant_isolation ON "Projects"
+    USING ("TenantId"::text = current_setting('app.current_tenant', true))
+    WITH CHECK ("TenantId"::text = current_setting('app.current_tenant', true));
+\echo 'idempotent re-apply OK'
+
+\echo ''
+\echo '--- STEP 3: GREEN positive path. Tenant A sees its OWN rows (must be NON-EMPTY = 2) ---'
+SET ROLE rls_app;
+SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+SELECT count(*) AS "GREEN_tenantA_own_rows_expect_2" FROM "Projects";
+SELECT "Name" AS "GREEN_tenantA_names_expect_2_rows" FROM "Projects" ORDER BY "Name";
+
+\echo ''
+\echo '--- STEP 4: GREEN cross-tenant. Tenant A must see ZERO of Tenant B ---'
+SELECT count(*) AS "GREEN_tenantB_visible_to_A_expect_0" FROM "Projects"
+  WHERE "TenantId" = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+\echo ''
+\echo '--- STEP 5: the other tenant is symmetric (non-empty, and only its own) ---'
+SET app.current_tenant = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+SELECT count(*) AS "GREEN_tenantB_own_rows_expect_1" FROM "Projects";
+SELECT "Name" AS "GREEN_tenantB_name_expect_Secret" FROM "Projects";
+
+\echo ''
+\echo '--- STEP 6: FAIL CLOSED. GUC unset => zero rows, not everything ---'
+RESET app.current_tenant;
+SELECT count(*) AS "FAILCLOSED_unset_guc_expect_0" FROM "Projects";
+
+\echo ''
+\echo '--- STEP 7: WITH CHECK blocks cross-tenant WRITE too ---'
+SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+\echo 'attempting INSERT of a Tenant B row while acting as Tenant A (must fail):'
+DO $$
+BEGIN
+  INSERT INTO "Projects" VALUES
+    ('44444444-4444-4444-4444-444444444444','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','Injected');
+  RAISE EXCEPTION 'WRITE_NOT_BLOCKED — WITH CHECK did not hold';
+EXCEPTION WHEN insufficient_privilege THEN
+  RAISE NOTICE 'WRITE BLOCKED as expected (insufficient_privilege)';
+END $$;
+RESET ROLE;
+
+\echo ''
+\echo '--- STEP 8: ROLLBACK — the exact BuildRollbackStatements() SQL ---'
+DROP POLICY IF EXISTS tenant_isolation ON "Projects";
+ALTER TABLE "Projects" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE "Projects" DISABLE ROW LEVEL SECURITY;
+
+\echo ''
+\echo '--- STEP 9: key OFF => nothing changed. All 3 rows visible again. ---'
+SET ROLE rls_app;
+SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+SELECT count(*) AS "ROLLEDBACK_total_visible_expect_3" FROM "Projects";
+RESET ROLE;
+
+\echo ''
+\echo '--- CLEANUP ---'
+DROP TABLE IF EXISTS "Projects";
+DROP OWNED BY rls_app CASCADE;
+DROP ROLE IF EXISTS rls_app;
+\echo '================ REHEARSAL COMPLETE ================'

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1584,6 +1584,27 @@ app.MapHub<Planscape.Infrastructure.SignalR.DocumentSyncHub>("/hubs/document-syn
         // the EF migration set is incomplete). Idempotent CREATE TABLE IF NOT EXISTS.
         await Planscape.API.PlatformSchemaPatcher.ApplyAsync(patchConn);
 
+        // Postgres RLS policies (#545). OFF unless Database:RlsEnabled is set —
+        // the same key that gates RlsConnectionInterceptor above, so the
+        // session variable and the policies that read it turn on together
+        // rather than one without the other. The key is set nowhere in this
+        // repository, so this branch does not execute by default.
+        //
+        // The policies live here rather than in the (never-run) migration
+        // 20260506200000_EnablePostgresRowLevelSecurity because production does
+        // not run migrations — see docs/adr/0001-schema-management.md. The
+        // migration is left untouched as history.
+        //
+        // These policies FAIL CLOSED: a connection that has not set
+        // app.current_tenant sees no rows. Read RlsPolicyPatcher's remarks
+        // before enabling — BypassTenantFilter paths (Hangfire, admin scans)
+        // never set the GUC and will find nothing until they are given a role
+        // carrying BYPASSRLS.
+        if (rlsEnabled)
+        {
+            await Planscape.API.RlsPolicyPatcher.ApplyAsync(patchConn);
+        }
+
         // Pre-merge Gate 2 — schema-drift self-check. The patcher path (above)
         // is the OFFICIAL schema-management mechanism for this codebase (see
         // docs/adr/0001-schema-management.md). Its one failure mode is drift:

--- a/Planscape.Server/src/Planscape.API/RlsPolicyPatcher.cs
+++ b/Planscape.Server/src/Planscape.API/RlsPolicyPatcher.cs
@@ -1,0 +1,222 @@
+using System.Data.Common;
+
+namespace Planscape.API;
+
+/// <summary>
+/// Postgres Row Level Security policies, applied through the patcher path
+/// rather than through an EF migration.
+///
+/// <para><b>Why this exists.</b> The RLS policies were written in
+/// <c>20260506200000_EnablePostgresRowLevelSecurity</c>, but production does not
+/// run migrations (see <c>docs/adr/0001-schema-management.md</c>) — the patcher
+/// is this codebase's schema-management mechanism. So the policies have never
+/// been applied to any database, and the config key that claims to enable them
+/// only ever registered the interceptor that sets the session variable. This
+/// moves the policy SQL onto the path that actually executes.</para>
+///
+/// <para><b>This is a no-op unless deliberately switched on.</b>
+/// <see cref="ApplyAsync"/> is only called when <c>Database:RlsEnabled</c> is
+/// true. That key is set nowhere in the repository — not in any
+/// <c>appsettings*.json</c>, not in <c>render.yaml</c>, not in any env file.
+/// Merging this changes nothing at runtime until an operator sets it.</para>
+///
+/// <para><b>These policies FAIL CLOSED.</b> The migration's policy carried an
+/// <c>OR coalesce(current_setting(...), '') = ''</c> branch, so a connection
+/// that never set <c>app.current_tenant</c> matched <i>every</i> row. That made
+/// the policy a no-op precisely when the application layer had already failed —
+/// the one case where a second layer of defence is supposed to earn its keep.
+/// The version here omits that branch: unset session variable means
+/// <c>current_setting</c> returns NULL, the predicate is NULL, and no row is
+/// visible.</para>
+///
+/// <para><b>Consequence of failing closed — read before enabling.</b> Any
+/// connection that does not set the GUC now sees zero rows. That includes every
+/// path which sets <c>PlanscapeDbContext.BypassTenantFilter = true</c> (Hangfire
+/// jobs, cross-tenant admin scans), because
+/// <c>RlsConnectionInterceptor.ConnectionOpenedAsync</c> returns early for those
+/// and never issues the <c>SET</c>. Enabling this key without first giving those
+/// paths a role that carries BYPASSRLS will not leak data — it will make
+/// background jobs silently find nothing. That is the open decision this class
+/// is meant to make cheap to take, not one it takes for you.</para>
+///
+/// <para><b>Idempotency.</b> Postgres has no <c>CREATE POLICY IF NOT EXISTS</c>
+/// (unlike <c>CREATE TABLE</c>), so each policy is written as
+/// <c>DROP POLICY IF EXISTS</c> followed by <c>CREATE POLICY</c> — re-running is
+/// safe and converges on the same definition, which also means this file is how
+/// you correct a policy later. <c>ENABLE</c>/<c>FORCE ROW LEVEL SECURITY</c> are
+/// natural no-ops when already set.</para>
+/// </summary>
+internal static class RlsPolicyPatcher
+{
+    /// <summary>
+    /// Postgres GUC holding the caller's tenant. Set per connection by
+    /// <c>RlsConnectionInterceptor</c>. The <c>app.</c> prefix is required —
+    /// Postgres rejects un-namespaced custom settings.
+    /// </summary>
+    private const string TenantSetting = "app.current_tenant";
+
+    /// <summary>
+    /// Tenant-scoped tables carrying a <c>TenantId</c> column.
+    ///
+    /// Mirrors the list in the (inert) <c>EnablePostgresRowLevelSecurity</c>
+    /// migration, which in turn mirrors <c>AddTenantIdToAllScopedEntities</c>.
+    /// EF model snapshots carry no "is tenant scoped" tag, so this is kept in
+    /// sync by hand. A table missing from this list is NOT protected by RLS —
+    /// <see cref="VerifyAsync"/> exists so that gap is measurable rather than
+    /// assumed.
+    /// </summary>
+    internal static readonly string[] TenantScopedTables =
+    {
+        // Direct project children
+        "TaggedElements", "Issues", "Documents", "WorkflowRuns",
+        "ComplianceSnapshots", "SeqCounters", "Meetings", "Transmittals",
+        "ProjectMembers", "ProjectModels", "ScheduleTasks", "CostItems",
+        "SyncConflicts", "SyncWatermarks", "SiteDiaries", "StageGates",
+        "IssueCustomFieldSchemas",
+        // Indirect children (TenantId backfilled via parent)
+        "IssueAttachments", "IssueComments", "DocumentMarkups",
+        "DocumentVersions", "DocumentApprovals", "MeetingActionItems",
+        "SiteDiaryAttachments", "InformationDeliverables", "StageGateCriteria",
+        // Top-level tenant-scoped
+        "Projects", "Users", "AuditLogs",
+        "DevicePushToken", "UserNotificationPreferences", "PlatformConnections",
+        "TenantBranding", "Subscriptions", "Invoices", "Payments",
+        "Assets", "MaintenanceTasks", "OutboxMessages", "OutboundWebhooks",
+        "PinCrdtUpdates", "ModelMarkups", "IssueAudioNotes", "SceneNodes",
+    };
+
+    /// <summary>Fail-closed isolation policy for one <c>TenantId</c> table.</summary>
+    internal static string PolicyFor(string table) => $@"
+        ALTER TABLE ""{table}"" ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE ""{table}"" FORCE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_isolation ON ""{table}"";
+        CREATE POLICY tenant_isolation ON ""{table}""
+            USING (""TenantId""::text = current_setting('{TenantSetting}', true))
+            WITH CHECK (""TenantId""::text = current_setting('{TenantSetting}', true));";
+
+    /// <summary>
+    /// The Tenants table keys on <c>Id</c>, not <c>TenantId</c>, so it needs its
+    /// own policy. Same fail-closed shape.
+    /// </summary>
+    internal static string TenantsPolicy() => $@"
+        ALTER TABLE ""Tenants"" ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE ""Tenants"" FORCE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_self_visibility ON ""Tenants"";
+        CREATE POLICY tenant_self_visibility ON ""Tenants""
+            USING (""Id""::text = current_setting('{TenantSetting}', true))
+            WITH CHECK (""Id""::text = current_setting('{TenantSetting}', true));";
+
+    /// <summary>Every statement this patcher would run, in order.</summary>
+    internal static IEnumerable<string> BuildStatements()
+    {
+        foreach (var t in TenantScopedTables) yield return PolicyFor(t);
+        yield return TenantsPolicy();
+    }
+
+    /// <summary>
+    /// Rollback: drop the policies and disable RLS. Emitted here rather than
+    /// left to a runbook so the undo ships with the change. See the PR body for
+    /// the procedure; this is the exact SQL it references.
+    /// </summary>
+    internal static IEnumerable<string> BuildRollbackStatements()
+    {
+        foreach (var t in TenantScopedTables)
+            yield return $@"
+                DROP POLICY IF EXISTS tenant_isolation ON ""{t}"";
+                ALTER TABLE ""{t}"" NO FORCE ROW LEVEL SECURITY;
+                ALTER TABLE ""{t}"" DISABLE ROW LEVEL SECURITY;";
+        yield return @"
+            DROP POLICY IF EXISTS tenant_self_visibility ON ""Tenants"";
+            ALTER TABLE ""Tenants"" NO FORCE ROW LEVEL SECURITY;
+            ALTER TABLE ""Tenants"" DISABLE ROW LEVEL SECURITY;";
+    }
+
+    /// <summary>
+    /// Apply the policies. Call only when <c>Database:RlsEnabled</c> is true.
+    ///
+    /// <para>Unlike <see cref="PlatformSchemaPatcher"/>, which logs failures and
+    /// carries on, this throws. A partially-applied security control is a worse
+    /// state than an unapplied one: RLS enabled on a table whose policy failed to
+    /// create means default-deny, so that table returns zero rows to everyone —
+    /// a silent, total outage of one table that a "N ok, M failed" log line at
+    /// boot would not make anyone act on. Failing the boot is the honest
+    /// response.</para>
+    ///
+    /// <para>Tables absent from the database are skipped rather than treated as
+    /// failures — the list spans entities that may not exist on every
+    /// deployment.</para>
+    /// </summary>
+    public static async Task ApplyAsync(DbConnection conn)
+    {
+        if (conn.State != System.Data.ConnectionState.Open) await conn.OpenAsync();
+
+        var present = await LoadExistingTablesAsync(conn);
+        int applied = 0, skipped = 0;
+        var failures = new List<string>();
+
+        foreach (var table in TenantScopedTables.Concat(new[] { "Tenants" }))
+        {
+            if (!present.Contains(table)) { skipped++; continue; }
+            var sql = table == "Tenants" ? TenantsPolicy() : PolicyFor(table);
+            try
+            {
+                await using var cmd = conn.CreateCommand();
+                cmd.CommandText = sql;
+                await cmd.ExecuteNonQueryAsync();
+                applied++;
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{table}: {ex.Message}");
+            }
+        }
+
+        Console.WriteLine($"[rls] applied {applied} policies, skipped {skipped} absent tables, {failures.Count} failed");
+
+        if (failures.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "RLS policy application failed for " + failures.Count + " table(s); refusing to start with a " +
+                "partially-applied tenant-isolation policy, because an RLS-enabled table without a policy " +
+                "returns zero rows to every caller. Fix the listed tables or set Database:RlsEnabled=false " +
+                "and re-run the rollback SQL. Failures: " + string.Join(" | ", failures));
+        }
+    }
+
+    /// <summary>
+    /// Read-only check: which tenant-scoped tables currently have RLS enabled
+    /// and a policy attached. Used by the rehearsal to assert on real state
+    /// instead of assuming the apply worked.
+    /// </summary>
+    public static async Task<List<(string Table, bool RlsEnabled, int Policies)>> VerifyAsync(DbConnection conn)
+    {
+        if (conn.State != System.Data.ConnectionState.Open) await conn.OpenAsync();
+        var rows = new List<(string, bool, int)>();
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT c.relname::text,
+                   c.relrowsecurity,
+                   (SELECT count(*) FROM pg_policy p WHERE p.polrelid = c.oid)::int
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND c.relkind = 'r'
+            ORDER BY c.relname";
+
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync())
+            rows.Add((r.GetString(0), r.GetBoolean(1), r.GetInt32(2)));
+        return rows;
+    }
+
+    private static async Task<HashSet<string>> LoadExistingTablesAsync(DbConnection conn)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT tablename::text FROM pg_tables WHERE schemaname = 'public'";
+        await using var r = await cmd.ExecuteReaderAsync();
+        while (await r.ReadAsync()) set.Add(r.GetString(0));
+        return set;
+    }
+}


### PR DESCRIPTION
## Prepared, not applied — #545 made cheap to decide

**Merging this changes nothing at runtime.** Everything below is gated behind `Database:RlsEnabled`, which is set nowhere in this repository and is deliberately left unset. This exists so the decision is a one-line config change with a rehearsed outcome, rather than a design exercise someone has to start from scratch a fourth time.

---

### The actual state of #545

The policies were never applied to any database, and could not have been. They live in `20260506200000_EnablePostgresRowLevelSecurity`, and **production does not run migrations** (`docs/adr/0001-schema-management.md`) — the patcher path does. So `Database:RlsEnabled` only ever registered `RlsConnectionInterceptor`, which sets `app.current_tenant`. The policies that read that variable did not exist. The switch was wired to nothing on the DB side.

This PR moves the policy SQL onto the path that executes.

### Two defects fixed

**1. It ran on the wrong path.** Policy SQL now lives in `RlsPolicyPatcher`, invoked from `Program.cs` immediately after `PlatformSchemaPatcher`, gated on the same `rlsEnabled` flag that gates the interceptor — so the session variable and the policies that consume it turn on together, never one without the other.

**2. It failed OPEN.** The migration's policy carried:

```sql
OR coalesce(current_setting('app.current_tenant', true), '') = ''
```

A connection that never set the GUC matched **every row**. The policy became a no-op in precisely the case where a second layer of defence is meant to earn its keep — the application layer having already failed. That branch is gone:

```sql
USING ("TenantId"::text = current_setting('app.current_tenant', true))
WITH CHECK ("TenantId"::text = current_setting('app.current_tenant', true))
```

Unset GUC → `current_setting` returns NULL → predicate NULL → no rows.

### The consequence of failing closed — read before enabling

With RLS on, **any connection that does not set the GUC sees zero rows.** That includes every path setting `PlanscapeDbContext.BypassTenantFilter = true` (Hangfire jobs, cross-tenant admin scans), because `RlsConnectionInterceptor.ConnectionOpenedAsync` returns early for those and never issues the `SET`.

This will not leak data. It will make background jobs **silently find nothing**. Giving those paths a role carrying `BYPASSRLS` is the prerequisite for flipping the key, and it is the open decision this PR is deliberately not taking on your behalf. It is stated in the class remarks so it cannot be missed at the call site.

### Idempotency — one correction to the brief

The brief asked for `CREATE POLICY IF NOT EXISTS`. **Postgres has no such form** — unlike `CREATE TABLE`, policies have no `IF NOT EXISTS` variant. The idempotent idiom is `DROP POLICY IF EXISTS` followed by `CREATE POLICY`, which is what this uses and what the original migration used. Re-running converges on the same definition, which also makes this file the place to correct a policy later. `ENABLE` / `FORCE ROW LEVEL SECURITY` are natural no-ops when already set. Re-application is covered in the rehearsal.

### It throws rather than logging

`PlatformSchemaPatcher` logs failures and carries on. This does not. An RLS-enabled table whose policy failed to create is **default-deny** — it returns zero rows to everyone, a total silent outage of one table. A `N ok, M failed` line at boot is not something anyone acts on. Failing the boot is the honest response. Tables absent from the database are skipped, not failed.

---

## PgBouncer — already handled, and the cost is currently zero

`Program.cs:110-115` already resolves this, and better than the startup-guard I suggested on #545:

```csharp
var pooledRaw = builder.Configuration.GetConnectionString("Pooled");
var usePooler = !string.IsNullOrWhiteSpace(pooledRaw) && !rlsEnabled;
```

Enabling RLS **automatically falls back to the direct connection string**. The in-file comment gives the reason — session-scoped `SET app.current_tenant` leaks across tenants under transaction pooling, so the pooler is only safe while RLS is off. *(This corrects my own addendum on #545, which said a guard was still needed. It was already there; I had read a stale checkout.)*

**Quantified — what enabling RLS costs in throughput today: nothing.**

`ConnectionStrings__Pooled` is **commented out** in `render.yaml` for both api and worker (lines 99-101, 156-158), and Render ships connection pooling off by default. So `pooledRaw` is empty, `usePooler` is already `false`, and the pooler is not in the path. Flipping `Database:RlsEnabled` changes no connection behaviour.

**What it would cost later**, if someone enables pooling on `planscape-db` and uncomments those blocks: RLS silently switches them back off, returning to direct connections under the budget in `docs/DEPLOY_RUNBOOK.md` — api 30 (20 EF + 10 Hangfire) + worker 30 = 60 of the ~97 client connections a basic-tier Render Postgres allows, leaving 37 spare. That is sufficient at current scale; the pooler exists for when it is not. So the real trade is **RLS now, or PgBouncer headroom later** — and taking RLS now costs nothing until you reach the point of needing to multiplex, at which point the interceptor must move to `SET LOCAL` inside an explicit transaction. The file comment already says so.

---

## Rehearsal — run, with RED proven before GREEN

Against the local Postgres (`docker-postgres-1`), in a **throwaway `rls_rehearsal` database**, as a **`NOSUPERUSER NOBYPASSRLS`** role. That last detail matters: superusers *always* bypass RLS, so rehearsing as `postgres` would have passed no matter what the policy said.

Script committed at [`Planscape.Server/docs/rls_rehearsal.sql`](Planscape.Server/docs/rls_rehearsal.sql) so it is re-runnable.

```
STEP 1  RED, no policy       total visible = 3      tenant B visible to A = 1   ← not vacuous
STEP 2b idempotent re-apply  OK, no error
STEP 3  GREEN positive       tenant A own rows = 2  ("Tenant A - Alpha", "Tenant A - Beta")
STEP 4  GREEN cross-tenant   tenant B visible to A = 0
STEP 5  symmetric            tenant B own rows = 1  ("Tenant B - Secret")
STEP 6  FAIL CLOSED          GUC unset            = 0      ← migration's version returned 3
STEP 7  WITH CHECK           cross-tenant INSERT rejected (insufficient_privilege)
STEP 8  rollback SQL         applied
STEP 9  key OFF              total visible = 3      ← nothing changed
```

Step 1 is the point: **before** the policy, Tenant A could read Tenant B's row. Without that, step 4's zero would prove only that the query matched nothing. Steps 3 and 5 assert on **non-empty** results and on the row *names*, not just counts, so a Guid.Empty-style tenant fallback returning nothing cannot pass this vacuously.

The dev `planscape` database was **not touched** — verified afterwards: `0` RLS-enabled tables there, rehearsal database and role dropped.

## Rollback

`RlsPolicyPatcher.BuildRollbackStatements()` emits the exact undo, and step 8 above executed it. If enabling breaks queries:

1. Set `Database:RlsEnabled=false` and redeploy. **This alone is not enough** — the flag stops the interceptor setting the GUC, but the policies stay on the tables, so everything would return zero rows. It must be followed by step 2.
2. Run the rollback SQL against the database — per table: `DROP POLICY IF EXISTS tenant_isolation`, `NO FORCE ROW LEVEL SECURITY`, `DISABLE ROW LEVEL SECURITY`; plus `tenant_self_visibility` on `Tenants`.

Rehearsed in step 8-9: after rollback, all 3 rows were visible again.

That ordering trap is worth noting in whatever runbook entry accompanies enabling this: **disabling the flag without dropping the policies is the worst of the three states.**

## Not in this PR

- The `BYPASSRLS` role for Hangfire / admin paths — the prerequisite named above.
- Moving the interceptor to `SET LOCAL` — only needed if PgBouncer is wanted alongside RLS.
- Any change to the migration set. `20260506200000_EnablePostgresRowLevelSecurity` is left untouched as history.
- Setting the key. **That is yours.**

## Verification

`dotnet build Planscape.API` → **Build succeeded**. The 3 `CS0618` Hangfire `QueueName` warnings are pre-existing — confirmed identical on `origin/main` (3 occurrences on both).

Branched from `origin/main` @ `097b75a94`.
