### PR TITLE
docs(roles): propose four role fields → three, and the sheet that resolves them by hand

### DIFF
--- a/Planscape.Server/tools/role-reconciliation-sheet.sql
+++ b/Planscape.Server/tools/role-reconciliation-sheet.sql
@@ -1,0 +1,104 @@
+-- role-reconciliation-sheet.sql — one row per project member, for hand-resolution.
+--
+-- READ-ONLY. Produces the sheet the product owner fills in before any role
+-- migration runs. Nothing here writes.
+--
+--   docker exec -i docker-postgres-1 psql -U planscape -d planscape \
+--     -f - --csv < tools/role-reconciliation-sheet.sql > role-reconciliation.csv
+--
+-- ── WHY A SHEET AND NOT AN AUTOMATIC RULE ───────────────────────────────────
+-- ProjectMember.Iso19650Role holds values from TWO different vocabularies:
+--
+--   ISO 19650 ROLE (ProjectMembersController.GetRoles)
+--     A PM BC BA AR SE ME CE QS CA CT SC FM OM CL M V Z
+--   STING DISCIPLINE (ASS_DISCIPLINE_COD_TXT, TAG_CONFIG_v5_0_DISC_SYS_FUNC.csv)
+--     A E FP H LV M MG P RP S
+--
+-- They overlap on exactly TWO codes, and those two are the most common values
+-- in the data:
+--     "A" -> Appointing Party (role)  OR  Architectural (discipline)
+--     "M" -> Model Author    (role)  OR  Mechanical    (discipline)
+--
+-- A stored "M" cannot be resolved by looking at it. Capability is derived from
+-- the role, so guessing wrong grants or denies real permissions. Hence: propose,
+-- flag confidence, and let someone who knows these people by name decide.
+--
+-- The confidence column is the point of the sheet. Sort by it and only the
+-- AMBIGUOUS and REVIEW rows need a human.
+
+WITH role_vocab(code) AS (VALUES
+    ('A'),('PM'),('BC'),('BA'),('AR'),('SE'),('ME'),('CE'),('QS'),
+    ('CA'),('CT'),('SC'),('FM'),('OM'),('CL'),('M'),('V'),('Z')),
+discipline_vocab(code) AS (VALUES
+    ('A'),('E'),('FP'),('H'),('LV'),('M'),('MG'),('P'),('RP'),('S')),
+member AS (
+    SELECT pm."Id"            AS member_id,
+           p."Code"           AS project,
+           u."DisplayName"    AS display_name,
+           u."Email"          AS email,
+           pm."ProjectRole"   AS project_role,
+           pm."Iso19650Role"  AS iso_stored,
+           u."Role"::text     AS app_user_role,
+           (pm."Iso19650Role" IN (SELECT code FROM role_vocab))       AS in_role_vocab,
+           (pm."Iso19650Role" IN (SELECT code FROM discipline_vocab)) AS in_disc_vocab
+      FROM "ProjectMembers" pm
+      JOIN "Users"    u ON u."Id"  = pm."UserId"
+      JOIN "Projects" p ON p."Id"  = pm."ProjectId"
+)
+SELECT
+    member_id,
+    project,
+    display_name,
+    email,
+    project_role,
+    iso_stored,
+    app_user_role,
+
+    -- Proposed ISO 19650 role. Blank where a human must choose.
+    CASE
+        WHEN in_role_vocab AND NOT in_disc_vocab THEN iso_stored
+        WHEN in_role_vocab AND in_disc_vocab     THEN NULL          -- A / M: ambiguous
+        ELSE CASE project_role                                       -- fall back to ProjectRole
+                 WHEN 'Manager'     THEN 'PM'
+                 WHEN 'Coordinator' THEN 'BC'
+                 WHEN 'Contributor' THEN 'BA'
+                 WHEN 'Viewer'      THEN 'V'
+                 WHEN 'ClientGuest' THEN 'CL'
+                 WHEN 'PM'          THEN 'PM'   -- legacy value; see ProjectRoles.LegacyProjectRolePm
+                 ELSE NULL                       -- Owner / Admin have no ISO equivalent
+             END
+    END AS proposed_iso_role,
+
+    -- Proposed discipline. Only inferable when the stored code is
+    -- discipline-only; otherwise unknown and left for the sheet.
+    CASE
+        WHEN in_disc_vocab AND NOT in_role_vocab THEN iso_stored
+        ELSE NULL
+    END AS proposed_discipline,
+
+    CASE
+        WHEN in_role_vocab AND in_disc_vocab THEN
+            'AMBIGUOUS — "' || iso_stored || '" is BOTH an ISO role and a discipline. Human must choose.'
+        WHEN iso_stored IS NOT NULL AND NOT in_role_vocab AND NOT in_disc_vocab THEN
+            'REVIEW — "' || iso_stored || '" is in neither vocabulary (likely a typo; e.g. EL for E).'
+        WHEN in_role_vocab THEN
+            'HIGH — unambiguous ISO role; kept as-is.'
+        WHEN in_disc_vocab THEN
+            'HIGH — unambiguous discipline; ISO role derived from ProjectRole.'
+        WHEN project_role IN ('Owner','Admin') THEN
+            'REVIEW — ProjectRole "' || project_role || '" has no ISO equivalent.'
+        ELSE
+            'MEDIUM — no stored ISO value; ISO role derived from ProjectRole alone.'
+    END AS confidence,
+
+    ''::text AS approved_iso_role,      -- ← product owner fills these two in
+    ''::text AS approved_discipline
+FROM member
+ORDER BY
+    CASE
+        WHEN in_role_vocab AND in_disc_vocab THEN 0                          -- ambiguous first
+        WHEN iso_stored IS NOT NULL AND NOT in_role_vocab AND NOT in_disc_vocab THEN 1
+        WHEN project_role IN ('Owner','Admin') THEN 2
+        ELSE 3
+    END,
+    project, display_name;

