### PR TITLE
fix: invite accept lands in the project; unblock the API deploy; fix search starvation

### DIFF
--- a/Planscape.Server/docker/Dockerfile
+++ b/Planscape.Server/docker/Dockerfile
@@ -99,6 +99,31 @@ RUN if [ "$PLANSCAPE_FACE_MODEL" = "true" ]; then \
     fi
 
 ENV ASPNETCORE_URLS=http://+:8080
+
+# ── Do not use inotify for file watching ──
+# WebApplication.CreateBuilder registers appsettings*.json with
+# reloadOnChange:true, which opens an inotify instance the moment the host
+# config is built. `fs.inotify.max_user_instances` is a HOST-WIDE limit (128 by
+# default) shared by every container of the same user, so on a busy shared host
+# the very first line of Main throws:
+#
+#   System.IO.IOException: The configured user limit (128) on the number of
+#   inotify instances has been reached …
+#     at System.IO.FileSystemWatcher.StartRaisingEvents()
+#     … at Program.<Main>$ in Program.cs:line 25
+#
+# That killed a Render deploy (exit 139, "no open ports detected") — the process
+# died before it could bind. We cannot raise the host limit, so don't consume it:
+#
+#   reloadConfigOnChange=false → no watcher registered for config at all. Config
+#     is supplied by env vars on this platform and a running container's
+#     appsettings.json never changes, so live reload buys nothing here.
+#   USE_POLLING_FILE_WATCHER → belt-and-braces: should anything else ask a
+#     PhysicalFileProvider to Watch(), it polls instead of taking an inotify
+#     instance. Inert while nothing watches.
+ENV DOTNET_hostBuilder__reloadConfigOnChange=false \
+    DOTNET_USE_POLLING_FILE_WATCHER=1
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -935,8 +935,22 @@ public class AuthController : ControllerBase
 
     // ── Reset Password (confirm reset) ────────────────────────────────────────
 
-    /// <summary>Reset password using a token from the forgot-password email.</summary>
-    /// <response code="200">Password reset — user can log in with new password.</response>
+    /// <summary>
+    /// Reset password using a token from the forgot-password / invite email.
+    ///
+    /// Returns a SESSION as well as a confirmation. The caller has just proved
+    /// possession of a single-use, short-lived token delivered to the address on
+    /// the account — the same proof <c>/login</c> would demand a password for —
+    /// so issuing a session here grants no capability the caller didn't already
+    /// have (they could simply log in with the password they just chose). What
+    /// it does buy is the invite flow working at all: the accept-invite page is
+    /// served by the API but the product lives on a DIFFERENT origin, so it has
+    /// no way to hand the invitee a signed-in browser without this.
+    ///
+    /// <c>webAppUrl</c> tells that page where the product actually is, instead
+    /// of it guessing from its own hostname (see <see cref="WebAppUrl"/>).
+    /// </summary>
+    /// <response code="200">Password reset — response carries a live session.</response>
     /// <response code="400">Invalid/expired token or password too short.</response>
     [EnableRateLimiting("auth")]
     [HttpPost("reset-password")]
@@ -952,6 +966,7 @@ public class AuthController : ControllerBase
         // ACTIVATES them (below), so the invite link is a complete onboarding step.
         // IgnoreQueryFilters: anonymous endpoint, so bypass the tenant filter.
         var user = await _db.Users.IgnoreQueryFilters()
+            .Include(u => u.Tenant)   // Tier, for the session payload below
             .FirstOrDefaultAsync(u => u.RefreshToken == hashed
                 && u.RefreshTokenExpiresAt > DateTime.UtcNow);
 
@@ -970,9 +985,54 @@ public class AuthController : ControllerBase
         // S6 / S5 — bump the iat-floor so any access token issued before
         // the reset (including ones the attacker may have minted while
         // they had the password) is rejected immediately.
+        //
+        // ORDER MATTERS: the floor is "now" in whole seconds and the policy
+        // handler rejects on `iat < floor`, so the session below — minted after
+        // this call — survives it. Minting first would race the floor.
         await _revocations.RevokeAllPriorTokensAsync(user.Id);
 
-        return Ok(new { message = "Password has been reset. Please log in." });
+        // Issue a live session so the accept-invite page can land the recipient
+        // IN the product instead of at a second sign-in they have no context
+        // for. Mirrors the tail of Login: JWT + hashed refresh token + activity
+        // key. The RESET: marker occupied RefreshToken and was cleared above, so
+        // this column is free to hold the real refresh-token hash now.
+        var accessToken = GenerateJwt(user);
+        var refreshToken = Guid.NewGuid().ToString("N");
+        user.RefreshToken = HashRefreshToken(refreshToken);
+        user.RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(7);
+        user.LastLoginAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        // SEC-EA-08 — seed the sliding-inactivity clock, as Login does. Best
+        // effort: a Redis outage must not fail a password reset that has
+        // already been committed.
+        try
+        {
+            await _redis.GetDatabase().StringSetAsync(
+                RefreshActivityKey(refreshToken),
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                TimeSpan.FromDays(7));
+        }
+        catch (Exception ex) when (ex is RedisException or TimeoutException or System.Net.Sockets.SocketException)
+        {
+            _logger.LogWarning(ex,
+                "Redis unavailable while seeding refresh-token activity key after password reset; "
+              + "SEC-EA-08 inactivity expiry degraded for this session.");
+        }
+
+        return Ok(new
+        {
+            message      = "Password has been set.",
+            accessToken,
+            refreshToken,
+            expiresAt    = DateTime.UtcNow.Add(AccessTokenLifetime),
+            userName     = user.DisplayName,
+            role         = user.Role.ToString(),
+            tier         = user.Tenant?.Tier.ToString() ?? "Starter",
+            // Where the browser app lives. Null when the server can't determine
+            // it — the page then shows a result instead of navigating nowhere.
+            webAppUrl    = Planscape.API.WebAppUrl.Resolve(_config, Request)
+        });
     }
 
     // ── Cloud handoff (planscape.build → this API) ──────────────────────────

