### PR TITLE
test(bcc): headless transport harness for the site-photo client — 11 pass / 3 skip, and 11 fail against main

### DIFF
--- a/StingTools.SitePhotos.Tests/CaptureServer.cs
+++ b/StingTools.SitePhotos.Tests/CaptureServer.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace StingTools.SitePhotos.Tests;
+
+/// <summary>
+/// A minimal in-process HTTP server the client can be pointed at.
+///
+/// It exists for one reason the real docker stack cannot serve: proving a
+/// NEGATIVE. "The client-side guard fired before any request was made" is only
+/// demonstrable by counting the requests that arrived, and that requires owning
+/// the server. Every request is recorded with its method and path.
+///
+/// It also lets the export tests hand back an exact byte sequence (a real PDF
+/// header, or a deliberately empty body) which a live server will not reproduce
+/// on demand.
+/// </summary>
+public sealed class CaptureServer : IDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<(string Method, string Path)> _requests = new();
+    private readonly object _lock = new();
+
+    /// <summary>Handlers keyed by path suffix; first match wins. Return (status, contentType, body).</summary>
+    public List<(Func<string, bool> Match, Func<HttpListenerRequest, (int Status, string ContentType, byte[] Body)> Handle)> Routes { get; } = new();
+
+    public string BaseUrl { get; }
+
+    public CaptureServer()
+    {
+        var port = FreePort();
+        BaseUrl = $"http://127.0.0.1:{port}";
+        _listener.Prefixes.Add(BaseUrl + "/");
+        _listener.Start();
+        _ = Task.Run(LoopAsync);
+
+        // Auth is not what these tests are about, but every client method calls
+        // EnsureAuthenticatedAsync() before its guards, so a session has to exist
+        // or every assertion would collapse into "Not connected."
+        Routes.Add((p => p.EndsWith("/api/auth/login", StringComparison.OrdinalIgnoreCase),
+            _ => (200, "application/json", Encoding.UTF8.GetBytes(
+                "{\"accessToken\":\"" + FakeJwt() + "\"," +
+                "\"refreshToken\":\"r\"," +
+                "\"expiresAt\":\"" + DateTime.UtcNow.AddHours(8).ToString("o") + "\"," +
+                "\"userName\":\"harness@test\",\"tier\":\"Professional\"}"))));
+    }
+
+    /// <summary>Requests seen so far, oldest first.</summary>
+    public IReadOnlyList<(string Method, string Path)> Requests
+    {
+        get { lock (_lock) return _requests.ToArray(); }
+    }
+
+    public int RequestCount { get { lock (_lock) return _requests.Count; } }
+
+    /// <summary>Paths seen since a marker count — the basis of "no call was made".</summary>
+    public IReadOnlyList<string> PathsSince(int marker)
+    {
+        lock (_lock)
+        {
+            var outp = new List<string>();
+            for (int i = marker; i < _requests.Count; i++) outp.Add(_requests[i].Path);
+            return outp;
+        }
+    }
+
+    /// <summary>Stop accepting connections — used to simulate the API going down mid-session.</summary>
+    public void Kill()
+    {
+        try { _cts.Cancel(); } catch { }
+        try { _listener.Stop(); } catch { }
+        try { _listener.Close(); } catch { }
+    }
+
+    private async Task LoopAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            HttpListenerContext ctx;
+            try { ctx = await _listener.GetContextAsync().ConfigureAwait(false); }
+            catch { return; } // listener stopped
+
+            var path = ctx.Request.Url?.AbsolutePath ?? "";
+            lock (_lock) _requests.Add((ctx.Request.HttpMethod, path));
+
+            int status = 404;
+            string contentType = "application/json";
+            byte[] body = Encoding.UTF8.GetBytes("{\"error\":\"no_route\"}");
+
+            foreach (var (match, handle) in Routes)
+            {
+                if (!match(path)) continue;
+                try { (status, contentType, body) = handle(ctx.Request); }
+                catch (Exception ex)
+                {
+                    status = 500;
+                    body = Encoding.UTF8.GetBytes("{\"error\":\"" + ex.Message.Replace("\"", "'") + "\"}");
+                }
+                break;
+            }
+
+            try
+            {
+                ctx.Response.StatusCode = status;
+                ctx.Response.ContentType = contentType;
+                ctx.Response.ContentLength64 = body.Length;
+                await ctx.Response.OutputStream.WriteAsync(body, 0, body.Length).ConfigureAwait(false);
+                ctx.Response.OutputStream.Close();
+            }
+            catch { /* client hung up */ }
+        }
+    }
+
+    /// <summary>
+    /// Three base64url segments so ParseTenantAndUser can split it. Its body is a
+    /// real JSON payload with a tenant id, because the client decodes it — a
+    /// malformed token is swallowed there, but a valid one keeps the test honest
+    /// about what the client actually receives.
+    /// </summary>
+    private static string FakeJwt()
+    {
+        string B64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var payload = "{\"tenant_id\":\"" + Guid.NewGuid() + "\",\"sub\":\"" + Guid.NewGuid() + "\"}";
+        return B64("{\"alg\":\"none\",\"typ\":\"JWT\"}") + "." + B64(payload) + ".sig";
+    }
+
+    private static int FreePort()
+    {
+        var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        var p = ((IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return p;
+    }
+
+    public void Dispose() => Kill();
+}

--- a/StingTools.SitePhotos.Tests/LiveStackRoundTripTests.cs
+++ b/StingTools.SitePhotos.Tests/LiveStackRoundTripTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using StingTools.BIMManager;
+using Xunit;
+
+namespace StingTools.SitePhotos.Tests;
+
+/// <summary>
+/// Round-trip against the real docker stack. Everything here asserts on NON-EMPTY
+/// data: the tenant filter falls back to Guid.Empty in places, which makes an
+/// empty-result assertion pass without proving anything.
+///
+/// When the stack is unreachable these are REAL xUnit skips carrying the URL that
+/// was probed — not a conditionally-excluded class, and not a silently empty run.
+/// Read the skip count, not just the failure count.
+/// </summary>
+public class LiveStackRoundTripTests
+{
+    private const string StackUrl = "http://localhost:5000";
+    private const string Email    = "admin@planscape.demo";
+    private const string Password = "admin123";
+
+    private static PlanscapeServerClient Client => PlanscapeServerClient.Instance;
+
+    private static async Task<string> StackUnavailableReasonAsync()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(4) };
+            var r = await http.GetAsync($"{StackUrl}/health");
+            if (!r.IsSuccessStatusCode)
+                return $"docker stack at {StackUrl}/health returned HTTP {(int)r.StatusCode} — start it with: " +
+                       "docker compose -f Planscape.Server/docker/docker-compose.yml up -d";
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return $"docker stack at {StackUrl}/health is unreachable ({ex.GetType().Name}: {ex.Message}) — start it with: " +
+                   "docker compose -f Planscape.Server/docker/docker-compose.yml up -d";
+        }
+    }
+
+    private static async Task<(bool ok, string reason)> LoginAsync()
+    {
+        var down = await StackUnavailableReasonAsync();
+        if (down != null) return (false, down);
+        if (!await Client.LoginAsync(StackUrl, Email, Password))
+            return (false, $"login as {Email} against {StackUrl} failed: {Client.LastError}");
+        return (true, null);
+    }
+
+    private static async Task<Guid> FirstProjectIdAsync()
+    {
+        var projects = await Client.GetProjectsAsync();
+        if (projects == null || projects.Count == 0) return Guid.Empty;
+        var id = projects[0]["id"]?.Value<string>() ?? projects[0]["Id"]?.Value<string>();
+        return Guid.TryParse(id, out var g) ? g : Guid.Empty;
+    }
+
+    [SkippableFact]
+    public async Task Create_then_list_then_detail_round_trips_with_non_empty_results()
+    {
+        var (ok, reason) = await LoginAsync();
+        Skip.IfNot(ok, reason);
+
+        var projectId = await FirstProjectIdAsync();
+        Skip.If(projectId == Guid.Empty,
+            $"logged in as {Email} but the stack has no projects to test against — seed one first");
+
+        var name = $"harness-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
+
+        // CREATE — the default visibility must be the server's own default.
+        var created = await Client.CreatePhotoAlbumAsync(projectId, name, "created by the transport harness");
+        Assert.True(created != null, $"album create failed: {Client.LastError}");
+        Assert.NotEqual(Guid.Empty, created!.Id);
+        Assert.Equal(name, created.Name);
+        Assert.False(string.IsNullOrWhiteSpace(created.Visibility));
+        Assert.Contains(created.Visibility, new[] { "Internal", "Members", "Client", "Distribution" });
+
+        // LIST — must be non-empty AND must contain what we just made. A count>0
+        // assertion alone would pass on somebody else's data.
+        var albums = await Client.ListPhotoAlbumsAsync(projectId);
+        Assert.True(albums != null, $"album list failed: {Client.LastError}");
+        Assert.NotEmpty(albums!);
+        Assert.Contains(albums!, a => a.Id == created.Id);
+
+        // DETAIL — GetOne returns a wrapper { album, photos, ndaRequiredIds };
+        // mapping it flat yields a plausible, empty, wrong DTO.
+        var detail = await Client.GetPhotoAlbumAsync(projectId, created.Id);
+        Assert.True(detail != null, $"album detail failed: {Client.LastError}");
+        Assert.Equal(created.Id, detail!.Id);
+        Assert.Equal(name, detail.Name);
+    }
+
+    [SkippableFact]
+    public async Task Lock_then_unlock_round_trips_against_the_live_stack()
+    {
+        var (ok, reason) = await LoginAsync();
+        Skip.IfNot(ok, reason);
+
+        var projectId = await FirstProjectIdAsync();
+        Skip.If(projectId == Guid.Empty, "no projects on the stack to test against");
+
+        var name = $"harness-lock-{Guid.NewGuid():N}".Substring(0, 30);
+        var album = await Client.CreatePhotoAlbumAsync(projectId, name);
+        Assert.True(album != null, $"album create failed: {Client.LastError}");
+
+        Assert.True(await Client.LockPhotoAlbumAsync(projectId, album!.Id, true),
+            $"lock failed: {Client.LastError}");
+        var locked = await Client.GetPhotoAlbumAsync(projectId, album.Id);
+        Assert.True(locked != null, $"detail after lock failed: {Client.LastError}");
+        Assert.True(locked!.IsLocked, "album did not report locked after POST /lock");
+
+        Assert.True(await Client.LockPhotoAlbumAsync(projectId, album.Id, false),
+            $"unlock failed: {Client.LastError}");
+        var unlocked = await Client.GetPhotoAlbumAsync(projectId, album.Id);
+        Assert.True(unlocked != null, $"detail after unlock failed: {Client.LastError}");
+        Assert.False(unlocked!.IsLocked, "album still reports locked after POST /unlock");
+    }
+
+    [SkippableFact]
+    public async Task Checklists_list_and_detail_are_reachable_and_self_consistent()
+    {
+        var (ok, reason) = await LoginAsync();
+        Skip.IfNot(ok, reason);
+
+        var projectId = await FirstProjectIdAsync();
+        Skip.If(projectId == Guid.Empty, "no projects on the stack to test against");
+
+        var checklists = await Client.ListPhotoChecklistsAsync(projectId);
+
+        // Reachability is the assertion that always holds: non-null means the call
+        // succeeded. Non-EMPTY needs seed data, so its absence is a visible skip
+        // rather than a vacuous pass.
+        Assert.True(checklists != null, $"checklist list failed: {Client.LastError}");
+
+        Skip.If(checklists!.Count == 0,
+            $"project {projectId} has no photo checklists — fulfil cannot be exercised without seed data. " +
+            "Create one in the app, or seed one, then re-run.");
+
+        var first = checklists[0];
+        Assert.NotEqual(Guid.Empty, first.Id);
+        Assert.False(string.IsNullOrWhiteSpace(first.Name));
+        Assert.True(first.Done <= first.Total,
+            $"checklist '{first.Name}' reports Done={first.Done} > Total={first.Total}");
+    }
+
+    [SkippableFact]
+    public async Task Distribution_groups_list_is_reachable()
+    {
+        var (ok, reason) = await LoginAsync();
+        Skip.IfNot(ok, reason);
+
+        var projectId = await FirstProjectIdAsync();
+        Skip.If(projectId == Guid.Empty, "no projects on the stack to test against");
+
+        var groups = await Client.ListDistributionGroupsAsync(projectId);
+
+        // Non-null is the real assertion: null means the call failed, and the Admin
+        // sub-tab must render that as an error rather than "no groups yet".
+        Assert.True(groups != null, $"distribution group list failed: {Client.LastError}");
+    }
+}

