### PR TITLE
fix(load): make the capacity fixture self-cleaning, and fix a cleanup that never worked

### DIFF
--- a/Planscape.Server/load/cleanup-loadtest-data.sql
+++ b/Planscape.Server/load/cleanup-loadtest-data.sql
@@ -1,0 +1,93 @@
+-- cleanup-loadtest-data.sql — removes everything seed-loadtest-data.sql created.
+--
+-- LOCAL DEV ONLY, like the seed it undoes.
+--
+--   docker exec -i docker-postgres-1 psql -U planscape -d planscape \
+--     < load/cleanup-loadtest-data.sql
+--
+-- Normally you do not run this by hand — load/run-capacity.sh runs it on exit,
+-- including when the k6 run fails or is interrupted.
+--
+-- ── WHY THIS FILE EXISTS ────────────────────────────────────────────────────
+-- The seed used to document its own cleanup as two DELETEs:
+--
+--   DELETE FROM "Issues" WHERE "IssueCode" LIKE 'ISS-%';
+--   DELETE FROM "Users"  WHERE "Email" LIKE 'loadtest%';
+--
+-- The second one CANNOT SUCCEED. FK_ProjectMembers_Users_UserId is RESTRICT,
+-- and the seed gives every loadtest user a ProjectMembers row, so the delete
+-- aborts with a foreign-key violation and every user stays. That is not a
+-- hypothetical: it is why a demo tenant was found holding 426 users against a
+-- cap of 50, which read as a live onboarding blocker and sent two separate
+-- investigations down the wrong path. The excess was never the defect — the
+-- residue was.
+--
+-- Three FKs into "Users" are RESTRICT and therefore block the delete:
+--   ProjectMembers.UserId · DevicePushTokens.UserId · PhotoNdaAcceptances.UserId
+-- Everything else is SET NULL or CASCADE and needs no help. If a future
+-- scenario writes a row into some other RESTRICT table, the final DELETE throws
+-- and ON_ERROR_STOP makes psql exit non-zero — loudly, rather than leaving a
+-- partial mess behind. Add the table here when that happens.
+
+\set ON_ERROR_STOP on
+
+\set project_id '\'ae61a15c-6040-4e5c-8170-42fb59b44ffb\''
+
+BEGIN;
+
+-- Issues first: scoped by BOTH project and code prefix. 'ISS-' is the seed's
+-- own format; real seeded issues use RFI-/NCR-/CLASH-/SI-/BCF- and live on
+-- other projects. Scoping by both means a future collision cannot make this
+-- delete reach real data.
+DELETE FROM "Issues"
+ WHERE "ProjectId" = :project_id
+   AND "IssueCode" LIKE 'ISS-%';
+
+-- Then the RESTRICT dependants, in any order among themselves.
+DELETE FROM "ProjectMembers"
+ WHERE "UserId" IN (SELECT "Id" FROM "Users" WHERE "Email" LIKE 'loadtest%');
+
+DELETE FROM "DevicePushTokens"
+ WHERE "UserId" IN (SELECT "Id" FROM "Users" WHERE "Email" LIKE 'loadtest%');
+
+DELETE FROM "PhotoNdaAcceptances"
+ WHERE "UserId" IN (SELECT "Id" FROM "Users" WHERE "Email" LIKE 'loadtest%');
+
+-- Finally the users themselves.
+DELETE FROM "Users" WHERE "Email" LIKE 'loadtest%';
+
+-- ── Verify, in the same transaction ─────────────────────────────────────────
+-- A cleanup that reports success while leaving rows behind is the whole bug
+-- being fixed, so the check runs before COMMIT: any residue rolls the whole
+-- thing back and exits non-zero rather than half-cleaning.
+--
+-- No psql variables are referenced inside the dollar-quoted body — psql does
+-- not interpolate there, and a silently unsubstituted :project_id would make
+-- this assert on the wrong set.
+DO $$
+DECLARE
+    stale_users   int;
+    stale_members int;
+BEGIN
+    SELECT count(*) INTO stale_users
+      FROM "Users" WHERE "Email" LIKE 'loadtest%';
+
+    SELECT count(*) INTO stale_members
+      FROM "ProjectMembers" pm
+      JOIN "Users" u ON u."Id" = pm."UserId"
+     WHERE u."Email" LIKE 'loadtest%';
+
+    IF stale_users > 0 OR stale_members > 0 THEN
+        RAISE EXCEPTION
+            'loadtest cleanup INCOMPLETE: % users and % project members remain. '
+            'Transaction rolled back; the database is unchanged. Look for a new '
+            'RESTRICT foreign key into "Users" and add it to this file.',
+            stale_users, stale_members;
+    END IF;
+END $$;
+
+COMMIT;
+
+SELECT (SELECT count(*) FROM "Users" WHERE "Email" LIKE 'loadtest%')          AS users_remaining,
+       (SELECT count(*) FROM "Issues" WHERE "ProjectId" = :project_id
+                                        AND "IssueCode" LIKE 'ISS-%')         AS issues_remaining;

