### PR TITLE
fix(titleblocks): correct assembly title-block param stubs (T-10)

### DIFF
--- a/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_COND.params.txt
+++ b/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_COND.params.txt
@@ -23,7 +23,7 @@ ASS_SPOOL_DRAWING_REF_TXT (Text, Instance)
 DISCIPLINE             (Text, Instance) — Pipe / Duct / Electrical / Hanger
 
 LAYOUT NOTES
-- A1 landscape (594mm x 841mm)
+- A1 landscape (841mm x 594mm)
 - Right-hand strip 200mm wide reserved for BOM schedule
 - Title block at bottom 80mm
 - 5 viewport slots laid out by ShopDrawingComposer (PLAN, ISO, ELEV0, ELEV90, 3D)

--- a/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_DUCT.params.txt
+++ b/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_DUCT.params.txt
@@ -23,7 +23,7 @@ ASS_SPOOL_DRAWING_REF_TXT (Text, Instance)
 DISCIPLINE             (Text, Instance) — Pipe / Duct / Electrical / Hanger
 
 LAYOUT NOTES
-- A1 landscape (594mm x 841mm)
+- A1 landscape (841mm x 594mm)
 - Right-hand strip 200mm wide reserved for BOM schedule
 - Title block at bottom 80mm
 - 5 viewport slots laid out by ShopDrawingComposer (PLAN, ISO, ELEV0, ELEV90, 3D)

--- a/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_ELEC.params.txt
+++ b/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_ELEC.params.txt
@@ -10,7 +10,11 @@
 # Author the actual .rfa in Revit Family Editor. Required parameters
 # below must exist as Title Block instance parameters bound to the
 # shared parameters in StingTools.Core.Fabrication.AssyParams + the
-# ELC_* shared params from MR_PARAMETERS.txt.
+# ELC_* shared params from MR_PARAMETERS.txt. Two of the panel cells
+# below (ELC_PNL_VOLTAGE, ELC_GLAND_COUNT_NR) are NOT yet in
+# MR_PARAMETERS.txt — provision them (4-file: .txt + .csv mirror +
+# PARAMETER_REGISTRY.json + CATEGORY_BINDINGS.csv) before authoring, or
+# drop those two cells. Every other ELC_* below already exists.
 
 REQUIRED PARAMETERS (inherited from STING_TB_ASSEMBLY_COND)
 ASS_SPOOL_NR_TXT          (Text, Instance) — Auto-populated by ShopDrawingComposer
@@ -33,10 +37,10 @@ ELC_CDT_RUN_LENGTH_M      (Text, Instance) — total conduit run length (m)
 ELC_CDT_CABLE_COUNT_NR    (Text, Instance) — total cable count (BS EN 61386 fill table key)
 ELC_CDT_CBL_FILL_PCT      (Text, Instance) — worst-case fill percentage
 ELC_CDT_INSTALL_METHOD_TXT(Text, Instance) — CLIPPED / TRAY / EMBEDDED / CHASED
-ELC_PNL_NAME              (Text, Instance) — feeding panel reference
-ELC_PNL_VOLTAGE           (Text, Instance) — panel voltage class
+ELC_PNL_NAME_TXT          (Text, Instance) — feeding panel reference
+ELC_PNL_VOLTAGE           (Text, Instance) — panel voltage class          [NEW — not yet in MR_PARAMETERS.txt]
 ELC_PNL_FED_FROM          (Text, Instance) — upstream supply
-ELC_GLAND_COUNT_NR        (Text, Instance) — count of cable glands (IP-rated assemblies)
+ELC_GLAND_COUNT_NR        (Text, Instance) — count of cable glands (IP-rated assemblies) [NEW — not yet in MR_PARAMETERS.txt]
 ELC_IP_RATING_TXT         (Text, Instance) — assembly enclosure IP rating
 
 LAYOUT NOTES

