### PR TITLE
feat(tagsync): element delete (tombstone) channel for /api/tagsync/sync

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ComplianceController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ComplianceController.cs
@@ -237,6 +237,11 @@ public class ComplianceController : ControllerBase
         // query plan stays sortable on the bucket name. PG-only; the
         // `EnsureCreated` path is fine because every prod deployment runs
         // PostgreSQL.
+        //
+        // SOFT DELETE: raw SQL bypasses EF global query filters entirely, so
+        // the `"DeletedAtUtc" IS NULL` tombstone predicate that the filter adds
+        // to every LINQ read has to be spelled out by hand here. Without it
+        // this heat-map would keep counting elements deleted in Revit.
         const string sql = @"
 SELECT
   COALESCE(NULLIF(BTRIM(""Disc""), ''), '(unset)')                         AS discipline,
@@ -252,7 +257,7 @@ SELECT
   COUNT(*) FILTER (WHERE BTRIM(""Status"")  <> '' AND ""Status"" IS NOT NULL)::int AS status_n,
   COUNT(*) FILTER (WHERE BTRIM(""Rev"")     <> '' AND ""Rev""    IS NOT NULL)::int AS rev_n
 FROM ""TaggedElements""
-WHERE ""ProjectId"" = {0}
+WHERE ""ProjectId"" = {0} AND ""DeletedAtUtc"" IS NULL
 GROUP BY 1
 ORDER BY (CASE WHEN COALESCE(NULLIF(BTRIM(""Disc""), ''), '(unset)') = '(unset)' THEN 1 ELSE 0 END), 1;";
 

--- a/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
@@ -337,7 +337,15 @@ public class IfcIngestController : ControllerBase
         var mapping = LoadPsetMapping();
 
         // Index existing rows so we can update vs insert in one round-trip.
+        // IgnoreQueryFilters is REQUIRED: soft-deleted rows are hidden by the
+        // global tombstone filter, but this is an UPSERT — if a previously
+        // tombstoned element is re-ingested we must find its row and revive it.
+        // Without this the row looks absent, we INSERT, and the unique
+        // (ProjectId, UniqueId) index throws. Ownership is unchanged: projectId
+        // is already tenant-checked by the caller and (ProjectId, UniqueId) is
+        // this table's cross-host unique key space.
         var existing = await _db.TaggedElements
+            .IgnoreQueryFilters()
             .Where(t => t.ProjectId == projectId)
             .ToDictionaryAsync(t => t.UniqueId, ct);
 
@@ -387,6 +395,11 @@ public class IfcIngestController : ControllerBase
                 row.Tag1         = tag1.Length > 0 ? tag1 : row.Tag1;
                 row.Source       = result.Source;
                 row.SyncedAt     = DateTime.UtcNow;
+                // This path only carries LIVE elements (IFC ingest has no
+                // delete channel), so re-ingesting a tombstoned element is an
+                // undelete — otherwise the row would stay invisible behind the
+                // global filter despite having just been written.
+                row.DeletedAtUtc = null;
                 updated++;
             }
             else

--- a/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
@@ -86,7 +86,7 @@ public class TagSyncController : ControllerBase
         if (request.Elements.Count == 0)
             return Ok(new TagSyncResponse { Received = 0 });
 
-        int created = 0, updated = 0;
+        int created = 0, updated = 0, deleted = 0;
         var conflicts = new List<SyncConflictDto>();
         ComplianceSummaryDto metrics;
 
@@ -103,7 +103,22 @@ public class TagSyncController : ControllerBase
             // Runs inside the transaction so the snapshot is consistent for the
             // duration of the entire sync.
             var incomingIds = request.Elements.Select(e => e.RevitElementId).ToHashSet();
+            // IgnoreQueryFilters is REQUIRED here, not an optimisation.
+            // Tombstoned rows are hidden from every normal read by the global
+            // soft-delete filter, but the UPSERT must still see them: an
+            // undelete (Revit undo restoring a deleted element) has to find the
+            // existing row and clear its tombstone. Without this the row would
+            // look absent, we would INSERT, and the unique
+            // (ProjectId, RevitElementId) index would throw.
+            //
+            // In EF Core 8 IgnoreQueryFilters drops the TENANT predicate too, so
+            // ownership is carried explicitly instead: `project` was resolved by
+            // (Id + TenantId) above, and (ProjectId, RevitElementId) is this
+            // table's unique key space — a row under this ProjectId is by
+            // definition this project's data. Row-set is therefore exactly what
+            // it was before, plus the previously-hidden tombstones.
             var existingElements = await _db.TaggedElements
+                .IgnoreQueryFilters()
                 .Where(e => e.ProjectId == project.Id && incomingIds.Contains(e.RevitElementId))
                 .ToDictionaryAsync(e => e.RevitElementId);
 
@@ -124,6 +139,17 @@ public class TagSyncController : ControllerBase
 
                         if (clientTs.HasValue && serverTs.HasValue && clientTs.Value <= serverTs.Value)
                         {
+                            // A stale DELETE is rejected by exactly this same
+                            // last-write-wins gate — it must not bypass the
+                            // conflict path just because it is a tombstone.
+                            // A newer server-side edit therefore beats an
+                            // out-of-date client's delete, and the client is
+                            // told via a SERVER_WINS conflict. Only the
+                            // ConflictType distinguishes the two, so an
+                            // operator can tell "your delete was refused" from
+                            // "your edit was refused"; Resolution is
+                            // SERVER_WINS either way.
+                            var conflictType = dto.IsDeleted ? "STALE_DELETE" : "STALE_UPDATE";
                             // Deduplicate: only add a conflict row when none already exists for this
                             // element + client pair so concurrent pushes don't double-count.
                             bool alreadyLogged = await _db.SyncConflicts.AnyAsync(c =>
@@ -137,7 +163,7 @@ public class TagSyncController : ControllerBase
                                     ProjectId       = project.Id,
                                     TaggedElementId = existing.Id,
                                     ElementId       = dto.RevitElementId.ToString(),
-                                    ConflictType    = "STALE_UPDATE",
+                                    ConflictType    = conflictType,
                                     Resolution      = "SERVER_WINS",
                                     ServerTimestamp = serverTs,
                                     ClientTimestamp = clientTs,
@@ -153,13 +179,47 @@ public class TagSyncController : ControllerBase
                             }
                             // Do NOT overwrite — server wins.
                         }
