### PR TITLE
fix(csi): keep whitespace-insensitive MATCHING, report canonically spaced OUTPUT (#554)

### DIFF
--- a/StingTools.Tags.Tests/CsiMasterFormatTests.cs
+++ b/StingTools.Tags.Tests/CsiMasterFormatTests.cs
@@ -66,11 +66,90 @@ namespace StingTools.Tags.Tests
             Assert.Null(CsiMasterFormat.Resolve(rules, "Pipes", "Pipe", "", "REFRIG"));
         }
 
+        // ── #554: matching and display are two jobs, so assert both ─────
+        //
+        // This test used to demand that NormalizeSection RETURN the spaced form,
+        // which conflated them. NormalizeSection removes all whitespace on
+        // purpose — that is what lets SpecLink's "23 05 00" and a model's
+        // "230500" reconcile to one key. Asserting spaced output here would have
+        // meant reverting the reconciliation fix.
+        //
+        // So the test now pins the seam rather than picking a side: normalisation
+        // is whitespace-INSENSITIVE, and FormatSection renders the canonical CSI
+        // spacing for anything a human reads.
+
         [Fact]
-        public void NormalizeSection_collapses_whitespace_and_uppercases()
+        public void NormalizeSection_strips_all_whitespace_so_spaced_and_unspaced_match()
         {
-            Assert.Equal("23 31 00", CsiMasterFormat.NormalizeSection("  23   31  00 "));
+            // The point of normalisation: every spelling collapses to ONE key.
+            Assert.Equal("233100", CsiMasterFormat.NormalizeSection("  23   31  00 "));
+            Assert.Equal("233100", CsiMasterFormat.NormalizeSection("23 31 00"));
+            Assert.Equal("233100", CsiMasterFormat.NormalizeSection("233100"));
+
+            // Stated as an equality between spellings, not just as literals — this
+            // is the property SpecLink reconciliation actually depends on.
+            Assert.Equal(CsiMasterFormat.NormalizeSection("23 31 00"),
+                         CsiMasterFormat.NormalizeSection("233100"));
+
             Assert.Equal("", CsiMasterFormat.NormalizeSection(null));
+            Assert.Equal("", CsiMasterFormat.NormalizeSection("   "));
+
+            // Dots survive, so a child section stays distinct from its parent.
+            Assert.Equal("230500.13", CsiMasterFormat.NormalizeSection("23 05 00.13"));
+            Assert.NotEqual(CsiMasterFormat.NormalizeSection("23 05 00"),
+                            CsiMasterFormat.NormalizeSection("23 05 00.13"));
+        }
+
+        [Fact]
+        public void FormatSection_renders_the_canonical_CSI_spacing()
+        {
+            // Whatever spelling goes in, CSI's own form comes out.
+            Assert.Equal("23 31 00", CsiMasterFormat.FormatSection("233100"));
+            Assert.Equal("23 31 00", CsiMasterFormat.FormatSection("  23   31  00 "));
+            Assert.Equal("22 40 00", CsiMasterFormat.FormatSection("224000"));
+
+            // Level-4 child sections keep their suffix.
+            Assert.Equal("23 05 00.13", CsiMasterFormat.FormatSection("230500.13"));
+
+            // Shorter valid levels are still pairs.
+            Assert.Equal("23", CsiMasterFormat.FormatSection("23"));
+            Assert.Equal("23 05", CsiMasterFormat.FormatSection("2305"));
+
+            Assert.Equal("", CsiMasterFormat.FormatSection(null));
+
+            // Anything not a recognisable CSI number is returned UNCHANGED rather
+            // than forced into pairs. Inventing a shape for input we do not
+            // understand would print a confident wrong section number.
+            Assert.Equal("23050", CsiMasterFormat.FormatSection("23050"));     // odd length
+            Assert.Equal("DIV23", CsiMasterFormat.FormatSection("div23"));     // not digits
+        }
+
+        [Fact]
+        public void Matching_is_whitespace_insensitive_while_output_stays_canonically_spaced()
+        {
+            // The two halves of #554 in one statement, end to end: a model that
+            // stores sections UNSPACED still reconciles against a SPACED spec, and
+            // what gets reported back is spaced regardless of which side it came
+            // from.
+            var model = new Dictionary<string, string>
+            {
+                { "233100", "HVAC Ducts and Casings" },  // unspaced, as models store it
+                { "224000", "Plumbing Fixtures" },       // unspaced, model only → gap
+            };
+            var spec = new Dictionary<string, string>
+            {
+                { "23 31 00", "HVAC Ducts and Casings" }, // spaced, as SpecLink exports it
+                { "21 13 00", "Sprinkler Systems" },      // spaced, spec only → over-spec
+            };
+
+            var r = CsiMasterFormat.Reconcile(model, spec);
+
+            // Matching worked across the spelling difference: 23 31 00 is NOT a gap.
+            Assert.Single(r.SpecGaps);
+            Assert.Equal("22 40 00", r.SpecGaps[0].Section);   // reported spaced, given unspaced
+            Assert.Single(r.OverSpec);
+            Assert.Equal("21 13 00", r.OverSpec[0].Section);   // reported spaced, given spaced
+            Assert.Empty(r.TitleMismatches);
         }
 
         // ── Reconcile ───────────────────────────────────────────────────
