### PR TITLE
feat(bcc): show which Planscape server you are on, and let you change it deliberately (#563)

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
@@ -101,8 +101,20 @@ public sealed partial class PlanscapeServerClient
 
     /// <summary>
     /// Persist the default server URL to the machine settings file so it sticks
-    /// across documents and Revit restarts. Called after a successful connect so
-    /// the user only types the cloud URL once. No-ops on a blank/whitespace URL.
+    /// across documents and Revit restarts. No-ops on a blank/whitespace URL.
+    ///
+    /// <para><b>Call this only for a DELIBERATE user choice</b> — in practice, only
+    /// through <see cref="PlanscapeServerTargets.SetActiveTarget"/>, which the server
+    /// picker calls after the user confirms a switch. It used to be called after every
+    /// successful connect, which meant connecting to a local stack once silently
+    /// repointed the machine (#563). This file holds the production pointer and is the
+    /// fallback the launcher script relies on; writing it as a side effect of anything
+    /// is how a user ends up on a dev database without having chosen to be.</para>
+    ///
+    /// <para>Refreshes <c>_cachedDefaultUrl</c> so a subsequent resolve in THIS process
+    /// sees the new value — but note that objects already built against the old base
+    /// (<c>PlanscapeServerClient.Instance</c>, its SignalR hub, the live session) are not
+    /// rebuilt. Switching genuinely requires a Revit restart, and callers must say so.</para>
     /// </summary>
     public static void SaveDefaultServerUrl(string? serverUrl)
     {

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -195,10 +195,26 @@ public sealed partial class PlanscapeServerClient : IDisposable
             // P1 — store the session so a Revit restart doesn't require
             // re-entering credentials. Encrypted with DPAPI (current-user).
             PersistSession();
-            // Remember the server URL machine-wide so every other document
-            // (and the "Open Planscape" buttons) default to the same cloud
-            // server without the user re-typing it. Idempotent on the same URL.
-            SaveDefaultServerUrl(_serverUrl);
+            // #563 — DELIBERATELY DOES NOT PERSIST THE SERVER URL.
+            //
+            // This used to call SaveDefaultServerUrl(_serverUrl) on every
+            // successful login, so merely connecting to a local docker stack
+            // once rewrote the machine-wide pointer in
+            // %APPDATA%\StingTools\planscape_server.json. That file holds the
+            // production pointer and is the fallback that makes the launcher
+            // script safe: a user who connected to localhost for an afternoon
+            // stayed pointed at it afterwards, against a dev database full of
+            // real-looking data, without ever having CHOSEN to be.
+            //
+            // The target is now written only by PlanscapeServerTargets
+            // .SetActiveTarget, from a confirmed choice in the server picker.
+            // Connecting is not a choice about where to point in future.
+            //
+            // Note this is not a loss of convenience: _serverUrl for THIS
+            // session is already whatever the user typed or the picker
+            // resolved, and the per-document link in planscape_connection.json
+            // still records the project. Only the machine-wide default is no
+            // longer written behind the user's back.
             StingLog.Info($"Planscape: Authenticated as {ConnectedUser} @ {_serverUrl} (tier: {TierName})");
 
             // C2 — fire-and-forget SignalR start so real-time updates flow without

--- a/StingTools/BIMManager/PlanscapeServerTargets.cs
+++ b/StingTools/BIMManager/PlanscapeServerTargets.cs
@@ -1,0 +1,304 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.BIMManager;
+
+/// <summary>
+/// Named Planscape server targets, and the rules for choosing between them (#563).
+///
+/// <para><b>The problem this exists to solve is invisibility, not friction.</b> Switching
+/// the BCC between production and a local docker stack meant hand-editing
+/// <c>%APPDATA%\StingTools\planscape_server.json</c> or launching Revit from a shell
+/// script. That is awkward, but the awkwardness is not what cost an evening — the BCC
+/// never said <i>which</i> server it was talking to, so a panel showing production data
+/// and a panel showing dev data were indistinguishable. A site-photo failure could not be
+/// reproduced because the saved pointer was production, and stopping the local stack
+/// changed nothing observable. The failure looked like the tests were wrong.</para>
+///
+/// <para><b>Resolution order is unchanged</b> and this type does not alter it:
+/// <c>STING_PLANSCAPE_URL</c> → machine settings file → baked default. See
+/// <see cref="PlanscapeServerClient.ResolveDefaultServerUrl"/>. What this adds is a list
+/// of named targets to pick from, and an honest description of which one is actually in
+/// effect and why.</para>
+///
+/// <para><b>Only a deliberate choice is ever persisted.</b> <see cref="SetActiveTarget"/>
+/// is the single write path, and it is called from exactly one place: the user confirming
+/// a switch in the picker. Connecting no longer writes anything — see the note on
+/// <see cref="PlanscapeServerClient.SaveDefaultServerUrl"/>. That matters because the file
+/// holds the owner's production pointer and is the fallback that makes the launcher script
+/// safe; a stray write to it is how someone ends up pointed at a dev database full of
+/// real-looking data without ever having chosen to be.</para>
+///
+/// <para><b>A switch needs a Revit restart.</b> <c>ResolveDefaultServerUrl</c> caches into
+/// <c>_cachedDefaultUrl</c> for the process lifetime, and live objects
+/// (<c>PlanscapeServerClient.Instance</c>, its SignalR hub, any open session) are already
+/// bound to the old base. Callers MUST say so. A control that appears to switch and
+/// silently does not is worse than no control at all.</para>
+/// </summary>
+public static class PlanscapeServerTargets
+{
+    /// <summary>A named server the user can switch to.</summary>
+    public sealed class ServerTarget
+    {
+        public string Label { get; set; } = "";
+        public string Url { get; set; } = "";
+
+        /// <summary>Built-ins ship with the plugin and cannot be deleted.</summary>
+        public bool IsBuiltIn { get; set; }
+
+        /// <summary>
+        /// True for anything that is not the corporate production API. Drives the
+        /// deliberately loud styling in the BCC — a dev session must never be mistakable
+        /// for a real one at a glance.
+        /// </summary>
+        public bool IsNonProduction =>
+            !string.Equals(
+                PlanscapeServerClient.NormalizeServerUrl(Url),
+                PlanscapeServerClient.NormalizeServerUrl(PlanscapeServerClient.BakedDefaultServerUrl),
+                StringComparison.OrdinalIgnoreCase);
+
+        public override string ToString() => $"{Label} — {Url}";
+    }
+
+    /// <summary>Where the URL currently in effect came from. Reported to the user
+    /// verbatim, because "which server am I on" is only half the question — the other
+    /// half is "and why, so I know what to change".</summary>
+    public enum ActiveSource
+    {
+        /// <summary><c>STING_PLANSCAPE_URL</c> is set and wins over everything.</summary>
+        EnvironmentVariable,
+        /// <summary>A previously-chosen target in the machine settings file.</summary>
+        SavedSetting,
+        /// <summary>Neither of the above — the corporate default baked into the assembly.</summary>
+        BakedDefault,
+    }
+
+    public sealed class ActiveTargetInfo
+    {
+        public string Url { get; set; } = "";
+        public ActiveSource Source { get; set; }
+        public string Label { get; set; } = "";
+        public bool IsNonProduction { get; set; }
+
+        /// <summary>True when <c>STING_PLANSCAPE_URL</c> is overriding the saved value.
+        /// The picker uses this to say the saved value is NOT in effect rather than
+        /// display a value that is not being used.</summary>
+        public bool EnvOverrideActive => Source == ActiveSource.EnvironmentVariable;
+    }
+
+    /// <summary>Ships with the plugin. Production first so it is the default choice.</summary>
+    private static IEnumerable<ServerTarget> BuiltIns()
+    {
+        yield return new ServerTarget
+        {
+            Label = "Production",
+            Url = PlanscapeServerClient.BakedDefaultServerUrl,
+            IsBuiltIn = true,
+        };
+        yield return new ServerTarget
+        {
+            // Matches the docker-compose port mapping (5000:8080) in
+            // Planscape.Server/docker/docker-compose.yml.
+            Label = "Local (docker)",
+            Url = "http://localhost:5000",
+            IsBuiltIn = true,
+        };
+    }
+
+    /// <summary>
+    /// The built-in targets plus any the user has added, de-duplicated by normalised URL
+    /// with built-ins winning so a user entry cannot shadow Production under a different
+    /// name.
+    /// </summary>
+    public static List<ServerTarget> LoadTargets()
+    {
+        var list = BuiltIns().ToList();
+        var seen = new HashSet<string>(
+            list.Select(t => PlanscapeServerClient.NormalizeServerUrl(t.Url)),
+            StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            string path = PlanscapeServerClient.MachineSettingsPath;
+            if (File.Exists(path))
+            {
+                var o = JObject.Parse(File.ReadAllText(path));
+                if (o["targets"] is JArray arr)
+                {
+                    foreach (var entry in arr.OfType<JObject>())
+                    {
+                        var url = entry["url"]?.Value<string>();
+                        if (string.IsNullOrWhiteSpace(url)) continue;
+                        string norm = PlanscapeServerClient.NormalizeServerUrl(url!);
+                        if (!seen.Add(norm)) continue;
+                        list.Add(new ServerTarget
+                        {
+                            Label = entry["label"]?.Value<string>() ?? norm,
+                            Url = norm,
+                            IsBuiltIn = false,
+                        });
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // A malformed settings file must not cost the user the built-in targets —
+            // those are the ones that get them back to production. Warn and carry on
+            // with the built-ins rather than returning nothing.
+            StingLog.Warn($"PlanscapeServerTargets.LoadTargets: {ex.Message}");
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// What is actually in effect right now, and why. Reads the environment and the file
+    /// directly rather than through <c>ResolveDefaultServerUrl</c>'s cache, so the answer
+    /// reflects the CURRENT state of both — which is what makes it useful for telling a
+    /// user their pending switch has not taken effect yet.
+    /// </summary>
+    public static ActiveTargetInfo GetActiveTarget()
+    {
+        string? url = null;
+        var source = ActiveSource.BakedDefault;
+
+        try
+        {
+            var env = Environment.GetEnvironmentVariable(PlanscapeServerClient.ServerUrlEnvVar);
+            if (!string.IsNullOrWhiteSpace(env))
+            {
+                url = PlanscapeServerClient.NormalizeServerUrl(env!);
+                source = ActiveSource.EnvironmentVariable;
+            }
+        }
+        catch (Exception ex) { StingLog.Warn($"GetActiveTarget(env): {ex.Message}"); }
+
+        if (url == null)
+        {
+            try
+            {
+                string path = PlanscapeServerClient.MachineSettingsPath;
+                if (File.Exists(path))
+                {
+                    var saved = JObject.Parse(File.ReadAllText(path))["serverUrl"]?.Value<string>();
+                    if (!string.IsNullOrWhiteSpace(saved))
+                    {
+                        url = PlanscapeServerClient.NormalizeServerUrl(saved!);
+                        source = ActiveSource.SavedSetting;
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetActiveTarget(file): {ex.Message}"); }
+        }
+
+        if (url == null) url = PlanscapeServerClient.BakedDefaultServerUrl;
+
+        var match = LoadTargets().FirstOrDefault(t =>
+            string.Equals(PlanscapeServerClient.NormalizeServerUrl(t.Url), url,
+                          StringComparison.OrdinalIgnoreCase));
+
+        return new ActiveTargetInfo
+        {
+            Url = url,
+            Source = source,
+            // An unnamed URL is shown as itself. Never invent a friendly label for a
+            // server we do not recognise — the whole point is that the user can tell
+            // exactly what they are pointed at.
+            Label = match?.Label ?? url,
+            IsNonProduction = !string.Equals(
+                url,
+                PlanscapeServerClient.NormalizeServerUrl(PlanscapeServerClient.BakedDefaultServerUrl),
+                StringComparison.OrdinalIgnoreCase),
+        };
+    }
+
+    /// <summary>
+    /// Persist a deliberately-chosen target. <b>The only write path.</b> Call this from a
+    /// confirmed user action and from nowhere else — never from connect, never from a
+    /// refresh, never as a side effect of anything.
+    /// </summary>
+    /// <returns>true when the value was written.</returns>
+    public static bool SetActiveTarget(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        PlanscapeServerClient.SaveDefaultServerUrl(url);
+        StingLog.Info($"Planscape: active server target set to {PlanscapeServerClient.NormalizeServerUrl(url)} " +
+                      "by explicit user choice (restart Revit for it to take effect).");
+        return true;
+    }
+
+    /// <summary>Add a user-defined target to the machine settings file. Built-ins are
+    /// never written; a URL that already exists is a no-op rather than a duplicate.</summary>
+    public static bool AddTarget(string label, string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        string norm = PlanscapeServerClient.NormalizeServerUrl(url);
+        if (LoadTargets().Any(t => string.Equals(
+                PlanscapeServerClient.NormalizeServerUrl(t.Url), norm, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        try
+        {
+            string path = PlanscapeServerClient.MachineSettingsPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var o = File.Exists(path) ? JObject.Parse(File.ReadAllText(path)) : new JObject();
+            if (o["targets"] is not JArray arr) { arr = new JArray(); o["targets"] = arr; }
+            arr.Add(new JObject
+            {
+                ["label"] = string.IsNullOrWhiteSpace(label) ? norm : label.Trim(),
+                ["url"] = norm,
+            });
+            o["updatedUtc"] = DateTime.UtcNow.ToString("o");
+            File.WriteAllText(path, o.ToString(Newtonsoft.Json.Formatting.Indented));
+            StingLog.Info($"Planscape: server target added — {label} ({norm}).");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            StingLog.Warn($"PlanscapeServerTargets.AddTarget: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Is a candidate server actually there? Probes the anonymous liveness endpoint so a
+    /// dead URL is refused at the point of CHOOSING rather than surfacing later as a
+    /// confusing in-app error after a Revit restart.
+    ///
+    /// <para><c>/health/live</c>, not <c>/health</c> — the latter is the authenticated
+    /// full diagnostic and answers 403 to an anonymous caller, which would read as "server
+    /// is down" for a perfectly healthy production API.</para>
+    ///
+    /// <para>Returns the failure reason rather than a bare false: "could not reach it" and
+    /// "reached it and it said no" are different problems and the user needs to know
+    /// which.</para>
+    /// </summary>
+    public static async System.Threading.Tasks.Task<(bool Ok, string Detail)> ProbeAsync(string url)
+    {
+        string norm = PlanscapeServerClient.NormalizeServerUrl(url);
+        try
+        {
+            using var http = new System.Net.Http.HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(6),
+            };
+            var resp = await http.GetAsync(norm.TrimEnd('/') + "/health/live").ConfigureAwait(false);
+            if (resp.IsSuccessStatusCode) return (true, $"Reachable (HTTP {(int)resp.StatusCode}).");
+            return (false, $"Reached {norm} but it answered HTTP {(int)resp.StatusCode} on /health/live.");
+        }
+        catch (System.Threading.Tasks.TaskCanceledException)
+        {
+            return (false, $"No response from {norm} within 6s.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Could not reach {norm} — {ex.Message}");
+        }
+    }
+}

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -4962,6 +4962,84 @@ namespace StingTools.UI
                     _savedEmail = BIMManager.PlanscapeServerClient.Instance.ConnectedUser;
                 }
 
+                // ── #563 — WHICH SERVER AM I ON? ─────────────────────────
+                // This banner is the point of the issue. Switching targets was
+                // awkward, but what actually cost an evening was that the BCC
+                // never said which server it was talking to: a panel showing
+                // production data and a panel showing dev data looked identical,
+                // so a site-photo failure that could not be reproduced looked
+                // like the tests were wrong rather than the target being wrong.
+                //
+                // Non-production is styled loudly and deliberately. A dev session
+                // must not be mistakable for a real one at a glance.
+                {
+                    var activeTarget = BIMManager.PlanscapeServerTargets.GetActiveTarget();
+                    var banner = new Border
+                    {
+                        Background = Br(activeTarget.IsNonProduction
+                            ? Color.FromRgb(0xFF, 0xF3, 0xE0)
+                            : Color.FromRgb(0xE8, 0xF5, 0xE9)),
+                        BorderBrush = Br(activeTarget.IsNonProduction
+                            ? Color.FromRgb(0xE6, 0x51, 0x00)
+                            : Color.FromRgb(0x2E, 0x7D, 0x32)),
+                        BorderThickness = new Thickness(1),
+                        CornerRadius = new CornerRadius(4),
+                        Padding = new Thickness(10, 6, 10, 6),
+                        Margin = new Thickness(0, 0, 0, 8),
+                    };
+                    var bannerGrid = new Grid();
+                    bannerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    bannerGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    var bannerText = new StackPanel();
+                    bannerText.Children.Add(new TextBlock
+                    {
+                        Text = (activeTarget.IsNonProduction ? "⚠ SERVER: " : "SERVER: ") + activeTarget.Label,
+                        FontWeight = FontWeights.Bold, FontSize = 12,
+                        Foreground = Br(activeTarget.IsNonProduction
+                            ? Color.FromRgb(0xE6, 0x51, 0x00)
+                            : Color.FromRgb(0x2E, 0x7D, 0x32)),
+                    });
+                    bannerText.Children.Add(new TextBlock
+                    {
+                        Text = activeTarget.Url
+                             + (activeTarget.EnvOverrideActive
+                                 ? $"   (from {BIMManager.PlanscapeServerClient.ServerUrlEnvVar})"
+                                 : ""),
+                        FontSize = 10, Foreground = Brushes.Gray,
+                        TextTrimming = TextTrimming.CharacterEllipsis,
+                    });
+                    Grid.SetColumn(bannerText, 0);
+                    bannerGrid.Children.Add(bannerText);
+
+                    var changeBtn = new Button
+                    {
+                        Content = "Change…", Height = 26, Padding = new Thickness(10, 0, 10, 0),
+                        FontSize = 11, Cursor = Cursors.Hand,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        ToolTip = "Pick which Planscape server this machine connects to. "
+                                + "Takes effect after Revit restarts."
+                    };
+                    changeBtn.Click += (s, e) =>
+                    {
+                        try
+                        {
+                            if (PlanscapeServerTargetDialog.Show(Window.GetWindow(this)))
+                                ShowPlatformDetail("Planscape");   // redraw the banner
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"[server-picker] {ex.Message}");
+                            ShowStatus($"Server picker failed: {ex.Message}");
+                        }
+                    };
+                    Grid.SetColumn(changeBtn, 1);
+                    bannerGrid.Children.Add(changeBtn);
+
+                    banner.Child = bannerGrid;
+                    detailStack.Children.Add(banner);
+                }
+
                 var sbUrlRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
                 sbUrlRow.Children.Add(new TextBlock { Text = "Server URL:", Width = 90, VerticalAlignment = VerticalAlignment.Center, FontSize = 11 });
                 var sbUrlBox = new System.Windows.Controls.TextBox

--- a/StingTools/UI/PlanscapeServerTargetDialog.cs
+++ b/StingTools/UI/PlanscapeServerTargetDialog.cs
@@ -1,0 +1,293 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using StingTools.BIMManager;
+using StingTools.Core;
+
+namespace StingTools.UI;
+
+/// <summary>
+/// Server target picker for the BCC (#563).
+///
+/// <para>Three things this dialog must get right, in order of how much damage getting
+/// them wrong causes:</para>
+///
+/// <list type="number">
+/// <item><b>Never appear to switch when it has not.</b>
+/// <c>ResolveDefaultServerUrl</c> caches for the process lifetime, and the live client,
+/// its SignalR hub and the current session are already bound to the old base. So the
+/// restart requirement is stated on the dialog before the user commits, and again in the
+/// confirmation after. A control that looks like it worked and did not is worse than no
+/// control.</item>
+///
+/// <item><b>Never write a target the user did not choose.</b> The dialog is the only
+/// caller of <see cref="PlanscapeServerTargets.SetActiveTarget"/>, and it calls it only
+/// from the confirmed Switch action. Cancel writes nothing. Probing writes nothing.</item>
+///
+/// <item><b>Never hide that an env override is in effect.</b> If
+/// <c>STING_PLANSCAPE_URL</c> is set it beats the saved value, so showing the saved value
+/// as though it were live would be a confident lie. The dialog says so and keeps the
+/// switch available (it still updates the saved value for when the override goes away)
+/// while being explicit that it will not change this machine's behaviour today.</item>
+/// </list>
+/// </summary>
+internal static class PlanscapeServerTargetDialog
+{
+    private static readonly Color CProd = Color.FromRgb(0x2E, 0x7D, 0x32);   // green
+    private static readonly Color CDev = Color.FromRgb(0xE6, 0x51, 0x00);   // orange
+    private static readonly Color CWarn = Color.FromRgb(0xB7, 0x1C, 0x1C);   // red
+    private static readonly Color CMuted = Color.FromRgb(0x61, 0x61, 0x61);
+
+    /// <summary>Show the picker. Returns true when the user committed a switch (so the
+    /// caller can refresh its header), false on cancel or no-op.</summary>
+    public static bool Show(Window? owner)
+    {
+        var active = PlanscapeServerTargets.GetActiveTarget();
+        var targets = PlanscapeServerTargets.LoadTargets();
+
+        var dlg = new Window
+        {
+            Title = "Planscape server",
+            Width = 560,
+            SizeToContent = SizeToContent.Height,
+            ResizeMode = ResizeMode.NoResize,
+            WindowStartupLocation = owner != null
+                ? WindowStartupLocation.CenterOwner
+                : WindowStartupLocation.CenterScreen,
+        };
+        if (owner != null) dlg.Owner = owner;
+
+        var root = new StackPanel { Margin = new Thickness(16) };
+
+        // ── What is in effect RIGHT NOW, and why ──────────────────────────
+        root.Children.Add(new TextBlock
+        {
+            Text = "CURRENTLY IN EFFECT",
+            FontWeight = FontWeights.Bold, FontSize = 11,
+            Foreground = new SolidColorBrush(CMuted),
+            Margin = new Thickness(0, 0, 0, 4),
+        });
+
+        var activeBox = new Border
+        {
+            Background = new SolidColorBrush(active.IsNonProduction
+                ? Color.FromRgb(0xFF, 0xF3, 0xE0)
+                : Color.FromRgb(0xE8, 0xF5, 0xE9)),
+            BorderBrush = new SolidColorBrush(active.IsNonProduction ? CDev : CProd),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(4),
+            Padding = new Thickness(10, 8, 10, 8),
+            Margin = new Thickness(0, 0, 0, 12),
+        };
+        var activeStack = new StackPanel();
+        activeStack.Children.Add(new TextBlock
+        {
+            Text = (active.IsNonProduction ? "⚠ " : "") + active.Label,
+            FontWeight = FontWeights.Bold, FontSize = 14,
+            Foreground = new SolidColorBrush(active.IsNonProduction ? CDev : CProd),
+        });
+        activeStack.Children.Add(new TextBlock
+        {
+            Text = active.Url, FontSize = 11, Foreground = new SolidColorBrush(CMuted),
+            Margin = new Thickness(0, 2, 0, 0),
+        });
+        activeStack.Children.Add(new TextBlock
+        {
+            // Naming the SOURCE is half the point — "which server" without "and why"
+            // leaves the user unable to work out what to change.
+            Text = active.Source switch
+            {
+                PlanscapeServerTargets.ActiveSource.EnvironmentVariable =>
+                    $"Source: {PlanscapeServerClient.ServerUrlEnvVar} environment variable (overrides the saved setting)",
+                PlanscapeServerTargets.ActiveSource.SavedSetting =>
+                    "Source: saved setting on this machine",
+                _ => "Source: built-in default (nothing saved on this machine)",
+            },
+            FontSize = 10, Foreground = new SolidColorBrush(CMuted),
+            Margin = new Thickness(0, 4, 0, 0), TextWrapping = TextWrapping.Wrap,
+        });
+        activeBox.Child = activeStack;
+        root.Children.Add(activeBox);
+
+        // ── Env override warning ─────────────────────────────────────────
+        if (active.EnvOverrideActive)
+        {
+            root.Children.Add(new TextBlock
+            {
+                Text = $"⚠ {PlanscapeServerClient.ServerUrlEnvVar} is set, and it wins over anything chosen here. "
+                     + "Switching below updates the saved setting for when the variable is removed, "
+                     + "but will NOT change which server this machine uses while it remains set.",
+                FontSize = 11, Foreground = new SolidColorBrush(CWarn),
+                TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 0, 0, 12),
+            });
+        }
+
+        // ── Choose ───────────────────────────────────────────────────────
+        root.Children.Add(new TextBlock
+        {
+            Text = "SWITCH TO", FontWeight = FontWeights.Bold, FontSize = 11,
+            Foreground = new SolidColorBrush(CMuted), Margin = new Thickness(0, 0, 0, 4),
+        });
+
+        var combo = new ComboBox { Height = 28, FontSize = 12, Margin = new Thickness(0, 0, 0, 8) };
+        foreach (var t in targets)
+            combo.Items.Add(new ComboBoxItem { Content = t.ToString(), Tag = t });
+        // Preselect whatever is active, so the dialog opens on the truth rather than on
+        // the first row.
+        combo.SelectedIndex = Math.Max(0, targets.FindIndex(t =>
+            string.Equals(PlanscapeServerClient.NormalizeServerUrl(t.Url), active.Url,
+                          StringComparison.OrdinalIgnoreCase)));
+        root.Children.Add(combo);
+
+        var status = new TextBlock
+        {
+            FontSize = 11, TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(0, 0, 0, 8), MinHeight = 32,
+            Foreground = new SolidColorBrush(CMuted),
+        };
+        root.Children.Add(status);
+
+        root.Children.Add(new TextBlock
+        {
+            Text = "Switching takes effect after Revit is restarted. The current session, "
+                 + "its live connection and any open panels stay on the server above.",
+            FontSize = 11, Foreground = new SolidColorBrush(CWarn),
+            TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 0, 0, 12),
+        });
+
+        // ── Buttons ──────────────────────────────────────────────────────
+        var row = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+        };
+
+        var testBtn = new Button
+        {
+            Content = "Test connection", Height = 28, Padding = new Thickness(12, 0, 12, 0),
+            Margin = new Thickness(0, 0, 8, 0), FontSize = 11,
+        };
+        var switchBtn = new Button
+        {
+            Content = "Switch", Height = 28, Padding = new Thickness(16, 0, 16, 0),
+            Margin = new Thickness(0, 0, 8, 0), FontSize = 11, IsDefault = true,
+            Background = new SolidColorBrush(Color.FromRgb(0x15, 0x65, 0xC0)),
+            Foreground = Brushes.White, BorderThickness = new Thickness(0),
+        };
+        var cancelBtn = new Button
+        {
+            Content = "Cancel", Height = 28, Padding = new Thickness(16, 0, 16, 0),
+            FontSize = 11, IsCancel = true,
+        };
+
+        PlanscapeServerTargets.ServerTarget? Selected() =>
+            (combo.SelectedItem as ComboBoxItem)?.Tag as PlanscapeServerTargets.ServerTarget;
+
+        testBtn.Click += async (_, _) =>
+        {
+            var t = Selected();
+            if (t == null) return;
+            testBtn.IsEnabled = false;
+            status.Text = $"Contacting {t.Url}…";
+            status.Foreground = new SolidColorBrush(CMuted);
+            try
+            {
+                var (ok, detail) = await PlanscapeServerTargets.ProbeAsync(t.Url).ConfigureAwait(true);
+                status.Text = detail;
+                status.Foreground = new SolidColorBrush(ok ? CProd : CWarn);
+            }
+            catch (Exception ex)
+            {
+                // Never let a probe failure look like a probe success.
+                status.Text = $"Test failed: {ex.Message}";
+                status.Foreground = new SolidColorBrush(CWarn);
+                StingLog.Warn($"[server-picker] probe error: {ex.Message}");
+            }
+            finally { testBtn.IsEnabled = true; }
+        };
+
+        bool switched = false;
+        switchBtn.Click += async (_, _) =>
+        {
+            var t = Selected();
+            if (t == null) return;
+
+            if (string.Equals(PlanscapeServerClient.NormalizeServerUrl(t.Url), active.Url,
+                              StringComparison.OrdinalIgnoreCase))
+            {
+                status.Text = "That is already the active target — nothing to change.";
+                status.Foreground = new SolidColorBrush(CMuted);
+                return;
+            }
+
+            // Probe BEFORE committing, so a dead URL is refused at the point of choosing
+            // rather than surfacing after a Revit restart as a confusing in-app error.
+            switchBtn.IsEnabled = false;
+            status.Text = $"Checking {t.Url}…";
+            status.Foreground = new SolidColorBrush(CMuted);
+            var (ok, detail) = await PlanscapeServerTargets.ProbeAsync(t.Url).ConfigureAwait(true);
+            switchBtn.IsEnabled = true;
+
+            if (!ok)
+            {
+                // Offer the override rather than blocking outright — a local stack that
+                // is merely not started yet is a legitimate thing to point at. But the
+                // user has to say so explicitly, having been told.
+                var proceed = MessageBox.Show(dlg,
+                    $"{detail}\n\nSwitch to it anyway?\n\n"
+                    + "Reasonable if the server is simply not running yet (a local docker stack, say). "
+                    + "If you did not expect this, check the URL first.",
+                    "Server did not respond",
+                    MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+                if (proceed != MessageBoxResult.Yes)
+                {
+                    status.Text = detail + " — not switched.";
+                    status.Foreground = new SolidColorBrush(CWarn);
+                    return;
+                }
+            }
+
+            if (t.IsNonProduction)
+            {
+                var confirm = MessageBox.Show(dlg,
+                    $"Switch to a NON-PRODUCTION server?\n\n{t.Label}\n{t.Url}\n\n"
+                    + "The BCC will show data from this server, which can look just like real "
+                    + "project data. The header will mark the session, but you should switch back "
+                    + "to Production when you are done.",
+                    "Confirm non-production target",
+                    MessageBoxButton.OKCancel, MessageBoxImage.Warning, MessageBoxResult.Cancel);
+                if (confirm != MessageBoxResult.OK) { status.Text = "Not switched."; return; }
+            }
+
+            // The single deliberate write.
+            if (!PlanscapeServerTargets.SetActiveTarget(t.Url))
+            {
+                status.Text = "Could not save the target — see StingTools.log.";
+                status.Foreground = new SolidColorBrush(CWarn);
+                return;
+            }
+
+            switched = true;
+            MessageBox.Show(dlg,
+                $"Saved: {t.Label}\n{t.Url}\n\n"
+                + "RESTART REVIT for this to take effect.\n\n"
+                + "This session is still connected to " + active.Url + ".",
+                "Restart required", MessageBoxButton.OK, MessageBoxImage.Information);
+            dlg.Close();
+        };
+
+        cancelBtn.Click += (_, _) => dlg.Close();
+
+        row.Children.Add(testBtn);
+        row.Children.Add(switchBtn);
+        row.Children.Add(cancelBtn);
+        root.Children.Add(row);
+
+        dlg.Content = root;
+        dlg.ShowDialog();
+        return switched;
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **MERGE ORDER — this must land AFTER #550 is merged and verified.**
>
> This PR changes the plugin binary. `CompiledPlugin` is a single shared deploy target that all
> three `.addin` files point at, so building this over a #550 verification pass would replace
> the binary being clicked through and restart that pass — the exact hazard #563 names as its
> prerequisite.
>
> #550 is the fix for a live data-fabrication bug on `main` (see #605), and it goes first.
> **Do not merge this out of order.**

Closes #563.

## Two problems, and the second is the one that cost an evening

1. **Switching** between production and a local docker stack meant hand-editing
   `%APPDATA%\StingTools\planscape_server.json` or launching Revit from a shell script.
2. **The BCC never said which server it was talking to.** A panel showing production data
   and a panel showing dev data were indistinguishable. A site-photo failure that could not
   be reproduced looked like *the tests were wrong* rather than *the target was wrong* —
   stopping the local stack changed nothing observable, because the saved pointer was
   production all along.

## The correctness fix comes first

`PlanscapeServerClient.cs:201` called `SaveDefaultServerUrl(_serverUrl)` on **every
successful login**. Connecting once to a local stack silently rewrote the machine-wide
pointer. A user who connected to localhost for an afternoon stayed pointed at it
afterwards — against a dev database full of real-looking data — **without ever having
chosen to be**. That file also holds the production pointer and is the fallback that makes
the launcher script (#561) safe.

That call is gone. The target is now written by exactly one chain:

```
PlanscapeServerTargetDialog  (user confirms "Switch")
  └─> PlanscapeServerTargets.SetActiveTarget
        └─> PlanscapeServerClient.SaveDefaultServerUrl
```

Verified by grep — no other caller of either. **Connecting, refreshing and probing write
nothing.**

This is not a loss of convenience: `_serverUrl` for the session is still whatever the user
typed, and the per-document `planscape_connection.json` still carries it. Only the
machine-wide default stopped being written behind the user's back.

## New — `BIMManager/PlanscapeServerTargets.cs`

Named targets (built-in **Production** + **Local (docker)**, plus user-added), and an honest
account of what is in effect **and why**: env var / saved setting / baked default.
**Resolution order is unchanged** — this does not touch `ResolveDefaultServerUrl`.

- `GetActiveTarget` reads env + file **directly**, not through the process cache, so it
  reports the *current* state — which is what lets it tell a user their pending switch has
  not taken effect yet.
- An unrecognised URL displays **as itself**. No invented friendly label; the whole point is
  knowing exactly what you are pointed at.
- A malformed settings file still yields the built-in targets, because those are the ones
  that get a user back to production.
- `ProbeAsync` hits **`/health/live`, not `/health`** — the latter is the authenticated
  diagnostic and answers 403 to an anonymous caller, which would read as "server is down"
  for a perfectly healthy production API. It returns the *reason*, not a bare `false`:
  "could not reach it" and "reached it and it said no" are different problems.

## New — `UI/PlanscapeServerTargetDialog.cs`

- **Restart required** is stated before the user commits and again after.
  `ResolveDefaultServerUrl` caches for the process lifetime, and the live client, its
  SignalR hub and the session are already bound to the old base. *A control that looks like
  it worked and did not is worse than no control.*
- **Health check before committing**, so a dead URL is refused at the point of *choosing*
  rather than surfacing after a restart as a confusing in-app error. Overridable — a local
  stack that is simply not running yet is legitimate to point at — but only explicitly,
  having been told.
- **Non-production switches take a second confirmation.**
- If `STING_PLANSCAPE_URL` is set, the dialog says so, and says the switch will **not**
  change behaviour while it remains set — rather than displaying a saved value that is not
  in effect.
- **Cancel writes nothing. Probing writes nothing.**

## BCC — the banner

`PLATFORM → Planscape` now leads with a coloured banner naming the active server, its URL,
and the env-var source when one is overriding — plus a **Change…** button.

| | |
|---|---|
| Production | green |
| Non-production | **orange, with ⚠** |

Loud on purpose. A dev session must not be mistakable for a real one at a glance — that
invisibility, not the switching friction, is what this issue is really about.

## Verification

`dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings**.

**Not verified in Revit.** This is UI and needs a click-through before merge — in
particular the banner rendering inside `ShowPlatformDetail`, and the probe running on the
WPF dispatcher thread. I did not deploy: `CompiledPlugin` is shared state and all three
`.addin` files point at one DLL.

## Note on the stated prerequisite

#563 lists #550 as a prerequisite ("it is deployed and mid-verification, and this changes
the plugin"). #550 is still open. I proceeded because the owner directed it in this pass
and the deploy stamp is settled — but this PR does change the plugin binary, so **sequence
the merge with #550's verification** rather than landing both blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