+                        else if (dto.IsDeleted)
+                        {
+                            // TOMBSTONE. Deliberately does NOT call
+                            // MapDtoToEntity: a delete payload must not
+                            // overwrite the last known good tag data, which is
+                            // the whole point of keeping the row (audit +
+                            // valid SyncConflict.TaggedElementId FKs). We only
+                            // stamp the tombstone and the audit fields.
+                            //
+                            // Idempotent: re-deleting an already-tombstoned row
+                            // just refreshes the timestamp and counts again,
+                            // matching how a no-change update still counts as
+                            // Updated.
+                            var deletedAt = clientTs ?? DateTime.UtcNow;
+                            existing.DeletedAtUtc    = deletedAt;
+                            existing.Version        += 1;
+                            existing.LastModifiedUtc = deletedAt;
+                            existing.SyncedAt        = DateTime.UtcNow;
+                            existing.SyncedBy        = request.UserName;
+                            deleted++;
+                        }
                         else
                         {
+                            // Ordinary update — and also the UNDELETE path.
+                            // MapDtoToEntity clears DeletedAtUtc, so a live
+                            // element arriving for a previously-tombstoned row
+                            // simply restores it. No special case needed.
                             MapDtoToEntity(dto, existing, request.UserName);
                             existing.Version        += 1;
                             existing.LastModifiedUtc = ToUtc(clientTs) ?? DateTime.UtcNow;
                             updated++;
                         }
+                    }
+                    else if (dto.IsDeleted)
+                    {
+                        // Delete for an element the server has never seen (e.g.
+                        // created and removed between two syncs, or already
+                        // purged). Nothing to tombstone — a no-op by design:
+                        // NOT an error, and explicitly NOT an insert, which
+                        // would resurrect the element as a dead row.
+                        continue;
                     }
                     else
                     {
@@ -202,7 +262,7 @@ public class TagSyncController : ControllerBase
             {
                 var group = project.Id.ToString();
                 await _tagHub.Clients.Group(group)
-                    .SendAsync("TagsUpdated", new { created, updated, total = request.Elements.Count });
+                    .SendAsync("TagsUpdated", new { created, updated, deleted, total = request.Elements.Count });
                 await _complianceHub.Clients.Group(group)
                     .SendAsync("ComplianceUpdated", metrics);
 
@@ -212,7 +272,7 @@ public class TagSyncController : ControllerBase
                 // plugin). The legacy emits above are kept for backward compat.
                 var notifyGroup = $"project-{project.Id}";
                 await _notificationHub.Clients.Group(notifyGroup)
-                    .SendAsync("TagsUpdated", new { created, updated, total = request.Elements.Count });
+                    .SendAsync("TagsUpdated", new { created, updated, deleted, total = request.Elements.Count });
                 await _notificationHub.Clients.Group(notifyGroup)
                     .SendAsync("ComplianceUpdated", metrics);
             }
@@ -246,6 +306,12 @@ public class TagSyncController : ControllerBase
         var mappingDocGuid = request.HostDocumentGuid;
         var mappings = request.Elements
             .Where(e => !string.IsNullOrWhiteSpace(e.IfcGlobalId))   // true IFC GlobalId only
+            // Don't mint or refresh cross-host identity rows for elements the
+            // client just reported as DELETED — that would keep asserting an
+            // identity for something no longer in the model. Existing mapping
+            // rows are left untouched; their lifecycle is owned by the
+            // reconciliation job, not by this best-effort upsert.
+            .Where(e => !e.IsDeleted)
             .Select(e => new ElementMappingDto(
                 e.IfcGlobalId!,                       // cross-host key — NOT UniqueId
                 e.RevitElementId.ToString(),          // host_element_id = Revit ElementId
@@ -285,6 +351,7 @@ public class TagSyncController : ControllerBase
             Received = request.Elements.Count,
             Created = created,
             Updated = updated,
+            Deleted = deleted,
             CompliancePercent = metrics.CompliancePercent,
             RagStatus = metrics.RagStatus,
             Conflicts = conflicts
@@ -514,6 +581,12 @@ public class TagSyncController : ControllerBase
         entity.Status = dto.Status; entity.Rev = dto.Rev;
         entity.IsComplete = dto.IsComplete; entity.IsFullyResolved = dto.IsFullyResolved;
         entity.SyncedAt = DateTime.UtcNow; entity.SyncedBy = userName;
+        // UNDELETE, centralised: this method is only reached for an element the
+        // client reports as LIVE (the tombstone branch never calls it), so
+        // mapping a live element always clears any existing tombstone. Keeping
+        // it here rather than at the call site means no future caller can map a
+        // live element and forget to resurrect it.
+        entity.DeletedAtUtc = null;
     }
 
     /// <summary>Normalise a DateTime to UTC Kind — rejects Local, passes UTC and Unspecified through as UTC.</summary>

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1955,6 +1955,19 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // (c) PenetrationSignoffs.ElementIfcGlobalId — K1 cross-host identity column.
         "ALTER TABLE \"PenetrationSignoffs\" ADD COLUMN IF NOT EXISTS \"ElementIfcGlobalId\" character varying(22) NULL",
         "CREATE INDEX IF NOT EXISTS \"IX_PenetrationSignoffs_ProjectId_ElementIfcGlobalId\" ON \"PenetrationSignoffs\" (\"ProjectId\", \"ElementIfcGlobalId\")",
+        // TagSync element tombstones — TaggedElements.DeletedAtUtc.
+        // Per docs/adr/0001-schema-management.md this idempotent patch, NOT a
+        // `dotnet ef migrations add`, is how a new column reaches pre-existing
+        // databases: EnsureCreated short-circuits once Tenants exists, and
+        // Database.Migrate() is a no-op against the un-attributed migration set.
+        // Fresh DBs get the column from CreateTables via the EF model.
+        //
+        // NULL means "live", and it is nullable with NO default precisely so
+        // that every pre-existing row reads as not-deleted — which is what
+        // makes older plugins (that never send isDeleted) behave exactly as
+        // they did before.
+        "ALTER TABLE \"TaggedElements\" ADD COLUMN IF NOT EXISTS \"DeletedAtUtc\" timestamp with time zone NULL",
+        "CREATE INDEX IF NOT EXISTS \"IX_TaggedElements_ProjectId_DeletedAtUtc\" ON \"TaggedElements\" (\"ProjectId\", \"DeletedAtUtc\")",
     };
     int applied = 0, failed = 0;
     foreach (var sql in patches)

--- a/Planscape.Server/src/Planscape.Core/DTOs/SyncDtos.cs
+++ b/Planscape.Server/src/Planscape.Core/DTOs/SyncDtos.cs
@@ -68,6 +68,23 @@ public record TagElementDto
     /// Nullable for backward compatibility with older plugin builds.
     /// </summary>
     public DateTime? LastModifiedUtc { get; init; }
+
+    /// <summary>
+    /// Tombstone flag — true when the authoring tool reports this element as
+    /// DELETED from the model. The server soft-deletes the matching row
+    /// (stamps <c>TaggedElement.DeletedAtUtc</c>) so it stops counting toward
+    /// element totals and compliance, instead of leaving an orphan row behind
+    /// forever.
+    ///
+    /// BACKWARD COMPATIBILITY: deliberately a non-nullable <c>bool</c> with a
+    /// <c>false</c> default and NOT marked required. Older plugin builds never
+    /// send <c>isDeleted</c>; the absent field binds to false and the element
+    /// takes exactly the pre-existing insert-or-update path.
+    ///
+    /// Sending false for an already-tombstoned element UNDELETES it (Revit
+    /// undo restoring a deleted element), which is an ordinary update.
+    /// </summary>
+    public bool IsDeleted { get; init; }
 }
 
 public record TagSyncResponse
