### PR TITLE
refactor(quota): retire the per-user quota axes — D1 owns seat entitlement

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/OnboardingController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/OnboardingController.cs
@@ -88,10 +88,10 @@ public class OnboardingController : ControllerBase
         var added = new List<object>();
         foreach (var m in req.Members)
         {
-            // Quota check per member — fail mid-list cleanly with a 402.
+            // Seat entitlement is the StingTools licence, counted in D1 (#621) —
+            // this endpoint no longer refuses with 402. `role` still drives the
+            // UserRole / Iso19650Role written below and the response rows.
             var role = string.Equals(m.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Coordinator";
-            var q = await _quota.CheckCanAddUserAsync(role, ct);
-            if (!q.Allowed) return StatusCode(StatusCodes.Status402PaymentRequired, new { error = "quota_exceeded", added, denied = m, quota = q });
 
             var existing = await _db.Users.FirstOrDefaultAsync(u => u.Email == m.Email.ToLowerInvariant(), ct);
             if (existing != null) { added.Add(new { existing.Id, existing.Email, role, status = "exists" }); continue; }

--- a/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TenantAdminController.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
-using Planscape.Infrastructure.Services;
 
 namespace Planscape.API.Controllers;
 
@@ -13,9 +12,13 @@ namespace Planscape.API.Controllers;
 /// numbers a buyer needs to feel in control of their subscription:
 ///
 ///   • Plan, currency, trial expiry, billing-cycle
-///   • Live usage vs limits (authors / coordinators / projects / storage)
+///   • Live usage vs limits (projects / storage)
 ///   • Last-month revenue (if any payments) + next charge date
 ///   • Recent admin events (member invited, project created, plan changed)
+///
+/// Author / coordinator seat usage is NOT reported here. Seat entitlement is
+/// the StingTools licence, counted in D1 (#621); the counts that used to appear
+/// were derived from a ProjectRole predicate nothing writes (#619).
 ///
 /// All endpoints scoped to the resolved tenant by the global query filter
 /// from S1.1 — there is no path-parameter for tenant id so an admin can't
@@ -28,13 +31,11 @@ public class TenantAdminController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
     private readonly ITenantContext _tenantContext;
-    private readonly IQuotaGuardService _quota;
 
-    public TenantAdminController(PlanscapeDbContext db, ITenantContext tenantContext, IQuotaGuardService quota)
+    public TenantAdminController(PlanscapeDbContext db, ITenantContext tenantContext)
     {
         _db = db;
         _tenantContext = tenantContext;
-        _quota = quota;
     }
 
     /// <summary>Single dashboard payload — plan, usage, members, billing.</summary>
@@ -47,12 +48,6 @@ public class TenantAdminController : ControllerBase
         var limits = BillingPlanLimits.For(tenant.Plan);
 
         var memberCount = await _db.ProjectMembers.CountAsync(ct);
-        var authorIds = await _db.ProjectMembers
-            .Where(m => m.ProjectRole == "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
-        var coordIds  = await _db.ProjectMembers
-            .Where(m => m.ProjectRole != "Author")
-            .Select(m => m.UserId).Distinct().ToListAsync(ct);
         var projectCount = await _db.Projects.CountAsync(ct);
         var storageBytes = await _db.ProjectModels.AsNoTracking()
             .Where(m => m.DeletedAt == null)
@@ -81,8 +76,14 @@ public class TenantAdminController : ControllerBase
             },
             usage = new
             {
-                authors      = new { current = authorIds.Count,  max = limits.MaxAuthors },
-                coordinators = new { current = coordIds.Count,   max = limits.MaxCoordinators },
+                // `authors` and `coordinators` are gone. They were counted with
+                // the same ProjectRole == "Author" predicate as the retired
+                // quota axes — a literal none of this codebase's four writers
+                // produce — so `authors` always displayed 0 and `coordinators`
+                // displayed every member including Owners and Managers (#619).
+                // Seat usage now lives where seats are sold: the D1 licence
+                // count (#621). `limits` below still advertises what the plan
+                // includes; we simply no longer claim to measure it here.
                 projects     = new { current = projectCount,     max = limits.MaxProjects },
                 storage      = new { currentMb = storageBytes / 1024 / 1024, maxMb = limits.StorageMb },
                 memberSeats  = memberCount,
@@ -103,19 +104,10 @@ public class TenantAdminController : ControllerBase
     [HttpPost("invite")]
     public async Task<ActionResult> Invite([FromBody] InviteUserRequest req, CancellationToken ct)
     {
-        // Quota check — refuses with 402 if cap reached.
+        // Seat entitlement is the StingTools licence, counted in D1 (#621) — this
+        // endpoint no longer refuses with 402. `role` still drives the UserRole /
+        // Iso19650Role written below and the response.
         var role = string.Equals(req.Role, "Author", StringComparison.OrdinalIgnoreCase) ? "Author" : "Coordinator";
-        var quota = await _quota.CheckCanAddUserAsync(role, ct);
-        if (!quota.Allowed)
-            return StatusCode(StatusCodes.Status402PaymentRequired, new
-            {
-                error = "quota_exceeded",
-                axis = quota.Axis.ToString(),
-                current = quota.Current,
-                max = quota.Max,
-                reason = quota.Reason,
-                upgrade_url = "/billing/upgrade",
-            });
 
         // Existing user with this email?
         var existing = await _db.Users.FirstOrDefaultAsync(u => u.Email == req.Email.ToLowerInvariant(), ct);

--- a/Planscape.Server/src/Planscape.Infrastructure/Authorization/QuotaAttribute.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Authorization/QuotaAttribute.cs
@@ -23,12 +23,10 @@ namespace Planscape.Infrastructure.Authorization;
 public sealed class QuotaAttribute : Attribute, IAsyncActionFilter
 {
     private readonly QuotaAxis _axis;
-    private readonly string? _projectRoleHint;
 
-    public QuotaAttribute(QuotaAxis axis, string? projectRoleHint = null)
+    public QuotaAttribute(QuotaAxis axis)
     {
         _axis = axis;
-        _projectRoleHint = projectRoleHint;
     }
 
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -36,10 +34,16 @@ public sealed class QuotaAttribute : Attribute, IAsyncActionFilter
         var guard = context.HttpContext.RequestServices.GetRequiredService<IQuotaGuardService>();
         QuotaResult result = _axis switch
         {
-            QuotaAxis.Projects     => await guard.CheckCanAddProjectAsync(),
-            QuotaAxis.Authors      => await guard.CheckCanAddUserAsync(_projectRoleHint ?? "Author"),
-            QuotaAxis.Coordinators => await guard.CheckCanAddUserAsync(_projectRoleHint ?? "Coordinator"),
-            _                      => QuotaResult.Allow(_axis, 0, int.MaxValue),
+            QuotaAxis.Projects => await guard.CheckCanAddProjectAsync(),
+
+            // Storage is the ONLY axis that reaches here, and allowing it is
+            // correct rather than a fallback: the byte count is not known until
+            // the request body is read, so upload controllers call
+            // CheckCanUploadBytesAsync in the action body instead (see the
+            // class summary). The per-user axes that used to sit here are gone
+            // — QuotaAxis no longer declares them, so naming one is a compile
+            // error rather than something this arm would wave through.
+            _ => QuotaResult.Allow(_axis, 0, int.MaxValue),
         };
 
         if (!result.Allowed)

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/QuotaGuardService.cs
@@ -34,16 +34,6 @@ public class QuotaGuardService : IQuotaGuardService
         return Result(QuotaAxis.Projects, current, limits.MaxProjects);
     }
 
-    public async Task<QuotaResult> CheckCanAddUserAsync(string projectRole, CancellationToken ct = default)
-    {
-        // Authors and coordinators have separate caps.
-        var axis = string.Equals(projectRole, "Author", StringComparison.OrdinalIgnoreCase)
-                 ? QuotaAxis.Authors : QuotaAxis.Coordinators;
-        var (limits, current) = await CountAsync(axis, ct);
-        var max = axis == QuotaAxis.Authors ? limits.MaxAuthors : limits.MaxCoordinators;
-        return Result(axis, current, max);
-    }
-
     public async Task<QuotaResult> CheckCanUploadBytesAsync(long incomingBytes, CancellationToken ct = default)
     {
         var tenant = await _db.Tenants.AsNoTracking().FirstOrDefaultAsync(t => t.Id == _tenantContext.TenantId, ct);
@@ -72,10 +62,8 @@ public class QuotaGuardService : IQuotaGuardService
         var tid = _tenantContext.TenantId;
         var current = axis switch
         {
-            QuotaAxis.Projects     => await _db.Projects.CountAsync(p => p.TenantId == tid, ct),
-            QuotaAxis.Authors      => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole == "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
-            QuotaAxis.Coordinators => await _db.ProjectMembers.Where(m => m.TenantId == tid && m.ProjectRole != "Author").Select(m => m.UserId).Distinct().CountAsync(ct),
-            _                      => 0,
+            QuotaAxis.Projects => await _db.Projects.CountAsync(p => p.TenantId == tid, ct),
+            _                  => 0,
         };
         return (limits, current);
     }
@@ -93,11 +81,21 @@ public class QuotaGuardService : IQuotaGuardService
 public interface IQuotaGuardService
 {
     Task<QuotaResult> CheckCanAddProjectAsync(CancellationToken ct = default);
-    Task<QuotaResult> CheckCanAddUserAsync(string projectRole, CancellationToken ct = default);
     Task<QuotaResult> CheckCanUploadBytesAsync(long incomingBytes, CancellationToken ct = default);
 }
 
-public enum QuotaAxis { Projects, Authors, Coordinators, Storage }
+/// <summary>
+/// Authors and Coordinators are DELETED, not merely unused. Seat entitlement is
+/// the StingTools licence, counted in D1 by
+/// <c>marketing-site/functions/api/license/_lib/seats.ts</c> (#621).
+///
+/// Deleting the members rather than leaving them is the safer of the two: a
+/// stray <c>[Quota(QuotaAxis.Authors)]</c> is now a COMPILE error, where an
+/// unused member would have fallen to the filter's default arm and silently
+/// ALLOWED — which is indistinguishable from a working cap right up until
+/// someone relies on it. See #619 for what the removed arms actually counted.
+/// </summary>
+public enum QuotaAxis { Projects, Storage }
 
 public sealed record QuotaResult(bool Allowed, QuotaAxis Axis, long Current, long Max, string? Reason)
 {

--- a/planscape-web/app/settings/team/page.tsx
+++ b/planscape-web/app/settings/team/page.tsx
@@ -163,8 +163,11 @@ export default function TeamPage() {
 
       {data && (
         <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <Quota label="Authors" axis={data.usage.authors} />
-          <Quota label="Coordinators" axis={data.usage.coordinators} />
+          {/* Authors / Coordinators tiles removed with the .NET per-user quota
+              axes (#619) — seat entitlement is the StingTools licence, counted
+              in D1 (#621). The server no longer returns usage.authors or
+              usage.coordinators, and Quota reads axis.max directly, so leaving
+              these would throw on render rather than degrade. */}
           <Quota label="Projects" axis={data.usage.projects} />
           <Quota
             label="Storage (MB)"

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -299,8 +299,9 @@ export interface TenantDashboard {
     createdAt?: string;
   };
   usage: {
-    authors: TenantQuotaAxis;
-    coordinators: TenantQuotaAxis;
+    // No authors / coordinators: the .NET per-user quota axes are retired
+    // (#619) and seat entitlement is the StingTools licence counted in D1
+    // (#621). The dashboard no longer sends them.
     projects: TenantQuotaAxis;
     storage: { currentMb: number; maxMb: number };
     memberSeats?: number;


### PR DESCRIPTION
Retires the .NET per-user quota axes. Seat entitlement is the StingTools licence, recorded in D1 by `issue.ts` and counted by `_lib/seats.ts` (#621, merged). **Do not merge — for review.**

## Behaviour change

**Invites are no longer refused with 402 by the .NET server.** Both `POST /api/tenant/invite` and `POST /api/onboarding/team` previously returned `402 quota_exceeded`; they no longer can. Author entitlement is the D1 licence count.

`tenant.MaxUsers` is enforced separately and is **not** part of this retirement — see below.

## Why removed rather than repaired

`QuotaAxis.Authors` counted `ProjectMembers` with `ProjectRole == "Author"` — a literal none of the four writers in this codebase produce (`SeedData.cs:275/304` → Coordinator/Contributor, `AuthController.cs:1231` → Owner, `ProjectsController.cs:172` → Manager). `MaxAuthors` is 1 on every plan but Enterprise and was **never enforced**. `Coordinators`, its mirror (`!= "Author"`), counted every member including Owners and Managers.

### Measured, not inferred (RED)

A temporary characterisation test seeded four `ProjectMembers` using only the role strings the codebase actually writes, then asserted the defect against unmodified code:

| Assertion | Result |
|---|---|
| Control: members visible | `4` |
| `CheckCanAddUserAsync("Author")` | `Current=0, Max=1, Allowed=true` |
| `CheckCanAddUserAsync("Coordinator")` | `Current=4` (counts Owner + Manager) |

The control assertion is load-bearing: `PlanscapeDbContext`'s tenant filter falls back to `Guid.Empty`, so without first proving the four rows are visible, `Authors == 0` would have been indistinguishable from an empty result set. **Passed** — the defect is real.

That test is deleted in this PR. Its subject no longer exists, so it cannot survive the change it justified.

## Removed

- `CheckCanAddUserAsync` — `IQuotaGuardService` declaration and `QuotaGuardService` implementation
- The `Authors` / `Coordinators` arms of `CountAsync`
- The `Authors` / `Coordinators` arms of `QuotaAttribute`, plus the now-dead `projectRoleHint` constructor parameter
- The invite quota gate in `OnboardingController` and `TenantAdminController` (the `role` local is **kept** in both — it drives `UserRole` / `Iso19650Role` and the response rows)

## Kept

`QuotaAxis.Projects`, `QuotaAxis.Storage`, and the entire storage path. `[Quota(QuotaAxis.Projects)]` on `ProjectsController:116` still returns 402.

## Enum decision: DELETED, not left unused

`QuotaAxis` is now `{ Projects, Storage }`. A stray `[Quota(QuotaAxis.Authors)]` is a **compile error** — strictly stronger than the safe-default alternative, where an unused member would fall to the filter's `_ =>` arm and silently ALLOW, which is indistinguishable from a working cap until someone relies on it.

`Storage` is the only axis reaching the default arm, and allowing it there is correct rather than a fallback: the byte count isn't known until the body is read, so upload controllers call `CheckCanUploadBytesAsync` in the action body. Commented in place.

## Two things beyond the mapped blast radius

Both were required for the change to be honest, and both are flagged for review:

1. **`TenantAdminController`'s dashboard duplicated the same broken predicate** (`ProjectRole == "Author"`) for display at lines 48-55. Left in place, #619 could not be closed as "the broken predicate ceases to exist", and a billing page would keep showing a firm of four people "Authors 0/1". Removed from the `usage` payload; `limits` still advertises `MaxAuthors`/`MaxCoordinators` as plan metadata (they still feed `TotalSeats`).

2. **That is an API contract change with a live consumer.** `planscape-web/app/settings/team/page.tsx` renders `data.usage.authors` and `data.usage.coordinators` through a `Quota` component that reads `axis.max` directly — `undefined` would **throw on render**, not degrade. The two tiles and the two `lib/types.ts` fields are removed with it.

`inviteMessage`'s `402` branch in that page is left alone deliberately — it is defensive, costs nothing, and removing it is not required for correctness.

## `tenant.MaxUsers` — stays, but it is now mis-shaped

Not part of this retirement. It has **two** enforcement sites, not one:

- `ProjectMembersController:310` — invite-by-email, when creating a pending account
- `AdminController:86` — `POST /api/admin/users`

Both are `userCount >= tenant.MaxUsers` over active `AppUser` rows: a **total-account cap**, not a seat cap. It is derived from the same `BillingPlanLimits` this PR partly retires — `AuthController:463` and `:1098` set `MaxUsers = planLimits.TotalSeats`, which saturates (see `Tenant.cs:176-190`, #616).

**Recommendation: it stays for now, tracked separately — it should become an abuse ceiling decoupled from `TotalSeats`, not licence-derived.**

- It cannot be **licence-derived** today: that needs a .NET → D1 link that does not exist, and the D1 count meters *machines*, not accounts. Viewers hold no licence, so it could never bound them.
- It should not simply **go**: the invite endpoints create `AppUser` rows, and with the 402 gate gone `MaxUsers` is the last thing bounding account creation at all.
- But leaving it tracking `TotalSeats` keeps "viewers are free" half-true, exactly as you said. Studio is `MaxAuthors(1) + MaxCoordinators(5) = 6`, so a Studio firm is refused its 7th account — including a free viewer.

I have **not** filed this as an issue; say the word and I will.

## Verification

| | Result |
|---|---|
| RED (measurement on unmodified code) | 1 passed — defect confirmed |
| Baseline `dotnet test` on `origin/main` | **617 passed / 9 skipped / 626 total / 0 failed** |
| GREEN after removal | **617 passed / 9 skipped / 626 total / 0 failed** |
| `Planscape.API` build | 0 errors, 7 warnings (pre-existing NU1603 ×4 + CS0618 ×3) |
| `planscape-web` `tsc --noEmit` | 68 errors before **and** after — all pre-existing `Badge tone` / `Button variant` mismatches, none in the edited files |

No test referenced the removed paths, so the identical counts are expected rather than reassuring. The only quota test — `QuotaGuard_ProjectCap_*` in `SecurityCriticalPathTests` — exercises `CheckCanAddProjectAsync` / `QuotaAxis.Projects`, both kept, and still passes.

Known-broken CI (Build & Test / CI Gate failing on a Postgres service container, "role root does not exist") is broken on `main` itself and unrelated.

Closes #619.