### PR TITLE
fix(symbols): MEPAccessory falls back to Generic Model + keeps its category

### DIFF
--- a/StingTools/Core/Symbols/SymbolLibraryCreator.cs
+++ b/StingTools/Core/Symbols/SymbolLibraryCreator.cs
@@ -493,6 +493,10 @@ namespace StingTools.Core.Symbols
                 return null;
             }
 
+            // A Generic Model stand-in carries the wrong category; correct it before any
+            // geometry, parameters or connectors are added.
+            ApplySubstituteCategory(fdoc, def, templateFile, result);
+
             // Warn when generating from draft geometry — a hand-drafted seed .rfa is preferred.
             if (string.Equals(def.Status, "draft", StringComparison.OrdinalIgnoreCase))
                 result.Warnings.Add($"[DRAFT] {def.Id}: using approximate JSON geometry. " +
@@ -2430,6 +2434,70 @@ namespace StingTools.Core.Symbols
         /// returning the first match. Returns null (never throws) when no template
         /// is found so the caller can skip that symbol gracefully.
         /// </summary>
+        /// <summary>
+        /// When a family was built from a Generic Model stand-in because its proper
+        /// template is absent, sets the category the symbol actually needs.
+        ///
+        /// <para>The accessory .rft files ship in Autodesk's MEP content pack, which is
+        /// an optional install — this machine has 1328 templates and not one
+        /// *Accessory*.rft. Autodesk's own guidance for that case is to start from the
+        /// generic-model template and change the category, and OwnerFamily.FamilyCategory
+        /// is settable inside a family document.</para>
+        ///
+        /// <para>Graceful degradation, not parity: a re-categorised Generic Model may
+        /// differ from a true accessory in work-plane basedness and in how it breaks into
+        /// a run. Connectors are unaffected — those are added explicitly either way. The
+        /// substitution is therefore warned about, not performed silently.</para>
+        /// </summary>
+        private static void ApplySubstituteCategory(Document fdoc, SymbolDefinition def,
+            string templateFile, SymbolCreationResult result)
+        {
+            try
+            {
+                if (fdoc == null || !fdoc.IsFamilyDocument || def == null) return;
+                if (!string.Equals(def.FamilyType, "MEPAccessory", StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                // Only when the resolver actually fell through to a generic stand-in.
+                string tpl = Path.GetFileName(templateFile) ?? "";
+                if (tpl.IndexOf("Generic Model", StringComparison.OrdinalIgnoreCase) < 0) return;
+
+                bool isDuct = string.Equals(def.Discipline, "Mechanical", StringComparison.OrdinalIgnoreCase)
+                              && def.Connectors != null
+                              && def.Connectors.Any(c => string.Equals(c?.Domain, "HVAC", StringComparison.OrdinalIgnoreCase));
+                var target = isDuct ? BuiltInCategory.OST_DuctAccessory : BuiltInCategory.OST_PipeAccessory;
+
+                var cat = Category.GetCategory(fdoc, target);
+                if (cat == null)
+                {
+                    result.Warnings.Add($"{def.Id}: built from '{tpl}' but category {target} is " +
+                                        "unavailable in this document — left as Generic Model.");
+                    return;
+                }
+
+                using (var tx = new Transaction(fdoc, "STING Set substitute family category"))
+                {
+                    tx.Start();
+                    fdoc.OwnerFamily.FamilyCategory = cat;
+                    tx.Commit();
+                }
+
+                result.Warnings.Add($"{def.Id}: '{TrueAccessoryTemplate(isDuct)}' is not installed; " +
+                    $"built from '{tpl}' and re-categorised to {target}. Install the Autodesk MEP " +
+                    "content pack for a true accessory family.");
+            }
+            catch (Exception ex)
+            {
+                // Never fail the build over this — the family is still usable, just
+                // categorised as a Generic Model.
+                result.Warnings.Add($"{def.Id}: substitute category not applied — {ex.Message}");
+                StingLog.Warn($"ApplySubstituteCategory {def?.Id}: {ex.Message}");
+            }
+        }
+
+        private static string TrueAccessoryTemplate(bool isDuct)
+            => isDuct ? "Metric Duct Accessory.rft" : "Metric Pipe Accessory.rft";
+
         private static string ResolveTemplateFile(SymbolDefinition def, string folder, SymbolCreationResult result)
         {
             if (string.IsNullOrEmpty(folder))
@@ -2603,10 +2671,18 @@ namespace StingTools.Core.Symbols
             }
             if (string.Equals(ft, "MEPAccessory", StringComparison.OrdinalIgnoreCase))
             {
+                // The Generic Model tail matters: the accessory .rft files ship in the
+                // Autodesk MEP content pack, which is an optional install. Without it
+                // this branch resolved nothing and every MEPAccessory symbol failed —
+                // 42 of them — while the 838 others built, because every OTHER MEP
+                // branch already carried this same fallback. BuildOne restores the real
+                // category afterwards (see ApplySubstituteCategory).
                 if (string.Equals(disc, "Mechanical", StringComparison.OrdinalIgnoreCase)
                     && def.Connectors != null && def.Connectors.Any(c => string.Equals(c?.Domain, "HVAC", StringComparison.OrdinalIgnoreCase)))
-                    return new[] { "Metric Duct Accessory.rft", "Duct Accessory.rft" };
-                return new[] { "Metric Pipe Accessory.rft", "Pipe Accessory.rft" };
+                    return new[] { "Metric Duct Accessory.rft", "Duct Accessory.rft",
+                                   "Metric Generic Model.rft", "Generic Model.rft" };
+                return new[] { "Metric Pipe Accessory.rft", "Pipe Accessory.rft",
+                               "Metric Generic Model.rft", "Generic Model.rft" };
             }
             if (string.Equals(ft, "MEPEquipment", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
All **42** MEPAccessory symbols failed while the other 838 built. `Failed: 42`
matches the MEPAccessory count exactly (PipeAcc 20, FP 8, Plumbing 8, MEP 6).

### Cause is in our code, not just the Revit install

Every other MEP branch already ended with a Generic Model fallback:

```csharp
Sprinkler  -> { "Metric Sprinkler.rft",           "Metric Generic Model.rft", ... }
Plumbing   -> { "Metric Plumbing Fixture.rft",    "Metric Generic Model.rft", ... }
Mechanical -> { "Metric Mechanical Equipment.rft","Metric Generic Model.rft", ... }
```

**MEPAccessory returned only the accessory templates and nothing else.** Those
`.rft` files ship in Autodesk's *optional* MEP content pack — the test machine
has 1328 templates and not one `*Accessory*.rft` — so the branch resolved
nothing and the batch died at zero.

### Fix

Adds the same fallback tail, then repairs its consequence.
`ApplySubstituteCategory` sets `OwnerFamily.FamilyCategory` to
`OST_PipeAccessory` / `OST_DuctAccessory` when — and only when — the resolver
fell through to a generic template. This is Autodesk's own documented
workaround for a missing accessory template, and the property is settable
inside a family document.

Runs immediately after `NewFamilyDocument`, before geometry, parameters and
connectors, so everything downstream sees the right category.

### Honest limits

**Graceful degradation, not parity.** A re-categorised Generic Model can differ
from a true accessory in work-plane basedness and in how it breaks into a run.
Connectors are unaffected — added explicitly either way. The substitution
therefore **warns**, naming the missing template and pointing at the MEP content
pack, rather than passing silently.

Machines that *do* have the accessory templates are unaffected:
`ResolveTemplateFile` runs an exact-name pass over candidates **in order**
before any fuzzy pass, so the real template still wins.

Build: 0 warnings, 0 errors (Revit 2025). **Not yet re-run in Revit** — expect
`Failed 42 → 0` with 42 substitution warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)