### PR TITLE
fix(server): SLA priority lookup was case-sensitive, quietly serving 168h for 4h (#551)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IssuesController.cs
@@ -34,7 +34,17 @@ public class IssuesController : ControllerBase
     private readonly Planscape.Infrastructure.Services.OutboundWebhookDispatcher? _webhooks;
     private readonly IBackgroundJobClient _backgroundJobs;
 
-    private static readonly Dictionary<string, int> SLAHours = new()
+    // #551 - OrdinalIgnoreCase is load-bearing, not tidiness. The default
+    // comparer is case-SENSITIVE, so a client sending "critical" missed every
+    // key here and ComputeSLADeadline's GetValueOrDefault(priority, 168) served
+    // the MEDIUM fallback: a 4-hour SLA silently became one week, with nothing
+    // logged and nothing failed.
+    //
+    // Fixed in the CONTAINER rather than by normalising at the call site -
+    // ComputeSLADeadline is not the only way in, and a caller-side .ToUpper()
+    // leaves the next caller free to reintroduce exactly this. Guarded by
+    // IssueSlaLookupTests, which asserts the comparer directly.
+    internal static readonly Dictionary<string, int> SLAHours = new(StringComparer.OrdinalIgnoreCase)
     {
         ["CRITICAL"] = 4, ["HIGH"] = 24, ["MEDIUM"] = 168, ["LOW"] = 336
     };

--- a/Planscape.Server/tests/Planscape.Tests/IssueSlaLookupTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/IssueSlaLookupTests.cs
@@ -1,0 +1,101 @@
+using Planscape.API.Controllers;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Regression guard for #551.
+///
+/// IssuesController.SLAHours was a Dictionary&lt;string,int&gt; built with the
+/// DEFAULT comparer, which is ordinal and case-SENSITIVE. Its keys are upper
+/// case ("CRITICAL"), but the priority reaching ComputeSLADeadline is whatever
+/// the caller sent — CreateIssue at :323 passes `req.Priority ?? "MEDIUM"`
+/// straight through with no normalisation, and nothing on the DTO constrains
+/// the casing.
+///
+/// So a client sending "critical" missed the map entirely and
+/// GetValueOrDefault(priority, 168) served the MEDIUM fallback: a 4-hour SLA
+/// silently became one week. Nothing logged, nothing failed — the issue simply
+/// got a due date six days too late.
+///
+/// The fix belongs in the CONTAINER, not at the call site. Normalising the
+/// input where it is read would leave the next caller free to reintroduce the
+/// bug; a case-insensitive comparer makes the container correct for every
+/// caller, present and future.
+///
+/// Note the deliberate asymmetry asserted below: an UNKNOWN priority must still
+/// fall back to 168. That fallback is intentional policy for a value we do not
+/// recognise. What was wrong was reaching it for a value we DO recognise, only
+/// spelled in a different case.
+/// </summary>
+public class IssueSlaLookupTests
+{
+    [Theory]
+    [InlineData("CRITICAL")]
+    [InlineData("Critical")]
+    [InlineData("critical")]
+    [InlineData("cRiTiCaL")]
+    public void Critical_ResolvesTo4Hours_RegardlessOfCase(string priority)
+    {
+        Assert.Equal(4, IssuesController.SLAHours.GetValueOrDefault(priority, 168));
+    }
+
+    /// <remarks>
+    /// The "medium" row is a deliberate trap-marker: it PASSED before the fix,
+    /// because missing the map lands on the 168 fallback which happens to be
+    /// MEDIUM's own value. It proves nothing on its own. Kept so the next
+    /// reader can see why the surrounding rows are the ones that matter.
+    /// Pre-fix this theory failed on "high" and "low" only.
+    /// </remarks>
+    [Theory]
+    [InlineData("HIGH", 24)]
+    [InlineData("high", 24)]
+    [InlineData("MEDIUM", 168)]
+    [InlineData("medium", 168)]
+    [InlineData("LOW", 336)]
+    [InlineData("low", 336)]
+    public void EveryDefinedPriority_ResolvesTheSame_InEitherCase(string priority, int expectedHours)
+    {
+        Assert.Equal(expectedHours, IssuesController.SLAHours.GetValueOrDefault(priority, 168));
+    }
+
+    /// <summary>
+    /// The 168 fallback must remain reachable for genuinely unknown input —
+    /// but it has to be reached DELIBERATELY, not as the accidental
+    /// consequence of a comparer mismatch. These values are not priorities in
+    /// any casing, so the fallback is the correct answer for them.
+    /// </summary>
+    [Theory]
+    [InlineData("URGENT")]
+    [InlineData("blocker")]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void UnknownPriority_StillFallsBackTo168_Deliberately(string priority)
+    {
+        Assert.False(IssuesController.SLAHours.ContainsKey(priority));
+        Assert.Equal(168, IssuesController.SLAHours.GetValueOrDefault(priority, 168));
+    }
+
+    /// <summary>
+    /// Asserts the mechanism directly rather than only its symptom. If someone
+    /// later rebuilds this dictionary with a collection initialiser and drops
+    /// the comparer, the tests above would still pass for the upper-case rows
+    /// and fail only for the lower-case ones — this one names the actual cause.
+    /// </summary>
+    [Fact]
+    public void SlaHours_UsesACaseInsensitiveComparer()
+    {
+        Assert.Same(StringComparer.OrdinalIgnoreCase, IssuesController.SLAHours.Comparer);
+    }
+
+    /// <summary>
+    /// Guards the four-row shape. A silently dropped row would show up as an
+    /// unexplained one-week SLA, which is the same failure #551 produced.
+    /// </summary>
+    [Fact]
+    public void SlaHours_DefinesExactlyTheFourKnownPriorities()
+    {
+        Assert.Equal(4, IssuesController.SLAHours.Count);
+        Assert.All(new[] { "CRITICAL", "HIGH", "MEDIUM", "LOW" },
+            p => Assert.True(IssuesController.SLAHours.ContainsKey(p)));
+    }
+}


### PR DESCRIPTION
Closes #551.

## The defect

`IssuesController.cs:37` builds `SLAHours` with the **default** comparer — ordinal,
case-sensitive:

```csharp
private static readonly Dictionary<string, int> SLAHours = new()
{
    ["CRITICAL"] = 4, ["HIGH"] = 24, ["MEDIUM"] = 168, ["LOW"] = 336
};
```

The priority reaching `ComputeSLADeadline` is whatever the caller sent. `CreateIssue`
(`:323`) passes `req.Priority ?? "MEDIUM"` straight through, and nothing on the DTO
constrains casing. A client sending `"critical"` therefore missed every key, and
`GetValueOrDefault(priority, 168)` served the MEDIUM fallback.

**A 4-hour SLA silently became one week.** Nothing logged, nothing threw — the issue just
got a due date six days too late.

## The fix

`StringComparer.OrdinalIgnoreCase` on the container.

Deliberately **not** normalised at the call site. `ComputeSLADeadline` is not the only way
into this map, and a caller-side `.ToUpperInvariant()` leaves the container still wrong and
the next caller free to reintroduce exactly this. Fixing the container makes it correct for
every caller, present and future.

## Tests

`Planscape.Server/tests/Planscape.Tests/IssueSlaLookupTests.cs` — 16 cases.

**RED proven before GREEN.** Running the suite against the unmodified map:

```
Failed!  - Failed: 6, Passed: 10, Skipped: 0, Total: 16
  Critical_ResolvesTo4Hours_RegardlessOfCase(priority: "critical")  [FAIL]
  Critical_ResolvesTo4Hours_RegardlessOfCase(priority: "Critical")  [FAIL]
  Critical_ResolvesTo4Hours_RegardlessOfCase(priority: "cRiTiCaL")  [FAIL]
  EveryDefinedPriority_ResolvesTheSame_InEitherCase("high", 24)     [FAIL]
  EveryDefinedPriority_ResolvesTheSame_InEitherCase("low", 336)     [FAIL]
  SlaHours_UsesACaseInsensitiveComparer                             [FAIL]
```

After the fix: `Passed! - Failed: 0, Passed: 16`.

Three things the tests do on purpose:

1. **The unknown-priority fallback is asserted as deliberate.** `"URGENT"`, `"blocker"`,
   `""` and `"  "` must still yield 168 — that is intended policy for a value we do not
   recognise. What was wrong was reaching it for a value we *do* recognise, differently
   spelled. Fixing the casing must not quietly remove the fallback.

2. **One test asserts the comparer identity itself**, not just its symptom. If someone
   later rebuilds this dictionary and drops the comparer, the value tests would still pass
   for the upper-case rows; this one names the actual cause.

3. **The `"medium"` row is flagged in-source as the vacuous one.** It *passed before the
   fix* — missing the map lands on 168, which is MEDIUM's own value. Kept, and commented,
   so the next reader can see why the rows around it are the ones carrying the weight.

## One-line visibility change

`SLAHours` went `private` → `internal`. `Planscape.API.csproj:14` already carries
`InternalsVisibleTo("Planscape.Tests")`, so no new plumbing was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
