### PR TITLE
fix(adapters): clean the Bonsai spatial adapter — move IFC inference into core

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (A6 — clean the Bonsai spatial adapter: move IFC inference back into core)
+
+`stingtools-bonsai/ops/spatial_ops.py` (added by #585) re-implemented two pieces
+of core inference the Phase A6 boundary lint forbids in host adapters, so the
+`Core tests + adapter boundary` job went red on `main` (`check_adapter_boundary.py`:
+`IFC_CLASS_MAP` + `SYSTEM_GROUP_INFERENCE`). The logic now lives in
+`stingtools_core.hosts.inference` and the adapter delegates, exactly as
+`tagging_ops.py` already does:
+
+- The `_CLASS_TO_FUNC` map → `inference.FUNCTION_BY_IFC_CLASS` + `function_for_class()`
+  / `infer_function()` (unknown class → `GEN`, unchanged). All 31 mappings preserved.
+- The `IfcZone` / `IfcRelAssignsToGroup` zone group walk → `inference.zone_codes_for_model()`,
+  which returns `(element_id → zone_code, zone_count)`; the operator keeps its `ZZ` default.
+
+Verified: boundary lint + self-test exit 0; `stingtools-core` suite 100 passed / 1
+skipped (was 98 / 2 failed); both files compile; function-map parity asserted.
+
 #### Completed (Folder structure — end the sibling sprawl)
 
 Acts on [`FOLDER_STRUCTURE_REVIEW_2026-08.md`](FOLDER_STRUCTURE_REVIEW_2026-08.md),

--- a/stingtools-bonsai/ops/spatial_ops.py
+++ b/stingtools-bonsai/ops/spatial_ops.py
@@ -6,6 +6,12 @@ import json
 
 import bpy
 
+# Phase A3/A6 — IFC→token inference and the zone group walk live in
+# stingtools_core.hosts.inference (the shared core), NOT here. This module is a
+# thin Blender adapter that calls core; the boundary lint (Phase A6) enforces
+# that no inference logic is (re)defined in adapter files like this one.
+from stingtools_core.hosts import inference as _inf
+
 
 def _get_ifc():
     try:
@@ -110,29 +116,14 @@ class StingAutoDetectZoneOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         try:
-            import ifcopenshell.util.element as ifc_util
+            import ifcopenshell  # noqa: F401 — availability guard
         except ImportError as exc:
             self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        # Enumerate zones and assign codes
-        zones = ifc.by_type("IfcZone")
-        zone_code: dict[int, str] = {}
-        for idx, zone in enumerate(zones, start=1):
-            zone_code[zone.id()] = f"Z{idx:02d}"
-
-        # Map elements → zone via IfcRelAssignsToGroup
-        element_to_zone: dict[int, str] = {}
-        for rel in ifc.by_type("IfcRelAssignsToGroup"):
-            group = rel.RelatingGroup
-            if not group.is_a("IfcZone"):
-                continue
-            code = zone_code.get(group.id())
-            if code is None:
-                continue
-            for obj in (rel.RelatedObjects or []):
-                if obj.is_a("IfcElement"):
-                    element_to_zone[obj.id()] = code
+        # Zone membership (the IfcZone group walk) is core inference — delegate
+        # so that logic lives in stingtools_core, not this adapter (Phase A6).
+        element_to_zone, zone_count = _inf.zone_codes_for_model(ifc)
 
         stamped = 0
         for el in ifc.by_type("IfcElement"):
@@ -140,49 +131,13 @@ class StingAutoDetectZoneOperator(bpy.types.Operator):
             _write_stag(ifc, el, {"Zone": code})
             stamped += 1
 
-        self.report({"INFO"}, f"Zone stamped on {stamped} element(s) ({len(zones)} zone(s) found)")
+        self.report({"INFO"}, f"Zone stamped on {stamped} element(s) ({zone_count} zone(s) found)")
         return {"FINISHED"}
 
 
 # ---------------------------------------------------------------------------
 # Auto-detect Function
 # ---------------------------------------------------------------------------
-
-# IFC class prefix → STING Function code mapping
-_CLASS_TO_FUNC: dict[str, str] = {
-    "IfcAirTerminal":            "SUP",
-    "IfcAirTerminalBox":         "SUP",
-    "IfcFan":                    "SUP",
-    "IfcDuctSegment":            "SUP",
-    "IfcDuctFitting":            "SUP",
-    "IfcDuctSilencer":           "SUP",
-    "IfcFilter":                 "RET",
-    "IfcSanitaryTerminal":       "SAN",
-    "IfcSanitaryTerminalType":   "SAN",
-    "IfcFlowTerminal":           "SAN",
-    "IfcPipeSegment":            "SUP",
-    "IfcPipeFitting":            "SUP",
-    "IfcValve":                  "SUP",
-    "IfcPump":                   "SUP",
-    "IfcElectricDistributionBoard": "PWR",
-    "IfcElectricMotor":          "PWR",
-    "IfcLamp":                   "LTG",
-    "IfcLightFixture":           "LTG",
-    "IfcOutlet":                 "PWR",
-    "IfcCableCarrierSegment":    "PWR",
-    "IfcCableSegment":           "PWR",
-    "IfcProtectiveDevice":       "PWR",
-    "IfcSwitchingDevice":        "PWR",
-    "IfcFireSuppressionTerminal": "FP",
-    "IfcAlarm":                  "FP",
-    "IfcSensor":                 "FP",
-    "IfcBoiler":                 "HTG",
-    "IfcChiller":                "CLG",
-    "IfcCoolingTower":           "CLG",
-    "IfcHeatExchanger":          "HTG",
-    "IfcUnitaryEquipment":       "SUP",
-}
-
 
 class StingAutoDetectFunctionOperator(bpy.types.Operator):
     """Derive Function token from IFC element class."""
@@ -211,7 +166,7 @@ class StingAutoDetectFunctionOperator(bpy.types.Operator):
         stamped = unrecognised = 0
         for el in ifc.by_type("IfcElement"):
             ifc_class = el.is_a()
-            func = _CLASS_TO_FUNC.get(ifc_class, "GEN")
+            func = _inf.function_for_class(ifc_class)
             if func == "GEN":
                 unrecognised += 1
             _write_stag(ifc, el, {"Function": func})
@@ -220,7 +175,8 @@ class StingAutoDetectFunctionOperator(bpy.types.Operator):
         self.report(
             {"INFO"},
             f"Function stamped on {stamped} element(s) "
-            f"({unrecognised} mapped to GEN — add to _CLASS_TO_FUNC to refine)",
+            f"({unrecognised} mapped to GEN — add to stingtools_core "
+            f"FUNCTION_BY_IFC_CLASS to refine)",
         )
         return {"FINISHED"}
 

--- a/stingtools-core/python/stingtools_core/hosts/inference.py
+++ b/stingtools-core/python/stingtools_core/hosts/inference.py
@@ -42,6 +42,28 @@ DISCIPLINE_BY_IFC_CLASS: dict[str, str] = {
     "IfcFireSuppressionTerminal": "FP", "IfcAlarm": "FP",
 }
 
+# IFC class → STING Function code. Single source of truth (was inline as
+# ``_CLASS_TO_FUNC`` in the Bonsai spatial operator). Unknown class → ``GEN``,
+# never ``XX``: "generic" is a real function bucket, not a missing-value sentinel.
+FUNCTION_SENTINEL = "GEN"
+FUNCTION_BY_IFC_CLASS: dict[str, str] = {
+    "IfcAirTerminal": "SUP", "IfcAirTerminalBox": "SUP", "IfcFan": "SUP",
+    "IfcDuctSegment": "SUP", "IfcDuctFitting": "SUP", "IfcDuctSilencer": "SUP",
+    "IfcFilter": "RET",
+    "IfcSanitaryTerminal": "SAN", "IfcSanitaryTerminalType": "SAN",
+    "IfcFlowTerminal": "SAN",
+    "IfcPipeSegment": "SUP", "IfcPipeFitting": "SUP", "IfcValve": "SUP",
+    "IfcPump": "SUP",
+    "IfcElectricDistributionBoard": "PWR", "IfcElectricMotor": "PWR",
+    "IfcOutlet": "PWR", "IfcCableCarrierSegment": "PWR", "IfcCableSegment": "PWR",
+    "IfcProtectiveDevice": "PWR", "IfcSwitchingDevice": "PWR",
+    "IfcLamp": "LTG", "IfcLightFixture": "LTG",
+    "IfcFireSuppressionTerminal": "FP", "IfcAlarm": "FP", "IfcSensor": "FP",
+    "IfcBoiler": "HTG", "IfcHeatExchanger": "HTG",
+    "IfcChiller": "CLG", "IfcCoolingTower": "CLG",
+    "IfcUnitaryEquipment": "SUP",
+}
+
 # IfcSystem name keyword → STING system code, evaluated in order.
 _SYSTEM_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("HVAC", "AIR", "VENT", "DUCT"), "HVAC"),