@@ -75,6 +92,18 @@ public record TagSyncResponse
     public int Received { get; init; }
     public int Created { get; init; }
     public int Updated { get; init; }
+
+    /// <summary>
+    /// Elements tombstoned by this request — reported separately from
+    /// <see cref="Created"/>/<see cref="Updated"/> so a client can tell a
+    /// delete from an edit. Counts ACCEPTED delete instructions (mirroring how
+    /// <see cref="Updated"/> counts an accepted update even when no field
+    /// actually changed), so re-sending a delete for an already-tombstoned row
+    /// counts again and is harmless. Deletes REJECTED as stale are not counted
+    /// here — they appear in <see cref="Conflicts"/>. An undelete counts as
+    /// <see cref="Updated"/>.
+    /// </summary>
+    public int Deleted { get; init; }
     public double CompliancePercent { get; init; }
     public string RagStatus { get; init; } = "";
     public DateTime SyncedAt { get; init; } = DateTime.UtcNow;

--- a/Planscape.Server/src/Planscape.Core/Entities/ISoftDeletable.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ISoftDeletable.cs
@@ -1,0 +1,38 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// Marks an entity that is tombstoned rather than hard-deleted.
+///
+/// <para>WHY A NULLABLE TIMESTAMP AND NOT A <c>bool IsDeleted</c>:</para>
+/// <list type="bullet">
+///   <item>It carries <i>when</i>, so a tombstone is an audit record rather than
+///   a bare flag — needed to answer "when did this element leave the model?".</item>
+///   <item>Undelete (a Revit undo restoring a deleted element — which WILL
+///   happen) becomes an ordinary field update, <c>DeletedAtUtc = null</c>,
+///   not a special case.</item>
+///   <item><c>"DeletedAtUtc" IS NULL</c> is the cheap, index-friendly predicate
+///   the global query filter needs on every read.</item>
+/// </list>
+///
+/// <para>ENFORCEMENT: <c>PlanscapeDbContext.ApplyGlobalQueryFilters</c> AND-folds
+/// <c>DeletedAtUtc == null</c> into the global query filter of every implementing
+/// entity, so soft-deleted rows disappear from all LINQ reads by default. Two
+/// consequences callers must know:</para>
+/// <list type="number">
+///   <item>Code that must SEE tombstones (the TagSync upsert, which has to find a
+///   deleted row to undelete it) has to call <c>.IgnoreQueryFilters()</c>. Note
+///   that in EF Core 8 this drops the tenant predicate too, so such a query must
+///   carry its own ownership check.</item>
+///   <item>Raw SQL bypasses query filters entirely and must spell out
+///   <c>AND "DeletedAtUtc" IS NULL</c> by hand.</item>
+/// </list>
+/// </summary>
+public interface ISoftDeletable
+{
+    /// <summary>
+    /// UTC instant the row was tombstoned; <c>null</c> means live. Absent /
+    /// null is the backward-compatible default, so rows written before this
+    /// column existed read as live.
+    /// </summary>
+    DateTime? DeletedAtUtc { get; set; }
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/TaggedElement.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/TaggedElement.cs
@@ -4,7 +4,7 @@ namespace Planscape.Core.Entities;
 /// A tagged BIM element synced from the Revit plugin.
 /// Stores ISO 19650 8-segment tag data + TAG7 narrative + compliance state.
 /// </summary>
-public class TaggedElement : ITenantScoped
+public class TaggedElement : ITenantScoped, ISoftDeletable
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid TenantId { get; set; }
@@ -69,6 +69,20 @@ public class TaggedElement : ITenantScoped
     // server uses it to detect stale updates from out-of-date clients.
     public DateTime? LastModifiedUtc { get; set; }
     public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Tombstone timestamp — non-null once the authoring tool reported the
+    /// element as deleted (Revit plugin sends <c>isDeleted: true</c> on
+    /// <c>POST /api/tagsync/sync</c>). Null means live.
+    ///
+    /// The row is deliberately KEPT rather than hard-deleted: it preserves the
+    /// last known tag data for audit, keeps <c>SyncConflict.TaggedElementId</c>
+    /// FKs valid, and makes an undelete (Revit undo) a plain field update.
+    /// A tombstoned row is hidden from every LINQ read by the global query
+    /// filter, so it stops counting toward element totals and compliance.
+    /// See <see cref="ISoftDeletable"/>.
+    /// </summary>
+    public DateTime? DeletedAtUtc { get; set; }
 
     // P6 live-link fields — populated by P6LiveLinkService when a matching activity is found.
     public string?  P6ActivityId    { get; set; }

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -665,6 +665,11 @@ public class PlanscapeDbContext : DbContext
             // Delta-sync cutoff queries (`(LastModifiedUtc ?? SyncedAt) > cutoff`)
             // benefit from an index on the modification timestamp.
             e.HasIndex(t => t.LastModifiedUtc);
+            // Soft-delete: the global query filter appends `"DeletedAtUtc" IS NULL`
+            // to EVERY read of this table, and almost all of them are already
+            // scoped by project — so the composite is the shape that actually
+            // gets used (compliance aggregation, delta pull, element lists).
+            e.HasIndex(t => new { t.ProjectId, t.DeletedAtUtc });
         });
 
         // ── ExternalElementMapping ──
