### PR TITLE
docs(titleblocks): retire the "project-wide override" toggle tier

### DIFF
--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -504,11 +504,17 @@ namespace StingTools.Core
         // the {sys} token. UUIDv5, Planscape docs namespace (matches MR_PARAMETERS.txt).
         public const string PRJ_SHEET_SYSTEM       = "PRJ_SHEET_SYSTEM_TXT";
         public const string PRJ_SHEET_SYSTEM_GUID  = "972024c1-53c5-5b57-b9f7-98e89fa53572";
-        // Canonical home for these toggles is TB_SHOW_*_BOOL on the GROUP 26 TBL_TITLEBLOCK
-        // FamilyInstance (added in Drawing Template Manager). The PRJ_TB_SHOW_*_BOOL
-        // constants below are kept on ViewSheet for backwards compat with sheets that
-        // were authored before STING TB v1; new title block families should bind to the
-        // GROUP 26 TB_ versions.
+        // Canonical home for these toggles is the GROUP 26 TBL_TITLEBLOCK FamilyInstance
+        // (added in Drawing Template Manager). All five constants below name GROUP 26
+        // params; the root title-block spec A1_common_v2.0 declares them, so
+        // TitleBlockFactory mints them as INSTANCE family params onto every family it
+        // builds, and TITLE_BLOCK.csv seeds them through TitleBlockPopulate.
+        //
+        // Their GROUP 13 near-namesakes (PRJ_TB_SHOW_KEYPLAN_BOOL, ...SCALEBAR...,
+        // ...NORTHARROW..., ...DISCBAND...) are NOT a project-wide override tier — no
+        // code reads or writes them, and they bind to Generic Models / Project
+        // Information rather than Title Blocks. They remain in MR_PARAMETERS.txt only so
+        // models that already bound them keep the binding.
         public const string TB_SHOW_KEYPLAN        = "PRJ_TB_SHOW_KEY_PLAN_BOOL";
         public const string TB_SHOW_KEYPLAN_GUID   = "9a64e982-1b97-5922-9831-0948aaf1cf76";
         public const string TB_SHOW_SCALEBAR       = "PRJ_TB_SHOW_SCALE_BAR_BOOL";
@@ -518,9 +524,7 @@ namespace StingTools.Core
         // NB: this pair pointed at the GROUP 13 legacy param (PRJ_TB_SHOW_DISCBAND_BOOL
         // / 483f47d7) while its three siblings above already pointed at their GROUP 26
         // equivalents — the odd one out in a block whose stated contract is "the GROUP 26
-        // TB_ versions". Repointed to match. The GROUP 13 param still ships in
-        // MR_PARAMETERS.txt as the project-wide override; it is simply not what this
-        // constant means.
+        // TB_ versions". Repointed to match.
         public const string TB_SHOW_DISCBAND       = "PRJ_TB_SHOW_DISCIPLINE_BAND_BOOL";
         public const string TB_SHOW_DISCBAND_GUID  = "fcd1f7f2-8b64-5cd7-9d27-982d604a231e";
         // Gates the revision-history zone (the native Revit revision schedule

--- a/docs/guides/TITLE_BLOCK_CREATION_GUIDE.md
+++ b/docs/guides/TITLE_BLOCK_CREATION_GUIDE.md
@@ -994,12 +994,21 @@ The **project-level** title-block parameters bound to `ProjectInformation`. Edit
 | `PRJ_TB_LAST_SYNC_TXT` | Last sync timestamp (server) |
 | `PRJ_TB_LAST_SYNC_BY_TXT` | Last sync user (server) |
 | `PRJ_TB_LOCK_BOOL` | Per-project lock — when `1`, rev bumps require admin |
-| `PRJ_TB_SHOW_KEYPLAN_BOOL` | Project-wide override for key-plan visibility |
-| `PRJ_TB_SHOW_SCALEBAR_BOOL` | Project-wide override for scale-bar visibility |
-| `PRJ_TB_SHOW_NORTHARROW_BOOL` | Project-wide override for north-arrow visibility |
-| `PRJ_TB_SHOW_DISCBAND_BOOL` | Project-wide override for discipline-band visibility |
 | `PRJ_TB_SCALE_OVERRIDE_TXT` | If non-empty, overrides the scale shown in the strip |
 | `PRJ_TB_ISSUE_SUMMARY_TXT` | Multi-line summary printed on the start-up page |
+
+> **Visibility toggles live on the title block, not here.** Earlier revisions of
+> this section listed `PRJ_TB_SHOW_KEYPLAN_BOOL`, `PRJ_TB_SHOW_SCALEBAR_BOOL`,
+> `PRJ_TB_SHOW_NORTHARROW_BOOL` and `PRJ_TB_SHOW_DISCBAND_BOOL` as a
+> "project-wide override" tier. There is no such tier. Those four are the GROUP
+> 13 legacy params: nothing in the plugin reads or writes them, they are bound to
+> Generic Models and Project Information rather than Title Blocks, and
+> `TitleBlockPopulate` never touches them. Use the GROUP 26 toggles listed in §15
+> (`PRJ_TB_SHOW_KEY_PLAN_BOOL`, `PRJ_TB_SHOW_SCALE_BAR_BOOL`,
+> `PRJ_TB_SHOW_NORTH_ARROW_BOOL`, `PRJ_TB_SHOW_DISCIPLINE_BAND_BOOL`), which the
+> factory mints onto every title-block family and `TITLE_BLOCK.csv` seeds. The
+> legacy four still ship in `MR_PARAMETERS.txt` so models that already bound them
+> do not lose the binding — they are inert, not removed.
 
 ### 16.8 Deliverable / CDE
 