@@ -57,6 +79,11 @@ _SYSTEM_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
 def discipline_for_class(ifc_class: str) -> str:
     """Pure lookup: IFC class string → discipline code. ``XX`` when unknown."""
     return DISCIPLINE_BY_IFC_CLASS.get(ifc_class, SENTINEL)
+
+
+def function_for_class(ifc_class: str) -> str:
+    """Pure lookup: IFC class string → STING Function code. ``GEN`` when unknown."""
+    return FUNCTION_BY_IFC_CLASS.get(ifc_class, FUNCTION_SENTINEL)
 
 
 def infer_discipline(element: Any) -> str:
@@ -160,6 +187,39 @@ def infer_system(element: Any) -> str:
         return SENTINEL
     except Exception:
         return SENTINEL
+
+
+def infer_function(element: Any) -> str:
+    """Function code for an ifcopenshell element via its ``is_a()`` class."""
+    try:
+        return function_for_class(element.is_a())
+    except Exception:  # pragma: no cover - defensive
+        return FUNCTION_SENTINEL
+
+
+def zone_codes_for_model(model: Any) -> tuple[dict[int, str], int]:
+    """Map element id → zone code (``Z01``, ``Z02`` …) via ``IfcZone`` +
+    ``IfcRelAssignsToGroup``. Returns ``(element_id_to_zone, zone_count)``;
+    elements with no zone are absent, so the caller supplies the ``ZZ`` default.
+
+    Lives here, not in the adapters: the ``IfcRelAssignsToGroup`` group walk is
+    exactly the core-inference logic the Phase A6 boundary lint keeps out of
+    host adapter files.
+    """
+    zones = model.by_type("IfcZone")
+    zone_code = {z.id(): f"Z{i:02d}" for i, z in enumerate(zones, start=1)}
+    element_to_zone: dict[int, str] = {}
+    for rel in model.by_type("IfcRelAssignsToGroup"):
+        group = rel.RelatingGroup
+        if not group.is_a("IfcZone"):
+            continue
+        code = zone_code.get(group.id())
+        if code is None:
+            continue
+        for obj in (rel.RelatedObjects or []):
+            if obj.is_a("IfcElement"):
+                element_to_zone[obj.id()] = code
+    return element_to_zone, len(zones)
 
 
 def product_for_type_name(type_name: str | None) -> str:


