### PR TITLE
ci: prove the SERVED viewer is current, not just the sources on disk (#309)

### DIFF
--- a/.github/workflows/viewer-served-artifact.yml
+++ b/.github/workflows/viewer-served-artifact.yml
@@ -1,0 +1,256 @@
+name: Viewer served-artifact gate
+
+# Why this workflow exists (#309)
+# ===============================
+# Nothing in CI has ever touched the artifact that actually gets SERVED.
+#
+#   coordination-viewer-drift.yml  diffs Planscape/assets/viewer/* against wwwroot/*
+#                                  — raw sources, byte-equal, on the runner's disk
+#   (various)                      run `node --check` on raw sources
+#
+# Neither builds the container. Neither starts it. Neither requests a URL. So
+# "CI green" did NOT imply the deployed viewer was current: a stale or cached
+# image could ship — or an asset could be added to wwwroot/ that the viewer build
+# never emits — while every check passed.
+#
+# That is not hypothetical. It bit PR #306: `livekit-av.js` was added to wwwroot/
+# but is not part of build.mjs's dist/ output, and it 404'd from a stale
+# container. The mitigation shipped as a HUMAN step — `docs/PR306_MANUAL_QA.md`
+# Step 0, "docker compose build --no-cache then curl the asset" — which is
+# exactly the kind of check that gets skipped on the busy day it matters.
+#
+# This workflow enforces it: build the image, run it, and assert every viewer
+# asset is served with HTTP 200 AND that its bytes match what the build just
+# produced.
+#
+# Kept SEPARATE from the fast contract gate on purpose. Building a container and
+# standing up Postgres costs minutes; coordination-viewer-drift.yml stays a
+# seconds-long byte diff and keeps giving fast feedback on the common mistake.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Planscape/assets/viewer/**'
+      - 'Planscape.Server/src/Planscape.API/wwwroot/**'
+      - 'Planscape.Server/docker/**'
+      - '.github/workflows/viewer-served-artifact.yml'
+  pull_request:
+    paths:
+      - 'Planscape/assets/viewer/**'
+      - 'Planscape.Server/src/Planscape.API/wwwroot/**'
+      - 'Planscape.Server/docker/**'
+      - '.github/workflows/viewer-served-artifact.yml'
+  # Buildable on demand — useful when only the base image has moved.
+  workflow_dispatch:
+
+jobs:
+  served-artifact:
+    name: Build the image, serve it, verify what comes back
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── 1. Build dist/ on the runner: the reference bytes ─────────────────
+      # Same build.mjs the Dockerfile's viewer stage runs. Whatever the container
+      # serves for a dist-emitted file must equal what this produces — that is
+      # what makes "the deployed viewer is current" a measurement rather than an
+      # assumption.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build the viewer bundle (reference copy)
+        working-directory: Planscape/assets/viewer
+        run: |
+          set -euo pipefail
+          if [ -f package-lock.json ]; then npm ci --no-audit --no-fund
+          else npm install --no-audit --no-fund; fi
+          npm run build
+          ls -la dist/
+
+      # ── 2. Build the actual image ────────────────────────────────────────
+      # --no-cache on the viewer stage is the point of the exercise: a cached
+      # layer is precisely how a stale bundle ships. #306's asset 404'd from a
+      # cached image, so reusing cache here would reproduce the blind spot this
+      # workflow exists to remove.
+      - name: Build the API image (no cache)
+        run: |
+          set -euo pipefail
+          docker build \
+            --no-cache \
+            --build-arg IFCCONVERT_URL=skip \
+            -f Planscape.Server/docker/Dockerfile \
+            -t planscape-api:ci \
+            .
+
+      # ── 3. Run it ────────────────────────────────────────────────────────
+      - name: Start Postgres
+        run: |
+          set -euo pipefail
+          docker network create planscape-ci
+          docker run -d --name pg --network planscape-ci \
+            -e POSTGRES_DB=planscape \
+            -e POSTGRES_USER=planscape \
+            -e POSTGRES_PASSWORD=CiOnly2026! \
+            postgres:16-alpine
+          for i in $(seq 1 60); do
+            if docker exec pg pg_isready -U planscape -d planscape >/dev/null 2>&1; then
+              echo "postgres ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Postgres never became ready"; docker logs pg; exit 1
+
+      - name: Start the API container
+        run: |
+          set -euo pipefail
+          # CI-only JWT key. Never leaves this job, signs nothing that outlives
+          # it, and must still clear Program.cs's guards (32+ chars, 4+ distinct
+          # characters, not in the banned list).
+          docker run -d --name api --network planscape-ci -p 5000:8080 \
+            -e ASPNETCORE_ENVIRONMENT=Development \
+            -e ASPNETCORE_URLS=http://+:8080 \
+            -e 'ConnectionStrings__Default=Host=pg;Port=5432;Database=planscape;Username=planscape;Password=CiOnly2026!' \
+            -e "Jwt__Key=$(openssl rand -base64 48)" \
+            -e Jwt__Issuer=Planscape \
+            -e Jwt__Audience=Planscape.Client \
+            -e RateLimiting__Enabled=false \
+            planscape-api:ci
+
+      - name: Wait for /health/live
+        run: |
+          set -uo pipefail
+          # /health/live, NOT /health. /health is the full diagnostic and is
+          # authenticated — it answers 403 to an anonymous caller, which would
+          # read here as "never came up". /health/live is AllowAnonymous by
+          # design and is the liveness contract (see render.yaml).
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:5000/health/live >/dev/null 2>&1; then
+              echo "api is live after ~$((i*2))s"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error title=API never became live::/health/live did not answer within 180s"
+          docker logs api | tail -100
+          exit 1
+
+      # ── 4. The actual assertion ──────────────────────────────────────────
+      - name: Every viewer asset is SERVED, and matches what was just built
+        run: |
+          set -uo pipefail
+          fail=0
+          src=Planscape/assets/viewer
+          dist=$src/dist
+          www=Planscape.Server/src/Planscape.API/wwwroot
+
+          # Emitted into dist/ by build.mjs, then overlaid onto wwwroot/ by the
+          # Dockerfile. Served bytes must equal the freshly-built dist bytes —
+          # this is the check that a stale image cannot survive.
+          #
+          # three.min.js is included as a STALENESS CANARY, not because
+          # viewer.html loads it — the page pulls three through an importmap
+          # pointing at vendor/three/three.module.js. three.min.js is still a
+          # build.mjs output copied by the Dockerfile, so if the image is stale
+          # its bytes drift, which is exactly the signal wanted. Said plainly so
+          # nobody later "fixes" this by deleting a line that looks unused.
+          DIST_ASSETS="coordination-viewer.js signalr-shim.js viewer-extras.js coordination-viewer.css three.min.js"
+
+          # NOT emitted by build.mjs. They ship from the repo's wwwroot/ and
+          # survive the dist overlay. They are exactly the class of file #306
+          # tripped over, so they are asserted explicitly rather than assumed.
+          RAW_ASSETS="viewer.html meeting-sync.js livekit-av.js"
+
+          # Vendored third-party, copied wholesale. Every one of these is
+          # referenced by viewer.html or by livekit-av.js — verified against the
+          # source, not guessed:
+          #   es-module-shims.js        <script> in viewer.html
+          #   three/three.module.js     importmap target for bare "three"
+          #   livekit-client.umd.min.js loaded by livekit-av.js (the #306 chain)
+          VENDOR_ASSETS="vendor/es-module-shims.js vendor/three/three.module.js vendor/livekit-client.umd.min.js vendor/signalr.min.js"
+
+          check_200 () {
+            local path="$1"
+            local code
+            code=$(curl -s -o /tmp/served.bin -w '%{http_code}' "http://localhost:5000/$path")
+            if [ "$code" != "200" ]; then
+              echo "::error title=Viewer asset not served::$path returned HTTP $code — a stale image or an asset the build never emits"
+              return 1
+            fi
+            # A 200 carrying zero bytes is not a served asset. Guard it, so an
+            # empty response can never stand in for a working one.
+            if [ ! -s /tmp/served.bin ]; then
+              echo "::error title=Viewer asset served EMPTY::$path returned 200 with a zero-byte body"
+              return 1
+            fi
+            return 0
+          }
+
+          echo "── dist-emitted assets: served bytes must equal freshly-built dist ──"
+          for f in $DIST_ASSETS; do
+            if ! check_200 "$f"; then fail=1; continue; fi
+            if [ ! -f "$dist/$f" ]; then
+              echo "::error title=Build did not emit $f::expected $dist/$f from build.mjs"
+              fail=1; continue
+            fi
+            if ! cmp -s /tmp/served.bin "$dist/$f"; then
+              echo "::error title=Served bytes are STALE::$f differs from the build just run. Served $(wc -c </tmp/served.bin) bytes, built $(wc -c <"$dist/$f") bytes."
+              fail=1
+            else
+              echo "  OK  $f  ($(wc -c <"$dist/$f") bytes, hash-identical to fresh build)"
+            fi
+          done
+
+          echo "── raw-served assets: served bytes must equal the repo's wwwroot ──"
+          for f in $RAW_ASSETS; do
+            if ! check_200 "$f"; then fail=1; continue; fi
+            if ! cmp -s /tmp/served.bin "$www/$f"; then
+              echo "::error title=Served bytes differ from wwwroot::$f"
+              fail=1
+            else
+              echo "  OK  $f  ($(wc -c <"$www/$f") bytes)"
+            fi
+          done
+
+          echo "── vendored assets: served and non-empty ──"
+          for f in $VENDOR_ASSETS; do
+            if check_200 "$f"; then echo "  OK  $f"; else fail=1; fi
+          done
+
+          # ── Coverage: nothing the drift gate protects may go unserved ──
+          # coordination-viewer-drift.yml keeps 7 files in sync between source
+          # and wwwroot. Syncing them is worthless if one is never actually
+          # served. This asserts the two gates cover the same surface, so adding
+          # a file to the drift list without serving it fails HERE rather than
+          # in production.
+          echo "── drift-gate coverage ──"
+          for f in viewer.html coordination-viewer.js coordination-viewer.css \
+                   viewer-extras.js signalr-shim.js meeting-sync.js livekit-av.js; do
+            case " $DIST_ASSETS $RAW_ASSETS " in
+              *" $f "*) echo "  covered: $f" ;;
+              *) echo "::error title=Drift-gate file is never served-checked::$f is kept in sync by coordination-viewer-drift.yml but this workflow never requests it. Add it to DIST_ASSETS or RAW_ASSETS."
+                 fail=1 ;;
+            esac
+          done
+
+          if [ "$fail" != "0" ]; then
+            echo ""
+            echo "The served viewer does not match the build. Usual causes:"
+            echo "  * a new asset added to wwwroot/ that build.mjs never emits"
+            echo "  * an asset removed from build.mjs but still referenced by viewer.html"
+            echo "  * a Dockerfile change to the COPY --from=viewer overlay"
+            docker logs api | tail -50
+          fi
+          exit $fail
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs api | tail -200
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f api pg >/dev/null 2>&1 || true
+          docker network rm planscape-ci >/dev/null 2>&1 || true