--- a/Planscape.Server/src/Planscape.API/Controllers/SearchController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SearchController.cs
@@ -44,7 +44,19 @@ public class SearchController : ControllerBase
             : type.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                    .Select(t => t.ToLowerInvariant()).ToHashSet();
 
-        var results = new List<object>();
+        // One bucket per type, merged round-robin at the end (see below) rather
+        // than one flat list. Concatenating and then truncating meant a type that
+        // filled the limit STARVED the ones after it: with ≥25 matching tags and
+        // the default limit, a global search could not return a document, an
+        // issue or a meeting at all — they were fetched and then dropped.
+        var byType = new List<List<object>>();
+
+        // Every sub-query orders before Take. Without it Postgres returns an
+        // arbitrary subset of the matches — which rows you see for the same
+        // query can differ between identical requests, and it is what raises
+        // EF's RowLimitingOperationWithoutOrderByWarning in the logs. Newest
+        // first is the useful order for search; Id is the tiebreak that makes it
+        // total, so equal timestamps can't reorder between calls.
 
         // Search tagged elements
         if (types == null || types.Contains("tag"))
@@ -52,9 +64,10 @@ public class SearchController : ControllerBase
             var tags = await _db.TaggedElements
                 .Where(t => t.Project!.TenantId == tenantId &&
                     (EF.Functions.ILike(t.Tag1!, pattern) || EF.Functions.ILike(t.CategoryName!, pattern)))
+                .OrderByDescending(t => t.SyncedAt).ThenBy(t => t.Id)
                 .Select(t => new { Type = "tag", t.Id, Label = t.Tag1, Detail = t.CategoryName, ProjectId = t.ProjectId, ProjectName = t.Project!.Name })
                 .Take(limit).ToListAsync();
-            results.AddRange(tags);
+            byType.Add(tags.Cast<object>().ToList());
         }
 
         // Search issues — Phase 175: optional design-option filter so the
@@ -73,9 +86,10 @@ public class SearchController : ControllerBase
             if (!string.IsNullOrWhiteSpace(option))
                 qIssues = qIssues.Where(i => i.OptionName == option);
             var issues = await qIssues
+                .OrderByDescending(i => i.UpdatedAt).ThenBy(i => i.Id)
                 .Select(i => new { Type = "issue", i.Id, Label = $"{i.IssueCode}: {i.Title}", Detail = i.Status, ProjectId = i.ProjectId, ProjectName = i.Project!.Name, OptionSet = i.OptionSetName, Option = i.OptionName })
                 .Take(limit).ToListAsync();
-            results.AddRange(issues);
+            byType.Add(issues.Cast<object>().ToList());
         }
 
         // Search documents
@@ -84,9 +98,10 @@ public class SearchController : ControllerBase
             var docs = await _db.Documents
                 .Where(d => d.Project!.TenantId == tenantId &&
                     (EF.Functions.ILike(d.FileName!, pattern) || EF.Functions.ILike(d.DocumentType!, pattern)))
+                .OrderByDescending(d => d.UploadedAt).ThenBy(d => d.Id)
                 .Select(d => new { Type = "document", d.Id, Label = $"{d.DocumentType}: {d.FileName}", Detail = d.CdeStatus, ProjectId = d.ProjectId, ProjectName = d.Project!.Name })
                 .Take(limit).ToListAsync();
-            results.AddRange(docs);
+            byType.Add(docs.Cast<object>().ToList());
         }
 
         // Search meetings
@@ -98,12 +113,36 @@ public class SearchController : ControllerBase
                     // (the only narrative field on the entity).
                     (EF.Functions.ILike(m.Title!, pattern)
                      || (m.Minutes != null && EF.Functions.ILike(m.Minutes, pattern))))
+                .OrderByDescending(m => m.ScheduledAt).ThenBy(m => m.Id)
                 .Select(m => new { Type = "meeting", m.Id, Label = m.Title, Detail = m.ScheduledAt.ToString("yyyy-MM-dd"), ProjectId = m.ProjectId, ProjectName = m.Project!.Name })
                 .Take(limit).ToListAsync();
-            results.AddRange(meetings);
+            byType.Add(meetings.Cast<object>().ToList());
         }
 
