### PR TITLE
fix(admin): stop a tenant locking itself out of administration

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
@@ -40,6 +40,14 @@ public class AdminController : ControllerBase
     /// accounts against <c>tenant.MaxUsers</c>, which capped a Studio tenant at
     /// 6 accounts of ANY kind — a seventh read-only account was refused.</para>
     /// </summary>
+    /// <summary>
+    /// Can this account reach the admin surfaces? Mirrors
+    /// <c>[Authorize(Roles = "Admin,Owner")]</c>, and an inactive account cannot
+    /// sign in, so it does not count.
+    /// </summary>
+    private static bool IsAdministrator(UserRole role, bool isActive)
+        => isActive && (role == UserRole.Owner || role == UserRole.Admin);
+
     private async Task<string?> AuthorSeatRefusalAsync(UserRole role, CancellationToken ct = default)
     {
         if (!ProjectRoles.CanAuthorInformation(role)) return null;   // viewers are free
@@ -136,6 +144,41 @@ public class AdminController : ControllerBase
         // can't pivot through policy-gated endpoints. Display-name
         // changes don't trigger revocation — they're not security-
         // relevant.
+        // ── Last-administrator guard ────────────────────────────────────────
+        //
+        // Every admin surface is [Authorize(Roles = "Admin,Owner")]. Demote or
+        // deactivate the last account holding one of those roles and NOBODY can
+        // administer the tenant again — including undoing the change that caused
+        // it. There is no self-service recovery; it takes a manual database edit
+        // by the platform operator.
+        //
+        // Both routes are checked because they are the same lockout: a role
+        // change away from Owner/Admin, and IsActive = false, are equally final.
+        //
+        // This became materially more reachable when demotion turned into the
+        // seat-management tool ("free a seat by changing an author to Viewer") —
+        // the obvious way to release a seat was also the way to brick the tenant.
+        var intendedRole = req.Role != null
+                        && Enum.TryParse<UserRole>(req.Role, true, out var parsedRole)
+            ? parsedRole
+            : user.Role;
+        var intendedActive = req.IsActive ?? user.IsActive;
+
+        if (IsAdministrator(user.Role, user.IsActive) &&
+            !IsAdministrator(intendedRole, intendedActive))
+        {
+            var otherAdministrators = await _db.Users.CountAsync(u =>
+                u.TenantId == tenantId && u.Id != user.Id && !u.IsDeleted && u.IsActive &&
+                (u.Role == UserRole.Owner || u.Role == UserRole.Admin));
+
+            if (otherAdministrators == 0)
+                return BadRequest(
+                    "This is the tenant's last active Owner or Admin. Demoting or "
+                  + "deactivating them would leave nobody able to administer the "
+                  + "tenant, and the change could not be undone from the app. "
+                  + "Promote another user to Admin first.");
+        }
+
         var permissionChanged = false;
         if (req.DisplayName != null) user.DisplayName = req.DisplayName;
         if (req.Role != null && Enum.TryParse<UserRole>(req.Role, true, out var r) && user.Role != r)

--- a/Planscape.Server/tests/Planscape.Tests/LastAdministratorGuardTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/LastAdministratorGuardTests.cs
@@ -1,0 +1,138 @@
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// A tenant must not be able to lock itself out of administration.
+///
+/// Every admin surface is [Authorize(Roles = "Admin,Owner")], so if the last
+/// account holding one of those roles is demoted or deactivated, NOBODY can
+/// administer the tenant again — including undoing the change that caused it.
+/// There is no self-service recovery: the fix is a manual database edit by the
+/// platform operator.
+///
+/// PUT /api/admin/users/{id} could do this in a single request, and it became
+/// materially more reachable once demotion turned into the seat-management
+/// tool ("free a seat by changing an existing author to Viewer"). The obvious
+/// way to release a seat was also the way to brick the tenant.
+///
+/// TenantAdminController.RemoveUser already refuses to delete a UserRole.Owner,
+/// so that surface was partly covered; this closes the demote and deactivate
+/// routes, which were not.
+/// </summary>
+public class LastAdministratorGuardTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public LastAdministratorGuardTests(PlanscapeWebApplicationFactory factory)
+        => _factory = factory;
+
+    private int AdministratorCount()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        return db.Users.Count(u => u.TenantId == TestData.TenantId
+                                && !u.IsDeleted && u.IsActive
+                                && (u.Role == UserRole.Owner || u.Role == UserRole.Admin));
+    }
+
+    /// <summary>
+    /// Puts the seeded administrator back, straight through the DbContext.
+    ///
+    /// Needed because these tests are written against the INTENDED behaviour:
+    /// in the RED run the guard does not exist, so the demote/deactivate calls
+    /// SUCCEED and the tenant really does become unadministrable — which then
+    /// breaks authentication for every later test in the class. Recovering via
+    /// the API is impossible by definition (that is the bug), so recovery has to
+    /// bypass it. Once the guard exists these restores are no-ops.
+    /// </summary>
+    private void RestoreSeededAdministrator()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        var admin = db.Users.First(u => u.Id == TestData.AdminUserId);
+        admin.Role = UserRole.Owner;
+        admin.IsActive = true;
+        db.SaveChanges();
+    }
+
+    private static async Task<Guid> CreateAsync(HttpClient client, string role)
+    {
+        var res = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            email = $"zz-fixture-admin-{Guid.NewGuid():N}@example.com",
+            displayName = "ZZ-FIXTURE Admin",
+            password = "Zz-Fixture-Passw0rd!",
+            role,
+            iso19650Role = "M",
+        });
+        Assert.True(res.IsSuccessStatusCode,
+            $"create({role}) failed: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+        using var doc = System.Text.Json.JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("id").GetGuid();
+    }
+
+    [Fact]
+    public async Task The_last_administrator_cannot_be_demoted()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync(); // admin@test.org, Owner
+
+        // Non-vacuous: the guard only means something if there really is
+        // exactly one administrator to lose.
+        Assert.Equal(1, AdministratorCount());
+
+        try
+        {
+            var res = await client.PutAsJsonAsync($"/api/admin/users/{TestData.AdminUserId}",
+                new { role = "Viewer" });
+
+            Assert.False(res.IsSuccessStatusCode,
+                "the last administrator was demoted — the tenant is now unadministrable");
+            Assert.Equal(1, AdministratorCount());
+        }
+        finally { RestoreSeededAdministrator(); }
+    }
+
+    [Fact]
+    public async Task The_last_administrator_cannot_be_deactivated()
+    {
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        Assert.Equal(1, AdministratorCount());
+
+        try
+        {
+            var res = await client.PutAsJsonAsync($"/api/admin/users/{TestData.AdminUserId}",
+                new { isActive = false });
+
+            Assert.False(res.IsSuccessStatusCode,
+                "the last administrator was deactivated — same lockout by another route");
+            Assert.Equal(1, AdministratorCount());
+        }
+        finally { RestoreSeededAdministrator(); }
+    }
+
+    [Fact]
+    public async Task An_administrator_can_be_demoted_while_another_remains()
+    {
+        // The control. A guard that refuses every demotion would pass the two
+        // tests above while making role management impossible.
+        var client = await _factory.CreateAuthenticatedClientAsync();
+
+        var secondAdmin = await CreateAsync(client, "Admin");
+        Assert.Equal(2, AdministratorCount());
+
+        var res = await client.PutAsJsonAsync($"/api/admin/users/{secondAdmin}",
+            new { role = "Viewer" });
+
+        Assert.True(res.IsSuccessStatusCode,
+            $"demotion refused while another administrator remains: {(int)res.StatusCode} {await res.Content.ReadAsStringAsync()}");
+        Assert.Equal(1, AdministratorCount());
+    }
+}