@@ -91,6 +170,8 @@ namespace StingTools.Tags.Tests
             };
 
             var r = CsiMasterFormat.Reconcile(model, spec);
+            // #554 — reported identity is canonically spaced, NOT the normalised
+            // matching key. These read "22 40 00", not "224000".
             Assert.Single(r.SpecGaps);
             Assert.Equal("22 40 00", r.SpecGaps[0].Section);
             Assert.Single(r.OverSpec);

--- a/StingTools/Core/Classification/CsiMasterFormat.cs
+++ b/StingTools/Core/Classification/CsiMasterFormat.cs
@@ -120,6 +120,54 @@ namespace StingTools.Core.Classification
             return Regex.Replace(s.Trim().ToUpperInvariant(), "\\s+", "");
         }
 
+        /// <summary>
+        /// The DISPLAY form of a CSI section number: canonical CSI spacing,
+        /// "23 05 00" — what MasterFormat prints and what a QS expects to read.
+        ///
+        /// <para>This is the other half of <see cref="NormalizeSection"/>, and #554 is
+        /// what happens without it. Normalisation strips whitespace so SpecLink's spaced
+        /// "23 05 00" and a model's unspaced "230500" reconcile to one key — that is
+        /// correct and must stay. But <see cref="Reconcile"/> then reported the
+        /// normalised KEY as the section's identity, so its output read "224000" where
+        /// CSI canonically writes "22 40 00". A matching convention had leaked into
+        /// user-facing output.</para>
+        ///
+        /// <para>Matching and display are different jobs. Collapsing them either breaks
+        /// reconciliation across the two source formats or prints a section number in a
+        /// form CSI does not use; keeping both functions costs one method and closes the
+        /// seam instead of picking a loser.</para>
+        ///
+        /// <para>Level-4 child sections keep their dot suffix: "230500.13" renders as
+        /// "23 05 00.13". Anything that is not a recognisable CSI number is returned
+        /// UNCHANGED rather than forced into pairs — inventing a shape for input we do
+        /// not understand would print a confident wrong section number, which is worse
+        /// than printing exactly what we were given.</para>
+        /// </summary>
+        public static string FormatSection(string s)
+        {
+            string key = NormalizeSection(s);
+            if (key.Length == 0) return "";
+
+            // Split an optional level-4 suffix: "230500.13" → "230500" + ".13"
+            string stem = key, suffix = "";
+            int dot = key.IndexOf('.');
+            if (dot >= 0) { stem = key.Substring(0, dot); suffix = key.Substring(dot); }
+
+            // CSI numbers are an even count of digits in 2-digit pairs (division 23,
+            // level-2 2305, level-3 230500). Anything else is not ours to reformat.
+            if (stem.Length < 2 || stem.Length % 2 != 0) return key;
+            foreach (char c in stem) if (c < '0' || c > '9') return key;
+
+            var sb = new System.Text.StringBuilder(stem.Length + stem.Length / 2 + suffix.Length);
+            for (int i = 0; i < stem.Length; i += 2)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append(stem, i, 2);
+            }
+            sb.Append(suffix);
+            return sb.ToString();
+        }
+
         public class CsiTocEntry { public string Section; public string Title; }
         public class CsiReconcileResult
         {
@@ -143,16 +191,19 @@ namespace StingTools.Core.Classification
             var model = Norm(modelSections);
             var spec = Norm(specSections);
 
+            // #554 — MATCH on the normalised key (kv.Key), REPORT the display form.
+            // Ordering also uses the normalised key: it sorts identically to the spaced
+            // form and avoids re-deriving it per comparison.
             foreach (var kv in model.OrderBy(k => k.Key))
             {
                 if (!spec.TryGetValue(kv.Key, out string specTitle))
-                    result.SpecGaps.Add(new CsiTocEntry { Section = kv.Key, Title = kv.Value });
+                    result.SpecGaps.Add(new CsiTocEntry { Section = FormatSection(kv.Key), Title = kv.Value });
                 else if (!TitlesEqual(kv.Value, specTitle))
-                    result.TitleMismatches.Add((kv.Key, kv.Value, specTitle));
+                    result.TitleMismatches.Add((FormatSection(kv.Key), kv.Value, specTitle));
             }
             foreach (var kv in spec.OrderBy(k => k.Key))
                 if (!model.ContainsKey(kv.Key))
-                    result.OverSpec.Add(new CsiTocEntry { Section = kv.Key, Title = kv.Value });
+                    result.OverSpec.Add(new CsiTocEntry { Section = FormatSection(kv.Key), Title = kv.Value });
 
             return result;
         }


