### PR TITLE
fix(billing): meter seats on authoring capability, not on ISO 19650 role

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -460,7 +460,7 @@ public class AuthController : ControllerBase
             Plan          = BillingPlan.Trial,
             Currency      = currency,
             BillingCycle  = BillingCycle.Monthly,
-            MaxUsers      = planLimits.MaxAuthors + planLimits.MaxCoordinators,
+            MaxUsers      = planLimits.TotalSeats,
             MaxProjects   = planLimits.MaxProjects,
             MimEnabled    = false,
             TrialExpiresAt = DateTime.UtcNow.AddDays(30)
@@ -1095,7 +1095,7 @@ public class AuthController : ControllerBase
                     Plan           = BillingPlan.Trial,
                     Currency       = "USD",
                     BillingCycle   = BillingCycle.Monthly,
-                    MaxUsers       = limits.MaxAuthors + limits.MaxCoordinators,
+                    MaxUsers       = limits.TotalSeats,
                     MaxProjects    = limits.MaxProjects,
                     MimEnabled     = false,
                     TrialExpiresAt = DateTime.UtcNow.AddDays(365)

--- a/Planscape.Server/src/Planscape.API/Controllers/OnboardingController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/OnboardingController.cs
@@ -89,7 +89,12 @@ public class OnboardingController : ControllerBase
         foreach (var m in req.Members)
         {
             // Quota check per member — fail mid-list cleanly with a 402.
-            var role = string.Equals(m.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Coordinator";
+            // Two options = the two seat axes: can-author, or read-only. See the
+            // note in TenantAdminController.Invite — Coordinator is an authoring
+            // role, so the old Author-vs-Coordinator pair gated on one axis and
+            // consumed a seat on the other. API-visible: a member sent with
+            // role = "Coordinator" is now created read-only.
+            var role = string.Equals(m.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Viewer";
             var q = await _quota.CheckCanAddUserAsync(role, ct);
             if (!q.Allowed) return StatusCode(StatusCodes.Status402PaymentRequired, new { error = "quota_exceeded", added, denied = m, quota = q });
 
@@ -102,7 +107,9 @@ public class OnboardingController : ControllerBase
                 Email = m.Email.Trim().ToLowerInvariant(),
                 DisplayName = m.DisplayName,
                 PasswordHash = "INVITED",
-                Role = role == "Author" ? UserRole.Contributor : UserRole.Coordinator,
+                // UserRole is the seat: ProjectRoles.CanAuthorInformation reads it.
+                Role = role == "Author" ? UserRole.Contributor : UserRole.Viewer,
+                // ISO code is for deliverables/reporting only, never billing.
                 Iso19650Role = role == "Author" ? "A" : "C",
                 IsActive = false,
             };

--- a/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
@@ -106,7 +106,15 @@ public class TenantAdminController : ControllerBase
     public async Task<ActionResult> Invite([FromBody] InviteUserRequest req, CancellationToken ct)
     {
         // Quota check — refuses with 402 if cap reached.
-        var role = string.Equals(req.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Coordinator";
+        // The two options are the two SEAT axes: an account that can author
+        // information, or a read-only one. It used to be Author-vs-Coordinator,
+        // which does not map onto that split at all — Coordinator is an
+        // authoring role, so a "Coordinator" invite gated on the read-only axis
+        // and then consumed an authoring seat. Gate and write now agree.
+        //
+        // API-VISIBLE: a caller passing role = "Coordinator" now gets a Viewer,
+        // not a Coordinator. Anything that is not "Author" is read-only.
+        var role = string.Equals(req.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Viewer";
         var quota = await _quota.CheckCanAddUserAsync(role, ct);
         if (!quota.Allowed)
             return StatusCode(StatusCodes.Status402PaymentRequired, new
@@ -132,7 +140,14 @@ public class TenantAdminController : ControllerBase
             // Stub password — real flow sends an invite link with a one-time
             // password-set token. For S1.7 we just plant the row.
             PasswordHash = "INVITED",
-            Role        = role == "Author" ? UserRole.Contributor : UserRole.Coordinator,
+            // UserRole is what the seat meter reads (via
+            // ProjectRoles.CanAuthorInformation), so this write IS the seat.
+            Role        = role == "Author" ? UserRole.Contributor : UserRole.Viewer,
+            // Iso19650Role stays for ISO deliverables and reporting; it is NOT a
+            // billing input. Note the codes here are weak: "A" is Appointing
+            // Party (the client), which is not what an author seat means. Left
+            // as-is deliberately — changing what this stamps is an ISO data
+            // decision, not a billing one, and is reported separately.
             Iso19650Role = role == "Author" ? "A" : "C",
             IsActive    = false, // becomes true when invitee sets a password
         };

--- a/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
@@ -47,12 +47,14 @@ public class TenantAdminController : ControllerBase
         var limits = BillingPlanLimits.For(tenant.Plan);
 
         var memberCount = await _db.ProjectMembers.CountAsync(ct);
-        var authorIds = await _db.ProjectMembers
-            .Where(m => m.ProjectRole == "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
-        var coordIds  = await _db.ProjectMembers
-            .Where(m => m.ProjectRole != "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
+
+        // Seat counts come from the quota guard rather than being recomputed
+        // here. This block used to inline its own copy of the author/coordinator
+        // split, so the number the customer was shown and the number the invite
+        // gate enforced were two independent implementations that could disagree
+        // — and did, once the guard's definition of a seat changed. One source.
+        var authorSeats = await _quota.CheckCanAddUserAsync("Author", ct);
+        var coordSeats  = await _quota.CheckCanAddUserAsync("Coordinator", ct);
         var projectCount = await _db.Projects.CountAsync(ct);
         var storageBytes = await _db.ProjectModels.AsNoTracking()
             .Where(m => m.DeletedAt == null)
@@ -81,8 +83,8 @@ public class TenantAdminController : ControllerBase
             },
             usage = new
             {
-                authors      = new { current = authorIds.Count,  max = limits.MaxAuthors },
-                coordinators = new { current = coordIds.Count,   max = limits.MaxCoordinators },
+                authors      = new { current = authorSeats.Current, max = authorSeats.Max },
+                coordinators = new { current = coordSeats.Current,  max = coordSeats.Max },
                 projects     = new { current = projectCount,     max = limits.MaxProjects },
                 storage      = new { currentMb = storageBytes / 1024 / 1024, maxMb = limits.StorageMb },
                 memberSeats  = memberCount,

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
@@ -130,6 +130,60 @@ public static class ProjectRoles
           || m.Iso19650Role == IsoProjectManager
           || m.Iso19650Role == IsoAppointingParty;
 
+    // ── Capability: AuthorInformation ───────────────────────────────────────
+    //
+    // Can this account author information, or only read it? This is the seat
+    // boundary the billing meter uses, and it lives HERE — beside CanCurate and
+    // CanApproveSitePhotos — so that billing and access are the same source.
+    // Two sources for one question is what produced the eleven dead gates #540
+    // had to repair; a seat meter that derives its own answer would be the
+    // twelfth.
+    //
+    // WHY NOT Iso19650Role
+    // --------------------
+    // It is a functional/discipline taxonomy (A/M/E/S/H/P/C/I/K/Q/F/W/L/Z), and
+    // ISO 19650 assigns information-management responsibility — not software
+    // seats. "A" is the APPOINTING PARTY, i.e. the client, not "Author" and not
+    // "Architect": keying author seats on it counted the client as the sole
+    // author and read 0 for everyone else, while "BA" (BIM Author) fell to the
+    // other axis entirely. No amount of adding codes fixes that, because the
+    // taxonomy is not answering the seat question.
+    //
+    // WHY UserRole
+    // ------------
+    // UserRole is the tenant-level authority the product already enforces with,
+    // and it is what the invite paths write. It also survives the pending
+    // ProjectRole/Iso19650Role reconciliation without turning into a billing
+    // migration, because the capability is asked here rather than re-derived at
+    // each call site.
+
+    /// <summary>
+    /// True when the account can create or change information — every role above
+    /// read-only. <see cref="UserRole.Viewer"/> is the only consuming seat.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UserRole.SecurityOfficer"/> is deliberately NOT an authoring
+    /// seat: it is a separation-of-duties role that can revoke sessions but, by
+    /// its own definition on the enum, "can't edit projects, members, or
+    /// BIM-Manager roles". Billing it as an author would charge for an audit
+    /// control.
+    /// </remarks>
+    public static bool CanAuthorInformation(UserRole role) => role switch
+    {
+        UserRole.Viewer          => false,
+        UserRole.SecurityOfficer => false,
+        _                        => true,
+    };
+
+    /// <summary>
+    /// EF-translatable form of <see cref="CanAuthorInformation(UserRole)"/> for
+    /// use inside a <c>.Where(...)</c> — a per-row method call would silently
+    /// client-evaluate the whole Users table. Keep the two in step; the tests
+    /// assert they agree for every declared <see cref="UserRole"/>.
+    /// </summary>
+    public static Expression<Func<AppUser, bool>> CanAuthorInformationPredicate =>
+        u => u.Role != UserRole.Viewer && u.Role != UserRole.SecurityOfficer;
+
     private static bool Eq(string? a, string b)
         => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
 }

--- a/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
@@ -170,17 +170,63 @@ public enum BillingCycle
 /// </summary>
 public static class BillingPlanLimits
 {
-    public record Limits(int MaxAuthors, int MaxCoordinators, int MaxProjects, long StorageMb, decimal MonthlyUsd);
+    public record Limits(int MaxAuthors, int MaxCoordinators, int MaxProjects, long StorageMb, decimal MonthlyUsd)
+    {
+        /// <summary>
+        /// Total billable headcount — the number <c>Tenant.MaxUsers</c> is
+        /// derived from at registration.
+        ///
+        /// <para>SATURATES. This must never be written as
+        /// <c>MaxAuthors + MaxCoordinators</c>: with either side at
+        /// <c>int.MaxValue</c> that sum wraps NEGATIVE in C#'s default unchecked
+        /// context, and <c>MaxUsers</c> is consumed as
+        /// <c>userCount >= tenant.MaxUsers</c> — so a negative cap denies the
+        /// tenant's very first user. Enterprise already wrapped to -2 this way;
+        /// it was latent only because registration assigns Trial.</para>
+        ///
+        /// <para>When read-only seats are unlimited this reports the PAID
+        /// headcount (<see cref="MaxAuthors"/>) rather than infinity. That is a
+        /// deliberate no-giveaway choice: <c>MaxUsers</c> is the only cap
+        /// <c>AdminController</c> and <c>ProjectMembersController</c> enforce,
+        /// and neither of them consults the quota guard, so returning infinity
+        /// here would leave both paths able to add unlimited AUTHORING accounts
+        /// with nothing counting them. The cost of this choice is that free
+        /// viewers are not yet free in practice — a Studio tenant is still
+        /// capped at 6 accounts in total. Lifting that safely means teaching
+        /// those two paths the authoring-capability check; until then, erring
+        /// toward charging correctly beats erring toward giving seats away.</para>
+        /// </summary>
+        public int TotalSeats =>
+            MaxCoordinators == int.MaxValue
+                ? MaxAuthors                                   // paid headcount; also int.MaxValue for Enterprise
+                : MaxAuthors == int.MaxValue
+                    ? int.MaxValue
+                    : MaxAuthors + MaxCoordinators;
+    }
 
+    // MaxAuthors is the AUTHORING-seat cap — accounts that can create or change
+    // information (ProjectRoles.CanAuthorInformation). It carries each plan's
+    // former TOTAL headcount (MaxAuthors + MaxCoordinators), so the paid seat
+    // count per plan is unchanged: Trial 1, PluginOnly 1, Studio 6, Practice 12,
+    // Network 20.
+    //
+    // MaxCoordinators is now the READ-ONLY cap and is unlimited — viewers are
+    // free. It was previously the only enforced axis purely by accident: the
+    // author axis counted ProjectRole == "Author", which nothing ever wrote, so
+    // it read 0 forever and MaxAuthors = 1 was never actually tested against a
+    // real count. Once seats are counted by capability, a cap of 1 would have
+    // denied every realistic roster on every plan below Enterprise (measured:
+    // Owner + Manager + 3 Contributors = 5 authoring accounts, denied 5/1 on
+    // Trial, PluginOnly, Studio, Practice and Network).
     public static Limits For(BillingPlan plan) => plan switch
     {
-        BillingPlan.Trial      => new Limits(1,  0,           1,           5_000,      0m),
-        BillingPlan.PluginOnly => new Limits(1,  0, int.MaxValue,               0,     15m),
-        BillingPlan.Studio     => new Limits(1,  5,           5,          10_000,      35m),
-        BillingPlan.Practice   => new Limits(1, 11,          10,          25_000,      55m),
-        BillingPlan.Network    => new Limits(1, 19, int.MaxValue,          50_000,      90m),
+        BillingPlan.Trial      => new Limits( 1, int.MaxValue,            1,       5_000,  0m),
+        BillingPlan.PluginOnly => new Limits( 1, int.MaxValue, int.MaxValue,           0, 15m),
+        BillingPlan.Studio     => new Limits( 6, int.MaxValue,            5,      10_000, 35m),
+        BillingPlan.Practice   => new Limits(12, int.MaxValue,           10,      25_000, 55m),
+        BillingPlan.Network    => new Limits(20, int.MaxValue, int.MaxValue,      50_000, 90m),
         BillingPlan.Enterprise => new Limits(int.MaxValue, int.MaxValue, int.MaxValue, long.MaxValue, 0m),
-        _ => new Limits(1, 5, 1, 500, 0m),
+        _                      => new Limits( 6, int.MaxValue,            1,         500,  0m),
     };
 
     /// <summary>Map a legacy LicenseTier onto the new BillingPlan for migrations.</summary>

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
@@ -110,24 +110,30 @@ public class QuotaGuardService : IQuotaGuardService
         => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted, ct);
 
     /// <summary>
-    /// Author seats are the users carrying ISO 19650 role <c>"A"</c> — which is
-    /// exactly what the invite paths persist for an Author
-    /// (<c>Iso19650Role = role == "Author" ? "A" : "C"</c> in both
-    /// TenantAdminController and OnboardingController), so the meter and the
-    /// write agree by construction.
+    /// Author seats are accounts that can author information, asked of the
+    /// shared capability layer (<see cref="ProjectRoles.CanAuthorInformation"/>)
+    /// rather than decided here. Billing and access therefore read the SAME
+    /// source and cannot drift — two sources for one question is exactly what
+    /// produced the eleven dead gates #540 repaired.
     ///
-    /// <para>Coordinators are deliberately derived as <c>total - authors</c>
-    /// rather than as <c>Iso19650Role != "A"</c>. In SQL a NULL role makes both
-    /// <c>= 'A'</c> and <c>&lt;&gt; 'A'</c> evaluate to NULL, so a legacy row
-    /// with no role would fall off BOTH axes and silently hand out a free seat.
-    /// Subtraction is total by construction.</para>
+    /// <para>This deliberately does NOT key on <c>Iso19650Role</c>. That is a
+    /// functional/discipline taxonomy and ISO 19650 assigns information-
+    /// management responsibility, not software seats. <c>"A"</c> is the
+    /// APPOINTING PARTY — the client — not "Author": keying on it counted the
+    /// client as the only author (so the axis read 0 for everyone else) while
+    /// <c>"BA"</c>, BIM Author, fell to the other axis entirely. It is the wrong
+    /// question, not a missing code.</para>
+    ///
+    /// <para>The non-authoring axis is derived as <c>total - authors</c> rather
+    /// than by a negated predicate: subtraction is total by construction, so no
+    /// row — including one carrying a role this build has never heard of — can
+    /// fall off both axes and silently hand out a free seat.</para>
     /// </summary>
     private Task<int> CountAuthorSeatsAsync(Guid tid, CancellationToken ct)
-        => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted && u.Iso19650Role == AuthorIsoRole, ct);
-
-    /// <summary>ISO 19650 "Appointing Party" — the code the invite paths write
-    /// for an author seat.</summary>
-    private const string AuthorIsoRole = "A";
+        => _db.Users
+            .Where(u => u.TenantId == tid && !u.IsDeleted)
+            .Where(ProjectRoles.CanAuthorInformationPredicate)
+            .CountAsync(ct);
 
     private static QuotaResult Result(QuotaAxis axis, int current, int max)
     {

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
@@ -73,12 +73,61 @@ public class QuotaGuardService : IQuotaGuardService
         var current = axis switch
         {
             QuotaAxis.Projects     => await _db.Projects.CountAsync(p => p.TenantId == tid, ct),
-            QuotaAxis.Authors      => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole == "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
-            QuotaAxis.Coordinators => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole != "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
+            QuotaAxis.Authors      => await CountAuthorSeatsAsync(tid, ct),
+            QuotaAxis.Coordinators => await CountUserSeatsAsync(tid, ct) - await CountAuthorSeatsAsync(tid, ct),
             _                      => 0,
         };
         return (limits, current);
     }
+
+    /// <summary>
+    /// A seat is a PERSON in the tenant, so seats are counted over
+    /// <c>AppUser</c> — the row the seat-selling operations actually create.
+    ///
+    /// This used to count <c>ProjectMembers</c>, which meant the meter read a
+    /// table the metered operations never wrote: <c>POST /api/tenant/invite</c>
+    /// and <c>POST /api/onboarding/team</c> both gate on these axes and then
+    /// create an <c>AppUser</c> and nothing else — no <c>ProjectMember</c> — so
+    /// an accepted invite could never move the number it had just been checked
+    /// against. Meanwhile the only path that does create <c>ProjectMember</c>
+    /// rows (<c>ProjectMembersController</c>) never consults this guard.
+    /// Counting people also makes the pre-existing <c>.Distinct()</c> on UserId
+    /// unnecessary rather than merely approximate — a person on four projects
+    /// was always meant to be one seat.
+    ///
+    /// <para><c>!u.IsDeleted</c> is written out EXPLICITLY and must stay that
+    /// way. <c>AppUser</c> declares <c>HasQueryFilter(u =&gt; !u.IsDeleted)</c>
+    /// in its own entity block, but <c>ApplyGlobalQueryFilters</c> runs later in
+    /// <c>OnModelCreating</c> and — because EF Core 8 allows only ONE filter per
+    /// entity, a second call silently replacing the first — overwrites it with
+    /// the tenant predicate. <c>AppUser</c> does not implement
+    /// <c>ISoftDeletable</c> either, so nothing puts the tombstone predicate
+    /// back. That is documented in PlanscapeDbContext and is deliberately out of
+    /// scope to fix here; the consequence for billing is that relying on the
+    /// global filter would charge tenants for deleted users.</para>
+    /// </summary>
+    private Task<int> CountUserSeatsAsync(Guid tid, CancellationToken ct)
+        => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted, ct);
+
+    /// <summary>
+    /// Author seats are the users carrying ISO 19650 role <c>"A"</c> — which is
+    /// exactly what the invite paths persist for an Author
+    /// (<c>Iso19650Role = role == "Author" ? "A" : "C"</c> in both
+    /// TenantAdminController and OnboardingController), so the meter and the
+    /// write agree by construction.
+    ///
+    /// <para>Coordinators are deliberately derived as <c>total - authors</c>
+    /// rather than as <c>Iso19650Role != "A"</c>. In SQL a NULL role makes both
+    /// <c>= 'A'</c> and <c>&lt;&gt; 'A'</c> evaluate to NULL, so a legacy row
+    /// with no role would fall off BOTH axes and silently hand out a free seat.
+    /// Subtraction is total by construction.</para>
+    /// </summary>
+    private Task<int> CountAuthorSeatsAsync(Guid tid, CancellationToken ct)
+        => _db.Users.CountAsync(u => u.TenantId == tid && !u.IsDeleted && u.Iso19650Role == AuthorIsoRole, ct);
+
+    /// <summary>ISO 19650 "Appointing Party" — the code the invite paths write
+    /// for an author seat.</summary>
+    private const string AuthorIsoRole = "A";
 
     private static QuotaResult Result(QuotaAxis axis, int current, int max)
     {

--- a/Planscape.Server/tests/Planscape.Tests/BillingPlanLimitsTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/BillingPlanLimitsTests.cs
@@ -1,0 +1,89 @@
+using Planscape.Core.Entities;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The plan limits, after seats were re-keyed onto authoring capability.
+///
+/// MaxAuthors is now the AUTHORING-seat cap and carries each plan's former
+/// TOTAL headcount; MaxCoordinators is the read-only cap and is unlimited.
+/// The previous MaxAuthors = 1 was never tested against a real count — the
+/// author axis counted <c>ProjectRole == "Author"</c>, which nothing writes, so
+/// it read 0 forever. Counting by capability made that cap bite immediately.
+/// </summary>
+public class BillingPlanLimitsTests
+{
+    /// <summary>Paid headcount per plan BEFORE this change
+    /// (old MaxAuthors + old MaxCoordinators).</summary>
+    public static TheoryData<BillingPlan, int> PreviousTotalSeats => new()
+    {
+        { BillingPlan.Trial,      1 },
+        { BillingPlan.PluginOnly, 1 },
+        { BillingPlan.Studio,     6 },
+        { BillingPlan.Practice,  12 },
+        { BillingPlan.Network,   20 },
+    };
+
+    [Theory]
+    [MemberData(nameof(PreviousTotalSeats))]
+    public void Paid_headcount_per_plan_is_unchanged(BillingPlan plan, int previousTotal)
+    {
+        // Price-neutrality, asserted rather than asserted-in-prose. If someone
+        // later edits MaxAuthors, this fails and forces the pricing question to
+        // be answered on purpose.
+        Assert.Equal(previousTotal, BillingPlanLimits.For(plan).MaxAuthors);
+        Assert.Equal(previousTotal, BillingPlanLimits.For(plan).TotalSeats);
+    }
+
+    [Theory]
+    [MemberData(nameof(PreviousTotalSeats))]
+    public void Read_only_seats_are_unlimited(BillingPlan plan, int _)
+        => Assert.Equal(int.MaxValue, BillingPlanLimits.For(plan).MaxCoordinators);
+
+    [Fact]
+    public void Total_seats_never_wraps_negative_for_any_plan()
+    {
+        // Tenant.MaxUsers is derived from TotalSeats and consumed as
+        // `userCount >= tenant.MaxUsers`, so a negative cap denies the tenant's
+        // FIRST user. Written as MaxAuthors + MaxCoordinators this wraps in C#'s
+        // default unchecked context the moment either side is int.MaxValue:
+        // 1 + int.MaxValue = -2147483648, and Enterprise already wrapped to -2.
+        foreach (BillingPlan plan in Enum.GetValues<BillingPlan>())
+        {
+            var total = BillingPlanLimits.For(plan).TotalSeats;
+            Assert.True(total > 0,
+                $"{plan} yields TotalSeats = {total}; a non-positive cap denies every user.");
+        }
+    }
+
+    [Fact]
+    public void Unlimited_plans_saturate_rather_than_summing()
+    {
+        Assert.Equal(int.MaxValue, BillingPlanLimits.For(BillingPlan.Enterprise).TotalSeats);
+        Assert.Equal(int.MaxValue, BillingPlanLimits.For(BillingPlan.Studio).MaxCoordinators);
+
+        // Studio: 6 authoring + unlimited viewers must report the PAID number,
+        // not int.MaxValue — the authoring cap is what is actually sold.
+        Assert.Equal(6, BillingPlanLimits.For(BillingPlan.Studio).TotalSeats);
+    }
+
+    [Fact]
+    public void A_realistic_authoring_roster_fits_every_paid_multi_seat_plan()
+    {
+        // Owner + Manager + 3 Contributors = 5 authoring accounts. This was
+        // DENIED 5/1 on every plan below Enterprise before the limits change.
+        const int realisticRoster = 5;
+
+        foreach (var plan in new[] { BillingPlan.Studio, BillingPlan.Practice, BillingPlan.Network })
+        {
+            var limits = BillingPlanLimits.For(plan);
+            Assert.True(limits.MaxAuthors >= realisticRoster,
+                $"{plan} permits only {limits.MaxAuthors} authoring seats; a {realisticRoster}-person team cannot use it.");
+        }
+
+        // Single-seat plans are single-seat BY DESIGN and are not a regression:
+        // their former total was 1. Pinned so the distinction stays deliberate.
+        Assert.Equal(1, BillingPlanLimits.For(BillingPlan.Trial).MaxAuthors);
+        Assert.Equal(1, BillingPlanLimits.For(BillingPlan.PluginOnly).MaxAuthors);
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/QuotaSeatCapabilitySplitTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/QuotaSeatCapabilitySplitTests.cs
@@ -1,0 +1,168 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The seat split, keyed on CAPABILITY rather than on a role taxonomy.
+///
+/// WHY NOT Iso19650Role (the previous attempt, corrected)
+/// ------------------------------------------------------
+/// Iso19650Role is a functional/discipline taxonomy
+/// (A/M/E/S/H/P/C/I/K/Q/F/W/L/Z) and ISO 19650 assigns information-management
+/// responsibility, not software seats. "A" is the APPOINTING PARTY — the client
+/// — not "Author" and not "Architect". Metering on it counted the client as the
+/// only author (hence Authors reading 0 for everyone else) and dropped "BA",
+/// BIM Author, onto the other axis. It is the wrong question, not a missing
+/// code.
+///
+/// Author seats now come from ProjectRoles.CanAuthorInformation, the same
+/// capability layer access control uses, so billing and access cannot drift.
+/// </summary>
+public class QuotaSeatCapabilitySplitTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    // The DbContext MUST get an ITenantContext: CurrentTenantId falls back to
+    // Guid.Empty, which matches no rows, so a fixture without one reads zero of
+    // everything and every count assertion passes trivially.
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    /// <summary>A Studio tenant (1 author seat, 5 of the other axis) with a
+    /// realistic roster: Owner, Manager, 3 Contributors, plus 2 read-only
+    /// Viewers.</summary>
+    private static (SqliteConnection conn, Guid tenantId) NewDbWithRealisticRoster()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenantId = Guid.NewGuid();
+        using (var ctx = NewContext(conn, tenantId))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "Acme",
+                Slug = $"acme-{Guid.NewGuid():N}"[..16],
+                ContactEmail = "acme@example.com",
+                Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio,
+                MaxUsers = 50,
+                MaxProjects = 50,
+            });
+
+            var roles = new[]
+            {
+                UserRole.Owner, UserRole.Manager,
+                UserRole.Contributor, UserRole.Contributor, UserRole.Contributor,
+                UserRole.Viewer, UserRole.Viewer,
+            };
+            for (var i = 0; i < roles.Length; i++)
+            {
+                ctx.Users.Add(new AppUser
+                {
+                    Id = Guid.NewGuid(), TenantId = tenantId,
+                    Email = $"zz-user{i}-{Guid.NewGuid():N}@example.com",
+                    DisplayName = $"ZZ User {i}",
+                    PasswordHash = "x",
+                    Role = roles[i],
+                    // Deliberately NOT "A" anywhere. The split must not depend on
+                    // the ISO taxonomy at all — including its absence.
+                    Iso19650Role = "M",
+                    IsActive = true,
+                });
+            }
+            ctx.SaveChanges();
+        }
+        return (conn, tenantId);
+    }
+
+    private static QuotaGuardService NewGuard(SqliteConnection conn, Guid tenantId)
+        => new(NewContext(conn, tenantId), new FixedTenant(tenantId));
+
+    [Fact]
+    public async Task Every_account_that_can_author_consumes_an_author_seat()
+    {
+        var (conn, tenantId) = NewDbWithRealisticRoster();
+        using (conn)
+        {
+            var result = await NewGuard(conn, tenantId).CheckCanAddUserAsync("Author");
+
+            // Owner + Manager + 3 Contributors. None carries Iso19650Role "A",
+            // which is the whole point: capability, not taxonomy.
+            Assert.Equal(5, result.Current);
+        }
+    }
+
+    [Fact]
+    public async Task Read_only_accounts_consume_the_non_authoring_axis()
+    {
+        var (conn, tenantId) = NewDbWithRealisticRoster();
+        using (conn)
+        {
+            var result = await NewGuard(conn, tenantId).CheckCanAddUserAsync("Coordinator");
+
+            // The two Viewers, and only them.
+            Assert.Equal(2, result.Current);
+        }
+    }
+
+    [Fact]
+    public async Task A_viewer_promoted_to_contributor_moves_between_the_axes()
+    {
+        var (conn, tenantId) = NewDbWithRealisticRoster();
+        using (conn)
+        {
+            using (var ctx = NewContext(conn, tenantId))
+            {
+                var viewer = ctx.Users.First(u => u.Role == UserRole.Viewer);
+                viewer.Role = UserRole.Contributor;
+                ctx.SaveChanges();
+            }
+
+            Assert.Equal(6, (await NewGuard(conn, tenantId).CheckCanAddUserAsync("Author")).Current);
+            Assert.Equal(1, (await NewGuard(conn, tenantId).CheckCanAddUserAsync("Coordinator")).Current);
+        }
+    }
+
+    [Fact]
+    public void The_in_memory_and_EF_capability_forms_agree_for_every_UserRole()
+    {
+        // CanAuthorInformation is evaluated in memory; CanAuthorInformationPredicate
+        // is translated into SQL. If they ever disagree, access control and the
+        // seat meter disagree — the exact drift this split exists to prevent.
+        var compiled = ProjectRoles.CanAuthorInformationPredicate.Compile();
+
+        foreach (UserRole role in Enum.GetValues<UserRole>())
+        {
+            var user = new AppUser { Role = role };
+            Assert.Equal(ProjectRoles.CanAuthorInformation(role), compiled(user));
+        }
+    }
+
+    [Fact]
+    public async Task Seats_are_counted_per_tenant()
+    {
+        var (conn, tenantId) = NewDbWithRealisticRoster();
+        using (conn)
+        {
+            // Guards against a rework that drops the TenantId predicate.
+            var other = await NewGuard(conn, Guid.NewGuid()).CheckCanAddUserAsync("Author");
+            Assert.Equal(0, other.Current);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
@@ -92,19 +92,26 @@ public class QuotaSeatMeterWiringTests : IClassFixture<PlanscapeWebApplicationFa
         => await client.DeleteAsync($"/api/tenant/users/{userId}");
 
     [Fact]
-    public async Task Inviting_a_coordinator_consumes_a_coordinator_seat()
+    public async Task Inviting_a_viewer_consumes_a_read_only_seat()
     {
         var client = await _factory.CreateAuthenticatedClientAsync(); // Owner
 
         var before = await ReadSeatsAsync(client);
-        var userId = await InviteAsync(client, "Coordinator");
+        var userId = await InviteAsync(client, "Viewer");
         try
         {
             var after = await ReadSeatsAsync(client);
 
-            // The invite succeeded, so a coordinator seat was sold. The surface
+            // The invite succeeded, so a read-only seat was sold. The surface
             // the customer is billed against has to show it.
             Assert.Equal(before.Coordinators + 1, after.Coordinators);
+
+            // ...and it must NOT also land on the authoring axis. This is the
+            // assertion that would have caught the old Author-vs-Coordinator
+            // pairing, where a "Coordinator" invite gated on the read-only axis
+            // and then wrote UserRole.Coordinator — an authoring role — so one
+            // invite moved the wrong counter.
+            Assert.Equal(before.Authors, after.Authors);
         }
         finally
         {
@@ -146,7 +153,7 @@ public class QuotaSeatMeterWiringTests : IClassFixture<PlanscapeWebApplicationFa
         var client = await _factory.CreateAuthenticatedClientAsync();
 
         var before = await ReadSeatsAsync(client);
-        var userId = await InviteAsync(client, "Coordinator");
+        var userId = await InviteAsync(client, "Viewer");
         try
         {
             var after = await ReadSeatsAsync(client);

--- a/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/QuotaSeatMeterWiringTests.cs
@@ -1,0 +1,160 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The seat meter must count the seats the product actually sells.
+///
+/// THE DEFECT THESE PIN
+/// --------------------
+/// `POST /api/tenant/invite` gates on the coordinator seat axis: it calls
+/// `IQuotaGuardService.CheckCanAddUserAsync(role)` and returns
+/// **402 quota_exceeded** when that axis is full. So the endpoint's own
+/// contract says an invite consumes a seat.
+///
+/// It then creates an `AppUser` row and nothing else — no `ProjectMember`.
+/// But every reader of the seat axes counts `ProjectMembers`:
+///
+///   QuotaGuardService.CountAsync      ProjectMembers, split on ProjectRole
+///   TenantAdminController.Dashboard   ProjectMembers, same split inlined again
+///
+/// So the endpoint gates on a number it can never move. Invite a thousand
+/// coordinators and `usage.coordinators.current` stays where it was; the 402
+/// fires on a count driven entirely by a different code path
+/// (`ProjectMembersController`), which never consults the guard at all.
+///
+/// This is upstream of the author/coordinator split being inverted. Correcting
+/// which roles land on which axis would still leave the meter reading a table
+/// that the metered operation does not write — so these tests come first.
+///
+/// EXPECTED STATE
+/// --------------
+/// RED on current main: the count does not move. They are written against the
+/// INTENDED behaviour, not the current behaviour, so they go GREEN when the
+/// meter is wired to the writes.
+///
+/// The test tenant is `BillingPlan.Enterprise` (unlimited seats), so the quota
+/// check always allows and these tests isolate the *counting*, never the gate.
+/// </summary>
+public class QuotaSeatMeterWiringTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public QuotaSeatMeterWiringTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    private sealed record Seats(int Authors, int Coordinators, int MemberSeats, int UserCount);
+
+    /// <summary>
+    /// Reads the seat counters from the surface the customer is billed against.
+    /// Asserts the payload actually resolved a tenant: `ITenantContext.TenantId`
+    /// falls back to `Guid.Empty`, which matches no rows, and every count would
+    /// then read 0 — an increment assertion against an unresolved tenant would
+    /// be measuring nothing.
+    /// </summary>
+    private static async Task<Seats> ReadSeatsAsync(HttpClient client)
+    {
+        var res = await client.GetAsync("/api/tenant/dashboard");
+        Assert.True(res.IsSuccessStatusCode,
+            $"tenant dashboard failed: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        var usage = root.GetProperty("usage");
+
+        var users = root.GetProperty("users").GetArrayLength();
+        Assert.True(users > 0,
+            "The dashboard reported zero users, so the tenant did not resolve and " +
+            "these counts prove nothing. Check ITenantContext in the test host.");
+
+        return new Seats(
+            usage.GetProperty("authors").GetProperty("current").GetInt32(),
+            usage.GetProperty("coordinators").GetProperty("current").GetInt32(),
+            usage.GetProperty("memberSeats").GetInt32(),
+            users);
+    }
+
+    private static async Task<Guid> InviteAsync(HttpClient client, string role)
+    {
+        var email = $"zz-fixture-seat-{Guid.NewGuid():N}@example.com";
+        var res = await client.PostAsJsonAsync("/api/tenant/invite",
+            new { email, displayName = "ZZ-FIXTURE Seat Probe", role });
+
+        Assert.True(res.IsSuccessStatusCode,
+            $"invite({role}) failed: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("id").GetGuid();
+    }
+
+    private static async Task CleanUpAsync(HttpClient client, Guid userId)
+        => await client.DeleteAsync($"/api/tenant/users/{userId}");
+
+    [Fact]
+    public async Task Inviting_a_coordinator_consumes_a_coordinator_seat()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync(); // Owner
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Coordinator");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+
+            // The invite succeeded, so a coordinator seat was sold. The surface
+            // the customer is billed against has to show it.
+            Assert.Equal(before.Coordinators + 1, after.Coordinators);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+
+    [Fact]
+    public async Task Inviting_an_author_consumes_an_author_seat()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Author");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+
+            // `/api/tenant/invite` routes "Author" to the Authors axis and gates
+            // on MaxAuthors, so an accepted author invite must consume an author
+            // seat. Today the author axis is pinned at 0 for a second, separate
+            // reason — nothing ever writes ProjectRole = "Author" — but this
+            // assertion is about the seat being counted at all.
+            Assert.Equal(before.Authors + 1, after.Authors);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+
+    [Fact]
+    public async Task An_invited_user_is_visible_to_the_tenant_even_though_no_seat_moves_today()
+    {
+        // The control. It proves the invite genuinely persisted a user, so the
+        // two failures above are the METER failing to count a real seat — not
+        // the invite silently doing nothing. Without this, a broken invite and
+        // a broken meter are indistinguishable.
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var before = await ReadSeatsAsync(client);
+        var userId = await InviteAsync(client, "Coordinator");
+        try
+        {
+            var after = await ReadSeatsAsync(client);
+            Assert.Equal(before.UserCount + 1, after.UserCount);
+        }
+        finally
+        {
+            await CleanUpAsync(client, userId);
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #593 (closed — see the rationale there).

## Why the previous approach was wrong

`author = Iso19650Role == "A"` meters the **Appointing Party** — the client — not an author. `ProjectMembersController.GetRoles` is explicit:

```csharp
new { Code = "A",  Label = "Appointing Party" },   // not Architect, not Author
new { Code = "BA", Label = "BIM Author" },         // the actual author code
```

That is why the Authors axis always read 0: almost nobody carries `"A"`, while `"BA"` was counted as a coordinator.

Switching to `"BA"` was considered and rejected too. `Iso19650Role` is a functional/discipline taxonomy; **ISO 19650 defines information-management responsibility, not software seats**, so it can never be the standards-correct billing key. It would bill an MEP Engineer who authors models as a coordinator, and move a customer's bill when their discipline is corrected.

## What this does instead

**Capability split.** `ProjectRoles.CanAuthorInformation` plus an EF-translatable predicate, sitting beside `CanCurate` / `CanApproveSitePhotos`, so **billing and access read one source** and cannot drift apart — the failure mode that produced eleven dead gates in #540. A test asserts the in-memory and SQL forms agree for every declared `UserRole`.

`SecurityOfficer` is excluded from the author axis: it cannot edit projects, members, or BIM-Manager roles by its own definition, so billing it as an author would charge for an audit control.

**The invite sells the seat it meters.** Both paths now offer Author or Viewer and write `UserRole.Contributor` / `UserRole.Viewer`. The API-visible `role="Coordinator"` now creates a read-only account. A renamed test asserts the *author* axis does **not** move — the assertion that would have caught the original mispairing.

**Limits are price-neutral.** `MaxAuthors` = each plan's former total (Trial 1, PluginOnly 1, Studio 6, Practice 12, Network 20); read-only unlimited. `BillingPlanLimitsTests` pins the paid headcount per plan, so a later edit to `MaxAuthors` fails and forces the pricing question to be answered deliberately rather than silently.

## Integer overflow found while applying it — latent today

`tenant.MaxUsers` was `MaxAuthors + MaxCoordinators`. With either side at `int.MaxValue` it wraps negative — measured `1 + int.MaxValue = -2,147,483,648` — and it is consumed as `userCount >= tenant.MaxUsers`, so **a negative cap denies the tenant's first user**. Enterprise already wraps to `-2` today; it is only latent because registration assigns Trial.

Making viewers unlimited would have detonated this on every new tenant. Both call sites now use a saturating `TotalSeats`; grep confirms no raw sum remains.

## Known shortfall, stated deliberately

**"Viewers unlimited" is not yet true in practice.** Returning infinity for `TotalSeats` would let `AdminController` and `ProjectMembersController` add unlimited **authoring** accounts with nothing counting them, since `MaxUsers` is the only cap those two enforce and neither consults the quota guard. So `TotalSeats` reports the paid headcount instead.

The cost is real: a Studio tenant is still capped at **6 accounts total**, so a seventh free viewer is refused by `MaxUsers` even though the read-only axis is unlimited. Erring toward charging correctly beat erring toward giving seats away — but it is not the full intent.

Making viewers genuinely free needs those two paths to check authoring capability instead of `MaxUsers` — the same "meter the writes" move. That changes their enforcement behaviour, so it is deliberately left for its own PR.

## Test plan

- [x] Full suite: **Failed 0, Passed 598, Skipped 9, Total 607**
- [x] In-memory and SQL forms of the capability predicate agree for every declared `UserRole`
- [x] Invite writes the role it sells; author axis asserted not to move for `role="Coordinator"`
- [x] `BillingPlanLimitsTests` pins paid headcount per plan
- [x] Saturating `TotalSeats` at both call sites; no raw sum remains

## Before merging

This is a **pricing position**, not just a fix: `MaxAuthors` of 6 on Studio, with viewers free once the follow-up lands. Confirm the two-tier split is what is being sold — the engineering is sound either way, but that line is a business decision.

Note: `Build & Test` / `CI Gate` fail on a Postgres service container (`role "root" does not exist`) — broken on `main` itself and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)