### PR DESCRIPTION
**Stacked on #607** (which is stacked on #606). Merge order: #606 → #607 → this.

## The bug

Every admin surface is `[Authorize(Roles = "Admin,Owner")]`. Demote or deactivate the **last** account holding one of those roles and nobody can administer the tenant again — **including undoing the change that caused it**. There is no self-service recovery; it takes a manual database edit by the platform operator.

`PUT /api/admin/users/{id}` could do this in a single request, by either of two routes:

| route | before | after |
|---|---|---|
| `{ "role": "Viewer" }` on the last admin | ✅ succeeds → locked out | ❌ refused |
| `{ "isActive": false }` on the last admin | ✅ succeeds → locked out | ❌ refused |
| either, while another admin remains | ✅ succeeds | ✅ still succeeds |

## Why it is a separate PR

I found this while building #607 and reported it there rather than folding it in, because it changes behaviour on a path that PR only extended.

It is not academic. #607 makes demotion the seat-management tool — *"free a seat by changing an existing author to Viewer"* — so the obvious way to release a seat was also the way to brick the tenant. The two changes are related enough to sequence and separate enough to review independently.

`TenantAdminController.RemoveUser` already refuses to delete a `UserRole.Owner`, so the delete route was partly covered; demote and deactivate were not. `AdminController` has no delete endpoint.

## RED before GREEN

| | result |
|---|---|
| before | **Failed 2, Passed 1** |
| after | **Failed 0, Passed 3** |
| full suite | **Failed 0, Passed 606**, Skipped 9, Total 615 |

The passing test in the RED run is the **control** — demoting an administrator while another remains already worked and must keep working. A guard that refused *every* demotion would satisfy both lockout tests while making role management impossible; the control is what rules that out. The lockout tests also assert the administrator count is unchanged, not merely that the response was non-2xx.

### One detail worth knowing about the tests

The two lockout tests restore the seeded administrator through the `DbContext` in a `finally`. That is not tidiness. They are written against *intended* behaviour, so in the RED run the calls **succeed** and the tenant genuinely becomes unadministrable — which then breaks authentication for every later test in the class (my first RED run showed 3 failures for exactly this reason, not 2). Recovering through the API is impossible by definition, which is the bug, so recovery has to bypass it. Once the guard exists the restores are no-ops.

## Scope

One guard, one private helper (`IsAdministrator`, mirroring the `[Authorize]` roles; an inactive account cannot sign in, so it does not count). No response shapes, routes, prices, caps or quota axes touched.

CI’s Build & Test / CI Gate is broken on main itself (Postgres service container, "role root does not exist"), so verification is local. Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)