### PR TITLE
fix(symbols): annotation curves never drew — null sketchPlane on every line

### DIFF
--- a/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
+++ b/StingTools/Commands/Symbols/SymbolLibraryCommands.cs
@@ -217,6 +217,46 @@ namespace StingTools.Commands.Symbols
             + "  template files') must point at a folder containing the generic-annotation\n"
             + "  template (e.g. 'Metric Generic Annotation.rft'). Set it, then re-run.";
 
+        /// <summary>
+        /// The accurate version of <see cref="TemplateFixHint"/>.
+        ///
+        /// <para>The flat hint blamed the template FOLDER for every empty batch, which
+        /// misreads the common case: the folder is set and most catalogues build from it
+        /// fine, but one specific .rft (e.g. 'Metric Pipe Accessory.rft') is absent from
+        /// this Revit install. Telling users to set a path they have already set sends
+        /// them the wrong way, so name the missing family types instead.</para>
+        /// </summary>
+        public static string DescribeTemplateProblem(SymbolCreationResult r)
+        {
+            if (r == null) return TemplateFixHint;
+
+            var all = r.Warnings.Concat(r.Errors).Where(w => w != null).ToList();
+
+            // Folder-level failure: nothing on the machine resolved at all.
+            if (all.Any(w => w.IndexOf("no family template folder", StringComparison.OrdinalIgnoreCase) >= 0))
+                return TemplateFixHint;
+
+            // Per-type failure: harvest the "FamilyType/Discipline" tails so the user
+            // knows exactly which template to install.
+            const string marker = "no family template found for ";
+            var kinds = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var w in all)
+            {
+                int i = w.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+                if (i < 0) continue;
+                string tail = w.Substring(i + marker.Length).Trim();
+                if (tail.Length > 0) kinds.Add(tail);
+            }
+            if (kinds.Count == 0) return TemplateFixHint;
+
+            return "ACTION — 0 families created: this Revit install has no template for "
+                 + string.Join(", ", kinds) + ".\n"
+                 + "  The template FOLDER is fine — other catalogues built from it.\n"
+                 + "  Install the matching .rft (a Pipe Accessory batch needs\n"
+                 + "  'Metric Pipe Accessory.rft') into the folder set at Revit → Options →\n"
+                 + "  File Locations → 'Family Template Files', then re-run.";
+        }
+
         public static string FormatReport(string title, SymbolCreationResult r)
         {
             var sb = new StringBuilder();
@@ -227,7 +267,7 @@ namespace StingTools.Commands.Symbols
             if (LooksLikeMissingTemplate(r))
             {
                 sb.AppendLine();
-                sb.AppendLine(TemplateFixHint);
+                sb.AppendLine(DescribeTemplateProblem(r));
             }
             if (r.Warnings.Count > 0)
             {
@@ -280,7 +320,10 @@ namespace StingTools.Commands.Symbols
             {
                 report += "\n\n" + $"{emptyBatches.Count} catalogue(s) produced 0 families:\n"
                     + string.Join("\n", emptyBatches.Select(x => "  · " + x))
-                    + "\n\n" + SymbolBatchHelper.TemplateFixHint;
+                    // Aggregate, not a single batch: 838 families can build from a folder
+                    // that is plainly set while one catalogue's .rft is simply absent, so
+                    // the message must be derived from the warnings, not assumed.
+                    + "\n\n" + SymbolBatchHelper.DescribeTemplateProblem(aggregate);
             }
             TaskDialog.Show("STING - Symbol Library", report);
             return Result.Succeeded;

--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -800,6 +800,40 @@ namespace StingTools.Core.Symbols
             }
         }
 
