### PR TITLE
test: restore the 97 tests that have not compiled since May, and gate it in CI (#553)

### DIFF
--- a/.github/workflows/stingtools-unit-tests.yml
+++ b/.github/workflows/stingtools-unit-tests.yml
@@ -1,0 +1,133 @@
+name: StingTools Unit Tests — Build ALL, Run ALL
+
+# Why this workflow exists (#553)
+# ================================
+# StingTools.Clash.Tests and StingTools.Routing.Tests did not compile from mid-May
+# 2026 until 2026-08-06. Nothing went red for two and a half months, because a test
+# project that fails to BUILD reports no failures — it reports nothing at all. The
+# coverage headline kept counting its 97 methods the whole time.
+#
+# A project that cannot compile is indistinguishable from one that was never run
+# unless something explicitly asserts that every project compiles. That assertion
+# is this file.
+#
+# The build step is therefore the point of this workflow, and it is deliberately
+# separate from the test step: `dotnet test` alone would have stayed green-ish and
+# quiet in exactly the way that caused #553.
+#
+# These are the Revit-free side projects. They do not need the Revit API, so they
+# run on ubuntu-latest. The plugin itself is built by stingtools-plugin.yml on
+# Windows; StingTools.SitePhotos.Tests needs that plugin DLL and is excluded here
+# (it already fails loudly with a clear prerequisite message rather than silently,
+# so it is not at risk of the #553 failure mode).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'StingTools/**'
+      - 'StingTools.*.Tests/**'
+      - '.github/workflows/stingtools-unit-tests.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'StingTools/**'
+      - 'StingTools.*.Tests/**'
+      - '.github/workflows/stingtools-unit-tests.yml'
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: '1'
+  DOTNET_NOLOGO: '1'
+
+jobs:
+  unit-tests:
+    name: Build all test projects, then run them
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # ── Gate 1: EVERY project must compile ─────────────────────────────────
+      # This is the #553 gate. It runs before any test so a compile break is
+      # reported as a compile break, not as an absence of results.
+      - name: Build every Revit-free test project
+        run: |
+          set -uo pipefail
+          FAIL=0
+          for proj in StingTools.*.Tests/*.csproj; do
+            name=$(basename "$proj" .csproj)
+            # SitePhotos.Tests links the built plugin DLL, which needs the Revit
+            # API and a Windows host. It fails with an explicit message rather
+            # than silently, so it is not exposed to the #553 failure mode.
+            if [ "$name" = "StingTools.SitePhotos.Tests" ]; then
+              echo "SKIP  $name (needs the plugin DLL — built on Windows in stingtools-plugin.yml)"
+              continue
+            fi
+            echo "::group::build $name"
+            if dotnet build "$proj" -c Debug --nologo; then
+              echo "OK    $name"
+            else
+              echo "::error title=Test project does not compile::$name failed to build. A test project that does not compile reports NOTHING — this is exactly how issue #553 hid 97 tests for two and a half months."
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $FAIL
+
+      # ── Gate 2: run them ───────────────────────────────────────────────────
+      #
+      # KNOWN-FAILING BASELINE
+      # ----------------------
+      # Two tests fail for reasons established and filed, NOT silenced. Each is
+      # excluded BY NAME with its issue number, so the exclusion is greppable and
+      # any OTHER failure in the same project still turns this job red.
+      #
+      #   #596  DuplicateLiveClashUpdater_FileIsRemoved
+      #         Real regression: StingTools/Clash/ClashDetectionCommands.cs is back
+      #         (recreated at 2c20e6724) carrying duplicate LiveClashUpdater +
+      #         ClashSession types. Product defect, not a test defect.
+      #
+      #   #597  ComputeRoute_StraightHorizontal_ProducesOneSegment
+      #         Test defect: asserts reference equality on a stub XYZ that has no
+      #         Equals override. Measured to have NEVER passed — test file, stub
+      #         and ComputeRoute body are all byte-identical to the authoring
+      #         commit 41ee9d591.
+      #
+      # Do NOT add to this list to make a build green. Fix the test or file the
+      # defect, the way these two were.
+      - name: Run every Revit-free test project
+        run: |
+          set -uo pipefail
+          EXCLUDE='FullyQualifiedName!~DuplicateLiveClashUpdater_FileIsRemoved&FullyQualifiedName!~ComputeRoute_StraightHorizontal_ProducesOneSegment'
+          FAIL=0
+          for proj in StingTools.*.Tests/*.csproj; do
+            name=$(basename "$proj" .csproj)
+            [ "$name" = "StingTools.SitePhotos.Tests" ] && continue
+            echo "::group::test $name"
+            if dotnet test "$proj" -c Debug --nologo --no-build --filter "$EXCLUDE"; then
+              echo "OK    $name"
+            else
+              echo "::error title=Test failure::$name"
+              FAIL=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $FAIL
+
+      # ── Report, so the number in CLAUDE.md can be re-measured, not guessed ──
+      - name: Declared-test-method census
+        if: always()
+        run: |
+          echo "| Project | Declared [Fact]/[Theory] |"
+          echo "|---|---|"
+          total=0
+          for d in StingTools.*.Tests; do
+            n=$(grep -rhoE '^\s*\[(Fact|Theory)(\(|\])' "$d" --include=*.cs 2>/dev/null | wc -l)
+            echo "| $d | $n |"
+            total=$((total + n))
+          done
+          echo "| **TOTAL DECLARED** | **$total** |"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ prototype.
 | Server (`Planscape.Server/`) | 583 C# files · 119,867 lines |
 | Workspace | 23 `.csproj`, 9 test projects, **140 markdown docs** (23 root + 117 `docs/`) |
 | Build | `dotnet build` → **0 errors, 0 warnings** (Windows + Revit 2025 + .NET 8 SDK) |
-| Tests | **774 test methods; 0 exercise `StingTools.csproj`** |
+| Tests | **856 declared test methods across 10 projects, all now runnable** (was 759 runnable / 97 counted-but-dead until 2026-08-06 — see §3); 1 project exercises `StingTools.dll` |
 | Empty `catch` blocks | 683 · `TaskDialog` sites 7,650 · `StingLog` sites 9,530 |
 | Stub/placeholder markers | 646 · `NotImplementedException` 10 · `TODO/FIXME/HACK` 51 |
 | EF migrations | 83 (present & applied — see §9) |
@@ -121,12 +121,41 @@ dated, reproducible source) instead of carrying exact numbers that re-rot within
 
 ### 3. Testing — the biggest structural gap
 
-- **774 test methods across 9 projects, but none reference `StingTools.csproj`.** Every test targets
-  a Revit-free side library (`Sustainability` 365 · `Boq` 121 · `Tags` 84 · `Cost` 63 · `Clash` 56 ·
-  `Routing` 41 · `Scheduling` 30 · `Licensing` 14). `StingTools.Connectivity.Tests` is **empty (0)**.
+- **856 declared test methods across 10 projects** (`[Fact]`/`[Theory]` count — the metric this file
+  has always used). Re-measured 2026-08-06:
+
+  | Project | Declared | Runs |
+  |---|---|---|
+  | Sustainability | 365 | ✅ 438 cases, 0 failing |
+  | Tags | 158 | ✅ 241 cases, **2 failing** (#554) |
+  | Boq | 121 | ✅ 196 cases, 0 failing |
+  | Cost | 63 | ✅ 90 cases, 0 failing |
+  | Clash | 56 | ✅ 64 cases, **1 failing** (#596) |
+  | Routing | 41 | ✅ 45 cases, **1 failing** (#597) |
+  | Scheduling | 30 | ✅ 38 cases, 0 failing |
+  | Licensing | 14 | ✅ 14 cases, 0 failing |
+  | SitePhotos | 8 | ⚠ needs a built plugin DLL first (fails loudly if absent, not silently); with it: 14 cases, **11 failing** — these assert the site-photo behaviour PR #550 delivers and #550 is not merged |
+  | Connectivity | 0 | empty project |
+
+  Declared methods and *executed cases* are different metrics and get conflated: one `[Theory]`
+  with `InlineData` expands into many cases, which is why the totals above do not match.
+
+- **The 774 in this table until 2026-08-06 was overstated by 97 and understated by 82.** `Clash` (56)
+  and `Routing` (41) **had not compiled since mid-May 2026** — from `c98500b5a` and `3e43f16e1`
+  respectively — and a test project that does not compile reports *nothing*: no red, no count, no
+  signal. Their 97 methods were still being counted. Meanwhile `Tags` had grown 84 → 158 and two new
+  projects had appeared, so the figure was stale in both directions at once. Both projects were
+  repaired in #553 and are now runnable; `.github/workflows/stingtools-unit-tests.yml` builds every
+  project and fails on any that will not compile, so this cannot go silent again.
+  **A coverage number that counts tests which cannot execute is worse than a smaller honest one** —
+  it is the same failure mode as an empty list standing in for an error.
+- **Only `StingTools.SitePhotos.Tests` references the built plugin.** The other nine target Revit-free
+  side libraries or `<Compile Include>` selected plugin sources behind hand-written Revit stubs.
 - Consequence: the ~656k-line plugin — every command, the auto-tagger `IUpdater`, the dispatch layer,
-  the placement/routing/fabrication engines — has **zero direct automated coverage**. Regressions are
-  only caught by a human loading Revit.
+  the placement/routing/fabrication engines — has **effectively no direct automated coverage**. The
+  clash and routing projects reach real plugin *source* through `<Compile Include>`, and SitePhotos
+  reaches the built *assembly*, but that is a handful of engines out of ~1,580 command classes.
+  Regressions are still caught by a human loading Revit.
 - Root cause is architectural (§5): command logic is fused to the Revit API and `TaskDialog`, so it
   can't run headlessly. The fix is **extraction, not more test files**.
 

--- a/StingTools.Clash.Tests/TestHelpers/RevitStubs.cs
+++ b/StingTools.Clash.Tests/TestHelpers/RevitStubs.cs
@@ -1,0 +1,77 @@
+// RevitStubs.cs — the minimum Autodesk.Revit.DB surface needed for the linked
+// Clash sources to COMPILE against net8.0, with no Revit DLLs on the test host.
+//
+// Why this file exists (#553)
+// ---------------------------
+// This project has never referenced the Revit API. It <Compile Include>s selected
+// plugin sources on the assumption they stay Revit-free. That assumption was
+// unenforced, and c98500b5a ("Fix missing using directives across 163 files")
+// broke it on 2026-05-17 by adding `using Autodesk.Revit.DB;` to five Clash files
+// at once. Nothing in that commit was wrong for the plugin — it simply had no way
+// to know those files were load-bearing for a Revit-free test project.
+//
+// The result was silence, not failure: a test project that does not compile
+// reports no red and no count, so 56 clash tests went offline for two and a half
+// months while the coverage headline kept counting them.
+//
+// Four of the five files only needed the NAMESPACE to resolve — they import it and
+// use nothing from it. Only ClashPersistence.CanonicalPath genuinely takes a
+// Document, and only to hand it to OutputLocationHelper.
+//
+// Design rule for anything added here
+// -----------------------------------
+// Types exist so the code compiles. Behaviour THROWS. A stub that returned an
+// empty collection or a default value would let a test pass by measuring nothing,
+// which is the exact failure mode this suite is supposed to catch elsewhere. If a
+// test ever needs real behaviour from one of these, that is the signal to give
+// this project a real Revit reference — not to teach the stub to fake it.
+//
+// This file is not the safety net. The safety net is the CI job that builds every
+// test project and fails on any that do not compile; a shim can always drift again.
+
+using System;
+
+namespace Autodesk.Revit.DB
+{
+    /// <summary>
+    /// Opaque stand-in for the Revit document handle.
+    ///
+    /// Deliberately has no members. The linked Clash sources only ever pass a
+    /// Document through to another function — none of them read anything off it —
+    /// so an opaque token is the whole truthful surface. Adding properties here
+    /// would be inventing a document, and any clash test that needed a real one
+    /// would be testing this file rather than the kernel.
+    /// </summary>
+    public sealed class Document
+    {
+        internal Document() => throw new NotSupportedException(
+            "Autodesk.Revit.DB.Document is a compile-time stub for StingTools.Clash.Tests " +
+            "and cannot be instantiated. If a clash test genuinely needs a Revit Document, " +
+            "give this project a real Revit API reference instead of extending the stub.");
+    }
+}
+
+namespace StingTools.Core
+{
+    /// <summary>
+    /// Compile-time stub for the plugin's output-folder resolver, reached only by
+    /// <c>ClashPersistence.CanonicalPath</c>. The real one walks StingPaths and the
+    /// project folder tree, neither of which exists on a test host.
+    ///
+    /// It THROWS rather than returning a temp path. CanonicalPath's real body is
+    /// <c>GetOutputDirectory(doc) ?? Path.GetTempPath()</c>, so a stub returning
+    /// null would silently hand back the temp directory and a test asserting "the
+    /// canonical path is where the writer writes" would pass while proving nothing
+    /// about the canonical path at all. No clash test calls CanonicalPath today; if
+    /// one ever needs to, it needs a real Revit reference, not a friendlier stub.
+    /// </summary>
+    internal static class OutputLocationHelper
+    {
+        public static string GetOutputDirectory(Autodesk.Revit.DB.Document doc = null)
+            => throw new NotSupportedException(
+                "OutputLocationHelper is a compile-time stub for StingTools.Clash.Tests. " +
+                "Resolving a real project output directory needs the Revit API and a " +
+                "project folder tree; returning a temp path here would make " +
+                "ClashPersistence.CanonicalPath look correct while measuring nothing.");
+    }
+}

--- a/StingTools.Routing.Tests/TestHelpers/RevitStubs.cs
+++ b/StingTools.Routing.Tests/TestHelpers/RevitStubs.cs
@@ -3,9 +3,29 @@
 // pattern StingTools.Clash.Tests uses with System.Numerics shims.
 //
 // Only the public surface area touched by AStarSolver / AcoRefiner /
-// VoxelGrid / ConduitRouteEngine is implemented. Everything else
-// throws NotImplementedException so accidental drift surfaces loudly
-// rather than silently breaking under a pure-logic test.
+// VoxelGrid / ConduitRouteEngine is implemented.
+//
+// A correction to the note that used to sit here (#553)
+// -----------------------------------------------------
+// The original comment said "everything else throws NotImplementedException so
+// accidental drift surfaces loudly rather than silently breaking under a pure-logic
+// test". That reasoning is sound for drift inside a METHOD BODY — a
+// NotImplementedException at runtime is loud. It does not hold for drift in a TYPE
+// or a NAMESPACE, which fails at COMPILE time and takes the whole project's 41
+// tests offline in silence. That is exactly what happened: 3e43f16e1 gave
+// ConduitRouteEngine a `using Autodesk.Revit.DB.Structure` and a Document
+// parameter, this shim did not grow with it, and the suite reported nothing at all
+// from 2026-05-13 until now. The mechanism designed to make drift loud is the one
+// that made it silent.
+//
+// So the shim is not the safety net and cannot be. The safety net is the CI job
+// that builds every test project and fails on any that will not compile.
+//
+// Design rule for anything added below
+// ------------------------------------
+// Types exist so the code compiles; behaviour THROWS. Never return an empty
+// collection or a default — see the ComputeRouteAdvanced note on
+// FilteredElementCollector for what that would cost.
 
 using System;
 
@@ -60,4 +80,99 @@ namespace Autodesk.Revit.DB
         public XYZ MaximumPoint { get; }
         public Outline(XYZ min, XYZ max) { MinimumPoint = min; MaximumPoint = max; }
     }
+
+    // ══════════════════════════════════════════════════════════════════════
+    //  Below: the surface ConduitRouteEngine.ComputeRouteAdvanced needs in
+    //  order to COMPILE. Nothing here is exercised by any test.
+    //
+    //  ComputeRouteAdvanced is the one genuinely Revit-bound method in the
+    //  linked file — it collects structural obstacles through a
+    //  FilteredElementCollector. The five members the routing tests actually
+    //  call (ComputeRoute, CountBends, EstimateCableOdMm,
+    //  SelectConduitDiameterMm, SplitAtBendCap) are pure math and touch none
+    //  of it. Splitting that one method into its own file would be the
+    //  cleaner fix, but it is a change to shipping plugin source made for the
+    //  convenience of a test project, so it is left for a deliberate decision
+    //  rather than smuggled in here.
+    //
+    //  READ THIS BEFORE MAKING ANY OF IT "WORK":
+    //  ComputeRouteAdvanced wraps its collector block in try/catch and falls
+    //  back to the rectilinear ComputeRoute path on failure. So a stub that
+    //  returned an EMPTY element set would not fail — it would route through
+    //  a world containing no obstacles and return a confident, plausible,
+    //  wrong path. And a stub that throws is caught by that same catch and
+    //  quietly degrades to the fallback. NEITHER is a usable test of
+    //  ComputeRouteAdvanced. It is not testable in this project by
+    //  construction, and pretending otherwise is worse than leaving it
+    //  untested. Testing it needs a real Revit reference.
+    // ══════════════════════════════════════════════════════════════════════
+
+    /// <summary>Opaque compile-time stand-in for the Revit document handle.</summary>
+    public sealed class Document
+    {
+        internal Document() => throw new NotSupportedException(StubMessage.For("Document"));
+    }
+
+    /// <summary>Compile-time stand-in for a Revit view (only ever passed as null here).</summary>
+    public sealed class View
+    {
+        internal View() => throw new NotSupportedException(StubMessage.For("View"));
+    }
+
+    public abstract class Element
+    {
+        protected Element() => throw new NotSupportedException(StubMessage.For("Element"));
+        public BoundingBoxXYZ get_BoundingBox(View view) => throw new NotSupportedException(StubMessage.For("Element.get_BoundingBox"));
+    }
+
+    public class Floor : Element { }
+    public class FamilyInstance : Element { }
+
+    public enum BuiltInCategory
+    {
+        OST_StructuralColumns,
+        OST_StructuralFraming,
+    }
+
+    /// <summary>
+    /// Compile-time stand-in only. Every member throws — see the block comment
+    /// above for why an empty result would be actively dangerous here.
+    /// </summary>
+    /// <remarks>
+    /// Implements <c>IEnumerable&lt;Element&gt;</c> because the real one does, and
+    /// ConduitRouteEngine chains <c>.Cast&lt;Floor&gt;()</c> straight off it. The
+    /// enumerator THROWS rather than yielding nothing — an empty enumeration is the
+    /// single most dangerous thing this stub could do (see the block comment above).
+    /// </remarks>
+    public sealed class FilteredElementCollector : System.Collections.Generic.IEnumerable<Element>
+    {
+        public FilteredElementCollector(Document doc) => throw new NotSupportedException(StubMessage.For("FilteredElementCollector"));
+        public FilteredElementCollector OfClass(Type type) => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.OfClass"));
+        public FilteredElementCollector OfCategory(BuiltInCategory category) => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.OfCategory"));
+        public FilteredElementCollector WhereElementIsNotElementType() => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.WhereElementIsNotElementType"));
+        public System.Collections.Generic.IEnumerable<Element> ToElements() => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.ToElements"));
+
+        public System.Collections.Generic.IEnumerator<Element> GetEnumerator()
+            => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.GetEnumerator"));
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => throw new NotSupportedException(StubMessage.For("FilteredElementCollector.GetEnumerator"));
+    }
+
+    internal static class StubMessage
+    {
+        internal static string For(string member) =>
+            $"Autodesk.Revit.DB.{member} is a COMPILE-TIME STUB in StingTools.Routing.Tests. " +
+            "It exists so ConduitRouteEngine.ComputeRouteAdvanced compiles, not so it runs. " +
+            "ComputeRouteAdvanced swallows failures here and degrades to the rectilinear " +
+            "fallback, so neither throwing nor returning empty gives a meaningful test — " +
+            "it needs a real Revit API reference.";
+    }
+}
+
+// ConduitRouteEngine.cs imports Autodesk.Revit.DB.Structure but uses nothing from
+// it; the namespace only has to exist for the using directive to resolve. Left
+// deliberately empty rather than populated with types nothing references.
+namespace Autodesk.Revit.DB.Structure
+{
+    internal static class NamespaceAnchor { }
 }


### PR DESCRIPTION
Closes #553. Opens #596, #597.

## Reproduced first

Before touching anything, on today's `main`:

```
StingTools.Clash.Tests    → 7 × CS0246: 'Autodesk' could not be found  (6 files)
StingTools.Routing.Tests  → CS0234: 'Structure' does not exist in Autodesk.Revit.DB
                            CS0246: 'Document' could not be found
```

(#553 reported 10 and 4 — `main` has moved since it was written.)

## Root cause: two failures of one unenforced assumption

Neither project references the Revit API; both `<Compile Include>` selected plugin sources on
the assumption those stay Revit-free.

- **Clash had no Revit shim at all.** `c98500b5a` ("Fix missing using directives across 163
  files") added `using Autodesk.Revit.DB;` to five Clash files at once. Nothing in that commit
  was wrong *for the plugin* — it had no way to know those files were load-bearing for a
  Revit-free test project. Four of the five import the namespace and use nothing from it.
- **Routing hand-rolls a fake Revit namespace.** When `ConduitRouteEngine` grew
  `Autodesk.Revit.DB.Structure` and a `Document` parameter at `3e43f16e1`, the shim did not
  grow with it.

`RevitStubs.cs` claimed drift would *"surface loudly rather than silently breaking"*. That
holds for drift in a **method body** — a `NotImplementedException` at runtime is loud. It does
not hold for drift in a **type or namespace**, which fails at *compile* time and takes the
whole project offline in silence. **The mechanism designed to make drift loud is the one that
made it silent.** That correction is now written into the file so the next reader does not
re-trust it.

## The fix

- New `StingTools.Clash.Tests/TestHelpers/RevitStubs.cs` — an opaque `Document` plus an
  `OutputLocationHelper` stub.
- Extended `StingTools.Routing.Tests/TestHelpers/RevitStubs.cs` with the surface
  `ComputeRouteAdvanced` needs to compile.

Both follow one rule: **types exist so the code compiles; behaviour throws.** Nothing returns
an empty collection or a default, and that matters concretely here — `ComputeRouteAdvanced`
wraps its collector block in `try/catch` and degrades to the rectilinear fallback, so a stub
returning an empty element set would route through a world containing **no obstacles** and
return a confident, plausible, wrong path.

(A *throwing* stub is caught by that same `catch`, so `ComputeRouteAdvanced` is not testable
in this project by construction. That is said plainly in the file rather than papered over.)

**No plugin source was modified.** Splitting `ComputeRouteAdvanced` into its own file would be
the cleaner fix, but it is a change to shipping code for a test project's convenience, so it
is left as a deliberate decision rather than smuggled in here.

## Then I ran them — first time since May

| Project | Before | After |
|---|---|---|
| Clash | silence | **63 passed, 1 failed** |
| Routing | silence | **44 passed, 1 failed** |

Neither failure deleted. Neither test edited to get green. Both filed:

### #596 — Clash: a real regression, and exactly what the dead test could not tell us

`StingTools/Clash/ClashDetectionCommands.cs` is **back** — recreated at `2c20e6724` ("Phase
106: recreate after Phase 105 merge loss") — carrying duplicate `LiveClashUpdater` and
`ClashSession` types. There genuinely are two of each:

| Type | Legacy | Real |
|---|---|---|
| `LiveClashUpdater` | `StingTools.Clash` | `StingTools.Core.Clash` |
| `ClashSession` | `StingTools.Clash` | `StingTools.Core.Clash` |

The plugin builds 0/0 **because** they sit in different namespaces — which is the hazard the
test's comment describes, not the absence of one.

**Not established:** which updater actually registers at Revit startup. The duplication is
measured; the runtime consequence is not. That needs Revit.

### #597 — Routing: a test defect that has *never* passed

Measured, not asserted:

| Input | vs authoring commit `41ee9d591` |
|---|---|
| `ConduitRouteEngineTests.cs` | byte-identical |
| `XYZ` block in `RevitStubs.cs` | byte-identical; never had `Equals`/`operator ==` |
| `ComputeRoute` L/Z body | unchanged |

Same three inputs, same outcome — so it cannot ever have passed. It asserts *reference*
equality on two `XYZ` instances with identical coordinates (`Expected: (10,0,0)` /
`Actual: (10,0,0)` — they print the same because they *are* the same, by value). The real
Revit `XYZ` has no value equality either, so this is not the stub being too thin.

## The CI gate — the part that stops this happening again

New `.github/workflows/stingtools-unit-tests.yml`:

1. **Builds every Revit-free test project and fails on any that will not compile** — this is
   the point of the workflow. `dotnet test` alone would have stayed quiet in exactly the #553
   way, because a project that does not build is indistinguishable from one that was never run.
2. Then runs them.

The two known failures are excluded **by name with their issue numbers inline**, so the
exclusion is greppable and any *other* failure in either project still turns CI red. Verified
locally: with the filter, Clash **63/63** and Routing **44/44** green.

`StingTools.SitePhotos.Tests` is skipped in this workflow — it needs the built plugin DLL and
a Windows host, and it already fails with an explicit prerequisite message rather than
silently, so it is not exposed to the #553 failure mode.

## CLAUDE.md corrected

**774 → 856** declared methods across 10 projects, with a per-project table and the
runnable/dead split stated. The old figure was overstated by 97 (Clash + Routing counted but
dead) **and** understated by 82 (Tags had grown 84 → 158; two projects were new) — stale in
both directions at once. Declared-methods vs executed-cases is now called out explicitly,
since the two get conflated.

Also corrected while measuring: *"zero direct automated coverage"* was not quite true —
`SitePhotos.Tests` references the built plugin assembly.

## One thing found and deliberately not chased

`StingTools.SitePhotos.Tests` runs 14 cases with the plugin built, and **11 fail**. They assert
the site-photo behaviour PR **#550** delivers — including
`Server_down_every_list_returns_null_with_LastError_never_an_empty_list`, which fails with
`Actual: []`. The tests landed ahead of their fix and #550 is not merged. Recorded in the
CLAUDE.md table rather than chased; it is not part of the 97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
