### PR TITLE
fix(server): scope the approval-chain gate by revision (#552)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ApprovalChainsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ApprovalChainsController.cs
@@ -110,6 +110,14 @@ public class ApprovalChainsController : ControllerBase
             Status      = "OPEN",
             CreatedBy   = displayName,
             Description = req.Description,
+            // #552 — stamp the revision the approvers are opening the round against.
+            // Without this the gate in DocumentsController.CheckApprovalGate has no
+            // field to scope by, so a COMPLETED chain satisfies SHARED->PUBLISHED for
+            // every FUTURE revision of the document too: rework bumps to P02, the
+            // legacy path correctly demands fresh approval, and the P01 chain quietly
+            // supplies it. Whoever approved P01 ends up recorded as having sanctioned
+            // content they never saw.
+            RevisionSnapshot = doc.Revision,
         };
         _db.ApprovalChains.Add(chain);
 

--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -1551,8 +1551,20 @@ public class DocumentsController : ControllerBase
             var hasLegacyApproval = await _db.DocumentApprovals
                 .AnyAsync(a => a.DocumentId == docId && a.Transition == transitionKey && a.Status == "APPROVED"
                     && (a.RevisionSnapshot == null || a.RevisionSnapshot == currentRevision));
+            // #552 — scope the CHAIN path exactly as the legacy path above. Until
+            // ApprovalChain carried a RevisionSnapshot there was no field to filter on,
+            // so this branch matched on (DocumentId, Transition) alone. The two are
+            // OR'd, which meant the UNSCOPED branch won: a chain completed against P01
+            // satisfied the gate for P02, P03 and every revision after, while the
+            // scoped legacy check beside it correctly refused. The bypass left a
+            // COMPLETED chain in the audit trail, so it was invisible after the fact.
+            //
+            // NULL still matches, mirroring the legacy predicate — see the field's own
+            // remarks on ApprovalChain for why that compatible choice is deliberate and
+            // what exposure it leaves.
             var hasCompletedChain = await _db.ApprovalChains