--- a/docs/ROLE_MODEL_MIGRATION_PROPOSAL.md
+++ b/docs/ROLE_MODEL_MIGRATION_PROPOSAL.md
@@ -1,0 +1,154 @@
+# Role model: four fields → three — proposal
+
+**Status: PROPOSED. Nothing in this document has been run.** The reconciliation
+sheet generator (`Planscape.Server/tools/role-reconciliation-sheet.sql`) is
+read-only and is the only executable artefact.
+
+Measured 2026-08-06 against the local dev database. Production has not been
+measured — every count below is dev, and the sheet must be regenerated against
+production before anything is approved.
+
+---
+
+## Why this carries no revenue risk
+
+Entitlement is the **StingTools licence** (signed, offline, machine-bound), not a
+role. One licence = one author seat. Billing does not read `ProjectRole`,
+`Iso19650Role`, or `AppUser.Role` — so this migration cannot mis-bill anyone.
+Its blast radius is **permissions**, which is precisely why it is being done by
+hand rather than by rule.
+
+---
+
+## 1. The problem: one column, two vocabularies
+
+`ProjectMember.Iso19650Role` holds values drawn from **two different and
+unrelated vocabularies**:
+
+| Vocabulary | Source | Codes |
+|---|---|---|
+| ISO 19650 **role** | `ProjectMembersController.GetRoles()` | `A PM BC BA AR SE ME CE QS CA CT SC FM OM CL M V Z` |
+| STING **discipline** | `ASS_DISCIPLINE_COD_TXT`, `TAG_CONFIG_v5_0_DISC_SYS_FUNC.csv` | `A E FP H LV M MG P RP S` |
+
+They overlap on **exactly two codes**, and those two are the most common values
+in the data:
+
+- **`A`** → Appointing Party (role) **or** Architectural (discipline)
+- **`M`** → Model Author (role) **or** Mechanical (discipline)
+
+This also explains values previously dismissed as invalid: **`S` is Structural**,
+a perfectly good discipline code that was only ever wrong because it was stored
+in a column being read as a role.
+
+### Measured impact (dev, 34 member rows)
+
+| Confidence | Rows | Meaning |
+|---|---|---|
+| **AMBIGUOUS** | **20 (59%)** | stored code is `A` or `M` — unresolvable by inspection |
+| HIGH | 13 | stored code belongs to exactly one vocabulary |
+| REVIEW | 1 | `EL` — in neither vocabulary (near-miss for `E`) |
+
+**An automatic rule would silently mis-resolve the majority of rows.** Capability
+is derived from role, so a wrong resolution is a wrong permission. Hence: no
+auto-migration.
+
+The display names show why a human is needed rather than a cleverer rule —
+`Contributor + A` on *"Architectural Lead"* is obviously the discipline, while
+`Manager + A` on *"BIM Coordinator"* is genuinely arguable. Only someone who
+knows these people can say.
+
+---
+
+## 2. Target shape: four fields → three
+
+| Field | Purpose | Vocabulary | Change |
+|---|---|---|---|
+| `AppUser.Role` (`UserRole`) | **Authorization** | `Viewer…Owner`, `SecurityOfficer` | **UNCHANGED** |
+| `ProjectMember.Iso19650Role` | **Responsibility + capability source** | ISO 19650 role | Becomes the single role field |
+| `ProjectMember.Discipline` *(new)* | **Trade** | STING discipline | New column |
+| ~~`ProjectMember.ProjectRole`~~ | — | — | **Retired** after backfill |
+
+`AppUser.Role` stays because every admin surface is
+`[Authorize(Roles = "Admin,Owner")]`. Turning it into an ISO code means
+rewriting authorization across the API — a separate change with its own risk,
+and not required by this one.
+
+`AppUser.Iso19650Role` exists too and carries the same ambiguity; it is included
+in the sheet as context but is **out of scope** for this pass. Retiring it is a
+follow-up once `ProjectMember` is clean.
+
+---
+
+## 3. Capability map (explicit, to be tested)
+
+Derived from the ISO role only. Preserves the intent #540 established — curate is
+broader than approve, and the two are evaluated separately.
+
+| ISO role | Curate | Approve photos | Author information |
+|---|---|---|---|
+| `A` Appointing Party | ✅ | ✅ | ✅ |
+| `PM` Project Manager | ✅ | ✅ | ✅ |
+| `BC` BIM Coordinator | ✅ | ❌ | ✅ |
+| `CA` Contract Administrator | ✅ | ❌ | ✅ |
+| `BA` BIM Author · `M` Model Author | ❌ | ❌ | ✅ |
+| `AR` `SE` `ME` `CE` `QS` | ❌ | ❌ | ✅ |
+| `CT` Main Contractor · `SC` Subcontractor | ❌ | ❌ | ✅ |
+| `FM` · `OM` | ❌ | ❌ | ✅ |
+| `CL` Client Representative | ❌ | ❌ | ❌ |
+| `V` Viewer | ❌ | ❌ | ❌ |
+| `Z` Unassigned | ❌ | ❌ | ❌ |
+
+The map lives beside `CanCurate` / `CanApproveSitePhotos` in `ProjectRoles`, with
+a test asserting every code in `GetRoles()` has exactly one entry — so adding a
+role to the API without deciding its capability fails the build rather than
+defaulting to deny (or worse, allow).
+
+---
+
+## 4. Migration sequence — proposed, not run
+
+**Step 1 — schema, additive only.**
+Add `ProjectMember.Discipline` and `ProjectMember.RoleMigrationBackup`
+(text, holds the pre-migration `ProjectRole|Iso19650Role` pair). Nothing is
+dropped. Fully reversible: the backup column reconstructs the original state.
+
+**Step 2 — dual-write.**
+Writers set both the old and new fields; readers prefer the new field and fall
+back to the old. The system is correct at every point, and the change can be
+abandoned at any point without data loss.
+
+**Step 3 — reconciliation sheet.**
+Generate against **production**:
+
+```bash
+docker exec -i <pg> psql -U planscape -d planscape --csv \
+  -f - < Planscape.Server/tools/role-reconciliation-sheet.sql > role-reconciliation.csv
+```
+
+One row per member: name, email, current `ProjectRole`, current
+`Iso19650Role`, current `AppUser.Role`, a proposed resolution, and a confidence
+flag. Sorted so AMBIGUOUS and REVIEW rows come first. The product owner fills in
+`approved_iso_role` and `approved_discipline`. Only the flagged rows need
+attention — on dev that is 21 of 34.
+
+**Step 4 — backfill from the approved sheet only.**
+Import the completed CSV; write `Iso19650Role` and `Discipline` from the
+*approved* columns, never from the proposed ones. Refuse to run if any flagged
+row is unapproved — a half-approved sheet must fail loudly, not partially apply.
+
+**Step 5 — retire `ProjectRole`.**
+Only after the backfill is verified and dual-write has run clean for a release.
+Drop it in a separate migration, with `RoleMigrationBackup` retained for at
+least one further release.
+
+---
+
+## 5. What is deliberately NOT in this proposal
+
+- **No auto-migration.** See §1.
+- **`AppUser.Role` is untouched.** Rewriting `[Authorize]` is its own change.
+- **`AppUser.Iso19650Role`** carries the same ambiguity and is a follow-up.
+- **No billing coupling.** Entitlement is the licence; billing reads none of
+  these fields, before or after.
+- **`EL`** is not silently corrected to `E`. It goes to the sheet as REVIEW,
+  because a plausible typo fix is still a guess about a permission.


