### PR TITLE
fix(billing): count seats over the rows the seat-selling paths actually write

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
@@ -47,12 +47,14 @@ public class TenantAdminController : ControllerBase
         var limits = BillingPlanLimits.For(tenant.Plan);
 
         var memberCount = await _db.ProjectMembers.CountAsync(ct);
-        var authorIds = await _db.ProjectMembers
-            .Where(m => m.ProjectRole == "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
-        var coordIds  = await _db.ProjectMembers
-            .Where(m => m.ProjectRole != "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
+
+        // Seat counts come from the quota guard rather than being recomputed
+        // here. This block used to inline its own copy of the author/coordinator
+        // split, so the number the customer was shown and the number the invite
+        // gate enforced were two independent implementations that could disagree
+        // — and did, once the guard's definition of a seat changed. One source.
+        var authorSeats = await _quota.CheckCanAddUserAsync("Author", ct);
+        var coordSeats  = await _quota.CheckCanAddUserAsync("Coordinator", ct);
         var projectCount = await _db.Projects.CountAsync(ct);
         var storageBytes = await _db.ProjectModels.AsNoTracking()
             .Where(m => m.DeletedAt == null)
@@ -81,8 +83,8 @@ public class TenantAdminController : ControllerBase
             },
             usage = new
             {
-                authors      = new { current = authorIds.Count,  max = limits.MaxAuthors },
-                coordinators = new { current = coordIds.Count,   max = limits.MaxCoordinators },
+                authors      = new { current = authorSeats.Current, max = authorSeats.Max },
+                coordinators = new { current = coordSeats.Current,  max = coordSeats.Max },
                 projects     = new { current = projectCount,     max = limits.MaxProjects },
                 storage      = new { currentMb = storageBytes / 1024 / 1024, maxMb = limits.StorageMb },
                 memberSeats  = memberCount,

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
@@ -73,12 +73,61 @@ public class QuotaGuardService : IQuotaGuardService
         var current = axis switch
         {
             QuotaAxis.Projects     => await _db.Projects.CountAsync(p => p.TenantId == tid, ct),
-            QuotaAxis.Authors      => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole == "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
-            QuotaAxis.Coordinators => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole != "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
+            QuotaAxis.Authors      => await CountAuthorSeatsAsync(tid, ct),
+            QuotaAxis.Coordinators => await CountUserSeatsAsync(tid, ct) - await CountAuthorSeatsAsync(tid, ct),
             _                      => 0,
         };
         return (limits, current);
     }
+
+    /// <summary>
+    /// A seat is a PERSON in the tenant, so seats are counted over
+    /// <c>AppUser</c> — the row the seat-selling operations actually create.
+    ///
+    /// This used to count <c>ProjectMembers</c>, which meant the meter read a
+    /// table the metered operations never wrote: <c>POST /api/tenant/invite</c>
+    /// and <c>POST /api/onboarding/team</c> both gate on these axes and then
+    /// create an <c>AppUser</c> and nothing else — no <c>ProjectMember</c> — so
+    /// an accepted invite could never move the number it had just been checked
+    /// against. Meanwhile the only path that does create <c>ProjectMember</c>
+    /// rows (<c>ProjectMembersController</c>) never consults this guard.
+    /// Counting people also makes the pre-existing <c>.Distinct()</c> on UserId
+    /// unnecessary rather than merely approximate — a person on four projects
+    /// was always meant to be one seat.
+    ///
+    /// <para><c>!u.IsDeleted</c> is written out EXPLICITLY and must stay that
+    /// way. <c>AppUser</c> declares <c>HasQueryFilter(u =&gt; !u.IsDeleted)</c>
+    /// in its own entity block, but <c>ApplyGlobalQueryFilters</c> runs later in
+    /// <c>OnModelCreating</c> and — because EF Core 8 allows only ONE filter per
+    /// entity, a second call silently replacing the first — overwrites it with
+    /// the tenant predicate. <c>AppUser</c> does not implement
+    /// <c>ISoftDeletable</c> either, so nothing puts the tombstone predicate
+    /// back. That is documented in PlanscapeDbContext and is deliberately out of
+    /// scope to fix here; the consequence for billing is that relying on the
+    /// global filter would charge tenants for deleted users.</para>
+    /// </summary>
+    private Task<int> CountUserSeatsAsync(Guid tid, CancellationToken ct)
+        => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted, ct);
+
+    /// <summary>
+    /// Author seats are the users carrying ISO 19650 role <c>"A"</c> — which is
+    /// exactly what the invite paths persist for an Author
+    /// (<c>Iso19650Role = role == "Author" ? "A" : "C"</c> in both
+    /// TenantAdminController and OnboardingController), so the meter and the
+    /// write agree by construction.
+    ///
+    /// <para>Coordinators are deliberately derived as <c>total - authors</c>
+    /// rather than as <c>Iso19650Role != "A"</c>. In SQL a NULL role makes both
+    /// <c>= 'A'</c> and <c>&lt;&gt; 'A'</c> evaluate to NULL, so a legacy row
+    /// with no role would fall off BOTH axes and silently hand out a free seat.
+    /// Subtraction is total by construction.</para>
+    /// </summary>
+    private Task<int> CountAuthorSeatsAsync(Guid tid, CancellationToken ct)
+        => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted && u.Iso19650Role == AuthorIsoRole, ct);
+
+    /// <summary>ISO 19650 "Appointing Party" — the code the invite paths write
+    /// for an author seat.</summary>
+    private const string AuthorIsoRole = "A";
 
     private static QuotaResult Result(QuotaAxis axis, int current, int max)
     {

--- a/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
@@ -1,0 +1,160 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The seat meter must count the seats the product actually sells.
+///
+/// THE DEFECT THESE PIN
+/// --------------------
+/// `POST /api/tenant/invite` gates on the coordinator seat axis: it calls
+/// `IQuotaGuardService.CheckCanAddUserAsync(role)` and returns
+/// **402 quota_exceeded** when that axis is full. So the endpoint's own
+/// contract says an invite consumes a seat.
+///
+/// It then creates an `AppUser` row and nothing else — no `ProjectMember`.
+/// But every reader of the seat axes counts `ProjectMembers`:
+///
+///   QuotaGuardService.CountAsync      ProjectMembers, split on ProjectRole
+///   TenantAdminController.Dashboard   ProjectMembers, same split inlined again
+///
+/// So the endpoint gates on a number it can never move. Invite a thousand
+/// coordinators and `usage.coordinators.current` stays where it was; the 402
+/// fires on a count driven entirely by a different code path
+/// (`ProjectMembersController`), which never consults the guard at all.
+///
+/// This is upstream of the author/coordinator split being inverted. Correcting
+/// which roles land on which axis would still leave the meter reading a table
+/// that the metered operation does not write — so these tests come first.
+///
+/// EXPECTED STATE
+/// --------------
+/// RED on current main: the count does not move. They are written against the
+/// INTENDED behaviour, not the current behaviour, so they go GREEN when the
+/// meter is wired to the writes.
+///
+/// The test tenant is `BillingPlan.Enterprise` (unlimited seats), so the quota
+/// check always allows and these tests isolate the *counting*, never the gate.
+/// </summary>
+public class QuotaSeatMeterWiringTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public QuotaSeatMeterWiringTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    private sealed record Seats(int Authors, int Coordinators, int MemberSeats, int UserCount);
+
+    /// <summary>
+    /// Reads the seat counters from the surface the customer is billed against.
+    /// Asserts the payload actually resolved a tenant: `ITenantContext.TenantId`
+    /// falls back to `Guid.Empty`, which matches no rows, and every count would
+    /// then read 0 — an increment assertion against an unresolved tenant would
+    /// be measuring nothing.
+    /// </summary>
+    private static async Task<Seats> ReadSeatsAsync(HttpClient client)
+    {
+        var res = await client.GetAsync("/api/tenant/dashboard");
+        Assert.True(res.IsSuccessStatusCode,
+            $"tenant dashboard failed: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        var usage = root.GetProperty("usage");
+
+        var users = root.GetProperty("users").GetArrayLength();
+        Assert.True(users > 0,
+            "The dashboard reported zero users, so the tenant did not resolve and " +
+            "these counts prove nothing. Check ITenantContext in the test host.");
+
+        return new Seats(
+            usage.GetProperty("authors").GetProperty("current").GetInt32(),
+            usage.GetProperty("coordinators").GetProperty("current").GetInt32(),
+            usage.GetProperty("memberSeats").GetInt32(),
+            users);
+    }
+
+    private static async Task<Guid> InviteAsync(HttpClient client, string role)
+    {
+        var email = $"zz-fixture-seat-{Guid.NewGuid():N}@example.com";
+        var res = await client.PostAsJsonAsync("/api/tenant/invite",
+            new { email, displayName = "ZZ-FIXTURE Seat Probe", role });
+
+        Assert.True(res.IsSuccessStatusCode,
+            $"invite({role}) failed: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("id").GetGuid();
+    }
+
+    private static async Task CleanUpAsync(HttpClient client, Guid userId)
+        => await client.DeleteAsync($"/api/tenant/users/{userId}");
+
+    [Fact]
+    public async Task Inviting_a_coordinator_consumes_a_coordinator_seat()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync(); // Owner
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Coordinator");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+
+            // The invite succeeded, so a coordinator seat was sold. The surface
+            // the customer is billed against has to show it.
+            Assert.Equal(before.Coordinators + 1, after.Coordinators);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+
+    [Fact]
+    public async Task Inviting_an_author_consumes_an_author_seat()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Author");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+
+            // `/api/tenant/invite` routes "Author" to the Authors axis and gates
+            // on MaxAuthors, so an accepted author invite must consume an author
+            // seat. Today the author axis is pinned at 0 for a second, separate
+            // reason — nothing ever writes ProjectRole = "Author" — but this
+            // assertion is about the seat being counted at all.
+            Assert.Equal(before.Authors + 1, after.Authors);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+
+    [Fact]
+    public async Task An_invited_user_is_visible_to_the_tenant_even_though_no_seat_moves_today()
+    {
+        // The control. It proves the invite genuinely persisted a user, so the
+        // two failures above are the METER failing to count a real seat — not
+        // the invite silently doing nothing. Without this, a broken invite and
+        // a broken meter are indistinguishable.
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Coordinator");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+            Assert.Equal(before.UserCount + 1, after.UserCount);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+}


### PR DESCRIPTION
Two commits: the RED proof, then the fix. **Billing-affecting** — please read the split rationale before merging.

## The defect, upstream of the known inversion

`POST /api/tenant/invite` gates on the seat axes — it calls `CheckCanAddUserAsync(role)` and returns **402 `quota_exceeded`** when full — so by its own contract an accepted invite consumes a seat. It then creates an `AppUser` **and nothing else. No `ProjectMember`.**

But every reader of the axes counted `ProjectMembers`:

| reader | counted |
|---|---|
| `QuotaGuardService.CountAsync` | `ProjectMembers`, split on `ProjectRole` |
| `TenantAdminController.Dashboard` | `ProjectMembers`, **the same split inlined a second time** |

So the endpoint gated on a number it could never move, while that number was driven entirely by `ProjectMembersController` — which **never consults the guard at all**. Gate and meter sat on opposite sides of a wall.

This is upstream of the author/coordinator inversion tracked in #538: correcting *which* roles land on *which* axis would still leave the meter reading a table the metered operation does not write.

## Proof first

`QuotaSeatMeterWiringTests` asserts intended behaviour against the customer-facing billing surface (`GET /api/tenant/dashboard`):

| | RED (before) | GREEN (after) |
|---|---|---|
| `Inviting_a_coordinator_consumes_a_coordinator_seat` | **FAIL** — Expected 1, Actual 0 | pass |
| `Inviting_an_author_consumes_an_author_seat` | **FAIL** — Expected 1, Actual 0 | pass |
| `An_invited_user_is_visible_to_the_tenant…` (control) | pass | pass |
| | **Failed 2, Passed 1** | **Failed 0, Passed 3** |

The control is what makes the other two mean anything: it proves the invite genuinely persisted a user, so the failures are the **meter** failing to count a real seat rather than the invite doing nothing. Without it the two failure modes are indistinguishable.

The dashboard reader also asserts the users array is non-empty — `ITenantContext.TenantId` falls back to `Guid.Empty`, which matches no rows, and an increment assertion against an unresolved tenant measures nothing.

## The split, and why each choice

**Seats count `AppUser`** — a seat is a person. This also makes the pre-existing `.Select(UserId).Distinct()` unnecessary rather than merely approximate: someone on four projects was always meant to be one seat.

**Author = `Iso19650Role == "A"`**, which is exactly what both invite paths persist for an Author (`Iso19650Role = role == "Author" ? "A" : "C"`), so meter and write agree by construction. This retires `ProjectRole == "Author"`, which could never match: `"Author"` is not in `ProjectRoles.All`, and the only `ProjectRole` values first-party code writes are **Owner, Manager, Contributor, Coordinator**.

**Coordinators = `total − authors`**, not `Iso19650Role != "A"`. In SQL a NULL role makes both `= A` and `<> A` evaluate to NULL, so a legacy row would fall off **both** axes and silently hand out a free seat. Subtraction is total by construction.

**`!u.IsDeleted` is explicit and must stay that way.** `AppUser` declares `HasQueryFilter(u => !u.IsDeleted)` in its own entity block, but `ApplyGlobalQueryFilters` runs later and overwrites it (EF Core 8 allows one filter per entity; a second call silently replaces the first), and `AppUser` does not implement `ISoftDeletable`. That is already documented in `PlanscapeDbContext` and is out of scope to fix here — but relying on the dead filter would bill tenants for **deleted** users.

**One source of truth.** `Dashboard` now reads both axes from the guard instead of recomputing them, so the number shown to the customer and the number enforced at the gate cannot drift apart. **No response-shape change** — same field names, same types.

## Interaction with #538 — one test needs rewriting

Ran #538's `QuotaSeatCountingTests` against this branch: **Failed 1, Passed 3.** Only `A_member_explicitly_marked_Author_moves_between_the_two_axes` fails, because it asserts `ProjectRole = "Author"` moves a seat — precisely the semantics this retires. The other two characterisation tests still pass, since that fixture's users carry no `"A"` role. #538's own header anticipates this and says those tests should be rewritten when the split is corrected. **Whichever merges second should update that one test.**

## Scope — deliberately not changed

- `tenant.MaxUsers` enforcement (`AdminController:78`, `ProjectMembersController:256`) is a **separate** cap system, counting `AppUser` against a per-tenant column. Left alone.
- The D1 identity-handoff path (`AuthController:1118`) bypasses quotas by documented design ("never lock out a customer D1 considers paid"). Left alone.
- No cap value, plan limit or tenant data touched.

## Verification

- Full suite on this branch: **Failed 0, Passed 580, Skipped 9, Total 589.**
- CI's Build & Test / CI Gate is broken on main itself (Postgres service container, "role root does not exist"), so verification is local.
- Fixtures are `zz-fixture-*` and deleted in a `finally`.
- Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)