@@ -1042,7 +1051,7 @@ Drop the eight families into `Families/Annotations/` (or your project's annotati
 | Title block placed but viewports overlap reserved areas | `TB_RESERVED_REGIONS_JSON_TXT` is malformed JSON, so the engine ignored it | Validate the JSON in any online linter; commas / quotes are common culprits |
 | Validator reports "slot 3 exceeds drawable zone" | Slot rectangle (norm coords) extends past the drawable-zone boundary | Either widen the drawable zone or shrink the slot |
 | North arrow does not auto-rotate | Either `TB_NORTH_ARROW_AUTO_ROTATE_BOOL = 0` *or* the nested arrow family overrides its own rotation | Set the toggle, then open the nested family and unlock the rotation parameter |
-| Discipline colour band invisible | `PRJ_TB_SHOW_DISCIPLINE_BAND_BOOL` set to 0, *or* the project-wide override `PRJ_TB_SHOW_DISCBAND_BOOL` set to 0 | Set both to 1 |
+| Discipline colour band invisible | `PRJ_TB_SHOW_DISCIPLINE_BAND_BOOL` set to 0 — or absent from the title-block family, which is the case for any `.rfa` built before the parameter was added to the root spec | Set it to 1; if the parameter is not on the title block at all, rebuild the family with `TitleBlock_CreateAll`. Do not set `PRJ_TB_SHOW_DISCBAND_BOOL` — it is inert legacy (see §16.7) |
 | QR code stamps wrong URL | `TB_QR_PAYLOAD_TXT` was hand-edited and didn't match the deliverable id | Don't hand-edit; let `IssueDeliverable` rebuild it |
 | Authority submission fails on missing seal | The reserved seal rectangle is empty | Insert the seal image into the rectangle, save the project |
 | `corp-base` view template not applied | Project-scoped override missing or `STING_VIEW_STYLE_PACKS.json` invalid | Run **Drawing Types ▸ Inspect**; the diagnostic lists every routing rule and validation issue |


### PR DESCRIPTION
Closes the one question left open by #566 and #567.

## The contradiction

`MR_PARAMETERS.txt` marks the four GROUP-13 toggles `LEGACY`. `TITLE_BLOCK_CREATION_GUIDE` §16.7 documented them as a live **"project-wide override"** tier. Both shipped, and they cannot both be true.

## The code settles it — there is no such tier

- **Nothing reads or writes them.** `git grep -w` across `*.cs` / `*.xaml` for `PRJ_TB_SHOW_KEYPLAN_BOOL`, `…SCALEBAR…`, `…NORTHARROW…`, `…DISCBAND…` returns one hit, and it is the explanatory comment in `ParamRegistry` added by #566.
- **They are unreachable by design.** They bind to Generic Models + Project Information, not Title Blocks. `TitleBlockPopulate` writes to the sheet's title-block `FamilyInstance`, so it cannot touch them whatever the CSV says.
- **The canonical path is GROUP 26.** `AllTitleBlockParams` names that set exclusively, and since #567 the root spec `A1_common_v2.0` mints them onto all 32 families the factory builds.

The rest of the guide already assumed GROUP 26 throughout — §15's parameter table (rows 17-23), and every worked example in §§ 286-593. §16.7 and one troubleshooting row were the only drift.

## Changes

**§16.7** — the four rows are replaced by a note that says what happened and why, rather than silently deleting them. A reader who remembers the old table should not be left wondering whether they misread it.

**Troubleshooting, "discipline colour band invisible"** — the old row advised setting `PRJ_TB_SHOW_DISCIPLINE_BAND_BOOL` *and* `PRJ_TB_SHOW_DISCBAND_BOOL` to 1. The second does nothing. Replaced with the real post-#567 cause — the parameter is absent from any `.rfa` built before it was added to the root spec — and the real fix, `TitleBlock_CreateAll` (verified to be a live command tag).

**`ParamRegistry` TB_SHOW_* header comment** — claimed the constants were "kept on ViewSheet for backwards compat with sheets authored before STING TB v1". All five name GROUP-26 params, so that was misleading. Corrected, with the GROUP-13 set described as inert-not-removed.

**The #566 note on `TB_SHOW_DISCBAND`** — dropped its "still ships … as the project-wide override" clause, which repeated the same wrong framing.

## What is deliberately not done

The legacy four **stay in `MR_PARAMETERS.txt`**. Removing them would orphan the binding in any model that already carries them — the exact failure mode this whole series started with — and inert params cost nothing.

## Verification

- `dotnet build StingTools.csproj -c Debug` → **0 errors, 0 warnings**
- 2 files, 26 insertions / 13 deletions
- Every remaining mention of the legacy names in the guide is now an explicit "this is inert" reference (lines 1001-1002, 1054)
- §16.7 table has no duplicate rows; the cross-reference points at §15, which is the section that actually lists the GROUP-26 toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