### PR DESCRIPTION
**Proposal only — nothing here runs.** The one executable artefact, `tools/role-reconciliation-sheet.sql`, is read-only.

## No revenue risk — stated up front

Entitlement is the **StingTools licence** (signed, offline, machine-bound). Billing reads `ProjectRole`, `Iso19650Role` and `AppUser.Role` **neither before nor after** this change, so it cannot mis-bill anyone. The blast radius is **permissions only** — which is exactly why it is being done by hand.

## The root cause, named

`ProjectMember.Iso19650Role` holds values from **two unrelated vocabularies**:

| Vocabulary | Source | Codes |
|---|---|---|
| ISO 19650 **role** | `ProjectMembersController.GetRoles()` | `A PM BC BA AR SE ME CE QS CA CT SC FM OM CL M V Z` |
| STING **discipline** | `ASS_DISCIPLINE_COD_TXT`, `TAG_CONFIG_v5_0_DISC_SYS_FUNC.csv` | `A E FP H LV M MG P RP S` |

They overlap on **exactly two codes**, and those two are the most common values in the data: **`A`** = Appointing Party *or* Architectural; **`M`** = Model Author *or* Mechanical.

This also retires an earlier wrong call of mine: I reported `S` and `EL` as invalid role codes. **`S` is Structural** — a correct discipline code that only looked wrong because it sat in a column being read as a role. Giving discipline its own field fixes the collision at the root rather than papering over it.