### PR DESCRIPTION
## Why

`stingtools-bonsai/ops/spatial_ops.py` (added by **#585**) re-implemented two pieces of core inference that the **Phase A6 boundary lint** forbids in host adapters, so the **`Core tests + adapter boundary`** job has been **red on `main`** since #585 landed (`check_adapter_boundary.py`: `IFC_CLASS_MAP` + `SYSTEM_GROUP_INFERENCE`, `2 failed, 98 passed`). Adapters must be glue only — tag/enum/inference logic lives in `stingtools-core` and adapters call it. This makes `spatial_ops.py` delegate, exactly as its sibling `tagging_ops.py` already does.

## What moved into `stingtools_core.hosts.inference`

| Was inline in the adapter | Now in core |
|---|---|
| `_CLASS_TO_FUNC` (IFC class → Function code) | `FUNCTION_BY_IFC_CLASS` + `function_for_class()` / `infer_function()` — unknown class → `GEN`, unchanged; **all 31 mappings preserved** |
| `IfcZone` / `IfcRelAssignsToGroup` zone group walk | `zone_codes_for_model(model)` → `(element_id → zone_code, zone_count)`; the operator keeps its `ZZ` default |

The adapter now imports `from stingtools_core.hosts import inference as _inf` and calls `_inf.function_for_class(...)` / `_inf.zone_codes_for_model(...)`. No behaviour change — pure relocation.

## Verification (run in-sandbox)

- `python tools/ci/check_adapter_boundary.py` → **`[OK] adapter boundary clean`**, exit 0
- `--self-test` → **`[OK] self-test passed`**, exit 0
- `python -m pytest` over `stingtools-core/python/tests/` → **100 passed / 1 skipped** (was 98 / 2 failed)
- Both edited files `py_compile` clean; function-map parity asserted against the old `_CLASS_TO_FUNC` values

## Scope

`stingtools-bonsai/ops/spatial_ops.py`, `stingtools-core/python/stingtools_core/hosts/inference.py`, `docs/CHANGELOG.md`. No product/Revit code. The Blender operators are unchanged in behaviour; not exercised in Blender here (pure-Python core + lint are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkTZhAdWvzsWwF4vat3dKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkTZhAdWvzsWwF4vat3dKe)_