### PR TITLE
test(seed): tie the demo seeder to the user cap it writes (and correct the record)

### DIFF
--- a/Planscape.Server/src/Planscape.API/SeedData.cs
+++ b/Planscape.Server/src/Planscape.API/SeedData.cs
@@ -431,7 +431,57 @@ public static class SeedData
             catch { /* non-critical — viewer just shows "no models yet" */ }
         }
 
+        AssertSeedFitsUserCap(db, tenant);
+
         await db.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// The seeder sets <c>MaxUsers</c> on the demo tenant and then adds users to
+    /// it. Nothing tied those two numbers together, so growing the seed past the
+    /// cap it had just written would have gone unnoticed until a human hit
+    /// "add user" and got a 400 with no clue why.
+    ///
+    /// <para>It does not currently breach: the seed adds 13 users (1 admin + one
+    /// per lead role + one per project) against <c>MaxUsers = 50</c>. This is an
+    /// invariant made explicit, not a repair — it fires only if someone grows
+    /// <c>leadRoles</c> or the project list past the headroom, which is exactly
+    /// the moment it is useful.</para>
+    ///
+    /// <para>Throwing is deliberate. The seeder is development-only (it refuses
+    /// to run in Production unless <c>PLANSCAPE_ALLOW_DEMO_SEED</c> is set), and
+    /// a dev database that silently starts over its own cap is the failure this
+    /// guards — a loud startup failure naming both numbers is cheaper to
+    /// diagnose than a 400 from an unrelated endpoint days later.</para>
+    ///
+    /// <para>Counts the pending inserts in the change tracker plus rows already
+    /// persisted for this tenant, so it is correct whether the tenant is being
+    /// created now or was already minted by <c>DemoSandboxJob</c>.</para>
+    /// </summary>
+    private static void AssertSeedFitsUserCap(PlanscapeDbContext db, Tenant tenant)
+    {
+        var pending = db.ChangeTracker.Entries<AppUser>()
+            .Count(e => e.State == EntityState.Added && e.Entity.TenantId == tenant.Id);
+
+        // Already-persisted rows for this tenant. Uses the same BypassTenantFilter
+        // the rest of the seeder relies on (TenantContext.TenantId is Guid.Empty
+        // at startup), so this sees the real rows rather than none.
+        var existing = db.Users.Count(u => u.TenantId == tenant.Id && !u.IsDeleted);
+
+        var total = existing + pending;
+        if (total <= tenant.MaxUsers) return;
+
+        throw new InvalidOperationException(
+            $"SeedData would leave the '{tenant.Slug}' tenant over its own user cap: " +
+            $"{total} users ({existing} existing + {pending} being seeded) against " +
+            $"MaxUsers = {tenant.MaxUsers}. Nothing would have reported this at seed " +
+            "time — it surfaces later as a 400 from POST /api/admin/users and the " +
+            "project-member invite path, both of which refuse once the tenant is at " +
+            "cap. Fix by raising MaxUsers on the demo tenant in SeedData, or by " +
+            "seeding fewer users. NOTE: load/seed-loadtest-data.sql inserts 400 " +
+            "loadtest*@planscape.demo users straight into Postgres and is NOT " +
+            "counted by any application guard; if that is the cause, run its " +
+            "documented cleanup: DELETE FROM \"Users\" WHERE \"Email\" LIKE 'loadtest%';");
     }
 
     // ── Minimal GLB builder ────────────────────────────────────────────────

--- a/Planscape.Server/tests/Planscape.Tests/SeedDataUserCapTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/SeedDataUserCapTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Planscape.API;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The demo seeder writes <c>MaxUsers</c> on the tenant and then adds users to
+/// it. Nothing tied those two numbers together.
+///
+/// WHAT THIS IS AND IS NOT
+/// -----------------------
+/// It is NOT a repair of a live overage. Measured against the running dev
+/// database, the seeder accounts for **13** of the demo tenant's users
+/// (1 admin + 6 lead roles + 6 per-project leads) against its own
+/// <c>MaxUsers = 50</c>. It has always fitted.
+///
+/// The 400-user overage that once blocked <c>POST /api/admin/users</c> came
+/// from <c>load/seed-loadtest-data.sql</c>, which INSERTs
+/// <c>loadtest1..400@planscape.demo</c> straight into Postgres via
+/// <c>generate_series</c>. No application-level guard can see that, and none of
+/// it is the seeder's doing.
+///
+/// So this pins an invariant that currently holds, and proves the guard fires
+/// when it stops holding — which is the only moment it matters.
+/// </summary>
+public class SeedDataUserCapTests
+{
+    private sealed class StartupTenant : ITenantContext
+    {
+        // Guid.Empty is what TenantContext really returns during startup — there
+        // is no HTTP context — which is precisely why SeedData sets
+        // BypassTenantFilter. Modelling it faithfully keeps the test honest.
+        public Guid TenantId => Guid.Empty;
+        public string TenantSlug => "";
+        public LicenseTier Tier => LicenseTier.Premium;
+        public bool MimEnabled => false;
+    }
+
+    private sealed class DevEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "Planscape.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } =
+            new NullFileProvider();
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new StartupTenant());
+
+    private static SqliteConnection NewOpenDb()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        using var ctx = NewContext(conn);
+        ctx.Database.EnsureCreated();
+        return conn;
+    }
+
+    [Fact]
+    public async Task Seeding_leaves_the_demo_tenant_within_its_own_user_cap()
+    {
+        using var conn = NewOpenDb();
+        using var db = NewContext(conn);
+
+        await SeedData.SeedAsync(db, new DevEnvironment());
+
+        db.BypassTenantFilter = true;
+        var tenant = await db.Tenants.FirstAsync(t => t.Slug == "demo");
+        var users = await db.Users.CountAsync(u => u.TenantId == tenant.Id && !u.IsDeleted);
+
+        // Non-vacuous: a seeder that produced nothing would satisfy "<= cap"
+        // while proving nothing at all.
+        Assert.True(users > 0, "the seeder produced no users, so the cap assertion below is vacuous");
+
+        Assert.True(users <= tenant.MaxUsers,
+            $"the seeder left the demo tenant over its own cap: {users} users against MaxUsers = {tenant.MaxUsers}");
+    }
+
+    [Fact]
+    public async Task The_guard_fails_loudly_when_the_seed_would_exceed_the_cap()
+    {
+        using var conn = NewOpenDb();
+
+        // Pre-mint the demo tenant with a cap the seed cannot fit. SeedData
+        // find-or-creates on Slug == "demo" (DemoSandboxJob may get there first),
+        // so it adopts this row and its cap rather than writing its own.
+        using (var setup = NewContext(conn))
+        {
+            setup.BypassTenantFilter = true;
+            setup.Tenants.Add(new Tenant
+            {
+                Name = "Planscape Demo",
+                Slug = "demo",
+                Tier = LicenseTier.Premium,
+                MaxUsers = 2,            // the seed adds 13
+                MaxProjects = 20,
+                Plan = BillingPlan.Enterprise,
+            });
+            await setup.SaveChangesAsync();
+        }
+
+        using var db = NewContext(conn);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => SeedData.SeedAsync(db, new DevEnvironment()));
+
+        // The message has to be actionable on its own — this fires at startup,
+        // far from whoever last edited the seed list.
+        Assert.Contains("over its own user cap", ex.Message);
+        Assert.Contains("MaxUsers = 2", ex.Message);
+
+        // And it must fire BEFORE the write, or it is a report of damage rather
+        // than a guard against it.
+        db.BypassTenantFilter = true;
+        var persisted = await db.Users.CountAsync();
+        Assert.Equal(0, persisted);
+    }
+}