## Why no auto-migration

Measured on dev, 34 member rows:

| Confidence | Rows |
|---|---|
| **AMBIGUOUS** (`A` or `M`) | **20 (59%)** |
| HIGH | 13 |
| REVIEW (`EL`) | 1 |

Any automatic rule silently mis-resolves the **majority**, and capability derives from role, so a wrong resolution is a wrong permission. A cleverer rule would not help either — `Contributor + A` on *"Architectural Lead"* is plainly the discipline, while `Manager + A` on *"BIM Coordinator"* is genuinely arguable. Only someone who knows these people decides that.

## Target shape — four fields to three, not two

| Field | Purpose | Change |
|---|---|---|
| `AppUser.Role` | Authorization | **unchanged** |
| `ProjectMember.Iso19650Role` | ISO role: responsibility + capability | single role field |
| `ProjectMember.Discipline` | Trade | **new** |
| `ProjectMember.ProjectRole` | — | retired after backfill |

`AppUser.Role` stays because every admin surface is `[Authorize(Roles = "Admin,Owner")]`; making it an ISO code means rewriting authorization across the API — separate change, separate risk. `AppUser.Iso19650Role` carries the same ambiguity and is a follow-up.

## Sequence

Additive schema (plus a `RoleMigrationBackup` column holding the pre-migration pair, so it is reversible) → dual-write → generate the sheet **against production** → backfill from the **approved** columns only, refusing to run on a half-approved sheet → drop `ProjectRole` in a later migration.

The capability map is explicit and testable, with a test asserting every code `GetRoles()` serves has exactly one entry — so adding a role to the API without deciding its capability fails the build rather than defaulting to allow or deny.

## Honest limits

**Production has not been measured.** Every count here is the local dev database; the sheet must be regenerated against production before anything is approved. `EL` is deliberately **not** auto-corrected to `E` — a plausible typo fix is still a guess about a permission, so it goes to the sheet as REVIEW.

Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)