### PR TITLE
docs: name the real deploy target — two scripts fight over it, and the loser fails silently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2454,10 +2454,36 @@ dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Auto
 
 ### Deployment
 
-1. Build to produce `StingTools.dll`
-2. Copy `StingTools.addin` to `C:\ProgramData\Autodesk\Revit\Addins\2025\` (machine) or `%APPDATA%\Autodesk\Revit\Addins\2025\` (user)
-3. Copy `StingTools.dll` + `Newtonsoft.Json.dll` + `ClosedXML.dll` + `data/` folder alongside
-4. Restart Revit
+> **Check where Revit is actually loading from before you trust any deploy
+> instruction, including this one.** Two scripts compete to own that path (below),
+> so it changes depending on which ran last. One command settles it:
+>
+> ```bash
+> grep -h "<Assembly>" "$APPDATA/Autodesk/Revit/Addins"/*/StingTools.addin | sort -u
+> ```
+>
+> Deploying to the folder that is *not* in that manifest **fails silently** — the
+> copy succeeds, Revit loads the other DLL, and you debug code that never ran.
+> Several older runners hardcode one target or the other and are wrong half the
+> time; the manifest is the only source of truth.
+
+| Script | What it does |
+|---|---|
+| `build.bat` | Compile Release + stage to **this checkout's** `CompiledPlugin/`. Does **not** touch Revit — a parallel agent can verify a build without hijacking the add-in slot. |
+| `deploy.bat` | `STING_DEPLOY=1` + `build.bat` → also rewrites the manifest to point at **this checkout's** `CompiledPlugin/`. This is "make my checkout the live plugin". |
+| `deploy-gold.bat` | Builds, copies into the isolated `C:\Dev\STING_PLACEMENT_GOLD`, then re-pins the manifest to **GOLD**. |
+
+**The two deploy scripts deliberately fight.** `deploy.bat` points Revit at the
+shared `CompiledPlugin`, which every checkout rebuilds — so Revit loads whoever
+built last. `deploy-gold.bat` exists to escape exactly that, by re-pinning to a
+folder no other agent writes. Both are reasonable; they are simply mutually
+exclusive, and the loser's folder goes stale without any warning. As measured on
+2026-08-06 the manifest pointed at `CompiledPlugin` (built that day) while GOLD
+was **16 days stale** — so any doc saying "deploy to GOLD" was, that day, wrong.
+
+Whichever you use: close Revit first (it holds `StingTools.dll` and ~17
+dependencies; the Planscape Companion tray app holds them too and must be
+stopped, or the copy half-fails silently), then restart Revit afterwards.
 
 ### Branching
 

--- a/deploy-gold.bat
+++ b/deploy-gold.bat
@@ -1,15 +1,26 @@
 @echo off
 REM ============================================================================
-REM  deploy-gold.bat — refresh the isolated GOLD deploy folder Revit loads from.
+REM  deploy-gold.bat — build into the isolated GOLD folder and pin Revit to it.
 REM
-REM  Revit's StingTools.addin points at  C:\Dev\STING_PLACEMENT_GOLD\StingTools.dll
-REM  (a flat deploy folder, deliberately isolated from this shared working
-REM  checkout so parallel agents clobbering C:\Dev\STINGTOOLS can't break the
-REM  live plugin). The trade-off: GOLD does NOT auto-update. Run this to build
-REM  the current branch and copy the fresh DLL + data into GOLD.
+REM  GOLD (C:\Dev\STING_PLACEMENT_GOLD) is a flat deploy folder, deliberately
+REM  isolated from this shared working checkout so parallel agents clobbering
+REM  C:\Dev\STINGTOOLS can't break the live plugin. The trade-off: GOLD does NOT
+REM  auto-update. Run this to build the current branch and copy DLL + data in.
+REM
+REM  IMPORTANT — Revit does NOT necessarily load from GOLD right now.
+REM  This script PINS the manifest to GOLD (see the pin step below); deploy.bat
+REM  pins it to the shared CompiledPlugin. They are mutually exclusive and
+REM  whichever ran LAST wins, so the target moves. The loser's folder then goes
+REM  stale with no warning — on 2026-08-06 the manifest pointed at
+REM  CompiledPlugin (fresh) while GOLD was 16 days old.
+REM
+REM  Check before you trust either, and before debugging a "change that did
+REM  nothing" — a copy into the folder Revit is NOT loading fails silently:
+REM    grep -h "<Assembly>" "$APPDATA/Autodesk/Revit/Addins"/*/StingTools.addin
 REM
 REM  Usage:  close Revit  ->  deploy-gold.bat  ->  reopen Revit.