-                .AnyAsync(c => c.DocumentId == docId && c.Transition == transitionKey && c.Status == "COMPLETED");
+                .AnyAsync(c => c.DocumentId == docId && c.Transition == transitionKey && c.Status == "COMPLETED"
+                    && (c.RevisionSnapshot == null || c.RevisionSnapshot == currentRevision));
             if (!hasLegacyApproval && !hasCompletedChain)
                 return BadRequest(new
                 {

--- a/Planscape.Server/src/Planscape.API/PlatformSchemaPatcher.cs
+++ b/Planscape.Server/src/Planscape.API/PlatformSchemaPatcher.cs
@@ -412,6 +412,19 @@ internal static class PlatformSchemaPatcher
         @"CREATE INDEX IF NOT EXISTS ""IX_IfcAlignmentReports_TenantId"" ON ""IfcAlignmentReports"" (""TenantId"")",
         @"CREATE INDEX IF NOT EXISTS ""IX_IfcAlignmentReports_ProjectId_ProjectModelId"" ON ""IfcAlignmentReports"" (""ProjectId"", ""ProjectModelId"")",
         @"CREATE INDEX IF NOT EXISTS ""IX_IfcAlignmentReports_ProjectId_ValidatedAt"" ON ""IfcAlignmentReports"" (""ProjectId"", ""ValidatedAt"")",
+
+        // ── #552 — ApprovalChain.RevisionSnapshot ──
+        // Purely additive and nullable. Existing rows land on NULL, which the gate in
+        // DocumentsController.CheckApprovalGate treats as "matches any revision" — the
+        // same way DocumentApproval.RevisionSnapshot has always handled its own null
+        // case. So already-COMPLETED chains keep satisfying their gates and no live
+        // publish is blocked the day this ships. New chains stamp the revision at
+        // creation and are scoped from then on.
+        //
+        // No DEFAULT and no NOT NULL on purpose: a default would fabricate a revision
+        // for rounds whose real revision is unknown, which is exactly the confident-
+        // wrong-answer this field exists to prevent.
+        @"ALTER TABLE ""ApprovalChains"" ADD COLUMN IF NOT EXISTS ""RevisionSnapshot"" text",
     };
 
     public static async Task ApplyAsync(DbConnection conn)

--- a/Planscape.Server/src/Planscape.Core/Entities/ApprovalChain.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ApprovalChain.cs
@@ -30,6 +30,27 @@ public class ApprovalChain : ITenantScoped
 
     public DateTime? CompletedAt { get; set; }
 
+    /// <summary>
+    /// The document's revision at the moment this chain was OPENED — i.e. what the
+    /// approvers were actually looking at when the round began. Mirrors
+    /// <see cref="DocumentApproval.RevisionSnapshot"/> so both approval paths can be
+    /// scoped by the same predicate.
+    ///
+    /// Stamped at creation, deliberately not at completion: the point of the field is
+    /// to record the content that was sanctioned, and that is fixed when the round
+    /// opens, not when the last approver clicks.
+    ///
+    /// <para><b>NULL means "pre-dates this field, matches any revision".</b> Issue #552
+    /// left the backfill policy open with three options; this is the compatible one, and
+    /// it is chosen on purpose. Treating NULL as stale would close every historical hole
+    /// at once but would also stop every already-COMPLETED chain from satisfying its gate
+    /// the day it shipped — blocking real publishes on live projects with no warning.
+    /// That is a migration event, not a bug fix, and it is the owner's call. The residual
+    /// exposure is therefore known rather than assumed to be zero: chains completed
+    /// before this field existed keep their permanent pass.</para>
+    /// </summary>
+    public string? RevisionSnapshot { get; set; }
+
     /// <summary>Optional human-readable description of the chain rules.</summary>
     public string? Description { get; set; }
 

--- a/Planscape.Server/tests/Planscape.Tests/ApprovalChainRevisionScopeTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ApprovalChainRevisionScopeTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// #552 — the approval gate credited a COMPLETED chain from one revision to every
+/// revision after it.
+///
+/// <c>DocumentsController.CheckApprovalGate</c> scopes the LEGACY path by
+/// <c>RevisionSnapshot</c>, but the CHAIN path had no such field, so it matched on
+/// <c>(DocumentId, Transition)</c> alone. The two are OR'd, so the unscoped branch won:
+/// a chain completed against P01 satisfied SHARED-&gt;PUBLISHED for P02 as well, while
+/// the scoped legacy check beside it correctly refused. The bypass left a COMPLETED
+/// chain in the audit trail, so it did not look like a bypass afterwards.
+///
+/// The worse framing, and the reason this is worth a test rather than a comment: it is
+/// not "an approval is missing", it is "an approval for DIFFERENT CONTENT is being
+/// credited to this content". Whoever approved P01 ends up recorded as having sanctioned
+/// something they never saw.
+///
+/// These tests drive the real HTTP endpoint (<c>PUT .../documents/{id}/state</c>) rather
+/// than the predicate in isolation, because the gate is only reached through the whole
+/// transition path — role check, ACL, state machine — and a test that skipped those
+/// could pass while the real call never got as far as the gate.
+///
+/// <para><b>Both halves of the NULL contract are asserted.</b> The legacy-NULL case is
+/// not incidental compatibility, it is the deliberate backfill policy chosen in #552:
+/// treating NULL as stale would close every historical hole the day it shipped and
+/// simultaneously block every live document sitting on an already-completed chain. A
+/// future "tidy-up" that makes NULL mean stale must fail
+/// <see cref="Legacy_null_snapshot_chain_still_satisfies_the_gate"/> loudly.</para>
+/// </summary>
+public class ApprovalChainRevisionScopeTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public ApprovalChainRevisionScopeTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    private static string StateUrl(Guid docId)
+        => $"/api/projects/{TestData.ProjectId}/documents/{docId}/state";
+
+    // ── The hole #552 describes ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Chain_completed_against_an_earlier_revision_does_NOT_satisfy_a_later_one()
+    {
+        // The exact scenario from the issue: approved at P01, reworked to P02,
+        // published again with nobody having looked at P02.
+        var doc = SeedDocument("AC-STALE-CHAIN.pdf", revision: "P02");
+        SeedCompletedChain(doc.Id, revisionSnapshot: "P01");
+
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var res = await client.PutAsJsonAsync(StateUrl(doc.Id),
+            new { newState = "PUBLISHED", suitabilityCode = "S4", revision = (string?)null });
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+
+        // Assert on the reason, not just the status — a 400 from the state machine
+        // or the ACL would otherwise look identical to a 400 from the gate, and this
+        // test would pass for the wrong reason.
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.Contains("requires an approved DocumentApproval", body);
+    }
+
+    [Fact]
+    public async Task Chain_completed_against_the_CURRENT_revision_does_satisfy_the_gate()
+    {
+        // The other half. Without this, "scope the query" could be satisfied by a
+        // predicate that rejects everything, and the suite would still be green
+        // while approvals stopped working entirely.
+        var doc = SeedDocument("AC-MATCHING-CHAIN.pdf", revision: "P02");
+        SeedCompletedChain(doc.Id, revisionSnapshot: "P02");
+
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var res = await client.PutAsJsonAsync(StateUrl(doc.Id),
+            new { newState = "PUBLISHED", suitabilityCode = "S4", revision = (string?)null });
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.Equal("PUBLISHED", CurrentStatus(doc.Id));
+    }
+
+    // ── The backfill policy, asserted as policy ───────────────────────────────
+
+    [Fact]
+    public async Task Legacy_null_snapshot_chain_still_satisfies_the_gate()
+    {
+        // Chains that completed before RevisionSnapshot existed carry NULL, and NULL
+        // must keep meaning "matches any revision" — mirroring how DocumentApproval
+        // has always handled its own null case.
+        //
+        // This is the test that stops this fix from becoming an outage. If NULL were
+        // treated as stale, every document currently sitting on a completed chain
+        // would need a fresh approval round before it could publish again — sprung on
+        // live projects with no warning, on the day of a routine deploy.
+        var doc = SeedDocument("AC-LEGACY-NULL-CHAIN.pdf", revision: "P07");
+        SeedCompletedChain(doc.Id, revisionSnapshot: null);
+
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var res = await client.PutAsJsonAsync(StateUrl(doc.Id),
+            new { newState = "PUBLISHED", suitabilityCode = "S4", revision = (string?)null });
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.Equal("PUBLISHED", CurrentStatus(doc.Id));
+    }
+
+    // ── The control: no chain at all ──────────────────────────────────────────
+
+    [Fact]
+    public async Task No_chain_and_no_approval_is_still_refused()
+    {
+        // Proves the gate is actually being exercised by this setup. Without it, a
+        // scoping bug that made the query match nothing would be indistinguishable
+        // from a scoping bug that made it match everything.
+        var doc = SeedDocument("AC-NO-APPROVAL.pdf", revision: "P01");
+
+        var client = await _factory.CreateAuthenticatedClientAsync();
+        var res = await client.PutAsJsonAsync(StateUrl(doc.Id),
+            new { newState = "PUBLISHED", suitabilityCode = "S4", revision = (string?)null });
+
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    // ── The stamp itself ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Creating_a_chain_stamps_the_document_revision_at_that_moment()
+    {
+        // The snapshot is taken at OPEN, not at COMPLETED, because the point of the
+        // field is to record what the approvers were looking at when the round began.
+        var doc = SeedDocument("AC-STAMP-AT-CREATE.pdf", revision: "P03");
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var res = await client.PostAsJsonAsync(
+            $"/api/projects/{TestData.ProjectId}/documents/{doc.Id}/approval-chain",
+            new
+            {
+                transition = "SHARED->PUBLISHED",
+                description = "revision stamp test",
+                stages = new[]
+                {
+                    new { mode = "PARALLEL", label = "Review",
+                          requiredApprovers = new[] { TestData.MemberUserId } }
+                }
+            });
+
+        Assert.Equal(HttpStatusCode.Created, res.StatusCode);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        var chain = db.ApprovalChains.Single(c => c.DocumentId == doc.Id);
+
+        // NOT-NULL is the assertion that matters here. A vacuous pass on this suite
+        // would be a chain row that was never written at all, so prove the row exists
+        // AND carries the revision.
+        Assert.NotNull(chain.RevisionSnapshot);
+        Assert.Equal("P03", chain.RevisionSnapshot);
+    }
+
+    // ── Seeding ───────────────────────────────────────────────────────────────
+
+    private DocumentRecord SeedDocument(string fileName, string revision)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        var existing = db.Documents.FirstOrDefault(d => d.FileName == fileName);
+        if (existing != null) return existing;
+
+        var doc = new DocumentRecord
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestData.TenantId,
+            ProjectId = TestData.ProjectId,
+            FileName = fileName,
+            DocumentType = "DR",
+            CdeStatus = "SHARED",
+            SuitabilityCode = "S3",
+            Revision = revision,
+            UploadedBy = "Test Admin",
+            UploadedAt = DateTime.UtcNow.AddDays(-1),
+            ScanStatus = "CLEAN",
+        };
+        db.Documents.Add(doc);
+        db.SaveChanges();
+        return doc;
+    }
+
+    private void SeedCompletedChain(Guid docId, string? revisionSnapshot)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        db.ApprovalChains.Add(new ApprovalChain
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestData.TenantId,
+            ProjectId = TestData.ProjectId,
+            DocumentId = docId,
+            Transition = "SHARED->PUBLISHED",
+            Status = "COMPLETED",
+            CreatedBy = "Test Admin",
+            CreatedAt = DateTime.UtcNow.AddDays(-2),
+            CompletedAt = DateTime.UtcNow.AddDays(-1),
+            RevisionSnapshot = revisionSnapshot,
+        });
+        db.SaveChanges();
+    }
+
+    private string CurrentStatus(Guid docId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        return db.Documents.Single(d => d.Id == docId).CdeStatus;
+    }
+}