--- a/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_HANGER.params.txt
+++ b/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_HANGER.params.txt
@@ -23,7 +23,7 @@ ASS_SPOOL_DRAWING_REF_TXT (Text, Instance)
 DISCIPLINE             (Text, Instance) — Pipe / Duct / Electrical / Hanger
 
 LAYOUT NOTES
-- A1 landscape (594mm x 841mm)
+- A1 landscape (841mm x 594mm)
 - Right-hand strip 200mm wide reserved for BOM schedule
 - Title block at bottom 80mm
 - 5 viewport slots laid out by ShopDrawingComposer (PLAN, ISO, ELEV0, ELEV90, 3D)

--- a/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_PIPE.params.txt
+++ b/Families/AssemblyTitleBlocks/STING_TB_ASSEMBLY_PIPE.params.txt
@@ -23,7 +23,7 @@ ASS_SPOOL_DRAWING_REF_TXT (Text, Instance)
 DISCIPLINE             (Text, Instance) — Pipe / Duct / Electrical / Hanger
 
 LAYOUT NOTES
-- A1 landscape (594mm x 841mm)
+- A1 landscape (841mm x 594mm)
 - Right-hand strip 200mm wide reserved for BOM schedule
 - Title block at bottom 80mm
 - 5 viewport slots laid out by ShopDrawingComposer (PLAN, ISO, ELEV0, ELEV90, 3D)


### PR DESCRIPTION
## What & why

Continuation of the title-block workstream — closes finding **T-10** from `docs/DRAWINGS_PRODUCTION_REVIEW.md`, which was still open. The `Families/AssemblyTitleBlocks/*.params.txt` files are authoring guides for whoever builds the assembly title-block `.rfa` families; two defects would bite that author:

1. **Transposed A1 size.** COND / DUCT / HANGER / PIPE stubs said `A1 landscape (594mm x 841mm)`. A1 landscape is **841 × 594**. ELEC already had it right; the other four are corrected.

2. **Phantom / mistyped ELEC params.** The ELEC stub told the author to bind cells to shared params from `MR_PARAMETERS.txt`, but:
   - `ELC_PNL_NAME` → corrected to **`ELC_PNL_NAME_TXT`** (the real param).
   - `ELC_PNL_VOLTAGE` and `ELC_GLAND_COUNT_NR` **don't exist** in `MR_PARAMETERS.txt` — now flagged `[NEW — not yet in MR_PARAMETERS.txt]` with the 4-file provisioning note, instead of silently sending the author to bind phantom params. The header's blanket "bind to the ELC_* params from MR_PARAMETERS.txt" claim now names the two exceptions.
   - Verified every other referenced `ELC_*` (`ELC_CDT_BEND_COUNT_NR`, `_RUN_LENGTH_M`, `_CABLE_COUNT_NR`, `_CBL_FILL_PCT`, `_INSTALL_METHOD_TXT`, `ELC_IP_RATING_TXT`, `ELC_PNL_FED_FROM`) actually exists.

## Deliberately not changed (verified NOT defects)

- The review flagged an `ASS_FAB_LOC_TXT` vocab three-way mismatch — but `AssemblyBuilder.ResolveFabLocation` returns `"WORKSHOP"` / `"SITE"`, which is exactly what the stubs say. The stubs match runtime; no change.
- HANGER's `ASS_TEST_PRESSURE_BAR` / `ASS_INSULATION_AREA_M2` cells are a design choice for an as-yet-unbuilt family, not a correctness bug.

## Scope / verification

Authoring `.txt` files only — no compiled code, no build impact. Every param claim was checked against `StingTools/Data/MR_PARAMETERS.txt`; every dimension against ISO A1 (841 × 594). No Revit needed.

Context: this branch continues the title-block review after the originating session ran out of usage credits mid-follow-up; that session's specific unpushed corrections were not recoverable, so this is a fresh, verified pass at the open T-10 finding rather than a recovery of those commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh

---
_Generated by [Claude Code](https://claude.ai/code/session_017J6kXUV8oYpZHNke1swjNh)_