### PR TITLE
chore: ignore CompiledPlugin.bak-* redeploy backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,13 @@ build_output.txt
 # and gets COPIED here during build — the source is what we ship.
 CompiledPlugin/
 
+# Pre-redeploy backups of the above (CompiledPlugin.bak-<sha|label>/). Same
+# disposable build output, but `CompiledPlugin/` does not match them, so each
+# one shows up as ~18 MB of untracked DLL waiting to be committed by accident.
+# PR #501 covers the sibling `CompiledPlugin_backup_*` naming; this covers the
+# `.bak-` form the deploy steps actually produce.
+CompiledPlugin.bak-*/
+
 # Claude Code session worktrees + local settings.
 .claude/worktrees/
 .claude/settings.local.json


### PR DESCRIPTION
One line of `.gitignore`, on its own, ahead of anything else touching the tree.

## Why now

`CompiledPlugin/` is ignored (twice, at `.gitignore:11` and `:50`). The **pre-redeploy backups beside it are not** — the pattern does not match `CompiledPlugin.bak-<sha|label>/`.

Two are on disk in the shared checkout right now:

```
CompiledPlugin.bak-bf697ad4b/     (pre-existing)
CompiledPlugin.bak-pre-pr550/     (created during the #550 deploy)
```

Each carries an ~18 MB `StingTools.dll`. Both show as untracked, and both are one `git add -A` away from being committed — easy to do, annoying to undo once an 18 MB binary is in history.

## Not a duplicate of #501

**#501 ignores `CompiledPlugin_backup_*/`** — a different naming convention. Neither pattern matches the other's directories, so the two are complementary and **#501 is still wanted**. I checked its diff rather than assuming overlap; this deliberately does not subsume it.

The `.bak-` form is what the documented deploy steps in #550 actually produce, which is why it needs covering now.

## Scope

`.gitignore` only. No code, no behaviour, nothing to verify beyond `git status` no longer listing the backup directories.

Branched from `origin/main` @ `097b75a94`.