### PR TITLE
fix(viewer): floor the orthographic zoom-out, which maxDistance never bounded

### DIFF
--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1209,6 +1209,18 @@ THREE.ColorManagement.enabled = false;
     // way. OrbitControls enforces this through _clampDistance, including on the
     // zoomToCursor path. No clamp until a model is loaded (bounds empty).
     controls.maxDistance = box ? radius * 40 : Infinity;
+    // ZOOMCLAMP (ortho) — maxDistance does NOTHING in orthographic: the eye never
+    // moves, camera.zoom does the work. With OrbitControls' default minZoom of 0 the
+    // zoom-out is unbounded — measured on a 25 m model, 100 notches already widen the
+    // view to 600 m and 200 notches to 24 km, where the model is 0.05% of the frame,
+    // i.e. sub-pixel and effectively gone. It is recoverable (scrolling back in
+    // multiplies zoom straight back up) but the user has to scroll all the way home
+    // to find the model again. Floor it so the widest ortho view shows ~20× the model
+    // radius, which is the same framing maxDistance allows in perspective.
+    if (camera.isOrthographicCamera) {
+      const halfH = (camera.top - camera.bottom) / 2;
+      controls.minZoom = (box && halfH > 0) ? halfH / (radius * 20) : 0;
+    }
     // Far must clear the BACK of the model from wherever the eye now is, with slack
     // for pins, section box and the sky/ground helpers.
     const far = Math.max(dist + radius * 3, radius * 8, 1);

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1209,6 +1209,18 @@ THREE.ColorManagement.enabled = false;
     // way. OrbitControls enforces this through _clampDistance, including on the
     // zoomToCursor path. No clamp until a model is loaded (bounds empty).
     controls.maxDistance = box ? radius * 40 : Infinity;
+    // ZOOMCLAMP (ortho) — maxDistance does NOTHING in orthographic: the eye never
+    // moves, camera.zoom does the work. With OrbitControls' default minZoom of 0 the
+    // zoom-out is unbounded — measured on a 25 m model, 100 notches already widen the
+    // view to 600 m and 200 notches to 24 km, where the model is 0.05% of the frame,
+    // i.e. sub-pixel and effectively gone. It is recoverable (scrolling back in
+    // multiplies zoom straight back up) but the user has to scroll all the way home
+    // to find the model again. Floor it so the widest ortho view shows ~20× the model
+    // radius, which is the same framing maxDistance allows in perspective.
+    if (camera.isOrthographicCamera) {
+      const halfH = (camera.top - camera.bottom) / 2;
+      controls.minZoom = (box && halfH > 0) ? halfH / (radius * 20) : 0;
+    }
     // Far must clear the BACK of the model from wherever the eye now is, with slack
     // for pins, section box and the sky/ground helpers.
     const far = Math.max(dist + radius * 3, radius * 8, 1);


### PR DESCRIPTION
Follow-up to #622, which capped zoom-out at 20× the model diagonal with `controls.maxDistance`. I flagged at the time that ortho was not covered by it; this is that check, and the gap is real.

`maxDistance` does nothing in orthographic — the eye never moves, `camera.zoom` does the work, and OrbitControls' `minZoom` defaults to `0`. So ortho zoom-out was still unbounded.

## Measured, before

25.3 m box (radius 12.33), scrolling out in ortho:

| notches | view half-height | model, as % of frame height |
|---|---|---|
| 50 | 94.8 m | 13% |
| 100 | 601.1 m | 2.05% |
| 200 | 24,145.7 m | 0.05% — sub-pixel, gone |

## Change

`controls.minZoom` set alongside `maxDistance` in `updateClipPlanes`, so the widest ortho view shows ~20× the model radius — the same framing `maxDistance` allows in perspective. Recomputed per frame from `camera.top/bottom`, so it follows a re-fit or a resize.

## Measured, after

400 notches out pins at `zoom 0.055` / half-height **246.6 m** (= radius × 20), model a steady **5%** of frame height. Scrolling back in still works (246.6 → 56.3 m). Perspective untouched: `maxDistance` 493.2, `far` 99.

## Two honest notes

- **This is a framing floor, not a correctness fix.** Ortho does not clip on zoom-out — the span stays symmetric (`near -98.6` / `far 98.6` at the cap). So the original "blinks out while centred" report cannot have been ortho, and this does not explain it.
- **Unbounded ortho zoom is not an unrecoverable lock.** My first draft of the code comment said zoom reaches literally 0 and sticks; that was me misreading a `toFixed(4)` rendering of `0.0000`. Tested properly, zoom decays to 1.7e-14 after 400 notches and multiplies straight back up on scroll-in. The real cost is only that the model goes sub-pixel and you must scroll all the way home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)