### PR TITLE
build(bonsai): ship stingtools_core as a wheel — clears the extension-policy warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ planscape-web/playwright-report/
 
 # wrangler local build cache (marketing-site / Pages Functions)
 .wrangler/
+
+# Bonsai extension: core wheel is built at package time (see BUILD.md)
+stingtools-bonsai/wheels/*.whl

--- a/stingtools-bonsai/BUILD.md
+++ b/stingtools-bonsai/BUILD.md
@@ -1,0 +1,45 @@
+# Building the StingTools-for-Bonsai extension
+
+The extension bundles `stingtools_core` as a **wheel** declared in
+`blender_manifest.toml` (`wheels = [...]`). Blender installs that wheel into the
+extension's own isolated environment, so `import stingtools_core` works with no
+`sys.path` manipulation — which is what keeps Blender's extension-policy check
+clean. (The wheel is git-ignored; it's produced at build time.)
+
+## Build steps
+
+From the repo root, with Python 3.11+ and Blender 4.2+ on the machine:
+
+```bash
+# 1. Build the shared-core wheel INTO the extension's wheels/ folder.
+#    The filename must match the `wheels = [...]` entry in blender_manifest.toml.
+python -m build --wheel --outdir stingtools-bonsai/wheels stingtools-core/python
+
+# 2. Build the extension zip.
+blender --command extension build \
+  --source-dir stingtools-bonsai \
+  --output-dir stingtools-bonsai/dist
+
+# 3. Validate.
+blender --command extension validate stingtools-bonsai/dist/stingtools_bonsai-0.1.0.zip
+```
+
+Output: `stingtools-bonsai/dist/stingtools_bonsai-0.1.0.zip`.
+
+## Install (Blender 4.2+)
+
+1. Install **Bonsai** first (its IFC layer is a hard runtime dependency).
+2. `Edit → Preferences → Get Extensions → ⌄ → Install from Disk…` → the zip.
+3. Enable it → press `N` in the 3D viewport → the **STING** tab.
+
+## Bumping the core version
+
+If `stingtools-core`'s version changes, update the filename in the
+`wheels = [...]` line of `blender_manifest.toml` to match the new wheel, then
+rebuild.
+
+## Dev checkout (no wheel)
+
+When running from a monorepo checkout without the wheel installed, the
+extension's `__init__.py` falls back to adding `../stingtools-core/python` to
+`sys.path`. That path is dev-only; a packaged install always uses the wheel.

--- a/stingtools-bonsai/__init__.py
+++ b/stingtools-bonsai/__init__.py
@@ -34,21 +34,27 @@ bl_info = {
 }
 
 
-# Make `stingtools_core` resolvable when it lives in the repo's
-# stingtools-core/python/ folder during dev. In a packaged extension
-# it'll be vendored under _vendor/.
-import sys
-from pathlib import Path
+# Resolve `stingtools_core`. When packaged, it is provided by the wheel declared
+# in blender_manifest.toml (`wheels = [...]`), which Blender installs into the
+# extension's isolated environment — so a plain import works and NO sys.path
+# manipulation happens. That is what keeps Blender's extension-policy check clean
+# (the old _vendor/sys.path approach raised "top level module" + "sys.path"
+# policy violations). The fallback below runs ONLY in a monorepo dev checkout,
+# where the wheel isn't installed and core lives at ../stingtools-core/python.
+try:
+    import stingtools_core  # noqa: F401 — provided by the bundled wheel when packaged
+except ImportError:
+    import sys
+    from pathlib import Path
 
-_THIS = Path(__file__).resolve()
-_REPO_ROOT_CANDIDATES = [_THIS.parent.parent, _THIS.parent / "_vendor"]
-for _cand in _REPO_ROOT_CANDIDATES:
-    _core = _cand / "stingtools-core" / "python"
-    if _core.exists() and str(_core) not in sys.path:
-        sys.path.insert(0, str(_core))
-    _vendored = _cand / "stingtools_core"
-    if _vendored.exists() and str(_cand) not in sys.path:
-        sys.path.insert(0, str(_cand))
+    _THIS = Path(__file__).resolve()
+    for _cand in (_THIS.parent.parent, _THIS.parent / "_vendor"):
+        _core = _cand / "stingtools-core" / "python"
+        if _core.exists() and str(_core) not in sys.path:
+            sys.path.insert(0, str(_core))
+        _vendored = _cand / "stingtools_core"
+        if _vendored.exists() and str(_cand) not in sys.path:
+            sys.path.insert(0, str(_cand))
 
 
 def register():

--- a/stingtools-bonsai/_vendor/_README.md
+++ b/stingtools-bonsai/_vendor/_README.md
@@ -1,17 +1,1 @@
-# stingtools-bonsai/_vendor/
-
-Empty in the Day-1 scaffold + in dev installs. Populated only by the
-**packaged-extension build step** for distribution:
-
-```bash
-# Done at release time, not in dev:
-cp -r stingtools-core/python/stingtools_core \
-      stingtools-bonsai/_vendor/stingtools_core
-```
-
-The add-on's `__init__.py` injects `_vendor/` onto `sys.path` so a
-`zip`-packaged extension is self-contained (no PyPI dependency, no
-relative-path discovery of `stingtools-core/` upstream).
-
-In dev: `_vendor/` stays empty; `stingtools_core` resolves via the
-relative-path injection that walks up to the repo root.
+Empty on purpose — stingtools_core now ships as a wheel (see blender_manifest.toml + BUILD.md), not vendored here.

--- a/stingtools-bonsai/blender_manifest.toml
+++ b/stingtools-bonsai/blender_manifest.toml
@@ -28,6 +28,14 @@ blender_version_min = "4.2.0"
 license = ["SPDX:MIT"]
 copyright = ["2026 Planscape Limited"]
 
+# Bundled Python dependency — the shared STING core. Declaring it here is the
+# Blender-sanctioned way to ship a dependency: Blender installs the wheel into
+# the extension's own isolated environment, so `import stingtools_core` works
+# with NO sys.path manipulation and NO top-level-module policy violation (the
+# old _vendor/sys.path approach tripped both). Build the wheel into ./wheels/
+# before packaging — see BUILD.md. Not on PyPI, so it must be bundled.
+wheels = ["./wheels/stingtools_core-0.1.0-py3-none-any.whl"]
+
 # Relationship with Bonsai
 # ───────────────────────
 # Bonsai (formerly BlenderBIM) is the IFC layer for Blender.


### PR DESCRIPTION
## The gap (#2 from the live-testing round)
The extension put `stingtools_core` on `sys.path` from `_vendor/`, which tripped Blender 4.2's extension policy: **18× "Policy violation with top level module: stingtools_core.*"** + **"Policy violation with sys.path: ._vendor"**. Functional, but non-compliant, a module-collision risk, and a blocker for clean distribution.

## The fix
Declare the core wheel in `blender_manifest.toml` — `wheels = ["./wheels/stingtools_core-0.1.0-py3-none-any.whl"]` — the Blender-sanctioned way to ship a Python dependency (same mechanism Bonsai uses for ifcopenshell/lxml/pandas). Blender installs the wheel into the extension's isolated `site-packages`, so `import stingtools_core` works with **no `sys.path` manipulation**. `__init__.py` tries a plain import first (packaged) and only falls back to the dev `sys.path` shim in a monorepo checkout.

## Verified headlessly (isolated Blender config, user's install untouched)
- Extension **registers clean**, substrate loads (core imports).
- `stingtools_core.__file__` resolves under `.local/lib/python3.11/site-packages/` — **the wheel**, not `_vendor`.
- **No `_vendor`/repo entries on `sys.path`** → both policy violations structurally eliminated.

## Also
- `BUILD.md` documents the two-step build (build wheel into `wheels/`, then `extension build`).
- The wheel is git-ignored (produced at build time); `_vendor/` note updated.

Final UI confirmation is the reinstall, but the headless evidence is conclusive: the sys.path branch never runs when the wheel is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)