### PR TITLE
docs: log the viewer zoom fixes, and record what they did NOT explain

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Viewer zoom — the far plane, then both zoom-out bounds)
+
+Reported symptom: in the coordination viewer (`wwwroot/viewer.html`), the model
+disappeared after a modest scroll-out. Three PRs, of which only the first was a
+correctness fix; the other two bound the range.
+
+| PR | Change | Where |
+|---|---|---|
+| [#618](https://github.com/beckykyomugisha/STINGTOOLS/pull/618) | `updateClipPlanes()` recomputes near/far **every frame** from the camera's current distance to `modelBounds` | `viewer.html` (new fn + call in the animate loop) |
+| [#622](https://github.com/beckykyomugisha/STINGTOOLS/pull/622) | `controls.maxDistance = radius * 40` — perspective zoom-out capped at 20× the model diagonal | same fn |
+| [#627](https://github.com/beckykyomugisha/STINGTOOLS/pull/627) | `controls.minZoom` — ortho zoom-out floored to a view ~20× the model radius | same fn |
+
+**The original defect.** near/far were set **once**, by `fitCamera`, from the
+framing distance at load; the animate loop only ran `controls.update()`. For a
+~25 m building fit at ~32 m that froze `far` at ≈568 m, so the model crossed the
+far plane and vanished. `zoomToCursor` reaches that sooner than a plain dolly: a
+wheel-out retreats along the pointer ray and re-seats the orbit target ahead of
+the camera. Verified with three.js `Frustum.setFromProjectionMatrix` against the
+vendored `three.module.js` — the box leaves the frustum from 600 m under the old
+frozen plane and stays inside it at 600 m / 5 km / 100 km after.
+
+**Why two more PRs.** #618 is provably live (served bytes byte-identical to
+`main`, `Cache-Control: no-store`) and the symptom still reproduced *while the
+model stayed centred* — so the far plane was not the whole story. #622 and #627
+therefore bound the reachable range rather than explain it. Ortho needed its own
+bound because `maxDistance` does nothing there: the eye never moves, `camera.zoom`
+does the work, and OrbitControls' `minZoom` defaults to 0. Measured before the
+floor, on a 25.3 m box: 100 notches → 601 m view half-height, 200 → 24 km, model
+0.05% of frame. After: pinned at 246.6 m, model a steady 5%.
+
+**What is NOT explained** — see ROADMAP `VIEW-1`. Ortho is ruled out as the
+culprit (its span stays symmetric, `near -98.6` / `far 98.6`, so it never clips
+on zoom-out), and no code in the viewer or the overlay layers hides geometry by
+distance or zoom — no `scene.fog`, no LOD, no distance-driven `visible = false`,
+and every `renderer.clippingPlanes` writer is user-invoked (section box, clash
+section, section plane).
+
+Both `viewer.html` copies stay byte-identical (`Planscape/assets/viewer/` source
+and the committed `wwwroot/` copy); CI gates this with **Source ↔ wwwroot
+byte-equal** plus a container gate that builds the image, serves it, and diffs
+what comes back.
+
 #### Completed (Phase 231 — KUT gate presets, and the "26 dead buttons" that were not dead)
 
 **1. Six wired commands were in no preset.** `Program_Audit`, `OwnerStandards_Audit`,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,13 @@
 
 Open automation gaps, future-enhancement tables, and deep-review findings for the StingTools plugin. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`CHANGELOG.md`](CHANGELOG.md) for the history of closed items.
 
+## Coordination viewer — after the zoom fixes (2026-08-06)
+
+| ID | Item | Detail |
+|---|---|---|
+| VIEW-1 | **The original "model blinks out on zoom-out" is bounded, not explained** | [#618](https://github.com/beckykyomugisha/STINGTOOLS/pull/618) made near/far track the camera every frame and is provably live (served bytes byte-identical to `main`, `Cache-Control: no-store`) — yet the model still vanished **while staying centred**, which rules out both far-plane clipping and the `zoomToCursor` drift theory. [#622](https://github.com/beckykyomugisha/STINGTOOLS/pull/622) / [#627](https://github.com/beckykyomugisha/STINGTOOLS/pull/627) then capped perspective and ortho zoom-out so the camera cannot reach the range where it happened. **The mechanism is still unknown.** Ruled out by reading the served file: no `scene.fog`, no LOD, no distance- or zoom-driven `visible = false`, no camera-dependent clipping (every `renderer.clippingPlanes` writer — section box, clash section, section plane — is user-invoked), and ortho never clips on zoom-out (span stays symmetric, `near -98.6` / `far 98.6`). What is left is GPU/driver-level and only observable live: most plausibly depth-buffer behaviour under `logarithmicDepthBuffer: true`. **Diagnose only if it recurs** — the signal is the model vanishing *inside* the new bounds. The probe, run in the `viewer.html` frame (the viewer is an iframe; switch the DevTools console context), logs `STING_VIEWER.camera.near/far` against `position.length()` and `modelBounds` size while scrolling out; `far` frozen means the loop is not running, `far` growing with the model gone means the camera was never the cause, empty bounds means the fallback branch is sizing the frustum off the orbit distance. |
+| VIEW-2 | **The viewer cannot be exercised headlessly** | Unauthenticated hits on `/viewer.html` bounce to `/index.html` after ~1.5 s (`coordination-viewer.js` on the 401), so no CI or agent can drive the real viewer. Diagnosis of VIEW-1 needed a mirror of the deployed assets served locally — workable but manual, and it silently fails until every runtime-fetched vendor file is present (`vendor/three/addons/utils/BufferGeometryUtils.js` is fetched lazily and is easy to miss). Worth a token-gated or `?diag=1` boot path that skips the redirect, so viewer regressions can be caught by something other than a person scrolling. |
+
 ## Button + preset wiring — after Phase 230
 
 | ID | Item | Detail |


### PR DESCRIPTION
Three PRs landed on `main` — #618 (near/far per frame), #622 (perspective `maxDistance`), #627 (ortho `minZoom`) — with nothing written down. Per CLAUDE.md, completed work goes in `docs/CHANGELOG.md` and open gaps in `docs/ROADMAP.md`.

Docs only, no code change.

## CHANGELOG

The actual defect (near/far set once by `fitCamera`, frozen at ≈568 m for a ~25 m building, crossed on scroll-out), why `zoomToCursor` reaches it sooner than a plain dolly, and — the part worth recording — why two further PRs were needed *after* the real fix was already live.

## ROADMAP

**VIEW-1 — the original symptom is bounded, not explained.** #618 is provably live and the model still vanished *while centred*. The entry records everything ruled out by reading the served file (no fog, no LOD, no distance-driven `visible = false`, every clipping-plane writer user-invoked, ortho never clips), what's left (driver-level, plausibly the logarithmic depth buffer), the recurrence signal (vanishing *inside* the new bounds), and the console probe that splits the remaining hypotheses. Marked diagnose-only-if-it-recurs rather than left sitting as open work.

**VIEW-2 — the viewer can't be exercised headlessly.** `/viewer.html` bounces to `/index.html` on the 401, so no CI or agent can drive the real viewer. Diagnosing VIEW-1 needed a hand-built mirror of the deployed assets, which fails silently until every lazily-fetched vendor file is present (`BufferGeometryUtils.js` is easy to miss). Suggests a token-gated or `?diag=1` boot path.

The reason VIEW-1 is spelled out at this length: the next person to read the CHANGELOG will see three PRs closing a zoom bug and reasonably conclude it was solved. Two of the three only made the range unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)