### PR DESCRIPTION
Closes #552.

## The hole

`CheckApprovalGate` scoped the **legacy** approval path by `RevisionSnapshot` but not the
**chain** path, because `ApprovalChain` had no revision field to scope by. The two are
OR'd, so the unscoped branch won:

```csharp
var hasLegacyApproval = await _db.DocumentApprovals
    .AnyAsync(… && (a.RevisionSnapshot == null || a.RevisionSnapshot == currentRevision));  // scoped
var hasCompletedChain = await _db.ApprovalChains
    .AnyAsync(c => c.DocumentId == docId && c.Transition == transitionKey
                && c.Status == "COMPLETED");                                                // not scoped
if (!hasLegacyApproval && !hasCompletedChain) return BadRequest(…);
```

A chain COMPLETED against `P01` satisfied `SHARED→PUBLISHED` for `P02` and every revision
after it, while the scoped legacy check beside it correctly refused.

The framing that matters: this is not *"an approval is missing"*, it is **"an approval for
different content is being credited to this content"**. Whoever approved `P01` is recorded
as having sanctioned material they never saw — and the COMPLETED chain left behind makes
the bypass invisible after the fact.

## Changes

- `ApprovalChain` gains a **nullable** `RevisionSnapshot`, mirroring the field
  `DocumentApproval` has always carried.
