### PR TITLE
build(plugin): stop suppressing CS0472 — its one site is a real defect

### DIFF
--- a/StingTools/StingTools.csproj
+++ b/StingTools/StingTools.csproj
@@ -21,9 +21,21 @@
     <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
     <!-- Silence merge-leftover noise warnings:
          CS0414/CS0649 — fields never assigned / assigned but never used (Revit IUpdater fields wired by reflection)
-         CS0472 — bool == null comparison from merged null-guarded code
-         CS8600/CS8602/CS8625 — nullable-flow analysis on stubs (Nullable is disabled project-wide anyway). -->
-    <NoWarn>$(NoWarn);CS0414;CS0649;CS0472;CS8600;CS8602;CS8625</NoWarn>
+         CS8600/CS8602/CS8625 — nullable-flow analysis on stubs (Nullable is disabled project-wide anyway).
+
+         CS0472 (always-false comparison) was in this list, described as "bool == null
+         comparison from merged null-guarded code". It was not noise. Measured on a full
+         rebuild with the suppression lifted: it has exactly ONE site in ~1,440 sources —
+         SitePhotosAdminSubTab.cs:171 — and that site is a real defect. The Site-Photos
+         Admin "New group" button guards a Task<bool> with `if (grp == null)`, which can
+         never be true, so a failed server-side create shows the user nothing and the
+         list simply refreshes. Suppressing the diagnostic is what let it ship.
+
+         Scope, stated precisely so nobody over-reads this: ONE site, not a bug class.
+         Removing the code from NoWarn therefore costs nothing today and stops the
+         pattern returning silently. The remaining codes are NOT claimed to be noise —
+         they have not been measured. Measure before removing any of them. -->
+    <NoWarn>$(NoWarn);CS0414;CS0649;CS8600;CS8602;CS8625</NoWarn>
   </PropertyGroup>
 
   <!-- Default RevitApiPath when not passed via command line (e.g. Visual Studio) -->


### PR DESCRIPTION
One line of `StingTools.csproj`. Carry-over C.

## What it changes

`CS0472` (always-false comparison) is removed from the project-wide `NoWarn`, where it sat annotated as *"bool == null comparison from merged null-guarded code"* — i.e. filed as merge-leftover noise.

## Why — measured, not assumed

Full rebuild of current `main` with the code removed from `NoWarn`:

| | result |
|---|---|
| CS0472 sites across ~1,440 sources | **1** — `SitePhotosAdminSubTab.cs(171,21)` |
| Build | **succeeded, 0 errors** |

That one site is a live bug. The Site Photos Admin **"＋ New group"** button does:

```csharp
var grp = await ...CreateDistributionGroupAsync(...);  // Task<bool>
if (grp == null) { TaskDialog.Show("New group", ...LastError); return; }
await LoadGroupsAsync();
```

`grp` is a non-nullable `bool`, so `grp == null` is always false. The error branch is unreachable: a failed server-side create shows the user nothing and the list simply refreshes, which reads as success. Suppressing the diagnostic is what let that ship.

## Scope — please do not over-read this

**One site, not a bug class.** An earlier framing of this described it as a whole class of defects; measurement did not support that, and this PR is deliberately narrow:

- It does **not** sweep the codebase.
- It does **not** touch the defective line. `SitePhotosAdminSubTab.cs` is owned by concurrent work on the BCC site-photo suite (#550 and #560 stacked on it), and the fix belongs there — flagged on #550, with a ready-made one-liner on the pushed branch `claude/distgroups-server-canonical` (no PR, deliberately).
- The other suppressed codes (`CS0414`, `CS0649`, `CS8600`, `CS8602`, `CS8625`) are **not** claimed to be noise either — they have not been measured. The updated comment says so, so the next person measures rather than assumes.

## Is leaving a visible warning safe?

Yes, and it is the point — it marks real broken code until the owning PR fixes it. Verified there is no `TreatWarningsAsErrors` or `WarningsAsErrors` anywhere in the repo, and the plugin CI builds with `-v minimal` and does not fail on warnings. Once #550's stack fixes line 171, the build returns to 0 warnings (measured on a branch that has both changes: **0 warnings, 0 errors**).

## Verification

- `dotnet build StingTools/StingTools.csproj -c Debug -t:Rebuild` on this branch → **Build succeeded, 0 Errors**, the single CS0472 (listed twice: WPF temp project + real project, same site).
- Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)