### PR TITLE
fix(mobile): a refused CDE transition no longer claims the request was sent

### DIFF
--- a/Planscape/.gitignore
+++ b/Planscape/.gitignore
@@ -6,3 +6,6 @@ web-build/
 .DS_Store
 ios/Pods/
 android/.gradle/
+
+# #624 — transpiler output for scripts/verify-cde-transition-messages.cjs
+.verify-out/

--- a/Planscape/app/(tabs)/documents.tsx
+++ b/Planscape/app/(tabs)/documents.tsx
@@ -16,6 +16,7 @@ import { theme, getCDEColor } from '@/utils/theme';
 import { listProjects, listDocuments, transitionCDE, requestDocumentApproval, decideDocumentApproval, getMyProjectAccess, type MyProjectAccess, type ListDocumentsFilters } from '@/api/endpoints';
 import type { DocumentRecord, Project, CDEStatus } from '@/types/api';
 import { crashReporter } from '@/services/crashReporter';
+import { describeTransitionFailure } from '@/utils/cdeTransitionMessage';
 import { useAuthStore } from '@/stores/authStore';
 
 const CDE_STATES: CDEStatus[] = ['WIP', 'SHARED', 'PUBLISHED', 'ARCHIVE'];
@@ -150,32 +151,50 @@ export default function DocumentsScreen() {
   async function handleTransition(doc: DocumentRecord, newStatus: CDEStatus) {
     if (!activeProject) return;
     setTransitioning(true);
+
+    // #624 — the two branches below are separate outcomes and must report
+    // separately. They used to share one `catch` whose 403 arm said "The
+    // request has been sent", which was untrue on BOTH paths: on the direct
+    // path no approval request was ever attempted, and on the approval path
+    // the request is precisely what was refused. Either way nothing is
+    // pending, and the user was told to wait for an approval that would never
+    // arrive. Keep the attempts — and the messages — apart.
     try {
       if (requiresApproval(doc.cdeStatus, newStatus)) {
         // Fire the approval request — does NOT actually move the CDE state;
         // the approver's decideDocumentApproval call does that server-side.
-        await requestDocumentApproval(activeProject.id, doc.id, newStatus);
+        try {
+          await requestDocumentApproval(activeProject.id, doc.id, newStatus);
+        } catch (err: unknown) {
+          const failure = describeTransitionFailure(err, 'approval-request');
+          Alert.alert(failure.title, failure.body);
+          return;
+        }
         Alert.alert(
           'Approval requested',
           `CDE transition to ${newStatus} submitted for approval per ISO 19650-2 §5.6. You will be notified when it is approved or rejected.`,
         );
-        // Refresh so the "approval pending" badge appears if the server renders it
-        await loadData(activeProject.id);
+        // Refresh so the "approval pending" badge appears if the server renders it.
+        // A failure here is a refresh failure, not a transition failure — the
+        // request above did land — so it must not be reported as either.
+        try {
+          await loadData(activeProject.id);
+        } catch (refreshErr: unknown) {
+          crashReporter.warn('documents.handleTransition: refresh after approval request failed', {
+            e: String(refreshErr),
+          });
+        }
       } else {
-        const updated = await transitionCDE(activeProject.id, doc.id, newStatus);
+        let updated: DocumentRecord;
+        try {
+          updated = await transitionCDE(activeProject.id, doc.id, newStatus);
+        } catch (err: unknown) {
+          const failure = describeTransitionFailure(err, 'transition');
+          Alert.alert(failure.title, failure.body);
+          return;
+        }
         setDocuments((prev) => prev.map((d) => (d.id === updated.id ? updated : d)));
         setSelectedDoc(updated);
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Transition failed';
-      // 403 on a gated transition means the user tried to bypass approval
-      if (msg.includes('HTTP 403')) {
-        Alert.alert(
-          'Approval required',
-          'This transition needs BIM Coordinator sign-off. The request has been sent — check back when it is approved.',
-        );
-      } else {
-        Alert.alert('CDE Transition Failed', msg);
       }
     } finally {
       setTransitioning(false);

--- a/Planscape/scripts/tsconfig.verify.json
+++ b/Planscape/scripts/tsconfig.verify.json
@@ -1,0 +1,18 @@
+{
+  "//": "#624 — minimal transpile of the RN-free message module so scripts/verify-cde-transition-messages.mjs can exercise the REAL code rather than a hand-copied transcription of it. Output is gitignored.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "rootDir": "../src",
+    "outDir": "../.verify-out",
+    "baseUrl": "..",
+    "paths": { "@/*": ["src/*"] },
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "../src/utils/cdeTransitionMessage.ts",
+    "../src/api/apiError.ts"
+  ]
+}

--- a/Planscape/scripts/verify-cde-transition-messages.cjs
+++ b/Planscape/scripts/verify-cde-transition-messages.cjs
@@ -1,0 +1,126 @@
+/**
+ * #624 verification harness.
+ *
+ * Runs the REAL `src/utils/cdeTransitionMessage.ts` (transpiled to
+ * `.verify-out/`, see the npm script) against responses CAPTURED FROM A
+ * RUNNING PLANSCAPE API. Nothing below is invented; each `wire:` line is a
+ * verbatim status + body observed on 2026-08-06 against
+ * `docker compose` at http://localhost:5000. The capture commands are in the
+ * PR body so they can be re-run.
+ *
+ *   node scripts/verify-cde-transition-messages.cjs
+ *
+ * Exits non-zero if any assertion fails.
+ */
+const { describeTransitionFailure } = require('../.verify-out/utils/cdeTransitionMessage.js');
+const { ApiError } = require('../.verify-out/api/apiError.js');
+
+// Exactly src/api/client.ts — `body || \`HTTP ${status}\``.
+const wire = (status, body) => new ApiError(status, body || `HTTP ${status}`);
+
+/** The logic on origin/main (documents.tsx:169-179), for the before/after. */
+function originMain(err) {
+  const msg = err instanceof Error ? err.message : 'Transition failed';
+  if (msg.includes('HTTP 403')) {
+    return {
+      title: 'Approval required',
+      body: 'This transition needs BIM Coordinator sign-off. The request has been sent — check back when it is approved.',
+    };
+  }
+  return { title: 'CDE Transition Failed', body: msg };
+}
+
+const CASES = [
+  {
+    label: 'BRANCH 1 — requiresApproval FALSE. POST .../transition {"newStatus":"WIP"} as a Contributor',
+    attempt: 'transition',
+    status: 403,
+    body: '{"message":"Insufficient role for SHARED->WIP transition. Required: Coordinator, Current: Contributor"}',
+  },
+  {
+    label: 'BRANCH 2 — requiresApproval TRUE. POST .../approval-request {"targetState":"PUBLISHED"} as a project author with no active member row',
+    attempt: 'approval-request',
+    status: 403,
+    body: '{"error":"You are not a member of this project"}',
+  },
+  {
+    label: 'BRANCH 2 as origin/main actually calls it — POST .../approvals (no such route)',
+    attempt: 'approval-request',
+    status: 404,
+    body: '',
+  },
+  {
+    label: 'Empty-body 403 — ASP.NET Forbid(), e.g. ProjectMembersController.AddMember',
+    attempt: 'transition',
+    status: 403,
+    body: '',
+  },
+  {
+    label: 'Non-403 refusal — POST .../approval-request {"targetState":"SHARED"}; server does not gate WIP->SHARED',
+    attempt: 'approval-request',
+    status: 400,
+    body: 'Transition WIP->SHARED does not require approval',
+  },
+  {
+    label: 'Network failure — not an ApiError at all',
+    attempt: 'transition',
+    raw: new TypeError('Network request failed'),
+  },
+];
+
+const quote = (s) => s.split('\n').map((l) => '        │ ' + l).join('\n');
+
+for (const c of CASES) {
+  const err = c.raw ?? wire(c.status, c.body);
+  console.log('─'.repeat(104));
+  console.log(c.label);
+  console.log(`  wire: status=${c.raw ? '(none)' : c.status}  body=${c.raw ? '(none)' : JSON.stringify(c.body)}`);
+  const before = originMain(err);
+  const after = describeTransitionFailure(err, c.attempt);
+  console.log(`\n  origin/main   [${before.title}]`);
+  console.log(quote(before.body));
+  console.log(`\n  this branch   kind=${after.kind}  [${after.title}]`);
+  console.log(quote(after.body));
+  console.log();
+}
+
+const failures = [];
+const check = (name, ok) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`);
+  if (!ok) failures.push(name);
+};
+
+console.log('═'.repeat(104));
+
+const b1 = describeTransitionFailure(wire(403, CASES[0].body), 'transition');
+const b2 = describeTransitionFailure(wire(403, CASES[1].body), 'approval-request');
+const empty403 = describeTransitionFailure(wire(403, ''), 'transition');
+
+check('branch 1 no longer claims a request was sent',
+  !/request has been sent|check back/i.test(b1.body));
+check('branch 1 states explicitly that NOTHING was submitted',
+  /Nothing was submitted/.test(b1.body));
+check('branch 2 says the request was REFUSED, not sent',
+  /refused/i.test(b2.body) && !/has been sent/i.test(b2.body));
+check('the two branches do not share a title', b1.title !== b2.title);
+check('the two branches do not share a body', b1.body !== b2.body);
+check('branch 1 classified forbidden (not error)', b1.kind === 'forbidden');
+check('branch 2 classified forbidden (not error)', b2.kind === 'forbidden');
+check('both surface the server reason verbatim',
+  b1.body.includes('Required: Coordinator, Current: Contributor') &&
+  b2.body.includes('You are not a member of this project'));
+check('404 is NOT forbidden',
+  describeTransitionFailure(wire(404, ''), 'approval-request').kind === 'error');
+check('network failure is NOT forbidden',
+  describeTransitionFailure(new TypeError('Network request failed'), 'transition').kind === 'error');
+check('empty-body 403 is still forbidden, and admits no reason was given',
+  empty403.kind === 'forbidden' && empty403.body.includes('gave no reason'));
+check('regression witness: origin/main DID emit the false claim on an empty-body 403',
+  /request has been sent/.test(originMain(wire(403, '')).body));
+check('regression witness: origin/main missed every 403 carrying a reason, and dumped raw JSON',
+  originMain(wire(403, CASES[0].body)).title === 'CDE Transition Failed' &&
+  originMain(wire(403, CASES[0].body)).body.startsWith('{"message"'));
+
+console.log('═'.repeat(104));
+console.log(failures.length === 0 ? 'ALL ASSERTIONS PASSED' : `FAILED: ${failures.join(' | ')}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/Planscape/src/api/apiError.ts
+++ b/Planscape/src/api/apiError.ts
@@ -1,0 +1,20 @@
+/**
+ * The error every non-OK `apiFetch` response is thrown as.
+ *
+ * Lives in its own module — with no React Native / Expo imports — so that
+ * pure message-formatting code (and its harness) can depend on the error
+ * *shape* without dragging in `expo-secure-store` and the whole client.
+ * `client.ts` re-exports it, so existing `from '@/api/client'` imports are
+ * unaffected.
+ *
+ * `message` is the raw response body. It falls back to the literal string
+ * `HTTP <status>` only when the body is EMPTY — so testing `message` for
+ * "HTTP 403" is a test for an *empty body*, not for the status. Read the
+ * status from `.status`.
+ */
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}

--- a/Planscape/src/api/client.ts
+++ b/Planscape/src/api/client.ts
@@ -1,5 +1,6 @@
 import * as SecureStore from 'expo-secure-store';
 import { getLanguage } from '../i18n';
+import { ApiError } from './apiError';
 
 const TOKEN_KEY = 'planscape_token';
 const REFRESH_KEY = 'planscape_refresh';
@@ -106,12 +107,9 @@ async function refreshAccessToken(): Promise<string | null> {
   return refreshInFlight;
 }
 
-export class ApiError extends Error {
-  constructor(public status: number, message: string) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
+// Defined in ./apiError so RN-free code can depend on the shape; re-exported
+// here because every existing call site imports it from '@/api/client'.
+export { ApiError };
 
 export async function apiFetch<T>(
   path: string,

--- a/Planscape/src/api/endpoints.ts
+++ b/Planscape/src/api/endpoints.ts
@@ -1001,8 +1001,18 @@ export function deleteDocumentMarkup(projectId: string, documentId: string, mark
 }
 
 // Document approval (NEW-INT-15)
+//
+// #624 — the route is `approval-request`, not `approvals`. There has never
+// been an `/approvals` action on DocumentsController, so every call from this
+// function 404d before it reached any authorization check, which meant the
+// approval branch of documents.tsx could not be exercised at all. Measured
+// against a running API on 2026-08-06:
+//   POST .../documents/{id}/approvals        -> 404, empty body
+//   POST .../documents/{id}/approval-request -> 403 {"error":"You are not a member of this project"}
+// Sibling `decideDocumentApproval` below already carries the same class of
+// correction (`/approval/{id}`, singular); this one was missed.
 export function requestDocumentApproval(projectId: string, documentId: string, targetState: string): Promise<unknown> {
-  return apiFetch(`/api/projects/${projectId}/documents/${documentId}/approvals`, {
+  return apiFetch(`/api/projects/${projectId}/documents/${documentId}/approval-request`, {
     method: 'POST', body: JSON.stringify({ targetState }),
   });
 }

--- a/Planscape/src/utils/cdeTransitionMessage.ts
+++ b/Planscape/src/utils/cdeTransitionMessage.ts
@@ -1,0 +1,125 @@
+// Imported from the RN-free module, not from '@/api/client', so this file
+// stays runnable outside a React Native runtime — see apiError.ts. Relative
+// (not '@/...') because the verification harness transpiles this file with
+// plain tsc, which does not rewrite path aliases.
+import { ApiError } from '../api/apiError';
+
+/**
+ * Which server call was in flight when the failure came back.
+ *
+ * This distinction is the whole point of this module (#624). A refused CDE
+ * transition and a refused *approval request* are different outcomes, and the
+ * screen must not describe one as the other:
+ *
+ *   'transition'       — `POST .../transition`. No approval record was ever
+ *                        attempted. If this is refused, nothing is pending.
+ *   'approval-request' — `POST .../approval-request`. An approval record was
+ *                        attempted and the server refused to create it. Also
+ *                        nothing pending, but for a different reason.
+ *
+ * Do not collapse the two into one message "to keep the code tidy". Collapsing
+ * them is the defect this module exists to remove.
+ */
+export type TransitionAttempt = 'transition' | 'approval-request';
+
+export type TransitionFailure = {
+  /**
+   * 'forbidden' — the server refused on authority grounds (403).
+   * 'error'     — anything else: unreachable, 4xx, 5xx.
+   *
+   * Kept separate so the caller can render a refusal differently from a
+   * breakage. "Ask your project manager" and "call IT" are different actions.
+   */
+  kind: 'forbidden' | 'error';
+  title: string;
+  body: string;
+};
+
+/**
+ * The reason the SERVER gave, or null when it gave none.
+ *
+ * Never guesses. `ApiError.message` is the raw response body (see
+ * `api/client.ts` — `throw new ApiError(res.status, body || \`HTTP ${status}\`)`),
+ * so it is one of:
+ *
+ *   - a JSON object, `{"message": "..."}` or `{"error": "..."}` — the two
+ *     shapes every 403 in DocumentsController actually emits;
+ *   - plain prose, e.g. `Transition WIP->SHARED does not require approval`;
+ *   - the literal string `HTTP 403`, which is the *fallback for an empty body*
+ *     and therefore means "no reason given", not "403".
+ *
+ * That last point is why the old `msg.includes('HTTP 403')` test was wrong on
+ * its own terms: it fires only when the body is EMPTY, and misses every 403
+ * that carries a reason. Read the status off ApiError; read the reason off the
+ * body; never conflate the two.
+ */
+export function serverReason(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+
+  const raw = (err.message ?? '').trim();
+  if (!raw || raw === `HTTP ${err.status}`) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      const bag = parsed as Record<string, unknown>;
+      for (const key of ['message', 'error', 'detail']) {
+        const value = bag[key];
+        if (typeof value === 'string' && value.trim()) return value.trim();
+      }
+      // Structured, but not a shape we recognise (e.g. an RFC 9110
+      // ProblemDetails whose `title` is just "Not Found"). Better to say
+      // nothing than to dump JSON at an operator on a site.
+      return null;
+    }
+  } catch {
+    // Not JSON — the body is already prose, use it verbatim.
+  }
+  return raw;
+}
+
+const NOTHING_SENT =
+  'Nothing was submitted. This transition was refused outright, so there is no approval pending and nothing to wait for.';
+
+const REQUEST_REFUSED =
+  'Your approval request was refused, so no approval is pending.';
+
+const NO_REASON_GIVEN = 'The server refused this action but gave no reason.';
+
+/**
+ * Turn a failed CDE-transition call into exactly what happened.
+ *
+ * The predecessor of this function told every 403 that "The request has been
+ * sent — check back when it is approved", on both branches, when on neither
+ * branch had a request been accepted. A user who reads that waits instead of
+ * acting. Stating a false outcome is worse than stating an unhelpful one.
+ */
+export function describeTransitionFailure(
+  err: unknown,
+  attempt: TransitionAttempt,
+): TransitionFailure {
+  const reason = serverReason(err);
+  const forbidden = err instanceof ApiError && err.status === 403;
+
+  if (forbidden) {
+    return attempt === 'approval-request'
+      ? {
+          kind: 'forbidden',
+          title: 'Approval request refused',
+          body: `${reason ?? NO_REASON_GIVEN}\n\n${REQUEST_REFUSED}`,
+        }
+      : {
+          kind: 'forbidden',
+          title: 'Not permitted',
+          body: `${reason ?? NO_REASON_GIVEN}\n\n${NOTHING_SENT}`,
+        };
+  }
+
+  const fallback =
+    reason ??
+    (err instanceof Error && err.message ? err.message : 'Transition failed');
+
+  return attempt === 'approval-request'
+    ? { kind: 'error', title: 'Approval request failed', body: fallback }
+    : { kind: 'error', title: 'CDE Transition Failed', body: fallback };
+}


### PR DESCRIPTION
Closes #624.

## The defect

`Planscape/app/(tabs)/documents.tsx` wrapped both transition branches in one `try`, and the 403 arm of the shared `catch` rendered:

> **Approval required** — This transition needs BIM Coordinator sign-off. The request has been sent — check back when it is approved.

Nothing was pending on either path. The user waits instead of acting.

## What I measured (not asserted)

Against the local `docker compose` stack on 2026-08-06, as `a-lead@planscape.demo` (tenant role `Contributor`):

| Mobile branch | Call | Status | Body |
|---|---|---|---|
| `requiresApproval` **false** | `POST .../documents/{id}/transition` `{"newStatus":"WIP"}` | **403** | `{"message":"Insufficient role for SHARED->WIP transition. Required: Coordinator, Current: Contributor"}` |
| `requiresApproval` **true** | `POST .../documents/{id}/approval-request` `{"targetState":"PUBLISHED"}` | **403** | `{"error":"You are not a member of this project"}` |
| `requiresApproval` **true**, *as origin/main actually calls it* | `POST .../documents/{id}/approvals` | **404** | *(empty)* |

Branch-2's 403 was elicited by making the caller the project **author** with no active `ProjectMember` row — visible via `ProjectVisibility` (author clause), refused by `RequireProjectMemberAsync`.

### A correction to the issue's premise

The issue reads as though both branches hit the fabricated message. They hit the shared `catch`, but **which** message they got depends on the body, and that changes the story:

`ApiError.message` **is the raw response body**, falling back to the literal `HTTP <status>` **only when that body is empty** (`src/api/client.ts:157-159`). So `msg.includes('HTTP 403')` was never a status test — it was an *empty-body* test. Consequently, on `origin/main`:

* every 403 above, which carries a JSON body, **missed** the 403 arm and was dumped at the user as raw JSON — `{"message":"Insufficient role for SHARED->WIP transition. ..."}`;
* the fabricated "request has been sent" fires **only** on an empty-body 403, which is what ASP.NET `Forbid()` returns (`ProjectMembersController.AddMember:172` uses it today, so the shape is real in this API — it just is not produced by either of these two routes right now).

So today's live behaviour on these routes is a raw-JSON dump, and the fabricated claim is a latent trap that any future `Forbid()` on these paths would arm. Both are fixed. I have **not** reproduced the fabricated dialog from a live 403 on these two specific routes, because no current gate on them returns an empty body — I reproduced it from a real empty-body 403 shape. Stating that plainly rather than claiming more.

## The fix

`src/utils/cdeTransitionMessage.ts` — `describeTransitionFailure(err, attempt)` where `attempt` is `'transition' | 'approval-request'`.

* Status comes from `ApiError.status`. Reason comes from the body (`message` / `error` / `detail`, or plain prose). Unrecognised JSON yields *no reason* rather than a JSON dump at an operator on site.
* The two branches share **no title and no body**. The harness asserts that, so a later "tidy-up" that merges them fails loudly.

```
BRANCH 1 — POST .../transition, 403
  origin/main   [CDE Transition Failed]
                | {"message":"Insufficient role for SHARED->WIP transition. Required: Coordinator, Current: Contributor"}
  this branch   kind=forbidden  [Not permitted]
                | Insufficient role for SHARED->WIP transition. Required: Coordinator, Current: Contributor
                |
                | Nothing was submitted. This transition was refused outright, so there is no
                | approval pending and nothing to wait for.

BRANCH 2 — POST .../approval-request, 403
  origin/main   [CDE Transition Failed]
                | {"error":"You are not a member of this project"}
  this branch   kind=forbidden  [Approval request refused]
                | You are not a member of this project
                |
                | Your approval request was refused, so no approval is pending.

EMPTY-BODY 403 — ASP.NET Forbid()
  origin/main   [Approval required]
                | This transition needs BIM Coordinator sign-off. The request has been sent —
                | check back when it is approved.          <- the fabricated outcome
  this branch   kind=forbidden  [Not permitted]
                | The server refused this action but gave no reason.
                |
                | Nothing was submitted. This transition was refused outright, so there is no
                | approval pending and nothing to wait for.
```

## Two supporting corrections

**1. `requestDocumentApproval` called a route that does not exist.** It posted to `.../documents/{id}/approvals`; the action is `[HttpPost("{docId}/approval-request")]`. Every call 404d before reaching any authorization check, so the approval branch could not be exercised at all — including by the verification this issue asks for. Sibling `decideDocumentApproval` already carries the same class of correction (`/approval/{id}`, singular, "Phase 177"); this one was missed. Fixed, and flagged here rather than buried.

**2. `ApiError` moved to `src/api/apiError.ts`** (re-exported from `api/client`, so no call site changes) so the message logic has no Expo/RN imports and can actually be executed in a harness. `ApiError` had no other importer.

## Verification

```
node Planscape/scripts/verify-cde-transition-messages.cjs
```

Transpiles the **real** module and runs it against the six captured responses, then asserts 13 properties — including two *regression witnesses* that reproduce the origin/main behaviour, so the harness would fail if it were ever describing a fix that is not there. All 13 pass. `npx tsc --noEmit` gives 0 errors. `npx eslint` on all changed files gives 0 errors (3 pre-existing `no-explicit-any` warnings in `endpoints.ts`, lines 2435/2436/2686, untouched by this change).

Not verified: the dialog rendered on a physical device. There is no jest/RN test runner in `Planscape/` (`package.json` has `lint` and `typecheck` only), so the proof is the real module against real wire responses, not a screenshot.

## Deliberately not fixed here

* **Mobile and server disagree about which transitions need approval.** Mobile's `TRANSITIONS_REQUIRING_APPROVAL` holds `WIP->SHARED` and `SHARED->PUBLISHED`; the server's `ApprovalRequiredTransitions` holds `SHARED->PUBLISHED` and `PUBLISHED->SUPERSEDED`. With the route fixed, a WIP->SHARED approval request now reaches the server and gets `400 Transition WIP->SHARED does not require approval` (measured) instead of `404`. Honest and diagnostic, but the disagreement is real and needs someone to decide whose truth wins. Not a call to make inside this PR.
* **The shared forbidden treatment** — that is #558. This PR keeps the change reviewable on its own terms; the strings here will migrate to that helper.

## Also found, out of scope — reporting, not fixing

`Planscape.API/Authorization/ProjectMemberAcl.ResolveAsync` projects all three ACL columns to `(string?)null` (lines 70-76), so the Phase 177 per-folder ACL **never reads them**. Every member resolves to "everything allowed", and `ApplyTo` never narrows a document query. `PUT /members/{id}/acl` persists allow-lists that are then not enforced. I confirmed it live: a member restricted to `WIP,SHARED` was still allowed to request `PUBLISHED` (201). The projection carries a comment explaining it was defensive against an unapplied migration — the columns exist in the database now. Flagging for a separate issue; I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
