### PR TITLE
test(server): stop the Hangfire background server starting in tests — DEP-7 residue (#494)

### DIFF
--- a/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
+++ b/Planscape.Server/tests/Planscape.Tests/PlanscapeWebApplicationFactory.cs
@@ -118,6 +118,26 @@ public class PlanscapeWebApplicationFactory : WebApplicationFactory<Program>
         if (disposing && UsingPostgres) DropPgDatabase();
     }
 
+    /// <summary>
+    /// True for a service descriptor registered through an implementation FACTORY
+    /// that lives in a Hangfire assembly — the case a name check on
+    /// <c>ServiceType</c> / <c>ImplementationType</c> cannot see, because a
+    /// factory registration leaves <c>ImplementationType</c> null.
+    ///
+    /// The one that matters is <c>AddHangfireServer</c>'s
+    /// <c>Hangfire.BackgroundJobServerHostedService</c> (assembly
+    /// <c>Hangfire.NetCore</c>), registered as <c>IHostedService</c>. See #494.
+    ///
+    /// Matches on the assembly rather than the type name so a rename inside
+    /// Hangfire does not silently re-open the hole this closes.
+    /// </summary>
+    private static bool IsHangfireFactoryRegistration(ServiceDescriptor d)
+    {
+        var declaringAssembly = d.ImplementationFactory?.Method.DeclaringType?.Assembly;
+        var name = declaringAssembly?.GetName().Name;
+        return name != null && name.StartsWith("Hangfire", StringComparison.Ordinal);
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
@@ -181,11 +201,37 @@ public class PlanscapeWebApplicationFactory : WebApplicationFactory<Program>
             // executed — exactly what a controller test wants.
             var hangfireDescriptors = services
                 .Where(d => d.ServiceType.FullName?.Contains("Hangfire") == true
-                         || d.ImplementationType?.FullName?.Contains("Hangfire") == true)
+                         || d.ImplementationType?.FullName?.Contains("Hangfire") == true
+                         // DEP-7 residue (#494). AddHangfireServer registers its
+                         // background server as IHostedService through an
+                         // implementation FACTORY, so ServiceType is
+                         // Microsoft.Extensions.Hosting.IHostedService and
+                         // ImplementationType is NULL — neither of the two clauses
+                         // above can see it. The server therefore survived this
+                         // removal and really did start, despite the comment below
+                         // saying none does.
+                         //
+                         // Consequence: every host ran a BackgroundServerProcess,
+                         // and each one raced the others' in-memory storage on
+                         // teardown, logging 13 warnings per suite run:
+                         //
+                         //   [WRN] Server ... there was an exception, server may not be removed
+                         //   System.ObjectDisposedException: ... Hangfire.InMemory.State.Dispatcher`1
+                         //     at InMemoryConnection`1.RemoveServer(String serverId)
+                         //     at BackgroundServerProcess.ServerDelete(...)
+                         //
+                         // Benign today — Hangfire catches it and no test fails —
+                         // but it is the same shared-state-at-teardown class of bug
+                         // DEP-7 was, still live, and still able to grow teeth.
+                         || IsHangfireFactoryRegistration(d))
                 .ToList();
             foreach (var d in hangfireDescriptors) services.Remove(d);
 
             services.AddHangfire(cfg => cfg.UseInMemoryStorage());
+            // Note: AddHangfire alone registers no server, so nothing re-adds the
+            // hosted service removed above. Jobs are registered but never executed
+            // — exactly what a controller test wants.
+            //
             // Deliberately does NOT assign Hangfire.JobStorage.Current.
             //
             // Program.cs now registers its recurring jobs through the


### PR DESCRIPTION
Addresses #494 (DEP-7).

## First finding: the decided fix already landed

#494's chosen direction — **per-factory Hangfire storage, not an xUnit collection fixture** —
is already on `main`, from `bd5e2ea78` (PR #504). Measured today:

| Check | Result |
|---|---|
| `JobStorage.Current` assignments in src/test code | **0** |
| static `RecurringJob.AddOrUpdate` in `Program.cs` | **0** |
| DI-resolved `IRecurringJobManager` call sites | **34** |

So the `ObjectDisposedException` no longer **fails** tests.

## Second finding: it was still being thrown

13 times per suite run, at host teardown:

```
[WRN] Server ... there was an exception, server may not be removed
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'Hangfire.InMemory.State.Dispatcher`1[[System.UInt64, ...]]'
   at Hangfire.InMemory.InMemoryConnection`1.RemoveServer(String serverId)
   at Hangfire.Server.BackgroundServerProcess.ServerDelete(...)
```

Which flatly contradicted the factory's own comment — *"No Hangfire **server** is started"*.
One was. Verified by resolving `IHostedService` from a live test host:

```
before:  Hangfire.BackgroundJobServerHostedService | asm=Hangfire.NetCore   ← running
after:   (gone — OpenTelemetry, DataProtection, GenericWebHostService remain)
```

## Mechanism

The factory strips Hangfire by matching descriptor **names**:

```csharp
d.ServiceType.FullName?.Contains("Hangfire") == true
|| d.ImplementationType?.FullName?.Contains("Hangfire") == true
```

`AddHangfireServer` registers its server through an implementation **factory**, so
`ServiceType` is `Microsoft.Extensions.Hosting.IHostedService` and `ImplementationType` is
**null**. Neither clause can see it, so it survived every removal pass. Each host then ran
its own `BackgroundServerProcess`, and they raced each other's in-memory storage on shutdown.

Benign today — Hangfire catches it and no test fails — but it is the **same
shared-state-at-teardown class of bug DEP-7 was**, still live, and one behaviour change away
from growing teeth again. Leaving it would also leave the factory's comment lying about what
the test host does, which is how the next person loses an afternoon.

## Fix

`IsHangfireFactoryRegistration(ServiceDescriptor)` — true when the implementation factory's
declaring type lives in a Hangfire assembly. Matches on **assembly**, not type name, so a
rename inside Hangfire cannot silently reopen the hole. `AddHangfire` alone starts no server,
so nothing re-adds it.

Test-only change. No production code touched.

## Determinism — proven by repetition, not by one green run

A single green run does not close a nondeterminism bug. Three consecutive full-suite runs:

| Run | Total | Passed | Skipped | Failed | DEP-7 warnings |
|---|---|---|---|---|---|
| 1 | 586 | 577 | 9 | **0** | **0** |
| 2 | 586 | 577 | 9 | **0** | **0** |
| 3 | 586 | 577 | 9 | **0** | **0** |

Identical. The issue's signature — *"12, then 16, then 3 failures on three consecutive runs
of the same tree"* — does not appear.

## The honest limit on that evidence

#494 records that this **never reproduced locally**, only in CI. Three green local runs are
therefore *supporting* evidence, not proof about CI, and I am not claiming otherwise.

The conclusive part is the **mechanism**: there is no longer a `BackgroundServerProcess` in
the test host to race, and that was measured directly by enumerating the container's hosted
services — before and after — rather than inferred from a passing suite.

## Not done

`known-failing-tests.txt` is left untouched. It is already deliberately empty with a good
explanatory header, and this change adds nothing to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