@@ -1248,7 +1253,11 @@ public class PlanscapeDbContext : DbContext
         // unauthenticated background job sees nothing rather than
         // everything. Hot reads use the indexed TenantId column directly,
         // no joins required.
-        ApplyTenantQueryFilters(modelBuilder);
+        //
+        // This ALSO folds in the ISoftDeletable tombstone predicate — see the
+        // method remarks for why the two must be applied as one composed
+        // filter and cannot be two HasQueryFilter calls.
+        ApplyGlobalQueryFilters(modelBuilder);
         // Ensure every tenant-scoped entity has an index on TenantId so the
         // query filter doesn't degenerate into a sequential scan.
         AddTenantIdIndexes(modelBuilder);
@@ -1991,28 +2000,76 @@ public class PlanscapeDbContext : DbContext
     }
 
     /// <remarks>
-    /// Covers only types implementing <see cref="ITenantScoped"/>. Notably that
+    /// <para>Applies the TENANT predicate to every <see cref="ITenantScoped"/>
+    /// type and the SOFT-DELETE predicate to every <see cref="ISoftDeletable"/>
+    /// type, AND-ed together into a SINGLE filter per entity.</para>
+    ///
+    /// <para>The single-filter composition is not a style choice — it is
+    /// required. In EF Core 8 an entity has at most ONE query filter and a later
+    /// <c>HasQueryFilter</c> call silently REPLACES an earlier one. Applying the
+    /// tombstone predicate as a second call here would therefore have DROPPED
+    /// the tenant predicate and turned a soft-delete feature into a
+    /// cross-tenant data leak.</para>
+    ///
+    /// <para>That failure mode is not hypothetical — it is already live in this
+    /// file: <c>AppUser</c> declares <c>HasQueryFilter(u =&gt; !u.IsDeleted)</c>
+    /// in its own <c>modelBuilder.Entity&lt;AppUser&gt;</c> block, which this
+    /// method (running later in OnModelCreating) overwrites, so that
+    /// soft-delete filter never takes effect. Left as-is here because fixing it
+    /// changes AppUser visibility semantics well outside this change's scope;
+    /// it is reported separately.</para>
+    ///
+    /// <para><c>BypassTenantFilter</c> relaxes ONLY the tenant predicate. A
+    /// background job or migration that bypasses tenancy still must not see
+    /// tombstoned rows, or it would recount deleted elements. Code that
+    /// genuinely needs tombstones (the TagSync undelete path) calls
+    /// <c>.IgnoreQueryFilters()</c>, which drops both predicates and therefore
+    /// must carry its own ownership check.</para>
+    ///
+    /// <para>Covers only types implementing the marker interfaces. Notably that
     /// EXCLUDES <see cref="Tenant"/> itself, which is deliberate and load-bearing
     /// — filtering it would break the pre-auth slug-uniqueness check in
     /// AuthController.Register and let duplicate slugs through. See the remarks
     /// on the Tenant entity for the full reasoning and the 2026-07-30 audit.
+    /// </para>
     /// </remarks>
-    private void ApplyTenantQueryFilters(ModelBuilder modelBuilder)
+    private void ApplyGlobalQueryFilters(ModelBuilder modelBuilder)
     {
         var entityTypes = modelBuilder.Model.GetEntityTypes()
-            .Where(t => typeof(ITenantScoped).IsAssignableFrom(t.ClrType));
+            .Where(t => typeof(ITenantScoped).IsAssignableFrom(t.ClrType)
+                     || typeof(ISoftDeletable).IsAssignableFrom(t.ClrType));
 
         foreach (var entityType in entityTypes)
         {
             var clrType = entityType.ClrType;
             var parameter = System.Linq.Expressions.Expression.Parameter(clrType, "e");
-            var tenantIdProperty = System.Linq.Expressions.Expression.Property(parameter, nameof(ITenantScoped.TenantId));
-            var currentTenantIdProperty = System.Linq.Expressions.Expression.Property(
-                System.Linq.Expressions.Expression.Constant(this), nameof(CurrentTenantId));
-            var bypass = System.Linq.Expressions.Expression.Property(
-                System.Linq.Expressions.Expression.Constant(this), nameof(BypassTenantFilter));
-            var equality = System.Linq.Expressions.Expression.Equal(tenantIdProperty, currentTenantIdProperty);
-            var body = System.Linq.Expressions.Expression.OrElse(bypass, equality);
+            System.Linq.Expressions.Expression? body = null;
+
+            if (typeof(ITenantScoped).IsAssignableFrom(clrType))
+            {
+                var tenantIdProperty = System.Linq.Expressions.Expression.Property(parameter, nameof(ITenantScoped.TenantId));
+                var currentTenantIdProperty = System.Linq.Expressions.Expression.Property(
+                    System.Linq.Expressions.Expression.Constant(this), nameof(CurrentTenantId));
+                var bypass = System.Linq.Expressions.Expression.Property(
+                    System.Linq.Expressions.Expression.Constant(this), nameof(BypassTenantFilter));
+                var equality = System.Linq.Expressions.Expression.Equal(tenantIdProperty, currentTenantIdProperty);
+                body = System.Linq.Expressions.Expression.OrElse(bypass, equality);
+            }
+
+            if (typeof(ISoftDeletable).IsAssignableFrom(clrType))
+            {
+                // e.DeletedAtUtc == null  → only live rows.
+                var deletedAt = System.Linq.Expressions.Expression.Property(parameter, nameof(ISoftDeletable.DeletedAtUtc));
+                var notDeleted = System.Linq.Expressions.Expression.Equal(
+                    deletedAt,
+                    System.Linq.Expressions.Expression.Constant(null, typeof(DateTime?)));
+                body = body == null
+                    ? notDeleted
+                    : System.Linq.Expressions.Expression.AndAlso(body, notDeleted);
+            }
+
+            if (body == null) continue; // unreachable given the Where above; defensive.
+
             var lambda = System.Linq.Expressions.Expression.Lambda(body, parameter);
             modelBuilder.Entity(clrType).HasQueryFilter(lambda);
         }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcIngestService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcIngestService.cs
@@ -141,6 +141,13 @@ public sealed class IfcIngestService : IIfcIngestService
                     t.IsComplete = el.IsComplete; t.IsFullyResolved = el.IsFullyResolved; t.IsStale = el.IsStale;
                     t.ValidationErrors = el.ValidationErrors;
                     t.LastModifiedUtc = elLastMod ?? nowUtc;
+                    // This path only carries LIVE elements (IFC ingest has no
+                    // delete channel), so re-ingesting a tombstoned element is
+                    // an undelete. The existing-row load above already uses
+                    // IgnoreQueryFilters, so a tombstoned row IS found here —
+                    // without clearing the stamp it would be updated yet stay
+                    // hidden behind the global soft-delete filter.
+                    t.DeletedAtUtc = null;
                     updElements++;
                 }
                 else

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/PostgresBulkTagUpserter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/PostgresBulkTagUpserter.cs
@@ -110,6 +110,12 @@ public class PostgresBulkTagUpserter : IBulkTagUpserter
                     ""Seq""  = EXCLUDED.""Seq"",
                     ""Tag1"" = EXCLUDED.""Tag1"",
                     ""LastModifiedUtc"" = EXCLUDED.""LastModifiedUtc"",
