### PR TITLE
fix(billing): saturate the plan seat total so an unlimited plan cannot deny its first user

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -460,7 +460,7 @@ public class AuthController : ControllerBase
             Plan          = BillingPlan.Trial,
             Currency      = currency,
             BillingCycle  = BillingCycle.Monthly,
-            MaxUsers      = planLimits.MaxAuthors + planLimits.MaxCoordinators,
+            MaxUsers      = planLimits.TotalSeats,
             MaxProjects   = planLimits.MaxProjects,
             MimEnabled    = false,
             TrialExpiresAt = DateTime.UtcNow.AddDays(30)
@@ -1095,7 +1095,7 @@ public class AuthController : ControllerBase
                     Plan           = BillingPlan.Trial,
                     Currency       = "USD",
                     BillingCycle   = BillingCycle.Monthly,
-                    MaxUsers       = limits.MaxAuthors + limits.MaxCoordinators,
+                    MaxUsers       = limits.TotalSeats,
                     MaxProjects    = limits.MaxProjects,
                     MimEnabled     = false,
                     TrialExpiresAt = DateTime.UtcNow.AddDays(365)

--- a/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
@@ -170,7 +170,31 @@ public enum BillingCycle
 /// </summary>
 public static class BillingPlanLimits
 {
-    public record Limits(int MaxAuthors, int MaxCoordinators, int MaxProjects, long StorageMb, decimal MonthlyUsd);
+    public record Limits(int MaxAuthors, int MaxCoordinators, int MaxProjects, long StorageMb, decimal MonthlyUsd)
+    {
+        /// <summary>
+        /// Total billable headcount — the number <see cref="Tenant.MaxUsers"/> is
+        /// derived from at tenant creation.
+        ///
+        /// <para>SATURATES, and must never be rewritten as
+        /// <c>MaxAuthors + MaxCoordinators</c>. C# arithmetic is unchecked by
+        /// default, so that sum wraps NEGATIVE once either side is
+        /// <c>int.MaxValue</c> — <c>int.MaxValue + int.MaxValue = -2</c>, which
+        /// is what Enterprise produces today. <c>MaxUsers</c> is consumed as
+        /// <c>userCount &gt;= tenant.MaxUsers</c>, so a negative cap is true at
+        /// zero users and denies the tenant its FIRST user, reporting
+        /// "User limit (-2) reached".</para>
+        ///
+        /// <para>Reachable on main now; latent only because both creation paths
+        /// assign <c>BillingPlan.Trial</c> (1 + 0). It goes live the moment any
+        /// plan with an unlimited axis is assigned at creation. Guarded by
+        /// <c>BillingPlanSeatTotalTests</c>. See #616.</para>
+        /// </summary>
+        public int TotalSeats =>
+            MaxAuthors == int.MaxValue || MaxCoordinators == int.MaxValue
+                ? int.MaxValue
+                : MaxAuthors + MaxCoordinators;
+    }
 
     public static Limits For(BillingPlan plan) => plan switch
     {

--- a/Planscape.Server/tests/Planscape.Tests/BillingPlanSeatTotalTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/BillingPlanSeatTotalTests.cs
@@ -1,0 +1,63 @@
+using Planscape.Core.Entities;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// <c>Tenant.MaxUsers</c> is derived from the plan's seat total at tenant
+/// creation, and consumed as <c>userCount &gt;= tenant.MaxUsers</c>
+/// (<c>AdminController</c>, <c>ProjectMembersController</c>). A non-positive
+/// cap is therefore true at <c>userCount = 0</c> — the tenant is refused its
+/// very first user, with a message (<c>User limit (-2) reached</c>) that points
+/// at nothing.
+///
+/// C# arithmetic is unchecked by default, so <c>MaxAuthors + MaxCoordinators</c>
+/// wraps negative the moment either side is <c>int.MaxValue</c>:
+///
+///     1 + int.MaxValue            = -2,147,483,648
+///     int.MaxValue + int.MaxValue = -2
+///
+/// Enterprise is <c>(int.MaxValue, int.MaxValue)</c> today, so this is reachable
+/// on main right now. It is latent only because both tenant-creation paths
+/// (<c>AuthController</c> registration and the D1 handoff) assign
+/// <c>BillingPlan.Trial</c>, which is <c>1 + 0</c>. It goes live the moment any
+/// plan with an unlimited axis is assigned at creation.
+///
+/// See #616. The loop enumerates <see cref="BillingPlan"/> rather than listing
+/// plans on purpose: a plan added later is covered without anyone remembering
+/// this file exists.
+/// </summary>
+public class BillingPlanSeatTotalTests
+{
+    [Fact]
+    public void Total_seats_never_wraps_negative_for_any_plan()
+    {
+        foreach (BillingPlan plan in Enum.GetValues<BillingPlan>())
+        {
+            var total = BillingPlanLimits.For(plan).TotalSeats;
+
+            Assert.True(total > 0,
+                $"{plan} yields TotalSeats = {total}. A non-positive cap is written to " +
+                "Tenant.MaxUsers and compared as `userCount >= MaxUsers`, so it denies " +
+                "the tenant its first user. The sum must saturate, not wrap.");
+        }
+    }
+
+    [Fact]
+    public void An_unlimited_axis_saturates_instead_of_summing()
+    {
+        // The specific arithmetic that wraps, pinned so a future edit that
+        // "simplifies" TotalSeats back to a raw sum fails here rather than in
+        // production. Enterprise is the plan that has both axes unlimited.
+        Assert.Equal(int.MaxValue, BillingPlanLimits.For(BillingPlan.Enterprise).TotalSeats);
+    }
+
+    [Fact]
+    public void Finite_plans_still_report_their_real_total()
+    {
+        // Saturation must not become "everything is unlimited". Studio is
+        // 1 author + 5 coordinators on main.
+        var studio = BillingPlanLimits.For(BillingPlan.Studio);
+        Assert.Equal(studio.MaxAuthors + studio.MaxCoordinators, studio.TotalSeats);
+        Assert.NotEqual(int.MaxValue, studio.TotalSeats);
+    }
+}


### PR DESCRIPTION
Closes #616.

## The defect

`Tenant.MaxUsers` was derived as `MaxAuthors + MaxCoordinators`. C# arithmetic is unchecked by default, so that sum wraps **negative** once either side is `int.MaxValue`:

```
           1 + int.MaxValue = -2,147,483,648
int.MaxValue + int.MaxValue = -2          <- Enterprise, today
```

`MaxUsers` is consumed as `userCount >= tenant.MaxUsers` (`AdminController:78`, `ProjectMembersController:256`), so a negative cap is true at **zero users**: the tenant is refused its *first* user, reporting `User limit (-2) reached` — a message that points at nothing.

**Reachable on main now.** Latent only because both tenant-creation paths — `AuthController` registration (`:463`) and the D1 handoff (`:1098`) — assign `BillingPlan.Trial`, which is `1 + 0`. It goes live the moment any plan with an unlimited axis is assigned at creation, which is precisely what a "licences included" tier will do.

## Why this is its own PR, and a correction

#616 captured this requirement when the seat-model stack (#606, #607) was superseded by the licence-based model, on my assessment that the fix was **not independently salvageable**. That was too pessimistic of me.

The saturating *arithmetic* is separable from the author/coordinator split. This PR touches only the `Limits` record and the two `MaxUsers` writers — **no `QuotaGuardService`, no change to any plan’s numbers, no seat-model concept**. Nothing here re-introduces the superseded model, and nothing here depends on it.

Grep-verified: the only remaining `MaxAuthors + MaxCoordinators` in `src/` is inside the saturating property’s own guarded `else` branch.

## RED before GREEN

`TotalSeats` was first written as the raw sum, reproducing today’s behaviour, so the test demonstrably catches the real defect:

| | result |
|---|---|
| raw sum (today’s behaviour) | **Failed 2, Passed 1** |
| saturating | **Failed 0, Passed 3** |
| full suite | **Failed 0, Passed 585**, Skipped 9, Total 594 |

The test that passes in the RED run is `Finite_plans_still_report_their_real_total` — Studio (`1 + 5`) works today and must keep working, so saturation cannot be implemented as "everything is unlimited". Without that control, `TotalSeats => int.MaxValue` would satisfy the other two.

The main test enumerates `Enum.GetValues<BillingPlan>()` rather than listing plans, so **a plan added later is covered without anyone remembering this file exists** — which is the whole point of carrying the requirement forward rather than the code.

## Scope

Three files: the `Limits` record, `AuthController` (two lines), and one new test file. No response shapes, routes, prices, caps or quota axes changed.

CI’s Build & Test / CI Gate is broken on `main` itself (Postgres service container, "role root does not exist"), so verification is local. Not merged, per the standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)