### PR TITLE
tools: launch Revit against a local Planscape server, without persisting the override

### DIFF
--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -479,3 +479,41 @@ gracefully — IFC uploads are rejected with a "convert to GLB first" message an
 heavy jobs simply don't run — and add them when you need IFC conversion / photo
 redaction. Redis is also optional (the app fails open) but recommended once you
 run more than one API instance (SignalR backplane).
+
+---
+
+## Pointing the plugin at a local server (development)
+
+The Revit plugin resolves its API base URL in `PlanscapeServerClient.Settings.cs`,
+`ResolveDefaultServerUrl()`, in this order — first hit wins:
+
+| # | Source | Scope |
+|---|---|---|
+| 1 | `STING_PLANSCAPE_URL` environment variable | Whatever the process inherits |
+| 2 | `%APPDATA%\StingTools\planscape_server.json` → `"serverUrl"` | Persists across restarts, per user |
+| 3 | `BakedDefaultServerUrl` | Compiled into the assembly |
+
+The resolved value is cached in `_cachedDefaultUrl` **for the lifetime of the process**,
+so switching targets always requires restarting Revit. There is no in-session toggle.
+
+### Use the launcher, not the settings file
+
+```powershell
+.\tools\Start-RevitLocal.ps1                      # newest Revit -> http://localhost:5000
+.\tools\Start-RevitLocal.ps1 -Revit 2025          # a specific version
+.\tools\Start-RevitLocal.ps1 -SkipHealthCheck     # launch with the API deliberately down
+.\tools\Start-RevitLocal.ps1 -Prod                # no override; use the saved pointer
+```
+
+It sets level 1 **for the launched process only**, prints the saved level-2 pointer
+alongside the override so the active target is unambiguous, and health-checks the URL
+first so a dead stack fails immediately with the `docker start docker-api-1` command
+rather than as a confusing in-app error.
+
+**Do not use `setx`, a user-level environment variable, or hand-edit
+`planscape_server.json` to switch to local.** All three persist, and a forgotten local
+override points a real session at a dev database with no visible sign. Closing Revit
+clears the launcher's override; nothing has to be remembered or undone.
+
+`-SkipHealthCheck` is what the site-photo "could not load" verification needs: it starts
+Revit pointed at an API that is deliberately down, so the failure states can be observed.