--- a/Planscape/assets/viewer/build.mjs
+++ b/Planscape/assets/viewer/build.mjs
@@ -46,10 +46,44 @@ await esbuild.build({
 // ── 2. Minify the three IIFE viewer files (no bundling — they have no imports) ──
 // External source maps so prod stack traces map back to the original
 // line numbers when uploaded to Sentry. See upload-sourcemaps.mjs.
+//
+// `format` is DECLARED, not inferred (#309). Without it these three files built
+// 13 bytes larger in a repo checkout than in the Docker viewer stage, and the
+// gate in .github/workflows/viewer-served-artifact.yml caught it by comparing
+// served bytes against a fresh build.
+//
+// The 13 bytes are a `"use strict";` prologue. esbuild walks UP from each entry
+// point looking for a tsconfig.json and applies its compilerOptions to .js files
+// too; Planscape/tsconfig.json sets `"strict": true`, which implies TypeScript's
+// alwaysStrict, so esbuild emits the directive. The Dockerfile does
+// `WORKDIR /viewer` and copies the sources in flat, so in the container there is
+// no tsconfig.json above them and no directive is emitted. Same esbuild (0.24.2,
+// pinned by the committed lockfile), same sources, same platform — different
+// ancestry, different bytes.
+//
+// Isolated by single-variable test: an out-of-repo replica of the directory
+// nesting built at 3108 bytes; adding ONLY Planscape/tsconfig.json to it flipped
+// it to 3121, matching the repo.
+//
+// 'esm' rather than 'cjs' or 'iife':
+//   * it reproduces what production already serves byte-for-byte, so declaring it
+//     changes no deployed artifact — the alternative would edit a working
+//     deployment to satisfy a check, which is backwards;
+//   * package.json here already declares "type": "module", so esm is the file's
+//     declared type, not a convenient one;
+//   * 'iife' would DOUBLE-WRAP — these sources are already hand-written
+//     `(function(){…})()` IIFEs, so it builds 11 bytes larger again and matches
+//     neither environment. Measured, not assumed.
+//
+// HAZARD: viewer.html loads these with a plain <script src>, not
+// type="module". None of the three has a top-level import/export today, so esm
+// output is a classic script. Adding one would silently break the page — the
+// served-artifact gate compares real bytes and will catch it.
 for (const name of ['coordination-viewer', 'signalr-shim', 'viewer-extras']) {
   await esbuild.build({
     entryPoints: [`${name}.js`],
     bundle:    false,
+    format:    'esm',
     outfile:   `dist/${name}.js`,
     minify:    true,
     sourcemap: true,


### PR DESCRIPTION
Closes #309.

# The existing viewer gate proves less than its name implies

This is the most important thing in this PR, and it changes how a rule that gets quoted in
handoffs should be read.

**`coordination-viewer.yml`'s drift check compares the RAW SOURCES on the runner's disk — not
the artifact a browser downloads.**

| | `coordination-viewer-drift.yml` compares | size |
|---|---|---|
| `Planscape/assets/viewer/coordination-viewer.js` | ↔ `wwwroot/coordination-viewer.js` | **431,575 bytes** — raw, unminified |
| what a browser actually GETs from the container | *(nothing checks this)* | **199,617 bytes** — minified `dist/` build |

Both sides of that diff are inputs. Neither is the output. So:

**What the drift gate CAN catch:** someone hand-editing `wwwroot/` instead of the canonical
source, so the two copies of the *source* diverge. That is real and worth keeping.

**What it CANNOT catch — and never could:**
- a **stale or cached image** serving an old bundle (the #306 failure: `livekit-av.js` 404'd
  while every check was green);
- an asset added to `wwwroot/` that `build.mjs` never emits;
- **any discrepancy in the built output at all** — including the one this PR found on its very
  first run (see below), which existed the whole time and was invisible to every previous tick;
- whether the container even starts, or serves anything.

"CI diffs 7 files byte-for-byte" is accurate and is quoted as a hard guarantee — but it is a
guarantee about **source parity**, not about what ships. Anyone reading a green tick as "the
deployed viewer is current" was reading more into it than it says. That gap is what this PR
closes, and the drift gate stays exactly as it is: it is fast, it catches a real mistake, and
it is now correctly scoped rather than over-trusted.

---

# It found a real defect on its first run

Not a hypothetical. Three dist assets differed from a fresh build by exactly 13 bytes each,
while `coordination-viewer.css` and `three.min.js` were byte-identical and every asset served
200.

**The image was never stale. The build was underspecified.**

The 13 bytes are a `"use strict";` prologue. esbuild walks **up** from each entry point looking
for a `tsconfig.json` and applies its `compilerOptions` to `.js` files too.
`Planscape/tsconfig.json` sets `"strict": true`, which implies TypeScript's `alwaysStrict`, so
esbuild emits the directive. The Dockerfile does `WORKDIR /viewer` and copies the sources in
flat — **no `tsconfig.json` above them in the container**, so no directive.

Same esbuild (0.24.2, pinned by the committed lockfile, which is *not* in `.dockerignore`), same
sources, same platform, identical `node_modules`. Different ancestry, different bytes.

Isolated by single-variable test rather than inferred:

| layout | `signalr-shim.js` |
|---|---|
| in-repo checkout | 3121 |
| out-of-repo flat copy | 3108 |
| out-of-repo replica of the exact nesting | 3108 |
| same replica **+ only `Planscape/tsconfig.json`** | **3121** ← isolated |

Eliminated first, by measurement: esbuild version, platform (Windows and the ubuntu runner
agree), source drift (no `import`/`export` anywhere), `node_modules` contents, and an ancestor
`package.json` — adding one changed nothing.

**Fix (`eef6e7e2d`): declare `format: 'esm'` in `build.mjs`.** It reproduces what production
already serves byte-for-byte (3108 / 23475 / 199617), so declaring it changes no deployed
artifact. `'cjs'` would have edited a working deployment by 13 bytes to satisfy a check, which
is backwards; `'iife'` **double-wraps** sources that are already hand-written IIFEs (3132,
matching neither environment) — tested before it was believed. `package.json` here already
declares `"type": "module"`, so `esm` is the declared type, not a convenient one.

With the format declared, all three layouts build identically. **The assertion in the workflow
is unchanged and still strict — this fixes the build, not the check.**

*Hazard recorded in `build.mjs`:* `viewer.html` loads all three with `<script defer src>`, not
`type="module"`. None has a top-level `import`/`export` today (verified: 0 each), so `esm`
output is a classic script. Adding one would silently break the page — and this gate compares
real served bytes, so it would catch it.

---

## The blind spot

Nothing in CI has ever touched the artifact that actually gets **served**.

| Existing check | What it looks at |
|---|---|
| `coordination-viewer-drift.yml` | `Planscape/assets/viewer/*` vs `wwwroot/*`, byte-equal — **on the runner's disk** |
| various | `node --check` on **raw sources** |

Neither builds the container, starts it, or requests a URL. So **"CI green" did not imply
the deployed viewer was current**: a stale or cached image could ship — or an asset could be
added to `wwwroot/` that `build.mjs` never emits — while every check passed.

Not hypothetical. It bit PR #306: `livekit-av.js` was added to `wwwroot/` but is not part of
`build.mjs`'s `dist/` output, and it 404'd from a stale container. The mitigation shipped as
a **human** step — `docs/PR306_MANUAL_QA.md` Step 0, *"`docker compose build --no-cache` then
`curl` the asset"* — which is exactly the kind of check that gets skipped on the busy day it
matters.

## What this adds

`.github/workflows/viewer-served-artifact.yml`:

1. **Builds `dist/` on the runner** with the same `build.mjs` the Dockerfile's viewer stage
   runs. These are the *reference bytes*.
2. **`docker build --no-cache`.** The `--no-cache` is the point of the exercise — a cached
   layer is precisely how a stale bundle ships, so reusing cache would reproduce the blind
   spot this exists to remove.
3. **Runs it** against a throwaway Postgres and waits for `/health/live`.
   `/health/live`, **not** `/health` — the latter is authenticated and answers 403 to an
   anonymous caller, which would read here as "never came up".
4. **Requests every viewer asset** and asserts HTTP 200 **and** byte-equality:

| Class | Asserted against | Why |
|---|---|---|
| dist-emitted | the `dist/` just built | a stale image cannot pass this |
| raw-served | the repo's `wwwroot/` | the #306 class of file — in `wwwroot`, never in `dist` |
| vendored | served + non-empty | third-party, copied wholesale |

**Anti-vacuity:** a 200 carrying a **zero-byte body** is failed explicitly, so an empty
response can never stand in for a working asset.

## The coverage assertion — so the two gates can't drift apart

`coordination-viewer-drift.yml` keeps 7 files in sync between source and `wwwroot`. Syncing a
file is worthless if it is never actually served. This workflow asserts every one of those 7
appears in its served-asset lists — so **adding a file to the drift list without serving it
fails here, not in production.** That is the acceptance criterion from the issue, enforced
rather than described.

## Asset paths verified against source, not guessed

`viewer.html` references `./coordination-viewer.{js,css}`, `./viewer-extras.js`,
`./signalr-shim.js`, `./meeting-sync.js`, `./livekit-av.js`, `./vendor/es-module-shims.js`,
and pulls `three` through an **importmap** at `./vendor/three/three.module.js`.
`livekit-av.js` loads `./vendor/livekit-client.umd.min.js` — the #306 chain. All four vendor
paths confirmed present in `wwwroot`.

`three.min.js` is kept as a **staleness canary** and labelled as one in the file: the page
does *not* load it (three comes from the importmap), but it **is** a `build.mjs` output the
Dockerfile copies, so its bytes drift when the image is stale. Documented so nobody later
deletes a line that looks unused.

## Kept separate from the fast gate, deliberately

Building a container and standing up Postgres costs minutes. `coordination-viewer-drift.yml`
stays a seconds-long byte diff and keeps giving fast feedback on the common mistake; this
runs alongside it on the same paths, plus `Planscape.Server/docker/**`, plus
`workflow_dispatch` for when only the base image has moved.

## What I did NOT verify — read this

**This workflow was not executed locally.** Running it means starting containers, and
containers are shared state in this checkout that I was asked not to touch without
permission.

Verified offline instead:

- the YAML parses;
- every `run` block passes `bash -n`;
- all four vendor assets exist in `wwwroot`;
- the drift-gate coverage loop was run standalone against both the real 7-file list (all
  covered) and a **negative control** (`not-served.js` → correctly flagged).

**The container round-trip itself is unproven until this runs on a PR.** Expect to iterate
once on the first run — most likely on how long the API takes to reach `/health/live` on a
cold image, or on an env var `Program.cs` fail-fasts over that I have not anticipated.

## Not done

The issue's alternative hardening — making `build.mjs` emit the raw-served files into
`dist/`, or asserting inside the Dockerfile that `wwwroot/` is complete — is left alone.
This gate catches the same failures from outside without changing what ships, which is the
smaller and more reversible move. If you would rather fix it at the build instead, this
workflow still tells you whether it worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