-        var trimmed = results.Take(limit);
-        return Ok(new { query = q, count = trimmed.Count(), results = trimmed });
+        // Round-robin merge: one result from each type in turn until `limit` is
+        // filled. Every type that matched anything is represented, and a type
+        // with few matches donates its unused share to the others rather than
+        // leaving the response short. Replaces a flat concat + Take, which gave
+        // the whole budget to whichever type happened to be searched first.
+        var results = Interleave(byType, limit);
+        return Ok(new { query = q, count = results.Count, results });
+    }
+
+    private static List<object> Interleave(List<List<object>> buckets, int limit)
+    {
+        var merged = new List<object>(Math.Min(limit, buckets.Sum(b => b.Count)));
+        for (var round = 0; merged.Count < limit; round++)
+        {
+            var placedThisRound = false;
+            foreach (var bucket in buckets)
+            {
+                if (round >= bucket.Count) continue;
+                merged.Add(bucket[round]);
+                placedThisRound = true;
+                if (merged.Count == limit) return merged;
+            }
+            if (!placedThisRound) break;   // every bucket exhausted
+        }
+        return merged;
     }
 }

--- a/Planscape.Server/src/Planscape.API/WebAppUrl.cs
+++ b/Planscape.Server/src/Planscape.API/WebAppUrl.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Planscape.API;
+
+/// <summary>
+/// Single source of truth for the origin of the BROWSER app (planscape-web,
+/// the Next.js product surface) — as distinct from <see cref="PublicUrl"/>,
+/// which is this API's own public origin.
+///
+/// The two are different hosts in every real deployment (api.planscape.build vs
+/// app.planscape.build; planscape-api-free vs planscape-web-free on Render), so
+/// anything that must land a human IN THE PRODUCT — the accept-invite page most
+/// of all — needs this, not <see cref="PublicUrl"/>.
+///
+/// Why it exists: reset-password.html used to GUESS the web origin from its own
+/// hostname in JavaScript, with `location.origin` as the last resort. On any
+/// deployment whose API host doesn't match the api./planscape-api naming (a
+/// Cloudflare tunnel, a bare localhost run, a custom host), that fallback sent
+/// the freshly-activated invitee to <c>{api-origin}/projects/{id}</c> — a route
+/// the API does not serve and has no SPA fallback for, so the browser got an
+/// empty 404: the page "starts opening and then stops". Config beats guessing.
+///
+/// Resolution order:
+///   1. <c>Planscape:WebAppUrl</c> (env <c>Planscape__WebAppUrl</c>) — always wins.
+///   2. Derived from the API's own public origin using the deployment's naming
+///      convention (api. ↔ app., planscape-api* ↔ planscape-web*).
+///   3. <c>null</c> — meaning "unknown". Callers must then NOT navigate; showing
+///      a plain "your password is set, sign in" result beats a blank 404.
+/// </summary>
+public static class WebAppUrl
+{
+    /// <summary>
+    /// The browser app's origin, or null when it cannot be determined.
+    /// Never falls back to this API's own origin: that fallback is precisely
+    /// what produced the blank-page bug.
+    /// </summary>
+    public static string? Resolve(IConfiguration config, HttpRequest request)
+    {
+        var configured = config["Planscape:WebAppUrl"];
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured.Trim().TrimEnd('/');
+
+        return DeriveFromApiOrigin(PublicUrl.Resolve(config, request));
+    }
+
+    /// <summary>
+    /// Map an API origin onto its paired web origin using the two naming
+    /// conventions this platform actually deploys under. Returns null for any
+    /// host that matches neither — an unknown pairing is not a guess worth making.
+    /// </summary>
+    public static string? DeriveFromApiOrigin(string? apiOrigin)
+    {
+        if (string.IsNullOrWhiteSpace(apiOrigin)) return null;
+        if (!Uri.TryCreate(apiOrigin, UriKind.Absolute, out var uri)) return null;
+
+        var host = uri.Host;
+        string? webHost = null;
+
+        // Custom-domain pairing: api.planscape.build → app.planscape.build
+        if (host.StartsWith("api.", StringComparison.OrdinalIgnoreCase))
+            webHost = "app." + host.Substring(4);
+        // Render service pairing: planscape-api-free → planscape-web-free
+        else if (host.StartsWith("planscape-api", StringComparison.OrdinalIgnoreCase))
+            webHost = "planscape-web" + host.Substring("planscape-api".Length);
+
+        if (webHost == null) return null;
+
+        var port = uri.IsDefaultPort ? "" : $":{uri.Port}";
+        return $"{uri.Scheme}://{webHost}{port}";
+    }
+}

--- a/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/reset-password.html
@@ -68,32 +68,35 @@
       document.getElementById('go').textContent = 'Accept invite & continue';
     }
 
-    // After activating, send the recipient straight to the project they were
-    // invited to — not a bare landing page. Falls back to the sign-in page.
+    // After activating, send the recipient straight into the product — signed
+    // in, on the project they were invited to.
     //
