### PR TITLE
fix(bcc): validate the export selection before resolving an output folder (stacked on #550)

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
@@ -544,7 +544,18 @@ namespace StingTools.BIMManager
             if (!await EnsureAuthenticatedAsync()) { LastError = "Not connected."; return false; }
 
             var ids = photoIds?.Distinct().ToArray();
-            var ext  = string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase) ? "pdf" : "zip";
+            var isPdfExport = string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase);
+
+            // Validate the SELECTION before touching the environment. Resolving an
+            // output directory can fail for reasons that have nothing to do with the
+            // request (no Revit document context, no writable folder), and when it
+            // did run first, a user who selected 201 photos for a PDF was told
+            // "Could not resolve an output folder" instead of that the cap is 200.
+            // Cheap, deterministic validation belongs ahead of environment-dependent
+            // validation regardless of what it does for testability.
+            if (ExportSelectionRejected(null, ids, isPdfExport)) return false;
+
+            var ext  = isPdfExport ? "pdf" : "zip";
             var name = $"photos-{DateTime.Now:yyyyMMdd-HHmmss}.{ext}";
 
             string dir;
@@ -565,20 +576,11 @@ namespace StingTools.BIMManager
         {
             var isPdf = string.Equals(format, "pdf", StringComparison.OrdinalIgnoreCase);
 
-            if (albumId == null && (photoIds == null || photoIds.Length == 0))
-            {
-                // Mirrors the server's ids_or_album_required 400, but without a round trip.
-                LastError = "Select photos or an album to export.";
-                return null;
-            }
-
-            var cap = isPdf ? MaxPhotosPerPdfExport : MaxPhotosPerZipExport;
-            if (photoIds != null && photoIds.Length > cap)
-            {
-                LastError = $"{photoIds.Length} photos selected; the server caps a "
-                          + $"{(isPdf ? "PDF" : "ZIP")} export at {cap}. Export in batches or use an album.";
-                return null;
-            }
+            // Both cheap guards now live in ExportSelectionRejected so the public
+            // overload can run them BEFORE it resolves an output directory. Kept
+            // here too: this is the last gate for the album overload, which does
+            // not go through that path.
+            if (ExportSelectionRejected(albumId, photoIds, isPdf)) return null;
 
             var http = SnapshotHttpClient();
             if (http == null) { LastError = "Not connected."; return null; }
@@ -887,6 +889,35 @@ namespace StingTools.BIMManager
         // Server-side caps, mirrored so the client can refuse before a round trip.
         // PhotoExportController.MaxPhotosPerExport / MaxPhotosPerPdf; the album and
         // bulk routes each hard-code 500.
+        /// <summary>
+        /// The two export guards that need no I/O and no network: a selection must
+        /// name photos or an album, and it must sit under the server's per-format
+        /// cap. Sets <see cref="LastError"/> and returns true when the selection is
+        /// rejected.
+        ///
+        /// Shared so the wording exists once. The messages mirror the server's
+        /// ids_or_album_required and batch_too_large[_for_pdf] responses, but are
+        /// raised without a round trip.
+        /// </summary>
+        private bool ExportSelectionRejected(Guid? albumId, Guid[]? photoIds, bool isPdf)
+        {
+            if (albumId == null && (photoIds == null || photoIds.Length == 0))
+            {
+                LastError = "Select photos or an album to export.";
+                return true;
+            }
+
+            var cap = isPdf ? MaxPhotosPerPdfExport : MaxPhotosPerZipExport;
+            if (photoIds != null && photoIds.Length > cap)
+            {
+                LastError = $"{photoIds.Length} photos selected; the server caps a "
+                          + $"{(isPdf ? "PDF" : "ZIP")} export at {cap}. Export in batches or use an album.";
+                return true;
+            }
+
+            return false;
+        }
+
         private const int MaxPhotosPerZipExport  = 500;
         private const int MaxPhotosPerPdfExport  = 200;
         private const int MaxPhotosPerAlbumAdd   = 500;


### PR DESCRIPTION
Your call was to hoist it; here it is, **stacked on #550 rather than folded into it**. Saying why explicitly, as asked.

## Why a separate PR, and why stacked rather than main-based

Two reasons, one of them decisive:

1. **You are mid-run.** #550 is deployed to `CompiledPlugin` and you are clicking through M1/M2/M3 right now. Changing its code invalidates the binary under test and would make you start over — the exact thing you wanted to avoid when you sequenced the harness ahead of the manual pass.
2. **A main-based PR is impossible.** `PlanscapeServerClient.SitePhotos.cs` only exists on #550's branch. It is not on `main`, and not on #559 (which branched from main and adds only the test project). So this had to be based on #550 or be part of it.

Merge order is therefore **#550 → this**. It retargets to `main` automatically once #550 lands.

## The change

`ExportPhotosAsync(projectId, photoIds, format)` resolved an output directory at `:551`, and only then did `ExportPhotosCoreAsync` check the ids-or-album guard (`:568`) and the per-format cap (`:575`).

Both guards are pure comparisons on the arguments. Neither needs a folder to exist. Running them second meant a user selecting 201 photos for a PDF got:

> Could not resolve an output folder: …

instead of:

> 201 photos selected; the server caps a PDF export at 200. Export in batches or use an album.

The first sends someone to investigate their Documents folder for a problem that is not there. As you put it — cheap validation before environment-dependent validation is right regardless of testability, and this is a good illustration of why: the ordering bug was invisible until something tried to reach the second check.

Both checks move into a shared `ExportSelectionRejected` so the wording exists **once**, and the public overload calls it before touching `OutputLocationHelper`. `ExportPhotosCoreAsync` still calls it too — the album overload does not go through the ids path, so that remains its last gate. **No message text changed.**

## Verified with the #559 harness against this build

| | Passed | Skipped | Failed |
|---|---|---|---|
| #550 as deployed | 11 | 3 | 0 |
| **this branch** | **12** | **2** | **0** |

The skip became a real test, exactly as you predicted:

```
Passed   Pdf_export_over_the_200_cap_is_refused_before_any_request_is_made
Skipped  Pdf_export_at_the_cap_is_allowed_through
```

The cap is now reached headlessly, and the capture server confirms **zero HTTP requests** were made — so "refused before the round trip" is now asserted rather than assumed.

`Pdf_export_at_the_cap_is_allowed_through` **still skips, and correctly**: a 200-photo selection *passes* the cap and then legitimately needs the output folder, which needs a Revit document context. That one is not a testability problem to solve — it is the environment honestly reporting what it cannot do.

## Scope

One file. No message text, no route, no signature changed. `dotnet build -c Release -t:Rebuild` → **0 errors, 0 warnings**.

Draft until #550 leaves draft, since it cannot merge before its base.