- `ApprovalChainsController.Create` stamps it from the document's revision at chain
  **OPEN**, not at completion — the field records what the approvers were looking at when
  the round began, and that is fixed when it opens.
- `CheckApprovalGate`'s chain predicate now matches the legacy predicate exactly.
- `PlatformSchemaPatcher` gains
  `ALTER TABLE "ApprovalChains" ADD COLUMN IF NOT EXISTS "RevisionSnapshot" text`.
  Nullable, **no DEFAULT** on purpose: a default would fabricate a revision for rounds
  whose real revision is unknown, which is precisely the confident-wrong-answer this field
  exists to prevent.

**No EF migration added.** Per ADR-0001 the migration set is decorative and the live schema
is materialised by `EnsureCreated` + `PlatformSchemaPatcher`; a migration here would be
inert *and* would imply the column exists in a deployed database when it does not.

## Backfill policy — legacy NULL means "matches any revision"

Deliberate, and the reason this ships without an outage. #552 listed three options; this is
the compatible one.

Treating NULL as stale would close every historical hole the day it deployed — and
simultaneously stop **every already-COMPLETED chain** from satisfying its gate, blocking
live publishes with no warning. That is a migration event and the owner's call, not a side
effect of a bug fix.

So the residual exposure is **known rather than assumed to be zero**: chains completed
before this field existed keep their permanent pass. The tests below pin that as policy so
nobody "tidies it up" by accident.

## Tests — RED proven in *both* directions

`Planscape.Server/tests/Planscape.Tests/ApprovalChainRevisionScopeTests.cs`, driven through
the real `PUT .../documents/{id}/state` endpoint so the gate is reached the way production
reaches it (past role check, ACL and state machine — a test that skipped those could pass
while the real call never got as far as the gate).

I temporarily edited the shipped predicate twice to prove each guard bites:

| Predicate under test | Result |
|---|---|
| **Scoping dropped entirely** (the bug) | `Chain_completed_against_an_earlier_revision_does_NOT_satisfy_a_later_one` **FAILS** — the P01 chain publishes P02 |
| **Scoped, but NULL treated as stale** (the outage) | `Legacy_null_snapshot_chain_still_satisfies_the_gate` **FAILS** |
| **As shipped** | 5/5 pass; 38/38 across the related suites |

Two anti-vacuity measures, given the warning that empty results pass for free here:

1. The stale-chain test asserts the **reason** in the 400 body, not just the status. A 400
   from the state machine or the ACL would otherwise look identical and the test would pass
   for the wrong reason.
2. A `No_chain_and_no_approval_is_still_refused` control proves the gate is genuinely being
   exercised — so a predicate that matched *nothing* could not masquerade as a fix.

`Creating_a_chain_stamps_the_document_revision_at_that_moment` asserts `NotNull` before
asserting the value, so a chain row that was never written cannot pass.

## Knock-on

This unblocks the C1 decision recorded in #552 — *"flat stays canonical for the UI until
(a) `RevisionSnapshot` is added and (b) the chain query is scoped by it"*. Both have now
landed, so that decision can be revisited on its own merits rather than being blocked.

## Deliberately not done

Whether an **in-flight `OPEN` chain** should be invalidated when the revision bumps
underneath it (#552 item 3). Arguably yes — those approvers are reviewing superseded
content — but it is a behaviour change beyond closing this hole and should be settled
explicitly rather than fall out of an implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