--- a/tools/Start-RevitLocal.ps1
+++ b/tools/Start-RevitLocal.ps1
@@ -1,0 +1,177 @@
+<#
+.SYNOPSIS
+    Launch Revit with StingTools pointed at a LOCAL Planscape server (or
+    explicitly at production, with -Prod).
+
+.DESCRIPTION
+    The plugin resolves its API base URL in this order (PlanscapeServerClient
+    .Settings.cs, ResolveDefaultServerUrl):
+
+        1. STING_PLANSCAPE_URL environment variable
+        2. %APPDATA%\StingTools\planscape_server.json  ("serverUrl")
+        3. baked corporate default (BakedDefaultServerUrl)
+
+    The resolved value is cached in _cachedDefaultUrl for the lifetime of the
+    process, so changing the target always means restarting Revit. That is why
+    this is a launcher and not a toggle.
+
+    This script sets (1) for the launched process ONLY. The saved production
+    pointer in (2) is never touched, so there is no "change it back" step to
+    forget - close Revit and the override is gone.
+
+    Do NOT use setx or a user-level environment variable for this. That
+    persists, and a forgotten local override silently points a real session at
+    a dev database. Avoiding that is the entire point of the design; a script
+    that writes planscape_server.json would have the same failure mode as the
+    hand-editing it replaces.
+
+    NOTE: this file is deliberately pure ASCII, and the separators below are
+    plain hyphens for the same reason. Windows PowerShell 5.1 reads .ps1 as
+    ANSI when there is no BOM, so a stray em-dash or box-drawing character
+    corrupts the parse with "string is missing the terminator". Do not tidy
+    these back into Unicode.
+
+.PARAMETER Revit
+    Revit version to launch. Defaults to the newest installed.
+
+.PARAMETER Url
+    API base URL. Defaults to http://localhost:5000 (the docker stack's
+    published port for docker-api-1). Cannot be combined with -Prod.
+
+.PARAMETER Prod
+    Launch with NO override, so the plugin falls through to the saved pointer
+    in planscape_server.json. Use this to return to production without editing
+    a file by hand. Any STING_PLANSCAPE_URL inherited from the current shell is
+    explicitly cleared for the child process, so -Prod means production even if
+    you ran this script without it earlier in the same window.
+
+.PARAMETER SkipHealthCheck
+    Launch even if the URL does not answer. Use when you deliberately want to
+    start with the API down - which is exactly what the site-photo "could not
+    load" checks need.
+
+.PARAMETER Force
+    Skip the confirmation prompt when Revit is already running.
+
+.EXAMPLE
+    .\tools\Start-RevitLocal.ps1
+    Launch the newest installed Revit against http://localhost:5000.
+
+.EXAMPLE
+    .\tools\Start-RevitLocal.ps1 -Revit 2025 -SkipHealthCheck
+    Launch Revit 2025 against the local API even if it is down.
+
+.EXAMPLE
+    .\tools\Start-RevitLocal.ps1 -Prod
+    Launch with no override - the plugin uses the saved production pointer.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Local')]
+param(
+    [string] $Revit,
+
+    [Parameter(ParameterSetName = 'Local')]
+    [string] $Url = 'http://localhost:5000',
+
+    [Parameter(ParameterSetName = 'Prod', Mandatory = $true)]
+    [switch] $Prod,
+
+    [Parameter(ParameterSetName = 'Local')]
+    [switch] $SkipHealthCheck,
+
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Locate Revit ----------------------------------------------------------
+$autodesk = 'C:\Program Files\Autodesk'
+$installed = @()
+if (Test-Path $autodesk) {
+    $installed = Get-ChildItem $autodesk -Directory |
+        Where-Object { $_.Name -match '^Revit [0-9][0-9][0-9][0-9]$' } |
+        ForEach-Object { $_.Name.Substring(6) } |
+        Sort-Object -Descending
+}
+if (-not $installed) { throw "No Revit installation found under $autodesk." }
+
+if (-not $Revit) { $Revit = $installed[0] }
+if ($installed -notcontains $Revit) {
+    throw "Revit $Revit not found. Installed: $($installed -join ', ')"
+}
+
+$exe = Join-Path $autodesk "Revit $Revit\Revit.exe"
+if (-not (Test-Path $exe)) { throw "Missing executable: $exe" }
+
+# --- Read the saved (production) pointer so the active target is unambiguous -
+$settings = Join-Path $env:APPDATA 'StingTools\planscape_server.json'
+$savedUrl = '(none saved)'
+if (Test-Path $settings) {
+    try {
+        $savedUrl = (Get-Content $settings -Raw | ConvertFrom-Json).serverUrl
+        if (-not $savedUrl) { $savedUrl = '(no serverUrl key)' }
+    } catch { $savedUrl = '(unreadable)' }
+}
+
+# --- Warn if Revit is already up -------------------------------------------
+# The override is applied to the process this script starts. It cannot reach a
+# Revit that is already running, and _cachedDefaultUrl means that instance will
+# not re-read the setting either. Launching anyway gives you two Revits on two
+# different servers, which is a confusing way to lose an hour. Warn, then let
+# the operator decide - never kill anything.
+$running = @(Get-Process -Name 'Revit' -ErrorAction SilentlyContinue)
+if ($running.Count -gt 0 -and -not $Force) {
+    Write-Host ""
+    Write-Host "WARNING: Revit is already running (PID $($running.Id -join ', '))." -ForegroundColor Yellow
+    Write-Host "The override applies only to a NEWLY launched process, so the running"
+    Write-Host "instance keeps whatever target it started with. Continuing starts a"
+    Write-Host "SECOND Revit, and the two will talk to different servers."
+    Write-Host ""
+    Write-Host "Close the running instance first if you meant to switch its target."
+    Write-Host ""
+    $answer = Read-Host 'Launch a second instance anyway? [y/N]'
+    if ($answer -notmatch '^(y|yes)$') {
+        Write-Host "Aborted - nothing launched." -ForegroundColor Yellow
+        exit 2
+    }
+}
+
+# --- Fail fast if the local API is not answering ---------------------------
+if (-not $Prod -and -not $SkipHealthCheck) {
+    $health = $Url.TrimEnd('/') + '/health/live'
+    try {
+        $r = Invoke-WebRequest -Uri $health -TimeoutSec 5 -UseBasicParsing
+        Write-Host "Health   : $health -> $($r.StatusCode)" -ForegroundColor Green
+    } catch {
+        Write-Host "Health   : $health -> UNREACHABLE" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "The local API is not answering. Start it with:" -ForegroundColor Yellow
+        Write-Host "    docker start docker-api-1"
+        Write-Host ""
+        Write-Host "Or pass -SkipHealthCheck if you meant to start with it down."
+        exit 1
+    }
+}
+
+# --- Launch ----------------------------------------------------------------
+Write-Host ""
+Write-Host "Revit    : $Revit"
+if ($Prod) {
+    # Clear an inherited override so -Prod is honest even in a shell that ran
+    # the local form earlier. Start-Process inherits this process's environment.
+    Remove-Item Env:STING_PLANSCAPE_URL -ErrorAction SilentlyContinue
+    Write-Host "Override : none (STING_PLANSCAPE_URL cleared for this launch)" -ForegroundColor Cyan
+    Write-Host "Target   : $savedUrl  (from planscape_server.json)"
+} else {
+    $env:STING_PLANSCAPE_URL = $Url
+    Write-Host "Override : STING_PLANSCAPE_URL = $Url  (this process only)" -ForegroundColor Cyan
+    Write-Host "Saved    : $savedUrl  (untouched)"
+}
+Write-Host ""
+
+Start-Process -FilePath $exe
+
+if ($Prod) {
+    Write-Host "Launched against the saved pointer. No override was set." -ForegroundColor Green
+} else {
+    Write-Host "Launched. Close Revit and the override is gone - nothing to undo." -ForegroundColor Green
+}


### PR DESCRIPTION
## Why this exists

The BCC resolves its API base URL in `PlanscapeServerClient.Settings.cs`, `ResolveDefaultServerUrl()`:

1. `STING_PLANSCAPE_URL` environment variable
2. `%APPDATA%\StingTools\planscape_server.json` → `"serverUrl"`
3. `BakedDefaultServerUrl`

On a working machine level 2 points at **production**. That is why "stop the local docker stack and check the error state" did nothing for #550's verification — the plugin was never talking to localhost, so stopping localhost changed nothing observable. The resolved value is also cached in `_cachedDefaultUrl` for the process lifetime, so switching targets always means restarting Revit. Hence a launcher rather than a toggle.

## The design constraint, and why it is the whole point

**No `setx`. No user-level environment variable. No write to `planscape_server.json`.**

All three persist. A forgotten local override points a real session at a dev database with nothing on screen to say so — you would find out when a client's data looked wrong. A script that wrote the settings file would carry exactly the failure mode as the hand-editing it replaces, just faster.

So the override is set for the launched process only. The saved pointer is **read and printed, never written**. Close Revit and it is gone; there is no "change it back" step to forget.

## Pure ASCII, deliberately

The file is pure ASCII including the `---` separators, and the header says so. Windows PowerShell 5.1 reads `.ps1` as **ANSI when there is no BOM**, so a single em-dash or box-drawing character breaks the parse with *"string is missing the terminator"*. The first draft hit exactly that. The note in the header is load-bearing — please do not tidy the separators back into Unicode.

## Two additions over the draft

**Already-running detection.** The override cannot reach a Revit that is already up, and `_cachedDefaultUrl` means that instance will not re-read the setting either — so launching anyway gives you two Revits on two different servers, which is a confusing way to lose an hour. It now warns with the PIDs, explains why, and asks. `-Force` skips the prompt. **Nothing is ever killed.**

**`-Prod`.** Makes the round trip symmetrical so neither direction requires editing the settings file by hand. It launches with no override *and* explicitly clears an inherited `STING_PLANSCAPE_URL`, so `-Prod` means production even in a shell where the local form ran earlier. Parameter sets make `-Prod` and `-Url` mutually exclusive.

## Verification

| Check | Result |
|---|---|
| Non-ASCII bytes | **0** |
| UTF-8 BOM | absent (which is why the ASCII rule matters) |
| `Parser::ParseFile` | **OK** |
| Parameter sets | `Local{Revit,Url,SkipHealthCheck,Force}` / `Prod{Revit,Prod,Force}` |
| Dead URL (`127.0.0.1:59999`) | **exit 1**, Revit processes before 0 / after **0** |
| `-Prod -Url` together | rejected: *"Parameter set cannot be resolved"* |
| `http://localhost:5000/health/live` | **200** `{"status":"alive"}` |

**Not verified: the launch path itself.** Exercising it means starting Revit, which a background job cannot drive and which would hold the plugin DLL. The already-running prompt is likewise unexercised, since Revit is not running and I am not starting it. Both are stated rather than implied.

## Docs

`docs/DEPLOY_RUNBOOK.md` gains a short section covering the three-level resolution order, the process-lifetime caching, and the usage — appended there rather than as a new top-level doc, since the tree already carries 140 and sprawl is a tracked complaint.

## Usage

```powershell
.\tools\Start-RevitLocal.ps1                    # newest Revit -> http://localhost:5000
.\tools\Start-RevitLocal.ps1 -Revit 2025
.\tools\Start-RevitLocal.ps1 -SkipHealthCheck   # start with the API deliberately DOWN
.\tools\Start-RevitLocal.ps1 -Prod              # back to the saved production pointer
```

`-SkipHealthCheck` is the one #550's M1/M3 need: it launches pointed at an API that is deliberately down, so the could-not-load states can actually be observed.

Branched from `origin/main` @ `097b75a94`. Nothing merged; `%APPDATA%\StingTools\planscape_server.json` untouched; no container started, stopped or reconfigured.