+        /// <summary>
+        /// Creates one curve in a family document, picking the API the template actually
+        /// supports.
+        ///
+        /// <para>Annotation templates have NO sketch plane — ResolveSketchPlane returns
+        /// null for them deliberately, because SketchPlane.Create is forbidden there. The
+        /// draw path nevertheless passed that null straight into NewSymbolicCurve, whose
+        /// sketchPlane argument is mandatory, so every curve in every GenericAnnotation
+        /// family threw "Value cannot be null. Parameter name: sketchPlane", was caught,
+        /// warned and skipped. The families still saved — empty. Annotation curves belong
+        /// on the family's own view via NewDetailCurve, which needs no plane.</para>
+        /// </summary>
+        private static void CreateFamilyCurve(Document fdoc, View view, SketchPlane sketch,
+            Curve curve, bool isAnnotation, string id, SymbolCreationResult result)
+        {
+            if (isAnnotation)
+            {
+                if (view == null)
+                {
+                    result.Warnings.Add($"{id}: no view available for annotation curve — skipped.");
+                    return;
+                }
+                fdoc.FamilyCreate.NewDetailCurve(view, curve);
+                return;
+            }
+
+            if (sketch == null)
+            {
+                result.Warnings.Add($"{id}: no sketch plane available for model curve — skipped.");
+                return;
+            }
+            fdoc.FamilyCreate.NewModelCurve(curve, sketch);
+        }
+
         private static void DrawLine(Document fdoc, View view, SketchPlane sketch, TemplateKind kind,
             LineDefinition l, double symMm, SymbolCreationResult result, string id)
         {
@@ -820,12 +854,8 @@ namespace StingTools.Core.Symbols
                 Line line = Line.CreateBound(p1, p2);
                 if (fdoc.IsFamilyDocument)
                 {
-                    // Fix 1a — GenericAnnotation families use NewSymbolicCurve;
-                    // model families use NewModelCurve.
-                    if (IsAnnotationFamily(fdoc, null))
-                        fdoc.FamilyCreate.NewSymbolicCurve(line, sketch);
-                    else
-                        fdoc.FamilyCreate.NewModelCurve(line, sketch);
+                    CreateFamilyCurve(fdoc, view, sketch, line,
+                        IsAnnotationFamily(fdoc, null), id, result);
                 }
                 else
                 {
@@ -868,10 +898,7 @@ namespace StingTools.Core.Symbols
                 // warnings were swallowed by SymbolFailureSwallow.)
                 if (fdoc.IsFamilyDocument)
                 {
-                    if (isAnnotation)
-                        fdoc.FamilyCreate.NewSymbolicCurve(line, sketch);
-                    else
-                        fdoc.FamilyCreate.NewModelCurve(line, sketch);
+                    CreateFamilyCurve(fdoc, view, sketch, line, isAnnotation, id, result);
                 }
                 else
                 {
@@ -917,12 +944,8 @@ namespace StingTools.Core.Symbols
 
                 if (fdoc.IsFamilyDocument)
                 {
-                    // Fix 1a — GenericAnnotation families use NewSymbolicCurve;
-                    // model families use NewModelCurve.
-                    if (IsAnnotationFamily(fdoc, null))
-                        fdoc.FamilyCreate.NewSymbolicCurve(curve, sketch);
-                    else
-                        fdoc.FamilyCreate.NewModelCurve(curve, sketch);
+                    CreateFamilyCurve(fdoc, view, sketch, curve,
+                        IsAnnotationFamily(fdoc, null), id, result);
                 }
                 else
                 {


### PR DESCRIPTION
Found by live test. A full symbol build reported **Created 838 / Failed 42**
with **6047 warnings**, thousands identical:

```
SLD_MCB: line draw failed — Value cannot be null. Parameter name: sketchPlane
```

### The bug

`ResolveSketchPlane` returns `null` for Annotation templates **deliberately** —
`SketchPlane.Create` is forbidden there, and its own comment says the curves
belong on the family view via `NewDetailCurve`. But `DrawLine` and `DrawArc`
passed that null straight into `NewSymbolicCurve`, whose `sketchPlane` argument
is mandatory. Every curve threw, was caught, warned, skipped — **and the family
saved anyway, empty.** The `NewDetailCurve` branch was unreachable inside a
family document: it sits behind `!fdoc.IsFamilyDocument`.

**Every GenericAnnotation family — 730 of 880 symbols — has been building with
no linework at all.**

Three call sites (`DrawLine`, its section-view overload, `DrawArc`) now route
through `CreateFamilyCurve`, which picks `NewDetailCurve` for annotation and
`NewModelCurve` for model templates, and declines with a warning rather than
passing a null plane.

### Why this matters for the geometry work

P0 (#498) repaired the JSON→POCO binding so 206 filled regions and 115 arc
sweeps are now *read* correctly. This is what lets them actually reach Revit.

The cache invalidation is what exposed it — the run that produced this log
opens with `rebuilding cached families — no cache manifest — built before cache
invalidation existed`, forcing the first real rebuild these families have had.

### Second fix: the template hint was misleading

The same run built 838 families from the template folder while reporting *"the
Revit family TEMPLATE folder is not set"* for Pipe Accessories — whose
`Metric Pipe Accessory.rft` is simply absent from this install. Sending a user
to set a path they have already set is worse than saying nothing.
`DescribeTemplateProblem` now separates a genuinely unresolved folder from a
missing per-type template, and names the types.

Build: 0 warnings, 0 errors (Revit 2025, `-t:Rebuild`). **Not yet re-run in
Revit** — the next build should show the sketchPlane warnings gone and real
linework in the annotation families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)