-    // This page is served by the API, but the real product surface is the
-    // separate planscape-web Next.js app on its own origin. It used to
-    // redirect to /app/#models?project=… — a legacy static dashboard still
-    // sitting in this server's own wwwroot/app/ that was abandoned when the
-    // team moved to planscape-web. That page never gets a session from the
-    // password-set call above, so it just shows "Signing in…" forever —
-    // the recipient looks "stuck" right after successfully setting a
-    // password. Guess the web app's origin from this API origin's own
-    // naming convention (api./app. custom-domain pairing, or the
-    // planscape-api-*/planscape-web-* Render free-tier pairing) so this
-    // keeps working if either domain scheme changes shape later, with a
-    // same-origin fallback for local dev.
-    function guessWebAppOrigin() {
-      try {
-        var h = location.hostname;
-        if (h.indexOf('api.') === 0) return location.protocol + '//' + h.replace(/^api\./, 'app.');
-        if (h.indexOf('planscape-api') === 0) return location.protocol + '//' + h.replace('planscape-api', 'planscape-web');
-        return location.origin;
-      } catch (_) { return location.origin; }
-    }
-    function destinationAfterReset() {
-      var webOrigin = guessWebAppOrigin();
-      return project ? (webOrigin + '/projects/' + encodeURIComponent(project)) : (webOrigin + '/login');
+    // This page is served by the API; the product is the separate planscape-web
+    // app on ANOTHER origin. Two things follow, and getting either wrong is what
+    // made this flow dead-end right after a successful password set:
+    //
+    //  1. WHERE the app is. This page used to guess from its own hostname and
+    //     fall back to location.origin. On any deployment that doesn't match the
+    //     api./planscape-api naming (tunnel, localhost, custom host) that sent
+    //     the invitee to {api-origin}/projects/{id} — a route the API doesn't
+    //     serve and has no SPA fallback for, so the browser rendered an empty
+    //     404: the page "starts opening and then stops". The server now tells us
+    //     (webAppUrl, from Planscape:WebAppUrl or the derived pairing), and when
+    //     it cannot, we show a result instead of navigating nowhere.
+    //
+    //  2. WHO they are. Being on another origin, we cannot write the app's
+    //     session storage — so even a correct URL landed them on a guarded route
+    //     with no session, which bounces to /login and loses the project.
+    //     /api/auth/reset-password now returns a session and /accept installs it.
+    //     The token rides in the URL FRAGMENT so it never reaches a server log.
+    function destinationAfterReset(session) {
+      var webOrigin = (session && session.webAppUrl ? String(session.webAppUrl) : '').replace(/\/+$/, '');
+      if (!webOrigin) return null;                      // unknown → don't navigate
+      var accessToken = session && (session.accessToken || session.token);
+      if (!accessToken) return webOrigin + '/login';    // no session → plain sign-in
+      return webOrigin + '/accept'
+           + (project ? '?project=' + encodeURIComponent(project) : '')
+           + '#token=' + encodeURIComponent(accessToken);
     }
 
     var msg = document.getElementById('msg');
@@ -119,8 +122,19 @@
         });
         var data = await res.json().catch(function () { return {}; });
         if (res.ok) {
-          show('ok', project ? 'Password set! Opening your project…' : 'Password set! Redirecting to sign in…');
-          setTimeout(function () { location.href = destinationAfterReset(); }, 1400);
+          var dest = destinationAfterReset(data);
+          if (dest) {
+            show('ok', project ? 'Password set! Opening your project…' : 'Password set! Signing you in…');
+            setTimeout(function () { location.href = dest; }, 1200);
+          } else {
+            // The server could not tell us where the browser app lives (no
+            // Planscape:WebAppUrl set and the host doesn't match a known
+            // pairing). Say so plainly. A blank page from a navigation to a
+            // route that doesn't exist is the failure this replaces.
+            btn.disabled = true;
+            show('ok', 'Your password is set. Open Planscape in your browser and sign in as '
+                     + (email || 'your email address') + '.');
+          }
         } else {
           btn.disabled = false;
           show('err', (data && data.message) || ('Could not reset password (HTTP ' + res.status + ').'));

--- a/Planscape.Server/tests/Planscape.Tests/InviteTokenTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/InviteTokenTests.cs
@@ -69,6 +69,37 @@ public class InviteTokenTests : IClassFixture<PlanscapeWebApplicationFactory>
         Assert.Equal(HttpStatusCode.BadRequest, second.StatusCode);
     }
 