--- a/Planscape.Server/load/run-capacity.sh
+++ b/Planscape.Server/load/run-capacity.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# run-capacity.sh — seed, measure, and ALWAYS clean up.
+#
+# LOCAL DEV ONLY. Run from Planscape.Server/:
+#
+#   ./load/run-capacity.sh --project-id <guid> [--peak-rps 150]
+#
+# ── WHY THIS SCRIPT EXISTS ───────────────────────────────────────────────────
+# The capacity run used to be four commands pasted from the runbook, with
+# cleanup documented as a fifth that people were expected to remember. Two
+# things went wrong with that:
+#
+#   1. The documented cleanup could not work. FK_ProjectMembers_Users_UserId is
+#      RESTRICT, so `DELETE FROM "Users" WHERE "Email" LIKE 'loadtest%'` aborts
+#      on a foreign-key violation and every user stays.
+#   2. Nothing ran it anyway.
+#
+# The result was 400 abandoned accounts in a demo tenant, read later as
+# "426 users against a cap of 50" — a live onboarding blocker that was not one,
+# which cost two investigations. Exceeding the cap is what a capacity fixture is
+# FOR; leaving the residue behind is the defect.
+#
+# So cleanup is wired to an EXIT trap: it runs after a pass, after a failed k6
+# run, and after Ctrl-C. If cleanup itself fails, this script exits non-zero and
+# says so — a quiet failure here is what caused the original problem.
+#
+# It deliberately does NOT raise the tenant's user cap to make room for the
+# fixture. That would hide the seeder's own cap guard, which exists to catch
+# exactly this class of overrun.
+
+set -euo pipefail
+
+PROJECT_ID=""
+PEAK_RPS="${PEAK_RPS:-150}"
+BASE_URL="${BASE_URL:-http://localhost:5000}"
+PG_CONTAINER="${PG_CONTAINER:-docker-postgres-1}"
+PG_USER="${PG_USER:-planscape}"
+PG_DB="${PG_DB:-planscape}"
+ENV_FILE="${ENV_FILE:-.env.local}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --peak-rps)   PEAK_RPS="$2";   shift 2 ;;
+    --base-url)   BASE_URL="$2";   shift 2 ;;
+    -h|--help)    sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "ERROR: --project-id <guid> is required." >&2
+  exit 2
+fi
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+psql_file() { docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" < "$1"; }
+psql_q()    { docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -tAc "$1"; }
+
+# ── Cleanup, on every exit path ──────────────────────────────────────────────
+# Preserves the original exit code so a k6 failure is still reported as one,
+# but upgrades a clean run to a failure if the database was left dirty.
+cleanup() {
+  local rc=$?
+  echo
+  echo "── Cleaning up load-test fixture data ──────────────────────────────"
+
+  if ! psql_file "$here/cleanup-loadtest-data.sql"; then
+    echo >&2
+    echo "FAILED: load-test fixture data could NOT be removed." >&2
+    echo "The database still holds loadtest* accounts. Leaving them behind is" >&2
+    echo "what makes a demo tenant read as over its user cap. Investigate" >&2
+    echo "before running anything else against this database:" >&2
+    echo "  docker exec -i $PG_CONTAINER psql -U $PG_USER -d $PG_DB < load/cleanup-loadtest-data.sql" >&2
+    exit 1
+  fi
+
+  # Belt and braces: the SQL asserts and rolls back on residue, but assert here
+  # too, so a future edit that drops the in-transaction check cannot make this
+  # script silently start passing with rows left over.
+  local remaining
+  remaining="$(psql_q "SELECT count(*) FROM \"Users\" WHERE \"Email\" LIKE 'loadtest%';")"
+  if [[ "$remaining" != "0" ]]; then
+    echo "FAILED: cleanup reported success but $remaining loadtest users remain." >&2
+    exit 1
+  fi
+
+  echo "Cleanup verified: 0 loadtest accounts remain."
+  exit "$rc"
+}
+trap cleanup EXIT
+# Ctrl-C and `docker stop`-style TERM do not run an EXIT trap on their own — the
+# shell is killed instead. Converting them into an explicit exit makes the EXIT
+# trap fire exactly once, so an interrupted run still cleans up. An interrupted
+# run is the likeliest way residue accumulates in the first place.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# ── 1. Seed ──────────────────────────────────────────────────────────────────
+echo "── Seeding fixture data ────────────────────────────────────────────"
+psql_file "$here/seed-loadtest-data.sql"
+
+# ── 2. Mint tokens ───────────────────────────────────────────────────────────
+# Bulk login is impossible by design (the auth policy allows 5 logins per 5
+# minutes per IP), so tokens are signed directly with the dev key.
+echo "── Minting tokens ──────────────────────────────────────────────────"
+# An already-exported JWT_KEY wins, so a stack started from something other than
+# .env.local (compose defaults, a different env file, a secret manager) does not
+# have to invent one just to satisfy this script.
+if [[ -z "${JWT_KEY:-}" ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "ERROR: JWT_KEY is not set and $ENV_FILE does not exist." >&2
+    echo "Either export JWT_KEY, or point ENV_FILE at a file containing it." >&2
+    exit 2
+  fi
+  JWT_KEY="$(grep '^JWT_KEY=' "$ENV_FILE" | cut -d= -f2-)"
+fi
+JWT_KEY="$JWT_KEY" python "$here/mint-loadtest-tokens.py" > "$here/loadtest-tokens.json"
+
+# ── 3. Measure ───────────────────────────────────────────────────────────────
+echo "── Running k6 (PEAK_RPS=$PEAK_RPS) ─────────────────────────────────"
+docker run --rm --network host -v "$here:/load" \
+  -e BASE_URL="$BASE_URL" \
+  -e PROJECT_ID="$PROJECT_ID" \
+  -e PEAK_RPS="$PEAK_RPS" \
+  grafana/k6 run /load/tier-capacity.js
+
+# Cleanup runs from the EXIT trap.

--- a/Planscape.Server/load/seed-loadtest-data.sql
+++ b/Planscape.Server/load/seed-loadtest-data.sql
@@ -22,10 +22,24 @@
 -- measurement flatters the server badly: the same box measured a knee at
 -- 240 req/s empty versus roughly 120-180 req/s with real rows.
 --
+-- ── CLEANING UP ─────────────────────────────────────────────────────────────
+-- Prefer load/run-capacity.sh, which seeds, measures and cleans up on every
+-- exit path (including a failed or interrupted k6 run). To clean up by hand:
+--
+--   docker exec -i docker-postgres-1 psql -U planscape -d planscape \
+--     < load/cleanup-loadtest-data.sql
+--
+-- This file used to document its own cleanup as two DELETEs, the second being
+--   DELETE FROM "Users" WHERE "Email" LIKE 'loadtest%';
+-- That CANNOT SUCCEED: FK_ProjectMembers_Users_UserId is RESTRICT and the
+-- membership INSERT below gives every loadtest user a row, so the delete aborts
+-- on a foreign-key violation and all 400 users stay. Following those
+-- instructions left a demo tenant holding 426 users against a cap of 50, which
+-- was later read as a live onboarding blocker. cleanup-loadtest-data.sql
+-- deletes the RESTRICT dependants first and asserts the result before COMMIT.
+--
 -- Idempotent: re-running will not duplicate members. Users and issues WILL
--- duplicate on a second run -- clean up first if you need an exact count:
---   DELETE FROM "Issues" WHERE "IssueCode" LIKE 'ISS-%';
---   DELETE FROM "Users"  WHERE "Email" LIKE 'loadtest%';
+-- duplicate on a second run -- clean up first if you need an exact count.
 
 \set ON_ERROR_STOP on
 

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -407,6 +407,27 @@ The Redis SignalR backplane is already wired, so horizontal scaling works —
 
 Everything below runs against a local dev stack. Budget ~20 minutes.
 
+> **Use the runner, not the individual steps.** After pinning the API (step 1),
+> `./load/run-capacity.sh --project-id <guid> --peak-rps 150` performs steps 2–4
+> and then **removes the fixture data on every exit path** — after a pass, after
+> a failed k6 run, and after Ctrl-C. If cleanup fails it exits non-zero and says
+> so.
+>
+> This matters more than it sounds. The seed creates 400 accounts, and the
+> cleanup this runbook used to recommend — `DELETE FROM "Users" WHERE "Email"
+> LIKE 'loadtest%'` — **cannot succeed**: `FK_ProjectMembers_Users_UserId` is
+> `RESTRICT`, so it aborts on a foreign-key violation and every account stays.
+> That left a demo tenant reading 426 users against a cap of 50, which was
+> mistaken for a live onboarding blocker and cost two investigations. Exceeding
+> a cap is what a capacity fixture is *for*; leaving the residue behind is the
+> defect.
+>
+> The steps below remain as reference for running a phase on its own. If you do,
+> finish with:
+> ```bash
+> docker exec -i docker-postgres-1 psql -U planscape -d planscape < load/cleanup-loadtest-data.sql
+> ```
+
 **1. Pin the API to the tier you want to measure.**
 
 ```bash
@@ -450,7 +471,16 @@ that is CPU saturation. A run that instead shows high failures with a *low* p95
 is not saturation: it is 429s, and it means either too few seeded users or the
 offered rate exceeds `users × 100 / 60`.
 
-**5. Watch the pools while it runs**, to confirm the cap holds and nothing
+**5. Clean up.** `run-capacity.sh` does this for you. If you ran step 4 by hand,
+do it now — and check it actually worked, because the failure mode is silent
+accumulation:
+
+```bash
+docker exec -i docker-postgres-1 psql -U planscape -d planscape < load/cleanup-loadtest-data.sql
+# expects: users_remaining | issues_remaining  ->  0 | 0
+```
+
+**6. Watch the pools while it runs**, to confirm the cap holds and nothing
 approaches the 97-connection ceiling:
 
 ```bash


### PR DESCRIPTION
The residue was the defect, not the excess. Exceeding a cap is what a capacity fixture is *for*; leaving 400 accounts behind is what made a demo tenant read **426 users against a cap of 50**, which looked like a live onboarding blocker and sent two investigations down the wrong path.

## The documented cleanup could never have worked

`seed-loadtest-data.sql` told you to run:

```sql
DELETE FROM "Users" WHERE "Email" LIKE 'loadtest%';
```

`FK_ProjectMembers_Users_UserId` is **RESTRICT**, and the seed gives every loadtest user a membership row — so it aborts and all 400 users stay. Verified against the live dev database rather than reasoned about:

```
ERROR: update or delete on table "Users" violates foreign key constraint
       "FK_ProjectMembers_Users_UserId" on table "ProjectMembers"
```

So this was never "someone forgot". **Following the instructions could not have worked.** That reframes it from a discipline problem to a broken tool.

Three FKs into `"Users"` are `RESTRICT` and block the delete — `ProjectMembers.UserId`, `DevicePushTokens.UserId`, `PhotoNdaAcceptances.UserId` — enumerated from `information_schema`, not guessed. Everything else is `SET NULL` or `CASCADE`.

## What lands

**`load/cleanup-loadtest-data.sql`** — deletes the RESTRICT dependants first, then the users, and **asserts the result inside the transaction**. Residue raises and rolls back, so a half-clean is impossible. Issues are scoped by project **and** `ISS-` prefix; real seeded issues use `RFI-`/`NCR-`/`CLASH-`/`SI-`/`BCF-` codes on other projects, so the delete cannot reach real data.

**`load/run-capacity.sh`** — seeds, mints tokens, runs k6, and cleans up from an `EXIT` trap: after a pass, after a failure, and after Ctrl-C. `INT`/`TERM` are converted to explicit exits, because a bare signal kills the shell *without* running an EXIT trap — and an interrupted run is the likeliest way residue accumulates. Cleanup failure exits non-zero with the manual command. It re-counts afterwards too, so a future edit that drops the in-transaction assert cannot make the script silently start passing.

`JWT_KEY` may now be exported instead of read from `.env.local`, so a stack started any other way can still use the runner.

## Verified against the live dev database

| what | result |
|---|---|
| **Failure path** — cleanup with the final `DELETE` removed | raised `loadtest cleanup INCOMPLETE: 400 users … rolled back`, psql **exit 3**, database left **exactly** as before (400 / 400 / 5000) |
| **Success path** | 400 users, 400 members, 5000 issues → **0 / 0**, exit 0 |
| **End to end** — ran `run-capacity.sh`, sent `TERM` mid-run | trap fired, removed 5000 issues + 400 members + 400 users, verified 0 remaining, script exited non-zero |
| **Demo tenant** | **426 users → 26** |

The interrupted run is the important one: it reproduces the exact scenario that produced the residue, and it now self-heals.

## Deliberately not done

- **The demo cap is not raised.** That would hide the seeder’s own cap guard (#601), which exists to catch this class of overrun.
- **`MaxUsers` on the demo tenant is still 100000**, raised by an earlier session to work around this residue. With the residue gone, 26 users sit comfortably under the original 50 — but restoring it is a tenant-data change, so it is reported rather than done. Say the word.

`loadtest-tokens.json` holds signed JWTs and is gitignored (`.gitignore:122`); confirmed absent from this diff, and the generated token/result files were removed from the worktree.

Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)