### PR TITLE
fix(planscape): write the project link where the readers actually read (#570, #571)

### DIFF
--- a/StingTools/BIMManager/PlanscapeProjectLink.cs
+++ b/StingTools/BIMManager/PlanscapeProjectLink.cs
@@ -61,14 +61,82 @@ namespace StingTools.BIMManager
             => Path.Combine(BIMManagerEngine.GetBIMManagerDir(doc), ConfigFileName);
 
         /// <summary>Config path derived from a model (.rvt) file path. No directory creation.</summary>
+        /// <remarks>
+        /// LEGACY FALLBACK ONLY. A bare model path carries no project root, so this
+        /// resolves to the sibling <c>&lt;rvtDir&gt;\STING_BIM_MANAGER\</c> and NOT to the
+        /// canonical <c>&lt;root&gt;\_data\STING_BIM_MANAGER\</c> bucket that every reader uses.
+        /// <para>
+        /// Writing through this path is how issue #570 happened: the BCC link button
+        /// persisted the project id beside the .rvt while <c>PluginSyncTickBridge</c> and
+        /// <c>SitePhotosTab</c> both read the canonical bucket, so a model that had just
+        /// logged "linked to project a3af2ad2-..." reported "no Planscape project linked"
+        /// five minutes later, every five minutes, forever.
+        /// </para>
+        /// <para>
+        /// Prefer <see cref="ResolveConfigPath"/>, which upgrades to
+        /// <see cref="ConfigPathFor(Document)"/> whenever the document is open. This
+        /// overload remains only for genuinely document-less callers and for
+        /// <see cref="Load(string)"/>'s legacy-sibling migration.
+        /// </para>
+        /// </remarks>
         public static string ConfigPathForModel(string? modelPath)
         {
             if (string.IsNullOrEmpty(modelPath)) return "";
-            // path-discipline: legacy-fallback -- a bare model path carries no project
-            // root, so this cannot resolve the canonical bucket. Callers holding a
-            // Document must use ConfigPathFor(doc) instead, which does.
             string dir = Path.Combine(Path.GetDirectoryName(modelPath) ?? "", "STING_BIM_MANAGER");
             return Path.Combine(dir, ConfigFileName);
+        }
+
+        /// <summary>
+        /// The config path a caller holding only a model path should use.
+        ///
+        /// Finds the open <see cref="Document"/> for that model and resolves the
+        /// CANONICAL bucket through <see cref="ConfigPathFor(Document)"/>; only falls
+        /// back to the legacy sibling when the document genuinely is not open. Callers
+        /// that hold a Document should still call <see cref="ConfigPathFor(Document)"/>
+        /// directly.
+        /// </summary>
+        public static string ResolveConfigPath(string? modelPath)
+        {
+            try
+            {
+                var app = StingTools.UI.StingCommandHandler.CurrentApp;
+                var active = app?.ActiveUIDocument?.Document;
+
+                // No model named: the caller means "the document in front of the user".
+                if (string.IsNullOrEmpty(modelPath))
+                    return active != null ? ConfigPathFor(active) : "";
+
+                if (active != null && PathsEqual(active.PathName, modelPath))
+                    return ConfigPathFor(active);
+
+                // Not the active document - look through the rest before giving up,
+                // so a BCC opened over a background document still resolves canonically.
+                var docs = app?.Application?.Documents;
+                if (docs != null)
+                {
+                    foreach (Document d in docs)
+                    {
+                        if (d != null && !d.IsFamilyDocument && PathsEqual(d.PathName, modelPath))
+                            return ConfigPathFor(d);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"PlanscapeProjectLink.ResolveConfigPath: {ex.Message}");
+            }
+
+            StingLog.Warn("PlanscapeProjectLink.ResolveConfigPath: no open document matched " +
+                          $"'{modelPath}' - falling back to the legacy sibling path. The link " +
+                          "will not be visible to readers that use the canonical bucket.");
+            return ConfigPathForModel(modelPath);
+        }
+
+        private static bool PathsEqual(string? a, string? b)
+        {
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
+            try { return string.Equals(Path.GetFullPath(a), Path.GetFullPath(b), StringComparison.OrdinalIgnoreCase); }
+            catch { return string.Equals(a, b, StringComparison.OrdinalIgnoreCase); }
         }
 
         /// <summary>Read the persisted link. Returns an empty <see cref="LinkInfo"/> when no file / no link.</summary>
@@ -165,7 +233,28 @@ namespace StingTools.BIMManager
         public static LinkInfo RestoreInto(Document doc)
         {
             LinkInfo info = default;
-            try { info = Load(ConfigPathFor(doc)); }
+            try
+            {
+                string canonical = ConfigPathFor(doc);
+                info = Load(canonical);
+
+                // Heal #570 in place. Models linked by an older build wrote the id to
+                // the sibling path and nothing has ever read it there, so without this
+                // they stay silently unlinked even after the write path is fixed. Only
+                // adopt when the canonical bucket has no link of its own - a canonical
+                // link is always authoritative over a legacy one.
+                if (!info.IsLinked)
+                {
+                    var legacy = Load(ConfigPathForModel(doc.PathName));
+                    if (legacy.IsLinked)
+                    {
+                        StingLog.Info($"PlanscapeProjectLink: adopting legacy sibling link {legacy.ProjectId} " +
+                                      $"({legacy.Label}) for {doc.Title} and migrating it to the canonical bucket.");
+                        Set(canonical, legacy.ProjectId, legacy.Name, legacy.Code);
+                        info = legacy;
+                    }
+                }
+            }
             catch (Exception ex) { StingLog.Warn($"PlanscapeProjectLink.RestoreInto: {ex.Message}"); }
 
             PlanscapeServerClient.Instance.CurrentProjectId = info.ProjectId; // Empty when not linked

--- a/StingTools/BIMManager/PlanscapeProjectLink.cs
+++ b/StingTools/BIMManager/PlanscapeProjectLink.cs
@@ -82,6 +82,9 @@ namespace StingTools.BIMManager
         public static string ConfigPathForModel(string? modelPath)
         {
             if (string.IsNullOrEmpty(modelPath)) return "";
+            // path-discipline: legacy-fallback -- a bare model path carries no project
+            // root, so this cannot resolve the canonical bucket. Callers holding a
+            // Document must use ConfigPathFor(doc) or ResolveConfigPath(modelPath).
             string dir = Path.Combine(Path.GetDirectoryName(modelPath) ?? "", "STING_BIM_MANAGER");
             return Path.Combine(dir, ConfigFileName);
         }

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -702,15 +702,43 @@ public sealed partial class PlanscapeServerClient : IDisposable
     {
         try
         {
-            var settings = new JObject
+            // MERGE, never replace. This used to build a fresh JObject and write it
+            // over whatever was there, and the post-login call site passes no
+            // projectId - so saving connection settings silently DELETED the project
+            // link of an already-linked model (issue #571). That defect was dormant
+            // only because the block that calls this never ran: it dereferenced a
+            // null ExternalCommandData and died on an NRE that was logged as
+            // "non-fatal". Fixing the NRE without fixing this would have turned a
+            // harmless log line into link loss on every login.
+            JObject settings;
+            if (File.Exists(configPath))
             {
-                ["serverUrl"]       = _serverUrl,
-                ["email"]           = email,
-                ["lastConnected"]   = DateTime.UtcNow.ToString("o")
-            };
+                try { settings = JObject.Parse(File.ReadAllText(configPath)); }
+                catch (Exception parseEx)
+                {
+                    // Do not silently discard a file we cannot read - it may hold the
+                    // only copy of the project link.
+                    StingLog.Warn($"Planscape: {Path.GetFileName(configPath)} is unreadable " +
+                                  $"({parseEx.Message}); keeping a .corrupt backup before rewriting.");
+                    try { File.Copy(configPath, configPath + ".corrupt", true); } catch { }
+                    settings = new JObject();
+                }
+            }
+            else
+            {
+                settings = new JObject();
+            }
+
+            settings["serverUrl"]     = _serverUrl;
+            settings["email"]         = email;
+            settings["lastConnected"] = DateTime.UtcNow.ToString("o");
+            // Only ever ADD a project id. An absent argument means "not specified",
+            // never "clear the link".
             if (projectId != Guid.Empty)
                 settings["projectId"] = projectId.ToString();
 
+            var dir = Path.GetDirectoryName(configPath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
             File.WriteAllText(configPath, settings.ToString(Formatting.Indented));
         }
         catch (Exception ex) { StingLog.Warn($"Planscape: Could not save connection settings: {ex.Message}"); }

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -2423,9 +2423,15 @@ namespace StingTools.BIMManager
                         return;
                     }
 
-                    string bimDir = BIMManagerEngine.GetBIMManagerDir(doc);
-                    string cfgPath = Path.Combine(bimDir, "planscape_connection.json");
-                    Guid projectId = PlatformSyncCommand.LoadPlanscapeProjectId(cfgPath);
+                    // Prefer the in-memory link, then the canonical bucket via
+                    // RestoreInto (which also migrates a legacy sibling link written
+                    // by an older build). Reading only the file, only from the
+                    // canonical bucket, is issue #570: this tick logged "no Planscape
+                    // project linked" every five minutes for a model that HAD been
+                    // linked - the id had simply been written somewhere nothing read.
+                    Guid projectId = client.CurrentProjectId;
+                    if (projectId == Guid.Empty)
+                        projectId = PlanscapeProjectLink.RestoreInto(doc).ProjectId;
                     if (projectId == Guid.Empty)
                     {
                         StingLog.Info($"PluginSyncTickBridge tick: no Planscape project linked for {doc.Title}, skipping payload build");
@@ -2674,8 +2680,15 @@ namespace StingTools.BIMManager
                 // that downgrades to a log line and still reports success.
                 try
                 {
-                    // Persist connection settings (no password stored)
-                    var doc = commandData.Application.ActiveUIDocument?.Document;
+                    // StingCommandHandler.RunCommand<T> passes null for
+                    // ExternalCommandData BY DESIGN and says so - commands are
+                    // expected to fall back to CurrentApp. This block did not, and
+                    // `commandData.Application` threw an NRE on EVERY login, caught
+                    // below and logged as "non-fatal". It had therefore never run
+                    // once (issue #571). The `?.` guarded ActiveUIDocument, which was
+                    // never the null one.
+                    var app = commandData?.Application ?? StingCommandHandler.CurrentApp;
+                    var doc = app?.ActiveUIDocument?.Document;
                     if (doc != null)
                     {
                         string bimDir = BIMManagerEngine.GetBIMManagerDir(doc);
@@ -2699,7 +2712,24 @@ namespace StingTools.BIMManager
                 }
                 catch (Exception persistEx)
                 {
-                    StingLog.Warn($"Planscape: post-login persist step failed (non-fatal) — {persistEx.Message}");
+                    // Downgrading I/O failure here is right - a failed settings write
+                    // must not turn a working connection into an error dialog. But a
+                    // NullReferenceException is not an I/O failure, it is a bug, and
+                    // logging the two identically is how #571 hid for as long as it
+                    // did: "post-login persist step failed (non-fatal)" read as an
+                    // occasional disk problem when it actually meant this code has
+                    // never executed. Name it so the next one is obvious.
+                    bool programmingError = persistEx is NullReferenceException
+                                         || persistEx is ArgumentNullException;
+                    if (programmingError)
+                    {
+                        StingLog.Error("Planscape: post-login persist step hit a PROGRAMMING ERROR " +
+                                       "(not an I/O failure) - connection settings were NOT saved", persistEx);
+                    }
+                    else
+                    {
+                        StingLog.Warn($"Planscape: post-login persist step failed (non-fatal) — {persistEx.Message}");
+                    }
                 }
 
                 var client = PlanscapeServerClient.Instance;

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -4758,7 +4758,7 @@ namespace StingTools.UI
                             // link file in case the in-memory CurrentProjectId
                             // wasn't restored this session.
                             var link = BIMManager.PlanscapeProjectLink.Load(
-                                BIMManager.PlanscapeProjectLink.ConfigPathForModel(_data?.FilePath));
+                                BIMManager.PlanscapeProjectLink.ResolveConfigPath(_data?.FilePath));
                             if (link.IsLinked)
                             {
                                 projectGuid = link.ProjectId;
@@ -4864,7 +4864,7 @@ namespace StingTools.UI
                     if (projectGuid == Guid.Empty)
                     {
                         var link = BIMManager.PlanscapeProjectLink.Load(
-                            BIMManager.PlanscapeProjectLink.ConfigPathForModel(_data?.FilePath));
+                            BIMManager.PlanscapeProjectLink.ResolveConfigPath(_data?.FilePath));
                         if (link.IsLinked) { projectGuid = link.ProjectId; client.CurrentProjectId = projectGuid; }
                     }
                     if (projectGuid == Guid.Empty)
@@ -5071,7 +5071,7 @@ namespace StingTools.UI
                     Foreground = Br(CAccent), Margin = new Thickness(0, 6, 0, 4)
                 });
                 {
-                    string linkCfgPath = BIMManager.PlanscapeProjectLink.ConfigPathForModel(_data?.FilePath);
+                    string linkCfgPath = BIMManager.PlanscapeProjectLink.ResolveConfigPath(_data?.FilePath);
                     var curLink = BIMManager.PlanscapeProjectLink.Load(linkCfgPath);
                     // Keep the in-memory CurrentProjectId in step with the active
                     // document whenever this tab is shown (covers project switches
@@ -10983,7 +10983,7 @@ namespace StingTools.UI
                 try
                 {
                     var lk = BIMManager.PlanscapeProjectLink.Load(
-                        BIMManager.PlanscapeProjectLink.ConfigPathForModel(_data?.FilePath));
+                        BIMManager.PlanscapeProjectLink.ResolveConfigPath(_data?.FilePath));
                     if (lk.IsLinked) { attPid = lk.ProjectId; attClient.CurrentProjectId = attPid; }
                 }
                 catch (Exception lex) { StingLog.Warn($"[attendees] project-link resolve failed: {lex.Message}"); }
@@ -11270,7 +11270,7 @@ namespace StingTools.UI
                 try
                 {
                     var lk = BIMManager.PlanscapeProjectLink.Load(
-                        BIMManager.PlanscapeProjectLink.ConfigPathForModel(_data?.FilePath));
+                        BIMManager.PlanscapeProjectLink.ResolveConfigPath(_data?.FilePath));
                     if (lk.IsLinked) { recPid = lk.ProjectId; recClient.CurrentProjectId = recPid; }
                 }
                 catch (Exception lex) { StingLog.Warn($"[recordings] project-link resolve failed: {lex.Message}"); }

--- a/StingTools/UI/SitePhotosTab.cs
+++ b/StingTools/UI/SitePhotosTab.cs
@@ -1386,16 +1386,24 @@ namespace StingTools.UI
 
         /// <summary>Read the current Planscape project id from the document config —
         /// same source the Issues / Documents tabs use. Returns Guid.Empty if not linked.</summary>
-        private static Guid ResolveProjectId()
+        internal static Guid ResolveProjectId()
         {
             try
             {
+                // The in-memory value is set by PlanscapeProjectLink.Set the moment a
+                // link is made and by RestoreInto on document open, so it is correct
+                // before anything settles on disk. Reading the file first is what made
+                // #570 invisible: a link made in-session looked like no link at all.
+                var live = PlanscapeServerClient.Instance.CurrentProjectId;
+                if (live != Guid.Empty) return live;
+
                 var doc = StingCommandHandler.CurrentApp?.ActiveUIDocument?.Document;
                 if (doc == null) return Guid.Empty;
-                string bimDir = ProjectFolderEngine.GetMetaPath(doc, "STING_BIM_MANAGER");
-                if (string.IsNullOrEmpty(bimDir)) return Guid.Empty;
-                string cfgPath = Path.Combine(bimDir, "planscape_connection.json");
-                return PlatformSyncCommand.LoadPlanscapeProjectId(cfgPath);
+
+                // RestoreInto also migrates a legacy sibling link into the canonical
+                // bucket, so this covers models linked by an older build.
+                var info = PlanscapeProjectLink.RestoreInto(doc);
+                return info.ProjectId;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Closes #570. Closes #571.

## Why this PR exists

Commit `2ebb10fcc` on `claude/m-pass-deploy` was built, deployed to `CompiledPlugin`, and
**verified in Revit by the owner** — the BCC now reads the project link, and connecting no
longer throws. It has never had a pull request. `claude/m-pass-deploy` also carries #550,
#560 and the launcher work, all of which have their own PRs, so opening a PR for that branch
would duplicate them.

This branch is cut fresh off `main` and carries **only** the #570/#571 change.

## Verification status — read this before merging

The owner's Revit verification was against **`2ebb10fcc`, not against `aff06b305` (this
commit)**. Re-verification is owed if the rebase turns out to be non-trivial. Here is the
measurement so you can judge that rather than take my word:

The cherry-pick applied with **no conflicts**. Comparing the post-rebase blobs against the
verified commit's blobs:

| File | vs `2ebb10fcc` |
|---|---|
| `BIMManager/PlanscapeProjectLink.cs` | byte-identical |
| `BIMManager/PlanscapeServerClient.cs` | byte-identical |
| `BIMManager/PlatformLinkCommands.cs` | byte-identical |
| `UI/BIMCoordinationCenter.cs` | byte-identical |
| `UI/SitePhotosTab.cs` | differs — 4 lines, none of them this change |

The four `SitePhotosTab.cs` lines that differ are `SitePhotosTabHelpers.Reason(...)` call
sites belonging to `claude/sitephotos-d1-guards`, which is not on `main`. The cherry-pick
correctly kept `main`'s inline strings there. The *only* #570 hunk in that file —
`ResolveProjectId` — is byte-identical to the verified version.

So the rebase is as close to trivial as a rebase gets. I still would not call the Revit
verification transferred; I'd call it very likely to hold.

Build on this branch: `dotnet build StingTools/StingTools.csproj -c Debug -t:Rebuild`
→ **0 errors, 0 warnings**.

## What it fixes

### #570 — the link was persisted to a path nothing reads

`PlanscapeProjectLink` has two path resolvers, and its own doc comment marked one as unable
to reach the canonical bucket:

```
ConfigPathFor(doc)        -> <root>\_data\STING_BIM_MANAGER\   (canonical)
ConfigPathForModel(rvt)   -> <rvtDir>\STING_BIM_MANAGER\       (legacy sibling)
```

The BCC link button called the **legacy** one at five sites. Both readers —
`PluginSyncTickBridge` and `SitePhotosTab.ResolveProjectId` — read the **canonical** one.
Confirmed on disk: the id sat beside the `.rvt`; the canonical directory was empty. The log
said "model linked to project a3af2ad2-…" and then "no Planscape project linked" every five
minutes, forever, and SITE PHOTOS told a signed-in user to sign in.

- New `ResolveConfigPath(modelPath)` finds the open `Document` for that model and resolves
  canonically; it falls back to the sibling only when the document genuinely is not open,
  and logs when it does.
- The five BCC sites use it. `ConfigPathForModel` keeps its behaviour but now documents the
  cost of calling it.
- `RestoreInto` **adopts** a legacy sibling link and migrates it to the canonical bucket.
  Without this, models linked by an older build stay silently unlinked after the write path
  is fixed.
- Both readers now prefer `PlanscapeServerClient.CurrentProjectId`, which
  `PlanscapeProjectLink.Set` has always kept correct in memory. Going to disk first is what
  made an in-session link look like no link at all.

### #571 — a guaranteed NRE, and the clobber hiding behind it

`StingCommandHandler.RunCommand<T>` passes `null` for `ExternalCommandData` **by design** and
says so in a comment. `PlanscapeConnectCommand` dereferenced `commandData.Application` anyway,
so the post-login persist block threw on **every** login, was caught, and was logged as
"non-fatal". It had never executed once. The `?.` in the expression guarded
`ActiveUIDocument` — not the operand that was actually null.

- The command falls back to `StingCommandHandler.CurrentApp`.
- `SaveConnectionSettings` merges into the existing file, only ever *adds* a project id,
  creates the directory, and backs up an unparseable file rather than discarding what may be
  the only copy of the link.
- The catch still downgrades I/O failure — a failed settings write must not turn a working
  connection into an error dialog — but reports `NullReferenceException` /
  `ArgumentNullException` as programming errors. Logging the two identically is exactly how
  this hid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