### PR DESCRIPTION
## First, a correction — the premise I gave you was wrong

I previously reported that `SeedData` *"sets `MaxUsers = 50` and then seeds hundreds of users with no cap check"*. The second half was wrong. I had verified there is no cap check (true) and then inferred the rest from the fact that 422 of the demo tenant’s users carry `@planscape.demo` addresses — without checking which code produced them.

Measured properly this time, by email pattern against the running dev database:

| source | users |
|---|---|
| `loadtest*` — `load/seed-loadtest-data.sql` | **400** |
| **`SeedData`** | **13** |
| `zz` fixtures | 9 |
| other | 4 |
| **total** | **426** |

**`SeedData` accounts for 13 users against its own cap of 50, and always has** (1 admin + 6 lead roles + 6 per-project leads — matching the DB exactly). It is also **idempotent**: it returns early when `admin@planscape.demo` exists, so it cannot accumulate across runs.

The overage that once made `POST /api/admin/users` return 400 came from **`load/seed-loadtest-data.sql`**, which INSERTs `loadtest1..400@planscape.demo` straight into Postgres via `generate_series`. No application-level guard can see a raw SQL insert, and none of it is the seeder’s doing.

So the fix as scoped — "raise the seed cap to match the data" — is not needed: the cap (50) already exceeds the data (13) with 37 to spare.

## What this PR actually is

The second option you offered, and the one that still stands up: **make the seeder respect the cap and fail loudly if it can’t.** Not a repair — an unasserted invariant made explicit.

The seeder wrote `MaxUsers` and then added users to that tenant with *nothing relating the two*. Growing `leadRoles` or the project list past the headroom would have gone unnoticed until someone hit "add user" and got a 400 from an unrelated endpoint with no clue why.

`AssertSeedFitsUserCap` runs **before** the final `SaveChanges` and throws with both numbers, the existing/pending split, and the loadtest cleanup command — because it fires at startup, far from whoever last edited the seed list. It counts pending inserts in the change tracker **plus** rows already persisted, so it is correct whether the tenant is being created now or was already minted by `DemoSandboxJob`.

Throwing is deliberate: the seeder is development-only (it refuses to run in Production without `PLANSCAPE_ALLOW_DEMO_SEED`), and a loud startup failure naming both numbers is cheaper to diagnose than a 400 days later from somewhere else.

## Verification

| run | result |
|---|---|
| Guard call commented out (**RED**) | **Failed 1, Passed 1** — the loud-failure test fails; the invariant test still passes, correctly, because the seed does fit |
| Guard in place (**GREEN**) | **Failed 0, Passed 2** |
| Full suite | **Failed 0, Passed 579**, Skipped 9, Total 588 |

Two tests, each written against a specific way of fooling itself:

- `Seeding_leaves_the_demo_tenant_within_its_own_user_cap` asserts `users > 0` **before** asserting `users <= cap` — a seeder that produced nothing would satisfy the cap while proving nothing.
- `The_guard_fails_loudly_when_the_seed_would_exceed_the_cap` pre-mints the demo tenant with `MaxUsers = 2` (SeedData find-or-creates on `Slug == "demo"`, so it adopts that cap), then asserts the throw **and that nothing was persisted** — a guard that reports damage after writing it is not a guard.

## Deliberately not changed

`load/seed-loadtest-data.sql`. Going over cap is arguably what a capacity fixture is *for*, and it documents its own cleanup (`DELETE FROM "Users" WHERE "Email" LIKE loadtest%;`). That it leaves the app blocked afterwards is worth a separate decision — raising the demo cap for the duration, or running cleanup automatically — not a silent change here.

CI’s Build & Test / CI Gate is broken on main itself (Postgres service container, "role root does not exist"), so verification is local. Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)