+                    -- This path only ever carries LIVE elements (it has no
+                    -- delete channel), so an upsert onto a tombstoned row is an
+                    -- undelete — mirroring TagSyncController.MapDtoToEntity.
+                    -- Without this the row would stay hidden by the global
+                    -- soft-delete query filter despite having just been written.
+                    ""DeletedAtUtc"" = NULL,
                     ""Version"" = ""TaggedElements"".""Version"" + 1
                 RETURNING (xmax = 0) AS inserted)
               SELECT COUNT(*) FILTER (WHERE inserted),

--- a/Planscape.Server/tests/Planscape.Tests/TagSyncSoftDeleteTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/TagSyncSoftDeleteTests.cs
@@ -1,0 +1,504 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.API.Controllers;
+using Planscape.Core.DTOs;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.SignalR;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TagSync element tombstones — POST /api/tagsync/sync with <c>isDeleted</c>.
+///
+/// Before this channel existed the endpoint was insert-or-update only, so an
+/// element deleted in Revit left its TaggedElement row on the server forever,
+/// inflating element counts and skewing compliance. These tests pin the
+/// tombstone behaviour AND the read-path exclusion that makes it meaningful.
+///
+/// Structure mirrors <see cref="TagSyncConflictTests"/>: the controller is
+/// constructed directly against an in-memory PlanscapeDbContext with stubbed
+/// SignalR hubs and an injected tenant_id claim.
+/// </summary>
+public class TagSyncSoftDeleteTests
+{
+    private const long ElementId = 424242;
+
+    // ── Test rig ────────────────────────────────────────────────────────────
+
+    private static PlanscapeDbContext NewDb(string name)
+    {
+        var options = new DbContextOptionsBuilder<PlanscapeDbContext>()
+            .UseInMemoryDatabase($"{name}_{Guid.NewGuid():N}")
+            // SyncElements wraps its batches in an explicit RepeatableRead
+            // transaction the InMemory provider cannot honour; EF escalates
+            // TransactionIgnoredWarning to an exception without this. Production
+            // is PostgreSQL, where the transaction is real.
+            .ConfigureWarnings(w =>
+                w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId
+                    .TransactionIgnoredWarning))
+            .Options;
+
+        var db = new PlanscapeDbContext(options);
+        // Built directly rather than through DI, so _tenantContext is null and
+        // CurrentTenantId is Guid.Empty — the global tenant filter would hide
+        // the rows seeded below. BypassTenantFilter is the documented escape
+        // hatch. Note it deliberately does NOT relax the soft-delete predicate,
+        // which several assertions below rely on.
+        db.BypassTenantFilter = true;
+        return db;
+    }
+
+    private static async Task SeedAsync(PlanscapeDbContext db, Guid tenantId, Guid projectId,
+        params TaggedElement[] elements)
+    {
+        db.Tenants.Add(new Tenant
+        {
+            Id = tenantId, Name = "Test Org", Slug = $"test-{Guid.NewGuid():N}",
+            ContactEmail = "admin@test.org", Tier = LicenseTier.Premium,
+            MaxUsers = 10, MaxProjects = 5, IsActive = true
+        });
+        db.Projects.Add(new Project
+        {
+            Id = projectId, TenantId = tenantId,
+            Name = "Test Project", Code = $"TST-{Guid.NewGuid():N}"[..10],
+            Status = ProjectStatus.Active
+        });
+        foreach (var e in elements)
+        {
+            e.TenantId = tenantId;
+            e.ProjectId = projectId;
+            db.TaggedElements.Add(e);
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private static TaggedElement LiveElement(long revitId, string tag1, DateTime lastModified) => new()
+    {
+        Id = Guid.NewGuid(),
+        RevitElementId = revitId,
+        UniqueId = $"unique-{revitId}",
+        Disc = "M", Loc = "BLD1", Zone = "Z01", Lvl = "L02",
+        Sys = "HVAC", Func = "SUP", Prod = "AHU", Seq = "0001",
+        Tag1 = tag1,
+        CategoryName = "Mechanical Equipment",
+        FamilyName = "AHU_Standard",
+        IsComplete = true, IsFullyResolved = true,
+        LastModifiedUtc = lastModified,
+        Version = 1
+    };
+
+    private static TagSyncController NewController(PlanscapeDbContext db, Guid tenantId)
+    {
+        var scopeFactory = new ServiceCollection()
+            .BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
+        var controller = new TagSyncController(
+            db,
+            new NullHubContext<TagSyncHub>(),
+            new NullHubContext<ComplianceHub>(),
+            scopeFactory,
+            new NullHubContext<NotificationHub>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim("tenant_id", tenantId.ToString())
+                }, "TestAuth"))
+            }
+        };
+        return controller;
+    }
+
+    private static TagElementDto Dto(long revitId, bool isDeleted, DateTime? lastModified,
+        string tag1 = "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001") => new()
+    {
+        RevitElementId = revitId,
+        UniqueId = $"unique-{revitId}",
+        Disc = "M", Loc = "BLD1", Zone = "Z01", Lvl = "L02",
+        Sys = "HVAC", Func = "SUP", Prod = "AHU", Seq = "0001",
+        Tag1 = tag1,
+        CategoryName = "Mechanical Equipment",
+        FamilyName = "AHU_Standard",
+        IsComplete = true, IsFullyResolved = true,
+        IsDeleted = isDeleted,
+        LastModifiedUtc = lastModified
+    };
+
+    private static TagSyncResponse Sync(ActionResult<TagSyncResponse> result)
+    {
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        return Assert.IsType<TagSyncResponse>(ok.Value);
+    }
+
+    // ── 1. Delete marks the row ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_DeleteFlag_TombstonesRow_AndHidesItFromNormalReads()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var serverTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var clientTs = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(Sync_DeleteFlag_TombstonesRow_AndHidesItFromNormalReads));
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(ElementId, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        var response = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId,
+            UserName = "Deleter",
+            Elements = new List<TagElementDto> { Dto(ElementId, isDeleted: true, clientTs) }
+        }));
+
+        // Reported as a delete — NOT as a create or an update.
+        Assert.Equal(1, response.Deleted);
+        Assert.Equal(0, response.Created);
+        Assert.Equal(0, response.Updated);
+        Assert.Empty(response.Conflicts);
+
+        // The row still exists (tombstone, not hard delete) and carries when.
+        var tombstoned = await db.TaggedElements.IgnoreQueryFilters().AsNoTracking()
+            .SingleAsync(e => e.RevitElementId == ElementId);
+        Assert.NotNull(tombstoned.DeletedAtUtc);
+        Assert.Equal(clientTs, tombstoned.DeletedAtUtc);
+        Assert.Equal(2, tombstoned.Version);                  // Version bumped
+        Assert.Equal(clientTs, tombstoned.LastModifiedUtc);
+        // The delete payload must NOT overwrite the last known good tag data —
+        // preserving it is the reason the row is kept at all.
+        Assert.Equal("M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", tombstoned.Tag1);
+
+        // ...and it is invisible to an ordinary read. Note BypassTenantFilter
+        // is on, proving the bypass relaxes tenancy only, never the tombstone.
+        Assert.False(await db.TaggedElements.AnyAsync(e => e.RevitElementId == ElementId));
+    }
+
+    // ── 2. Delete of an unknown element is a no-op ──────────────────────────
+
+    [Fact]
+    public async Task Sync_DeleteOfUnknownElement_IsNoOp_NotAnInsert()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        await using var db = NewDb(nameof(Sync_DeleteOfUnknownElement_IsNoOp_NotAnInsert));
+        await SeedAsync(db, tenantId, projectId); // no elements at all
+
+        var controller = NewController(db, tenantId);
+
+        var response = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId,
+            UserName = "Deleter",
+            Elements = new List<TagElementDto>
+            {
+                Dto(999_999, isDeleted: true, new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc))
+            }
+        }));
+
+        // Accepted (200), but nothing happened — and crucially no row was
+        // inserted, which would have resurrected the element as a dead row.
+        Assert.Equal(1, response.Received);
+        Assert.Equal(0, response.Created);
+        Assert.Equal(0, response.Updated);
+        Assert.Equal(0, response.Deleted);
+        Assert.Empty(response.Conflicts);
+        Assert.Empty(await db.TaggedElements.IgnoreQueryFilters().ToListAsync());
+    }
+
+    // ── 3. A STALE delete loses, and records a SERVER_WINS conflict ─────────
+
+    [Fact]
+    public async Task Sync_StaleDelete_LosesToNewerServerRow_AndRecordsServerWinsConflict()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        // Server was edited AFTER the client's delete was issued.
+        var serverTs = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        var staleClientTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(Sync_StaleDelete_LosesToNewerServerRow_AndRecordsServerWinsConflict));
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(ElementId, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        var response = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId,
+            UserName = "StaleClient",
+            Elements = new List<TagElementDto> { Dto(ElementId, isDeleted: true, staleClientTs) }
+        }));
+
+        // The delete was REJECTED — it did not bypass the conflict path.
+        Assert.Equal(0, response.Deleted);
+        Assert.Equal(0, response.Updated);
+        Assert.Equal(0, response.Created);
+
+        var conflict = Assert.Single(response.Conflicts);
+        Assert.Equal(ElementId.ToString(), conflict.ElementId);
+        Assert.Equal("SERVER_WINS", conflict.Resolution);
+        Assert.Equal(serverTs, conflict.ServerTimestamp);
+        Assert.Equal(staleClientTs, conflict.ClientTimestamp);
+
+        // A SyncConflict row was persisted, exactly as a stale update does.
+        var persisted = await db.SyncConflicts.AsNoTracking()
+            .SingleAsync(c => c.ElementId == ElementId.ToString());
+        Assert.Equal("SERVER_WINS", persisted.Resolution);
+        // Typed as a delete so an operator can tell "your delete was refused"
+        // from "your edit was refused".
+        Assert.Equal("STALE_DELETE", persisted.ConflictType);
+        Assert.Equal(serverTs, persisted.ServerTimestamp);
+        Assert.Equal(staleClientTs, persisted.ClientTimestamp);
+        Assert.Equal("StaleClient", persisted.ClientUserName);
+
+        // The element survived, untombstoned and unbumped.
+        var survivor = await db.TaggedElements.AsNoTracking()
+            .SingleAsync(e => e.RevitElementId == ElementId);
+        Assert.Null(survivor.DeletedAtUtc);
+        Assert.Equal(1, survivor.Version);
+        Assert.Equal(serverTs, survivor.LastModifiedUtc);
+    }
+
+    // ── 4. Undelete restores ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sync_LiveElementAfterDelete_UndeletesAndUpdates()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var serverTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var deleteTs = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+        var restoreTs = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(Sync_LiveElementAfterDelete_UndeletesAndUpdates));
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(ElementId, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        // Delete it...
+        var deleteResponse = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId, UserName = "Deleter",
+            Elements = new List<TagElementDto> { Dto(ElementId, isDeleted: true, deleteTs) }
+        }));
+        Assert.Equal(1, deleteResponse.Deleted);
+
+        // ...then Revit undo restores it and the plugin re-sends it as live.
+        var restoreResponse = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId, UserName = "Restorer",
+            Elements = new List<TagElementDto>
+            {
+                Dto(ElementId, isDeleted: false, restoreTs, tag1: "M-BLD1-Z01-L02-HVAC-SUP-AHU-0099")
+            }
+        }));
+
+        // An undelete is an ordinary update, not a create — the row was reused,
+        // so no duplicate was inserted against the unique (ProjectId, RevitElementId).
+        Assert.Equal(1, restoreResponse.Updated);
+        Assert.Equal(0, restoreResponse.Created);
+        Assert.Equal(0, restoreResponse.Deleted);
+        Assert.Empty(restoreResponse.Conflicts);
+
+        // Visible to ordinary reads again, tombstone cleared, data updated.
+        var restored = await db.TaggedElements.AsNoTracking()
+            .SingleAsync(e => e.RevitElementId == ElementId);
+        Assert.Null(restored.DeletedAtUtc);
+        Assert.Equal("M-BLD1-Z01-L02-HVAC-SUP-AHU-0099", restored.Tag1);
+        Assert.Equal(3, restored.Version); // 1 seed -> 2 delete -> 3 undelete
+        Assert.Single(await db.TaggedElements.IgnoreQueryFilters().ToListAsync());
+    }
+
+    // ── 5a. Deleted elements drop out of compliance ─────────────────────────
+
+    [Fact]
+    public async Task Sync_DeletedElement_StopsCountingTowardComplianceAndTotals()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var serverTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var deleteTs = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(Sync_DeletedElement_StopsCountingTowardComplianceAndTotals));
+        // One TAGGED element and one UNTAGGED element => 1/2 = 50% compliant.
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(1001, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs),
+            LiveElement(1002, "", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        // Delete the UNTAGGED one. If tombstones still counted, compliance would
+        // stay at 50%; if they are excluded it becomes 1/1 = 100%.
+        var response = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId, UserName = "Deleter",
+            Elements = new List<TagElementDto> { Dto(1002, isDeleted: true, deleteTs, tag1: "") }
+        }));
+
+        Assert.Equal(1, response.Deleted);
+        Assert.Equal(100d, response.CompliancePercent);
+
+        // The denominator on the project row shrank too.
+        var project = await db.Projects.AsNoTracking().SingleAsync(p => p.Id == projectId);
+        Assert.Equal(1, project.TotalElements);
+        Assert.Equal(1, project.TaggedElements);
+        Assert.Equal(100d, project.CompliancePercent);
+
+        // And the dedicated compliance endpoint agrees.
+        var complianceResult = await controller.GetCompliance(projectId);
+        var complianceOk = Assert.IsType<OkObjectResult>(complianceResult.Result);
+        var summary = Assert.IsType<ComplianceSummaryDto>(complianceOk.Value);
+        Assert.Equal(1, summary.TotalElements);
+        Assert.Equal(0, summary.Untagged);
+    }
+
+    // ── 5b. Deleted elements drop out of the element pull ───────────────────
+
+    [Fact]
+    public async Task GetElements_ExcludesTombstonedElements()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var serverTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var deleteTs = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(GetElements_ExcludesTombstonedElements));
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(1001, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs),
+            LiveElement(1002, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0002", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId, UserName = "Deleter",
+            Elements = new List<TagElementDto> { Dto(1002, isDeleted: true, deleteTs) }
+        });
+
+        // NOTE: called without `lastSyncUtc`. The delta branch upserts the
+        // per-device watermark with ExecuteSqlRawAsync, which the InMemory
+        // provider cannot run. That branch only ADDS a LastModifiedUtc cutoff on
+        // top of the same `_db.TaggedElements` source, and the tombstone
+        // exclusion comes from the global query filter on that source — so it is
+        // exercised either way. The deleted row's LastModifiedUtc (Feb) is in
+        // fact NEWER than the live one's (Jan), so a delta pull would have
+        // surfaced it first if the filter were not applied.
+        var result = await controller.GetElements(projectId);
+        var ok = Assert.IsType<OkObjectResult>(result);
+
+        var payload = ok.Value!;
+        var totalProp = payload.GetType().GetProperty("total")!;
+        var elementsProp = payload.GetType().GetProperty("elements")!;
+        var total = (int)totalProp.GetValue(payload)!;
+        var elements = ((IEnumerable<TaggedElement>)elementsProp.GetValue(payload)!).ToList();
+
+        Assert.Equal(1, total);
+        Assert.Equal(1001, Assert.Single(elements).RevitElementId);
+    }
+
+    // ── 6. Backward compatibility: no isDeleted field at all ────────────────
+
+    [Fact]
+    public async Task Sync_WithoutIsDeletedField_BehavesExactlyAsBefore()
+    {
+        var tenantId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var serverTs = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var clientTs = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await using var db = NewDb(nameof(Sync_WithoutIsDeletedField_BehavesExactlyAsBefore));
+        await SeedAsync(db, tenantId, projectId,
+            LiveElement(1001, "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001", serverTs));
+
+        var controller = NewController(db, tenantId);
+
+        // An OLD plugin build: the DTOs below never set IsDeleted, exactly as a
+        // JSON payload with no `isDeleted` key would bind. One update + one insert.
+        var response = Sync(await controller.SyncElements(new TagSyncRequest
+        {
+            ProjectId = projectId, UserName = "LegacyPlugin",
+            Elements = new List<TagElementDto>
+            {
+                new()
+                {
+                    RevitElementId = 1001, UniqueId = "unique-1001",
+                    Disc = "M", Loc = "BLD1", Zone = "Z01", Lvl = "L02",
+                    Sys = "HVAC", Func = "SUP", Prod = "AHU", Seq = "0001",
+                    Tag1 = "M-BLD1-Z01-L02-HVAC-SUP-AHU-0001-EDITED",
+                    CategoryName = "Mechanical Equipment", FamilyName = "AHU_Standard",
+                    IsComplete = true, IsFullyResolved = true,
+                    LastModifiedUtc = clientTs
+                },
+                new()
+                {
+                    RevitElementId = 1002, UniqueId = "unique-1002",
+                    Disc = "E", Loc = "BLD1", Zone = "Z01", Lvl = "L02",
+                    Sys = "LV", Func = "PWR", Prod = "DB", Seq = "0002",
+                    Tag1 = "E-BLD1-Z01-L02-LV-PWR-DB-0002",
+                    CategoryName = "Electrical Equipment", FamilyName = "DB_Standard",
+                    IsComplete = true, IsFullyResolved = true,
+                    LastModifiedUtc = clientTs
+                }
+            }
+        }));
+
+        Assert.Equal(1, response.Updated);
+        Assert.Equal(1, response.Created);
+        Assert.Equal(0, response.Deleted);        // absent field => never a delete
+        Assert.Empty(response.Conflicts);
+
+        // Nothing was tombstoned, and both rows are live.
+        Assert.Equal(2, await db.TaggedElements.CountAsync());
+        Assert.All(await db.TaggedElements.AsNoTracking().ToListAsync(),
+            e => Assert.Null(e.DeletedAtUtc));
+    }
+
+    // ── Minimal SignalR hub-context stubs (the controller fires broadcasts
+    //    inside a try/catch so these no-ops are sufficient for unit testing).
+    private sealed class NullHubContext<T> : IHubContext<T> where T : Hub
+    {
+        public IHubClients Clients { get; } = new NullHubClients();
+        public IGroupManager Groups { get; } = new NullGroupManager();
+    }
+
+    private sealed class NullHubClients : IHubClients
+    {
+        private static readonly IClientProxy Proxy = new NullClientProxy();
+        public IClientProxy All => Proxy;
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Client(string connectionId) => Proxy;
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => Proxy;
+        public IClientProxy Group(string groupName) => Proxy;
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => Proxy;
+        public IClientProxy User(string userId) => Proxy;
+        public IClientProxy Users(IReadOnlyList<string> userIds) => Proxy;
+    }
+
+    private sealed class NullClientProxy : IClientProxy
+    {
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class NullGroupManager : IGroupManager
+    {
+        public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+        public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Why

`POST /api/tagsync/sync` was **insert-or-update only**. Delete a wall in Revit and its `TaggedElement` row lived on the server forever, inflating element counts and skewing compliance. This is the last missing piece of a live plugin→server element sync; a parallel workstream delivers the plugin side.

**Not related to PR #503 / `claude/complete-unwired-controllers-741d58`** — branched fresh off `main`.

## Contract

The plugin workstream owns `Planscape.Shared/Models/SyncModels.cs` and is adding `bool IsDeleted` → JSON `isDeleted`. **That file is not touched here.** This PR only teaches the server to understand the field.

## What changed

| Area | Change |
|---|---|
| `TagElementDto` | `+ bool IsDeleted` — default `false`, **not** required |
| `TaggedElement` | `+ DateTime? DeletedAtUtc`, implements new `ISoftDeletable` |
| `TagSyncResponse` | `+ int Deleted`, reported distinctly from Created/Updated |
| `TagSyncController` | delete / undelete / unknown-element branches |
| `PlanscapeDbContext` | soft-delete predicate folded into the global filter + `(ProjectId, DeletedAtUtc)` index |
| `ComplianceController` | raw-SQL heat-map gets `"DeletedAtUtc" IS NULL` |
| `Program.cs` | idempotent `ADD COLUMN IF NOT EXISTS` (see Migrations) |
| `PostgresBulkTagUpserter` | `ON CONFLICT` clears `DeletedAtUtc` |

### Behaviour

- `isDeleted: true` + row exists → tombstone, bump `Version`, **same** last-write-wins gate as an update.
- `isDeleted: true` + no row → **no-op**. Not an error, not an insert.
- `isDeleted: false` on a tombstoned row → **undelete** + update.
- **Stale delete** → loses to a newer server row and records a `SERVER_WINS` `SyncConflict`, typed `STALE_DELETE` so an operator can tell a refused delete from a refused edit. The conflict path is not bypassed.
- A delete does **not** call `MapDtoToEntity` — the last known good tag data is preserved, which is the point of keeping the row.

### Why a timestamp, not `bool IsDeleted`

It carries *when* (auditing), and makes **undelete** — a Revit undo restoring an element, which *will* happen — a normal field update rather than a special case. `IS NULL` is also the cheap, index-friendly predicate the global filter needs.

## ⚠ The EF Core 8 trap this had to avoid

EF Core 8 allows **one** query filter per entity; a later `HasQueryFilter` **replaces** an earlier one. Adding the tombstone predicate as a second call would have silently **dropped the tenant predicate** — turning a soft-delete feature into a cross-tenant leak.

So it is **AND-folded into the existing tenant filter** instead. `BypassTenantFilter` relaxes tenancy only, never the tombstone.

> **Pre-existing bug found, reported not fixed:** `AppUser` declares `HasQueryFilter(u => !u.IsDeleted)` at `PlanscapeDbContext.cs:632`, which the generic tenant filter (line ~1251, applied later) **overwrites** — so soft-deleted users are *not* actually hidden today. Fixing it changes AppUser visibility well outside this PR's scope.

## Migrations — none, deliberately

Per **`docs/adr/0001-schema-management.md`** (Accepted): the ~75 files under `Data/Migrations/` "are **not usable as an EF migration history**… carry **no `[Migration("id")]` attribute** and have **no `.Designer.cs` companions**… `Database.Migrate()` sees **zero** migrations and applies nothing." The ADR adopts "**EnsureCreated + idempotent-patcher path as the OFFICIAL, supported schema-management mechanism**".

**No `dotnet ef migrations add` was run.** The column reaches:
- **fresh DBs** via the EF model (`CreateTables`),
- **pre-existing DBs** via `ALTER TABLE … ADD COLUMN IF NOT EXISTS` in `PatchDevSchemaAsync`,
- and `SchemaDriftChecker` picks it up automatically (it enumerates the live EF model).

Nullable with **no default**, so every pre-existing row reads as live.

## Backward compatibility

Older plugins never send `isDeleted`. The field is a non-nullable `bool` defaulting to `false` and is **not** required, so an absent key binds to `false` and the element takes exactly the pre-existing path. Covered by a dedicated test.

## Tests

7 new cases in `TagSyncSoftDeleteTests`: tombstone marks the row (and stays hidden even under `BypassTenantFilter`); unknown-element delete is a no-op; stale delete loses **and** logs `SERVER_WINS`; undelete restores without inserting a duplicate; deleted elements leave compliance + project totals; deleted elements leave the element pull; legacy no-`isDeleted` payloads behave as before.

**Results:** `538 passed / 0 failed / 9 skipped` (547 total = 540 baseline + 7 new). The 9 skips are Postgres/environment-gated and pre-existing. `known-failing-tests.txt` is an intentional zero-failure baseline.

> **Flake note, verified:** the suite intermittently fails en masse (the documented DEP-7 order/parallelism issue). Reproduced on **unmodified `origin/main`**: 3 runs gave green / green / **54 failures**. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)