+    /// <summary>
+    /// Accepting an invite must hand back a LIVE SESSION, not just a "please log
+    /// in" message. The accept page is served by the API while the product lives
+    /// on another origin, so this response is the only way it can deliver a
+    /// signed-in browser — without it the invitee sets a password and is dumped
+    /// on a guarded route with no session, which is the "page opens and stops"
+    /// report this exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task AcceptingAnInvite_ReturnsAUsableSession()
+    {
+        var token = await SeedPendingInviteeAsync("pending-session@test.org", DateTime.UtcNow.AddDays(7));
+        var client = _factory.CreateClient();
+
+        var resp = await client.PostAsJsonAsync("/api/auth/reset-password",
+            new { token, newPassword = "BrandNewPass1!" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var body = await resp.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        var accessToken = body.GetProperty("accessToken").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(accessToken));
+        Assert.False(string.IsNullOrWhiteSpace(body.GetProperty("refreshToken").GetString()));
+
+        // And it must actually authenticate — a token the API itself rejects
+        // would reproduce the bug with extra steps.
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+        var me = await client.GetAsync("/api/projects");
+        Assert.NotEqual(HttpStatusCode.Unauthorized, me.StatusCode);
+    }
+
     [Fact]
     public async Task InviteToken_ExpiredIsRejected()
     {

--- a/Planscape.Server/tests/Planscape.Tests/SearchStarvationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/SearchStarvationTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Guards the bug /api/search shipped with: a global search that could not
+/// return a document.
+///
+/// The controller fetched up to `limit` rows PER TYPE, concatenated them
+/// tag → issue → document → meeting, then took the first `limit` of that flat
+/// list. Any type that filled the budget therefore starved every type after it:
+/// with 25+ matching tags and the default limit of 25, the document, issue and
+/// meeting rows were fetched from the database and then silently discarded.
+///
+/// Each sub-query was also unordered, so which rows survived was whatever
+/// Postgres felt like returning that call — the source of EF's
+/// RowLimitingOperationWithoutOrderByWarning in the production logs, and the
+/// reason two identical searches could disagree.
+///
+/// Requires real PostgreSQL: SearchController uses EF.Functions.ILike, an
+/// Npgsql-only translation that client-evaluates (and 500s) on EF InMemory.
+/// Set PLANSCAPE_TEST_PG to run these.
+/// </summary>
+public class SearchStarvationTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+    public SearchStarvationTests(PlanscapeWebApplicationFactory factory) => _factory = factory;
+
+    // The class fixture is ONE database shared by all three tests, so each test
+    // seeds under its own search term and its own RevitElementId block:
+    // the term keeps one test's rows out of another's result set (the count
+    // assertions below are exact), and the id block avoids the unique index on
+    // (ProjectId, RevitElementId).
+    private const string TermStarve = "zzstarveterm";
+    private const string TermStable = "zzstableterm";
+    private const string TermShare  = "zzshareterm";
+
+    /// <summary>
+    /// Seed enough matching tags to exhaust the limit on their own, plus exactly
+    /// one matching document — the row the old code could never surface.
+    /// </summary>
+    private async Task SeedAsync(string term, int idBase, int tagCount)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+
+        for (var i = 0; i < tagCount; i++)
+        {
+            db.TaggedElements.Add(new TaggedElement
+            {
+                TenantId = TestData.TenantId,
+                ProjectId = TestData.ProjectId,
+                RevitElementId = idBase + i,
+                UniqueId = $"{term}-uid-{i}",
+                Tag1 = $"M-{term}-{i:D4}",
+                CategoryName = "Ducts",
+                // Distinct timestamps so "newest first" is a total order and the
+                // assertions can't pass by luck.
+                SyncedAt = DateTime.UtcNow.AddMinutes(-i),
+            });
+        }
+
+        db.Documents.Add(new DocumentRecord
+        {
+            TenantId = TestData.TenantId,
+            ProjectId = TestData.ProjectId,
+            FileName = $"{term}-spec.pdf",
+            DocumentType = "SP",
+            UploadedBy = "seed",
+            UploadedAt = DateTime.UtcNow,
+        });
+
+        await db.SaveChangesAsync();
+    }
+
+    private static List<JsonElement> ResultsOf(JsonElement body) =>
+        body.GetProperty("results").EnumerateArray().ToList();
+
+    [SkippableFact]
+    public async Task ATypeThatFillsTheLimitDoesNotStarveTheOthers()
+    {
+        Skip.IfNot(PlanscapeWebApplicationFactory.UsingPostgres,
+            "PLANSCAPE_TEST_PG is not set — needs the real-PostgreSQL harness.");
+
+        await SeedAsync(TermStarve, idBase: 900_000, tagCount: 40);   // more tags than the limit
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.GetAsync($"/api/search?q={TermStarve}&limit=25");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var results = ResultsOf(await resp.Content.ReadFromJsonAsync<JsonElement>());
+        var types = results.Select(r => r.GetProperty("type").GetString()).ToList();
+
+        // THE regression: the single matching document must come back even
+        // though 40 tags matched. Before the fix this was always false.
+        Assert.Contains("document", types);
+        Assert.Contains("tag", types);
+        // The budget is still honoured — the fix shares it, it doesn't ignore it.
+        Assert.Equal(25, results.Count);
+    }
+
+    [SkippableFact]
+    public async Task RepeatedIdenticalSearchesReturnTheSameRows()
+    {
+        Skip.IfNot(PlanscapeWebApplicationFactory.UsingPostgres,
+            "PLANSCAPE_TEST_PG is not set — needs the real-PostgreSQL harness.");
+
+        await SeedAsync(TermStable, idBase: 910_000, tagCount: 40);
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        async Task<List<string?>> IdsAsync()
+        {
+            var resp = await client.GetAsync($"/api/search?q={TermStable}&limit=10");
+            var results = ResultsOf(await resp.Content.ReadFromJsonAsync<JsonElement>());
+            return results.Select(r => r.GetProperty("id").GetString()).ToList();
+        }
+
+        // Unordered Take(limit) let Postgres pick an arbitrary subset, so the
+        // same query could answer differently call to call. Ordering makes the
+        // result a function of the data.
+        Assert.Equal(await IdsAsync(), await IdsAsync());
+    }
+
+    [SkippableFact]
+    public async Task ATypeWithNoMatchesDonatesItsShare()
+    {
+        Skip.IfNot(PlanscapeWebApplicationFactory.UsingPostgres,
+            "PLANSCAPE_TEST_PG is not set — needs the real-PostgreSQL harness.");
+
+        // 40 tags + 1 document, nothing else matches. A naive "limit/4 each"
+        // split would return 11; the round-robin must fill the budget from the
+        // types that actually have rows.
+        await SeedAsync(TermShare, idBase: 920_000, tagCount: 40);
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var resp = await client.GetAsync($"/api/search?q={TermShare}&limit=25");
+        var results = ResultsOf(await resp.Content.ReadFromJsonAsync<JsonElement>());
+
+        Assert.Equal(25, results.Count);
+        Assert.Equal(24, results.Count(r => r.GetProperty("type").GetString() == "tag"));
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/WebAppUrlTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/WebAppUrlTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Guards the production failure WebAppUrl exists to prevent: an invitee who
+/// successfully sets a password and is then sent to a URL that renders nothing.
+///
+/// The accept-invite page is served by the API but the product lives on a
+/// different origin. The page used to guess that origin in JavaScript with
+/// `location.origin` as its last resort — which, on every deployment whose API
+/// host doesn't follow the api./planscape-api naming, pointed at
+/// {api-origin}/projects/{id}: a route the API does not serve and has no SPA
+/// fallback for, i.e. an empty 404. The page "starts opening, then stops".
+///
+/// The contract these tests lock down is therefore as much about the NULL as
+/// the happy path: "I don't know" must never degrade into "this origin".
+/// </summary>
+public class WebAppUrlTests
+{
+    private static IConfiguration Config(params (string key, string value)[] entries) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(entries.ToDictionary(e => e.key, e => (string?)e.value))
+            .Build();
+
+    private static HttpRequest Request(string scheme, string host, string? forwardedProto = null)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Scheme = scheme;
+        ctx.Request.Host = new HostString(host);
+        if (forwardedProto != null) ctx.Request.Headers["X-Forwarded-Proto"] = forwardedProto;
+        return ctx.Request;
+    }
+
+    [Fact]
+    public void ConfiguredWebAppUrlWins()
+    {
+        var url = Planscape.API.WebAppUrl.Resolve(
+            Config(("Planscape:WebAppUrl", "https://app.planscape.build/")),
+            Request("http", "anything-at-all.example", "https"));
+
+        Assert.Equal("https://app.planscape.build", url);
+    }
+
+    [Fact]
+    public void DerivesAppHost_FromCustomDomainApiHost()
+    {
+        var url = Planscape.API.WebAppUrl.Resolve(
+            Config(), Request("http", "api.planscape.build", "https"));
+
+        Assert.Equal("https://app.planscape.build", url);
+    }
+
+    [Fact]
+    public void DerivesWebService_FromRenderApiService()
+    {
+        var url = Planscape.API.WebAppUrl.Resolve(
+            Config(), Request("http", "planscape-api-free.onrender.com", "https"));
+
+        Assert.Equal("https://planscape-web-free.onrender.com", url);
+    }
+
+    [Theory]
+    // A Cloudflare quick tunnel — the shape this platform actually runs behind
+    // in the field, and the one the old JS fallback silently broke on.
+    [InlineData("random-words-here.trycloudflare.com")]
+    // A bare local run.
+    [InlineData("localhost:5000")]
+    // Any other custom host.
+    [InlineData("bim.someclient.co.ug")]
+    public void ReturnsNull_RatherThanThisOrigin_WhenThePairingIsUnknown(string host)
+    {
+        var url = Planscape.API.WebAppUrl.Resolve(Config(), Request("https", host));
+
+        // THE regression. Returning the API's own origin here is what produced
+        // the blank page; the caller must be told "unknown" so it can say so.
+        Assert.Null(url);
+    }
+
+    [Fact]
+    public void PreservesNonDefaultPort_WhenDeriving()
+    {
+        var url = Planscape.API.WebAppUrl.DeriveFromApiOrigin("http://api.local:8080");
+
+        Assert.Equal("http://app.local:8080", url);
+    }
+
+    [Fact]
+    public void HandlesNullAndGarbage()
+    {
+        Assert.Null(Planscape.API.WebAppUrl.DeriveFromApiOrigin(null));
+        Assert.Null(Planscape.API.WebAppUrl.DeriveFromApiOrigin(""));
+        Assert.Null(Planscape.API.WebAppUrl.DeriveFromApiOrigin("not a url"));
+    }
+}

--- a/planscape-web/app/accept/page.tsx
+++ b/planscape-web/app/accept/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+// Landing point for the accept-invite / password-reset handoff.
+//
+// The set-password page (reset-password.html) is served by the API, on a
+// DIFFERENT origin to this app — so it cannot write this app's localStorage and
+// cannot sign the invitee in itself. It used to just navigate here-ish and hope,
+// which left a freshly-activated invitee staring at a blank page or a sign-in
+// form seconds after choosing a password. Now /api/auth/reset-password returns a
+// real session and that page forwards it to this route.
+//
+// The session arrives in the URL *fragment*, never the query string: fragments
+// are not sent to servers, don't reach access logs, and don't leak via Referer.
+// It is stripped from the address bar and from history before we navigate on —
+// the same discipline /handoff uses for its ticket.
+
+import { useEffect, useRef, useState } from 'react';
+import { setToken } from '@/lib/api';
+
+export default function AcceptPage() {
+  const [message, setMessage] = useState('Signing you in…');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    // StrictMode double-mounts effects in dev; the fragment is consumed and
+    // erased on the first pass, so guard against the second.
+    if (ran.current) return;
+    ran.current = true;
+
+    const frag = new URLSearchParams((window.location.hash || '').replace(/^#/, ''));
+    const token = frag.get('token');
+    // ?project= stays in the query: it is not a secret and being able to see
+    // which project you were invited to is useful if anything goes wrong.
+    const project = new URLSearchParams(window.location.search).get('project');
+
+    // Erase the credential from the address bar and history immediately —
+    // before any navigation, so no entry ever carries it.
+    window.history.replaceState(null, '', project ? `/accept?project=${encodeURIComponent(project)}` : '/accept');
+
+    if (!token) {
+      // No session to install (a stale bookmark, or a link opened twice).
+      // Sign-in still works — the password was set — so send them there.
+      setMessage('This link has already been used. Please sign in.');
+      setTimeout(() => window.location.replace('/login'), 2000);
+      return;
+    }
+
+    setToken(token);
+
+    // FULL navigation, not a router push: AuthProvider reads the token once on
+    // mount, so a soft navigation would land on the destination with stale
+    // in-memory auth and bounce straight back to /login.
+    window.location.replace(project ? `/projects/${encodeURIComponent(project)}` : '/projects');
+  }, []);
+
+  return (
+    <main className="grid min-h-screen place-items-center p-4">
+      <div className="text-center">
+        <p className="text-lg font-medium">{message}</p>
+        <p className="mt-2 text-sm text-fg-muted">Planscape cloud</p>
+      </div>
+    </main>
+  );
+}

--- a/planscape-web/app/login/page.tsx
+++ b/planscape-web/app/login/page.tsx
@@ -1,12 +1,34 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useState, type FormEvent } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 
+/**
+ * Only ever return a same-origin path. `next` reaches us from the address bar,
+ * so an absolute URL here would turn the sign-in form into an open redirect.
+ */
+function safeNext(raw: string | null): string {
+  if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return '/projects';
+  return raw;
+}
+
+/**
+ * useSearchParams opts the subtree out of static prerendering, and `next build`
+ * fails outright if it isn't inside a Suspense boundary — hence the split.
+ */
 export default function LoginPage() {
+  return (
+    <Suspense fallback={<main className="grid min-h-screen place-items-center p-4" />}>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const { login } = useAuth();
   const router = useRouter();
+  const next = safeNext(useSearchParams()?.get('next') ?? null);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -18,7 +40,7 @@ export default function LoginPage() {
     setBusy(true);
     try {
       await login(email.trim(), password);
-      router.replace('/projects');
+      router.replace(next);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sign-in failed.');
     } finally {

--- a/planscape-web/components/AppShell.tsx
+++ b/planscape-web/components/AppShell.tsx
@@ -54,9 +54,12 @@ export function AppShell({ children }: { children: ReactNode }) {
   // the user just navigated to.
   useEffect(() => setRailOpenMobile(false), [pathname]);
 
+  // No session → sign in, carrying where they were headed. Without `next` an
+  // invitee whose session didn't survive the hop lands on /projects and has to
+  // find the project they were invited to by hand.
   useEffect(() => {
-    if (ready && !user) router.replace('/login');
-  }, [ready, user, router]);
+    if (ready && !user) router.replace(`/login?next=${encodeURIComponent(pathname)}`);
+  }, [ready, user, router, pathname]);
 
   function toggleRail() {
     setCollapsed((v) => {

--- a/planscape-web/lib/routes.test.ts
+++ b/planscape-web/lib/routes.test.ts
@@ -65,11 +65,14 @@ describe('route migration (U4)', () => {
   });
 
   it('renders every page inside the AppShell, so no route escapes the chrome', () => {
-    // Deliberately outside the shell: /login and /handoff exist for users with
-    // no session yet, the error/not-found boundaries must render even when the
-    // shell itself is what broke, and /dashboard is a bare redirect stub kept
-    // for old bookmarks (it is not in the rail — see GLOBAL_NAV).
-    const outside = ['login', 'handoff', 'dashboard', 'error.tsx', 'not-found.tsx', join('app', 'page.tsx')];
+    // Deliberately outside the shell: /login, /handoff and /accept exist for
+    // users with no session yet — /accept is the invite landing that INSTALLS
+    // the session, so wrapping it in the shell would bounce the invitee to
+    // /login a moment before the token it came to deliver is stored — the
+    // error/not-found boundaries must render even when the shell itself is what
+    // broke, and /dashboard is a bare redirect stub kept for old bookmarks (it
+    // is not in the rail — see GLOBAL_NAV).
+    const outside = ['login', 'handoff', 'accept', 'dashboard', 'error.tsx', 'not-found.tsx', join('app', 'page.tsx')];
     const escaped = walk(appDir)
       .filter((p) => p.endsWith('page.tsx'))
       .filter((p) => !outside.some((o) => p.includes(o)))

--- a/render.free.yaml
+++ b/render.free.yaml
@@ -123,6 +123,12 @@ services:
         value: https://planscape.build
       - key: Cors__Origins__1
         sync: false             # https://planscape-web-free-XXXX.onrender.com (post-deploy)
+      # ── Where the BROWSER app lives (WebAppUrl.Resolve) ──
+      # Same post-deploy value as Cors__Origins__1. The accept-invite page needs
+      # it to land an invitee in the product after they set a password; leaving
+      # it unset only works while the API host keeps the planscape-api* naming.
+      - key: Planscape__WebAppUrl
+        sync: false             # https://planscape-web-free-XXXX.onrender.com (post-deploy)
       - key: Serilog__MinimumLevel__Default
         value: Warning
 

--- a/render.yaml
+++ b/render.yaml
@@ -343,6 +343,14 @@ envVarGroups:
       - key: Cors__Origins__1
         value: https://app.planscape.build
 
+      # ── Where the BROWSER app lives ──
+      # Read by WebAppUrl.Resolve. The accept-invite page (served by this API)
+      # must send a freshly-activated invitee to the product, which is a
+      # different origin — without this it can only infer the pairing from the
+      # API hostname, and infers nothing at all behind a tunnel or custom host.
+      - key: Planscape__WebAppUrl
+        value: https://app.planscape.build
+
       # ── Serilog ──
       - key: Serilog__MinimumLevel__Default
         value: Warning


### PR DESCRIPTION
Three fixes found while chasing "the invite page starts opening and then stops".

## 1. Accepting an invite dead-ended (the reported bug)

The invite, the member row and the emailed token all worked. Everything broke *after* the password was committed, for two independent reasons:

- **It navigated somewhere that renders nothing.** `reset-password.html` guessed the browser app's origin from its own hostname and fell back to `location.origin`. On any deployment not matching the `api.` / `planscape-api*` naming (tunnel, localhost, custom host) that sent the invitee to `{api-origin}/projects/{id}` — a route the API doesn't serve and has no SPA fallback for. Confirmed live: that URL returns a **zero-byte 404**. Blank page.
- **No session even on the correct origin.** The set-password page is served by the API; the product is a different origin, so it cannot write the app's storage, and `/api/auth/reset-password` returned only a message. The invitee landed on a guarded route with no session, bounced to `/login`, and lost the project.

Fix: new `WebAppUrl` resolver (config `Planscape:WebAppUrl` wins, else derive the api./app. and planscape-api*/planscape-web* pairings, else **null** — never falls back to this API's own origin, which is what caused the blank page). `reset-password` now issues a real session and reports `webAppUrl`; the page forwards it to a new `/accept` route with the token in the URL **fragment**; `/accept` installs it, erases the fragment from history and lands on the project. When the origin is unknown the page shows a plain "password set, sign in" result instead of navigating nowhere. `AppShell` now bounces to `/login?next=…` (same-origin guarded) so a lost session doesn't also lose the destination.

## 2. The API could not deploy at all

Unrelated, and blocking everything above. The container died on the first line of `Main`:

```
System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached
  at System.IO.FileSystemWatcher.StartRaisingEvents()
  … at WebApplication.CreateBuilder(String[])
  at Program.<Main>$ … Program.cs:line 25
```

`CreateBuilder` registers `appsettings*.json` with `reloadOnChange:true`, which takes an inotify instance. `fs.inotify.max_user_instances` is a **host-wide** limit shared across containers, so the app died through no fault of its own. Nothing in our code watches files. The runtime image now sets `DOTNET_hostBuilder__reloadConfigOnChange=false` + `DOTNET_USE_POLLING_FILE_WATCHER=1`.

## 3. `/api/search` could not return a document

Chasing the `RowLimitingOperationWithoutOrderByWarning` in the logs found a real defect. Search fetched `limit` rows **per type**, concatenated tag → issue → document → meeting, then took the first `limit`. Whichever type filled the budget starved the rest: with 25+ matching tags and the default limit, matching documents/issues/meetings were read and silently discarded. The web search box calls exactly this with `limit=25` and no type filter. Sub-queries were also unordered, so identical searches could disagree.

Fix: every sub-query orders before `Take` (newest first, `Id` tiebreak → total order), and the buckets merge round-robin so every type is represented and unused share is donated. `limit` contract unchanged.

## Verification

- API builds 0 errors; `next build` + `tsc --noEmit` clean.
- Full test suite **590/590 against real PostgreSQL**, 578 passed / 12 skipped on InMemory.
- New search tests confirmed **RED against the pre-fix controller**, green after.
- New `InviteTokenTests` case asserts the returned session actually authenticates.
- Drove the real `/accept` route in a browser: token installed, landed on `/projects/{id}` signed in. Verified the unknown-origin branch renders the result card instead of a blank page.
- The inotify fix can only be proven by a real deploy — that is the thing to watch when this merges.

## After merge

Set `Planscape__WebAppUrl` on `planscape-api-free` to `https://planscape-web-free.onrender.com`. It derives correctly from the hostname today, but setting it explicitly makes the behaviour independent of hostname shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)