### PR DESCRIPTION
Closes #554.

## Neither side was wrong

Two `CsiMasterFormatTests` have failed since 2026-06-20:

```
NormalizeSection_collapses_whitespace_and_uppercases   Expected "23 31 00"  Actual "233100"
Reconcile_finds_gaps_overspec_and_title_mismatches     Expected "22 40 00"  Actual "224000"
```

- `NormalizeSection` removes **all** whitespace so SpecLink's `"23 05 00"` and a model's
  `"230500"` reconcile to one key. That is correct and load-bearing — models store sections
  unspaced, SpecLink exports them spaced, and reconciling across the two *is* the feature.
- But `Reconcile` then reported the normalised **key** as the section's identity, so its
  output read `224000` where CSI canonically writes `22 40 00`.

A matching convention had leaked into user-facing output. Picking a winner breaks the other
side: force spacing into `NormalizeSection` and reconciliation stops matching; accept
`224000` and the report prints a section number in a form CSI does not use.

## Fix — one method, and the seam closes

Keep `NormalizeSection` for **matching**. Add `FormatSection` for **display**.

| Input | `NormalizeSection` (match) | `FormatSection` (display) |
|---|---|---|
| `"23 05 00"` | `230500` | `23 05 00` |
| `"230500"` | `230500` | `23 05 00` |
| `"230500.13"` | `230500.13` | `23 05 00.13` |
| `"2305"` | `2305` | `23 05` |
| `"23050"` (odd) | `23050` | `23050` — **unchanged** |
| `"div23"` | `DIV23` | `DIV23` — **unchanged** |

That last row is deliberate. Input that is not a recognisable CSI number is returned
**unchanged rather than forced into pairs** — inventing a shape for something we do not
understand would print a confident wrong section number, which is worse than printing
exactly what we were given.

`Reconcile` now matches on the normalised key and **reports** `FormatSection(key)`, for
`SpecGaps`, `OverSpec` and `TitleMismatches` alike.

## Reaches both user-facing surfaces with no further change

`CsiCommands.cs:193` (TaskDialog report) and `:288-290` (XLSX export) both read `.Section`.

The three `NormalizeSection` call sites in `CsiCommands` are all **ingest** — building match
keys from the model and from the TOC — and correctly stay normalised.

## Tests — both behaviours asserted, rather than one side chosen

The old `NormalizeSection` test demanded the spaced form *back from `NormalizeSection`*,
which is exactly what conflated the two jobs; satisfying it would have meant reverting the
reconciliation fix. Replaced with three tests that pin the seam:

1. **`NormalizeSection_strips_all_whitespace_so_spaced_and_unspaced_match`** — asserts the
   *equality between spellings*, not just literals, because that is the property SpecLink
   reconciliation actually depends on. Also pins that dots survive, so a child section stays
   distinct from its parent.
2. **`FormatSection_renders_the_canonical_CSI_spacing`** — canonical pairs, level-4 suffix,
   shorter levels, and the unchanged-passthrough above.
3. **`Matching_is_whitespace_insensitive_while_output_stays_canonically_spaced`** — the two
   halves end to end: an **unspaced** model reconciles against a **spaced** spec (so
   `23 31 00` is correctly *not* reported as a gap), and both a model-side and a spec-side
   finding come back spaced. This is the one that fails if either half regresses.

`Reconcile_finds_gaps_overspec_and_title_mismatches` keeps its original expectations
untouched — `"22 40 00"` was always what it wanted — now with a note on why.

## Results

| | Before | After |
|---|---|---|
| `StingTools.Tags.Tests` | 239 passed, **2 failed** (241) | **243 passed, 0 failed** |
| Plugin build | — | **0 errors, 0 warnings** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