-REM  (If Revit is open it may hold StingTools.dll locked and the copy fails.)
+REM  (If Revit is open it may hold StingTools.dll locked and the copy fails.
+REM   The Planscape Companion tray app holds them too — stop it as well.)
 REM ============================================================================
 setlocal
 set "SRC=%~dp0CompiledPlugin"


### PR DESCRIPTION
## Summary

Sweeping for the stale `STING_PLACEMENT_GOLD` deploy instruction found in the token-depth runner (#611) turned up the mechanism behind a long-running annoyance: **the Revit add-in target moves**, so any doc hardcoding one folder is wrong about half the time.

Two scripts each re-pin the manifest, deliberately and in opposite directions:

| Script | Pins Revit at |
|---|---|
| `deploy.bat` | this checkout's `CompiledPlugin/` (shared — every checkout rebuilds it) |
| `deploy-gold.bat` | the isolated `C:\Dev\STING_PLACEMENT_GOLD` |

`deploy-gold.bat`'s own comment states why it re-pins: `deploy.bat` aims Revit at the shared folder, so Revit loads whoever built last. Both positions are reasonable — they're mutually exclusive, **whichever ran last wins**, and the loser's folder goes stale with no warning.

That failure is *silent*, which is what makes it costly: the copy succeeds, Revit loads the other DLL, and you debug code that never ran.

**Measured 2026-08-06:** the manifest pointed at `CompiledPlugin` (built that day) while `GOLD/StingTools.dll` was **16 days stale** (2026-07-20). So every doc saying "deploy to GOLD" was wrong that day — and would become right again the moment someone runs `deploy-gold.bat`.

## Changes (comment-only — no logic, no behaviour)

- **`CLAUDE.md` Deployment section** described a manual `.addin` copy matching neither script. Replaced with what the three scripts actually do, the tug-of-war and why it exists, and the one command that settles it:
  ```bash
  grep -h "<Assembly>" "$APPDATA/Autodesk/Revit/Addins"/*/StingTools.addin | sort -u
  ```
- **`deploy-gold.bat`** asserted as present-tense fact: *"Revit's StingTools.addin points at ...GOLD\StingTools.dll"*. That is only true **after** you run it. Rewritten to say it *pins* the manifest, that the target moves, and to check first.

## Deliberately not done

**Picking a winner.** Whether to keep the GOLD isolation or standardise on `deploy.bat` is a workflow decision for the owner, not something a doc fix should settle — the isolation exists for a real reason (parallel agents clobbering the shared checkout). Happy to retire one on request.

**14 historical runners still hardcode the GOLD path** (`UNIVERSAL_TAG_*`, `BOQ_*_PROMPT`, various smoke tests). They're superseded by the canonical section rather than edited in place, on the same reasoning as #595 and #611 — mass-editing historical docs churns a lot for little gain, and the fix is one authoritative statement plus a verification command.

## Test plan

- [x] `git diff -- deploy-gold.bat` touches **`REM` lines only** — verified by filtering the diff for non-comment changes (empty)
- [x] Both deploy folders and the manifest inspected on disk; timestamps and target quoted above are measured, not inferred
- [x] Pipeline claims read from `build.bat`, `deploy.bat`, `extract_plugin.sh` (`STING_DEPLOY` gate, `<Assembly>$WIN_DEPLOY\StingTools.dll`)
- [x] Docs + comments only; no build required

🤖 Generated with [Claude Code](https://claude.com/claude-code)