--- a/StingTools.SitePhotos.Tests/SitePhotoTransportTests.cs
+++ b/StingTools.SitePhotos.Tests/SitePhotoTransportTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StingTools.BIMManager;
+using Xunit;
+
+// PlanscapeServerClient is a process-wide singleton holding one HttpClient and one
+// session. Parallel classes would race each other's base URL and token.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace StingTools.SitePhotos.Tests;
+
+public class SitePhotoTransportTests
+{
+    private static PlanscapeServerClient Client => PlanscapeServerClient.Instance;
+
+    private static async Task<CaptureServer> AuthedServerAsync()
+    {
+        var srv = new CaptureServer();
+        var ok = await Client.LoginAsync(srv.BaseUrl, "harness@test", "pw");
+        Assert.True(ok, $"harness login failed against the capture server: {Client.LastError}");
+        Assert.True(Client.IsConnected, "client reports not connected after a 200 login");
+        return srv;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // D2 — the defect this whole PR exists to prevent.
+    // A transport failure must be reported as a failure. An empty collection
+    // is an ANSWER, and renders as "this project has no albums".
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Server_down_every_list_returns_null_with_LastError_never_an_empty_list()
+    {
+        var srv = await AuthedServerAsync();
+
+        // Authenticated first, THEN the server dies — this is the real-world shape
+        // (session established, API goes away) rather than "never connected".
+        srv.Kill();
+
+        var albums = await Client.ListPhotoAlbumsAsync(Guid.NewGuid());
+        var albumsErr = Client.LastError;
+
+        var checklists = await Client.ListPhotoChecklistsAsync(Guid.NewGuid());
+        var checklistsErr = Client.LastError;
+
+        var groups = await Client.ListDistributionGroupsAsync(Guid.NewGuid());
+        var groupsErr = Client.LastError;
+
+        // Null, not empty. The distinction is the entire point.
+        Assert.Null(albums);
+        Assert.Null(checklists);
+        Assert.Null(groups);
+
+        Assert.False(string.IsNullOrWhiteSpace(albumsErr), "ListPhotoAlbumsAsync failed without setting LastError");
+        Assert.False(string.IsNullOrWhiteSpace(checklistsErr), "ListPhotoChecklistsAsync failed without setting LastError");
+        Assert.False(string.IsNullOrWhiteSpace(groupsErr), "ListDistributionGroupsAsync failed without setting LastError");
+    }
+
+    [Fact]
+    public async Task Server_down_album_detail_returns_null_not_an_empty_album()
+    {
+        var srv = await AuthedServerAsync();
+        srv.Kill();
+
+        var album = await Client.GetPhotoAlbumAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        // A non-null album with zero photos would render as "Album is empty" over a
+        // failed load, inviting an operator to re-add photos that are already there.
+        Assert.Null(album);
+        Assert.False(string.IsNullOrWhiteSpace(Client.LastError));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Client-side guards must fire BEFORE the request.
+    // Proven by counting what arrived at the server, not by reading the message.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Invalid_album_visibility_is_refused_before_any_request_is_made()
+    {
+        using var srv = await AuthedServerAsync();
+        var marker = srv.RequestCount;               // post-login baseline
+
+        // "Project" is the value the old stub defaulted to. The server rejects it
+        // with invalid_visibility; the client should not even ask.
+        var album = await Client.CreatePhotoAlbumAsync(Guid.NewGuid(), "harness album", null, "Project");
+
+        Assert.Null(album);
+        Assert.False(string.IsNullOrWhiteSpace(Client.LastError));
+        Assert.Empty(srv.PathsSince(marker));        // ← no HTTP call was made
+    }
+
+    [Fact]
+    public async Task Valid_visibilities_are_all_accepted_by_the_guard()
+    {
+        using var srv = await AuthedServerAsync();
+        foreach (var v in new[] { "Internal", "Members", "Client", "Distribution" })
+        {
+            var marker = srv.RequestCount;
+            await Client.CreatePhotoAlbumAsync(Guid.NewGuid(), "a", null, v);
+            // The call may fail at the server (no route registered) but it must have
+            // been ATTEMPTED — otherwise the guard is rejecting a legal value.
+            Assert.True(srv.PathsSince(marker).Count > 0,
+                $"visibility '{v}' is valid per the server contract but the client refused it locally");
+        }
+    }
+
+    [SkippableFact]
+    public async Task Pdf_export_over_the_200_cap_is_refused_before_any_request_is_made()
+    {
+        using var srv = await AuthedServerAsync();
+        var marker = srv.RequestCount;
+
+        var tooMany = Enumerable.Range(0, 201).Select(_ => Guid.NewGuid()).ToList();
+        var ok = await Client.ExportPhotosAsync(Guid.NewGuid(), tooMany, "pdf");
+
+        Assert.False(ok);
+
+        // The only public overload that carries photo ids resolves an output
+        // directory (SitePhotos.cs:550) BEFORE the cap check (:575). That resolution
+        // needs a Revit document context, so in a headless host the folder guard
+        // wins and the cap is unreachable. Skip visibly rather than assert on a path
+        // this environment cannot enter -- and note the ordering, because it means a
+        // 201-photo export is refused locally either way.
+        Skip.If((Client.LastError ?? "").Contains("Could not resolve an output folder"),
+            "cap unreachable headlessly: ExportPhotosAsync(projectId, photoIds, format) resolves the "
+            + "output directory before the 200-photo PDF cap, and OutputLocationHelper needs a Revit "
+            + "document context. LastError was: " + Client.LastError);
+
+        Assert.Contains("200", Client.LastError ?? "");
+        Assert.Empty(srv.PathsSince(marker));        // ← refused before the round trip
+    }
+
+    [SkippableFact]
+    public async Task Pdf_export_at_the_cap_is_allowed_through()
+    {
+        using var srv = await AuthedServerAsync();
+        var marker = srv.RequestCount;
+
+        var atCap = Enumerable.Range(0, 200).Select(_ => Guid.NewGuid()).ToList();
+        await Client.ExportPhotosAsync(Guid.NewGuid(), atCap, "pdf");
+
+        Skip.If((Client.LastError ?? "").Contains("Could not resolve an output folder"),
+            "same headless limitation as the over-cap test: the output directory is resolved before "
+            + "the cap is evaluated. LastError was: " + Client.LastError);
+
+        // Proves the guard is a cap and not a blanket refusal — an off-by-one here
+        // would silently block legitimate 200-photo exports.
+        Assert.True(srv.PathsSince(marker).Count > 0, "a 200-photo PDF export is at the cap and must be attempted");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // lock and unlock are TWO routes, not a boolean field.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Lock_and_unlock_hit_two_distinct_routes()
+    {
+        using var srv = await AuthedServerAsync();
+        srv.Routes.Insert(0, (p => p.EndsWith("/lock") || p.EndsWith("/unlock"),
+            _ => (200, "application/json", Encoding.UTF8.GetBytes("{\"id\":\"" + Guid.NewGuid() + "\"}"))));
+
+        var albumId = Guid.NewGuid();
+
+        var m1 = srv.RequestCount;
+        await Client.LockPhotoAlbumAsync(Guid.NewGuid(), albumId, true);
+        var lockPaths = srv.PathsSince(m1);
+
+        var m2 = srv.RequestCount;
+        await Client.LockPhotoAlbumAsync(Guid.NewGuid(), albumId, false);
+        var unlockPaths = srv.PathsSince(m2);
+
+        Assert.Contains(lockPaths, p => p.EndsWith("/lock", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(unlockPaths, p => p.EndsWith("/unlock", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(lockPaths, p => p.EndsWith("/unlock", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // photo-export streams a BINARY body. It is not JSON.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Pdf_export_writes_a_real_pdf_not_json()
+    {
+        using var srv = await AuthedServerAsync();
+
+        // %PDF-1.7 header + trailer. If the client parsed this as JSON, or wrote the
+        // JSON error envelope to disk, the magic-number assertion below catches it.
+        var pdf = Encoding.ASCII.GetBytes("%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF\n");
+        srv.Routes.Insert(0, (p => p.Contains("photo-export"),
+            _ => (200, "application/pdf", pdf)));
+
+        var outPath = Path.Combine(Path.GetTempPath(), $"sp-harness-{Guid.NewGuid():N}.pdf");
+        try
+        {
+            var written = await Client.ExportPhotosAsync(Guid.NewGuid(), outPath, Guid.NewGuid(), "pdf");
+
+            Assert.False(string.IsNullOrWhiteSpace(written), $"export returned no path: {Client.LastError}");
+            Assert.True(File.Exists(outPath), "export reported success but wrote no file");
+
+            var bytes = await File.ReadAllBytesAsync(outPath);
+            Assert.True(bytes.Length > 0, "export wrote a zero-byte file");
+            Assert.Equal(pdf.Length, bytes.Length);
+
+            // Magic number — the actual proof it is a PDF and not a JSON envelope.
+            Assert.Equal((byte)'%', bytes[0]);
+            Assert.Equal((byte)'P', bytes[1]);
+            Assert.Equal((byte)'D', bytes[2]);
+            Assert.Equal((byte)'F', bytes[3]);
+        }
+        finally { try { File.Delete(outPath); } catch { } }
+    }
+
+    [Fact]
+    public async Task An_empty_200_export_is_treated_as_failure_and_leaves_no_file()
+    {
+        using var srv = await AuthedServerAsync();
+        srv.Routes.Insert(0, (p => p.Contains("photo-export"),
+            _ => (200, "application/zip", Array.Empty<byte>())));
+
+        var outPath = Path.Combine(Path.GetTempPath(), $"sp-harness-{Guid.NewGuid():N}.zip");
+        try
+        {
+            var written = await Client.ExportPhotosAsync(Guid.NewGuid(), outPath, Guid.NewGuid(), "zip");
+
+            // A 0-byte "export" is a plausible-looking artefact of a failure.
+            // Reporting success here is the same anti-pattern as an empty list.
+            Assert.True(string.IsNullOrWhiteSpace(written), "a zero-byte export reported success");
+            Assert.False(File.Exists(outPath), "a zero-byte export left a file on disk");
+            Assert.False(string.IsNullOrWhiteSpace(Client.LastError));
+        }
+        finally { try { File.Delete(outPath); } catch { } }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Share link — expiry is an ABSOLUTE instant on the wire.
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Share_link_expiry_parses_to_a_real_absolute_time_in_the_future()
+    {
+        using var srv = await AuthedServerAsync();
+        var expected = DateTime.UtcNow.AddDays(7);
+        srv.Routes.Insert(0, (p => p.Contains("photo-share-links"),
+            _ => (200, "application/json", Encoding.UTF8.GetBytes(
+                "{\"token\":\"tok_harness\",\"expiresAt\":\"" + expected.ToString("o") + "\",\"forceRedacted\":false}"))));
+
+        var link = await Client.CreatePhotoShareLinkAsync(Guid.NewGuid(), Guid.NewGuid(), TimeSpan.FromDays(7), "harness");
+
+        Assert.NotNull(link);
+        Assert.False(string.IsNullOrWhiteSpace(link!.Token));
+        Assert.NotEqual(default, link.ExpiresAt);                       // not an unparsed zero
+        Assert.True(link.ExpiresAt.ToUniversalTime() > DateTime.UtcNow, // a real future instant
+            $"share link expiry is not in the future: {link.ExpiresAt:o}");
+        Assert.True(Math.Abs((link.ExpiresAt.ToUniversalTime() - expected).TotalMinutes) < 5,
+            $"expiry drifted from the wire value: got {link.ExpiresAt:o}, wire said {expected:o}");
+    }
+}

--- a/StingTools.SitePhotos.Tests/StingTools.SitePhotos.Tests.csproj
+++ b/StingTools.SitePhotos.Tests/StingTools.SitePhotos.Tests.csproj
@@ -1,0 +1,83 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Headless transport tests for the BCC site-photo client.
+
+    WHY <Reference> AND NOT <Compile Include>:
+    Every other plugin-facing test project in this repo pulls source files in with
+    <Compile Include="..\StingTools\..."> to dodge a Revit reference. That trick is
+    what broke StingTools.Clash.Tests and StingTools.Routing.Tests — see issue #553
+    — because the included sources later grew Revit dependencies and the projects
+    stopped compiling, silently taking 97 tests offline.
+
+    It cannot work here regardless: the six Site-Photos DTOs are declared in
+    StingTools/Core/MergeRecoveryStubs.cs, which imports Autodesk.Revit.DB and
+    declares Document / ElementId / IExternalEventHandler members. Including it
+    would require the Revit API on the test host.
+
+    Referencing the BUILT assembly avoids all of it. PlanscapeServerClient and all
+    ten of its partials import zero Revit or WPF namespaces, so the CLR never loads
+    a Revit assembly — verified by instantiating the client and driving it outside
+    Revit before this project was written.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>StingTools.SitePhotos.Tests</AssemblyName>
+    <RootNamespace>StingTools.SitePhotos.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <!--
+    HintPath is pinned to $(MSBuildThisFileDirectory) so it resolves the same from
+    any working directory (CI checks out and runs from the repo root; a developer
+    runs from the project folder). Release is preferred, Debug is the fallback, so
+    the harness works against whichever configuration was last built.
+  -->
+  <PropertyGroup>
+    <StingToolsDllRelease>$(MSBuildThisFileDirectory)..\StingTools\bin\Release\StingTools.dll</StingToolsDllRelease>
+    <StingToolsDllDebug>$(MSBuildThisFileDirectory)..\StingTools\bin\Debug\StingTools.dll</StingToolsDllDebug>
+    <!-- Explicit override, e.g. to run the harness against a different build:
+         dotnet test -p:StingToolsDllOverride=C:\path\to\StingTools.dll
+         Used to demonstrate the harness going RED against a build that still has
+         the empty-list stubs, and GREEN against one that does not. -->
+    <StingToolsDll Condition="'$(StingToolsDllOverride)' != ''">$(StingToolsDllOverride)</StingToolsDll>
+    <StingToolsDll Condition="'$(StingToolsDll)' == '' And Exists('$(StingToolsDllRelease)')">$(StingToolsDllRelease)</StingToolsDll>
+    <StingToolsDll Condition="'$(StingToolsDll)' == '' And Exists('$(StingToolsDllDebug)')">$(StingToolsDllDebug)</StingToolsDll>
+  </PropertyGroup>
+
+  <!--
+    If the plugin has not been built, FAIL THE BUILD with a message that names both
+    paths and the command that fixes it.
+
+    This is deliberately a build error and not a runtime skip. A <Reference> to a
+    missing assembly cannot be skipped at runtime — the project simply would not
+    compile — and a project that does not compile reports nothing at all, which is
+    precisely the #553 failure mode. A named error is the loudest available signal.
+  -->
+  <Target Name="AssertStingToolsBuilt" BeforeTargets="ResolveAssemblyReferences">
+    <Error Condition="'$(StingToolsDll)' == ''"
+           Text="StingTools.dll not found. Looked at:%0A  $(StingToolsDllRelease)%0A  $(StingToolsDllDebug)%0ABuild the plugin first:%0A  dotnet build StingTools/StingTools.csproj -c Release%0A(The plugin build needs the Revit API assemblies; these tests do not.)" />
+    <Message Importance="high" Text="[sitephotos-tests] referencing $(StingToolsDll)" />
+  </Target>
+
+  <ItemGroup>
+    <Reference Include="StingTools">
+      <HintPath>$(StingToolsDll)</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- Runtime-conditional skips that appear as REAL skips with a reason,
+         rather than a conditionally-excluded class that vanishes silently. -->
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Replaces most of #550's manual pass with tests. The client is Revit-free, so the transport-level acceptance criteria do not need a human clicking through Revit — and they should not be a one-time observation that evaporates.

## Results — read the skip count, not just the failures

| Referenced build | Passed | **Skipped** | Failed |
|---|---|---|---|
| **#550** (`claude/bcc-sitephotos-real-http`) | **11** | **3** | **0** |
| **main** (pre-#550, still has the stubs) | 2 | 1 | **11** |

Both runs were real; neither is a projection.

## RED before GREEN

Against main's build the harness fails on exactly the defect it exists to catch:

```
Server_down_every_list_returns_null_with_LastError_never_an_empty_list
  Assert.Null() Failure: Value is not null
  Expected: null
  Actual:   []
```

`[]` is the stub's `new List<T>()` — a confident, empty, wrong answer rendering as *"this project has no albums"* while the server is unreachable. That is what the harness is for, and it detects it.

## What it asserts

- **The D2 negative case.** Authenticate, *then* kill the server — the real-world shape, not "never connected". Every list method (`albums`, `checklists`, `distribution groups`) returns `null` with `LastError` set. Album detail returns `null`, not an empty album, because *"Album is empty"* over a failed load invites re-adding photos that are already there.
- **Guards fire before the request** — proven by counting what arrived at an in-process capture server, not by reading the error string. Invalid visibility (`"Project"`, the old stub default) makes **zero** HTTP calls. All four valid visibilities *are* attempted, so the guard is not over-refusing.
- **lock and unlock hit two distinct routes**, and the lock call does not touch `/unlock`.
- **photo-export is binary.** A `%PDF` magic-number assertion proves a real PDF was written rather than a JSON envelope. A zero-byte `200` is reported as failure and leaves no file on disk.
- **Share-link expiry** parses to a real absolute instant, in the future, matching the wire value — not an unparsed `default`.
- **Live round-trip** against the docker stack with real credentials: create → list → detail, and lock → unlock. Asserts **non-empty**, and that the list *contains the album just created* — a `count > 0` assertion alone would pass on somebody else's data, and the `Guid.Empty` tenant fallback makes empty-result assertions pass vacuously.

## Why `<Reference>` and not `<Compile Include>`

Every other plugin-facing test project pulls source in with `<Compile Include="..\StingTools\...">`. That is what broke `Clash.Tests` and `Routing.Tests` (**#553**) — the included sources later grew Revit dependencies and **97 tests silently stopped running**.

It could not work here regardless: all six Site-Photos DTOs are declared in `Core/MergeRecoveryStubs.cs`, which imports `Autodesk.Revit.DB` and declares `Document` / `ElementId` / `IExternalEventHandler` members. Referencing the built assembly sidesteps it **with no refactor** — the DTOs stay where they are.

## Skips are visible, never silent

- Every conditional skip is a **real xUnit skip with a reason**, carrying the URL or path it probed. No conditionally-excluded classes; no silently empty runs.
- **A missing plugin DLL fails the BUILD**, not the test run, with a message naming both paths and the fix. A `<Reference>` to a missing assembly cannot be skipped at runtime, and a project that does not compile reports nothing — the #553 failure mode. Verified by building without the plugin present:

```
error : StingTools.dll not found. Looked at:
error :   ...\StingTools\bin\Release\StingTools.dll
error :   ...\StingTools\bin\Debug\StingTools.dll
error : Build the plugin first:
error :   dotnet build StingTools/StingTools.csproj -c Release
```

### The 3 skips, and why

1–2. **The 200-photo PDF cap.** The only public overload carrying photo ids resolves an output directory (`SitePhotos.cs:550`) **before** the cap check (`:575`), and `OutputLocationHelper` needs a Revit document context. Headlessly the folder guard wins, so the cap is unreachable. Both tests skip with that reason rather than assert on a path this host cannot enter. Worth noting the ordering is not a defect — a 201-photo export is still refused locally either way — but the cap itself is only exercisable inside Revit.

3. **Checklist fulfil.** The stack has no seeded photo checklist. The test asserts reachability (non-null) unconditionally and skips the fulfil assertion with a reason, rather than passing vacuously on an empty list.

## Portability

`HintPath` is pinned to `$(MSBuildThisFileDirectory)`, so it resolves identically from the repo root or the project folder, preferring Release and falling back to Debug. `-p:StingToolsDllOverride=<path>` targets a specific build — that is how the RED/GREEN table above was produced.

**Stated plainly: this needs the plugin built first, so it inherits the plugin's Revit-API-at-build-time requirement.** If CI cannot build the plugin, this project cannot build there either. It will fail loudly with the message above rather than quietly run zero tests — but it is not a project that can be dropped into a Revit-less CI runner unchanged.

## Reduces, does not replace, the manual pass

#550's manual checklist drops to three items that need a rendered UI: a failed load shows a visible red error rather than an empty list; the create dialog's visibility default reads **Members**; and a failed album detail does not say *"Album is empty"*. Everything else is covered above.

#550 stays draft until this is green and those three are confirmed.

Branched from `origin/main` @ `097b75a94`.