### PR TITLE
One SCHEDULER for view schedules, plus tag schedules that reach a sheet

### DIFF
--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -49,6 +49,11 @@ namespace StingTools.Commands.TagStudio
         // Keep schedules SIMPLE — cap the union of discipline columns per category.
         private const int MaxColumns = 24;
 
+        // ExtraParam keys the Scheduler dashboard sets before dispatching here.
+        internal const string ParamMode    = "TagSched_Mode";     // Sheet | Full | Both
+        internal const string ParamBundles = "TagSched_Bundles";  // CSV of ARCH,GEN,HEALTH,MEP,STR
+        internal const string ParamPlace   = "TagSched_Place";    // "1" = place on sheets
+
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
             var ctx = ParameterHelpers.GetContext(commandData);
@@ -72,31 +77,56 @@ namespace StingTools.Commands.TagStudio
             }
 
             // ── Mode: sheet columns / full as-built / both ──
-            var modeDlg = new TaskDialog("Schedule Tag Expander");
-            modeDlg.MainInstruction = "Which schedules to build?";
-            modeDlg.MainContent =
-                "One ViewSchedule per model category. Column 1 = ASS_TAG_1_TXT (the tag), " +
-                "then the discipline columns, then Comments.";
-            modeDlg.CommonButtons = TaskDialogCommonButtons.Cancel;
-            modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
-                "Sheet columns (compact — recommended)",
-                "The curated discipline columns dropped from the universal tag (sheet_columns).");
-            modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
-                "Full as-built columns",
-                "The wider full_columns set (all discipline + fabrication params).");
-            modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink3,
-                "Both (sheet + full)",
-                "Two schedules per category: a compact sheet schedule and a wide as-built schedule.");
-            var mode = modeDlg.Show();
-            if (mode == TaskDialogResult.Cancel) return Result.Cancelled;
-            bool doSheet = mode == TaskDialogResult.CommandLink1 || mode == TaskDialogResult.CommandLink3;
-            bool doFull  = mode == TaskDialogResult.CommandLink2 || mode == TaskDialogResult.CommandLink3;
+            // The Scheduler dashboard pre-sets these via ExtraParams so the run
+            // is unattended; launched directly from a button, we still ask.
+            bool doSheet, doFull;
+            string presetMode = UI.StingCommandHandler.GetExtraParam(ParamMode);
+            if (!string.IsNullOrEmpty(presetMode))
+            {
+                doSheet = presetMode.Equals("Sheet", StringComparison.OrdinalIgnoreCase)
+                       || presetMode.Equals("Both", StringComparison.OrdinalIgnoreCase);
+                doFull  = presetMode.Equals("Full", StringComparison.OrdinalIgnoreCase)
+                       || presetMode.Equals("Both", StringComparison.OrdinalIgnoreCase);
+                if (!doSheet && !doFull)
+                {
+                    StingLog.Warn($"ScheduleTagExpander: unrecognised mode '{presetMode}' — defaulting to sheet columns.");
+                    doSheet = true;
+                }
+            }
+            else
+            {
+                var modeDlg = new TaskDialog("Schedule Tag Expander");
+                modeDlg.MainInstruction = "Which schedules to build?";
+                modeDlg.MainContent =
+                    "One ViewSchedule per model category. Column 1 = ASS_TAG_1_TXT (the tag), " +
+                    "then the discipline columns, then Comments.";
+                modeDlg.CommonButtons = TaskDialogCommonButtons.Cancel;
+                modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                    "Sheet columns (compact — recommended)",
+                    "The curated discipline columns dropped from the universal tag (sheet_columns).");
+                modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
+                    "Full as-built columns",
+                    "The wider full_columns set (all discipline + fabrication params).");
+                modeDlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink3,
+                    "Both (sheet + full)",
+                    "Two schedules per category: a compact sheet schedule and a wide as-built schedule.");
+                var mode = modeDlg.Show();
+                if (mode == TaskDialogResult.Cancel) return Result.Cancelled;
+                doSheet = mode == TaskDialogResult.CommandLink1 || mode == TaskDialogResult.CommandLink3;
+                doFull  = mode == TaskDialogResult.CommandLink2 || mode == TaskDialogResult.CommandLink3;
+            }
+
+            // ── Bundle filter (ARCH / GEN / HEALTH / MEP / STR) ──
+            // Empty = no filter, i.e. every bundle in the spec.
+            var bundleFilter = ParseBundles(UI.StingCommandHandler.GetExtraParam(ParamBundles));
+            bool placeOnSheets = UI.StingCommandHandler.GetExtraParam(ParamPlace) == "1";
 
             // ── Group entries by resolved category display name ──
             // categoryDisplay → (sheetCols union, fullCols union)
             var byCategory = new Dictionary<string, CategoryPlan>(StringComparer.OrdinalIgnoreCase);
             var unmatchedFamilies = new List<string>();
             int emptySkipped = 0;
+            int bundleSkipped = 0;
 
             foreach (var prop in spec.Properties())
             {
@@ -105,6 +135,12 @@ namespace StingTools.Commands.TagStudio
                 string family = e.Value<string>("family") ?? "";
                 var sheetCols = ReadStrArray(e, "sheet_columns");
                 var fullCols  = ReadStrArray(e, "full_columns");
+
+                if (bundleFilter.Count > 0)
+                {
+                    string bundle = e.Value<string>("bundle") ?? "";
+                    if (!bundleFilter.Contains(bundle)) { bundleSkipped++; continue; }
+                }
 
                 if (sheetCols.Count == 0 && fullCols.Count == 0) { emptySkipped++; continue; }
 
@@ -124,7 +160,8 @@ namespace StingTools.Commands.TagStudio
             {
                 TaskDialog.Show("Schedule Tag Expander",
                     $"No schedulable categories resolved from the spec.\n" +
-                    $"Skipped empty entries: {emptySkipped}, unmatched families: {unmatchedFamilies.Count}.");
+                    $"Skipped empty entries: {emptySkipped}, unmatched families: {unmatchedFamilies.Count}" +
+                    (bundleSkipped > 0 ? $", filtered out by bundle: {bundleSkipped}" : "") + ".");
                 return Result.Cancelled;
             }
 
@@ -138,6 +175,9 @@ namespace StingTools.Commands.TagStudio
             int created = 0, skippedExisting = 0, unresolvedCat = 0, notSchedulable = 0;
             int truncatedCols = 0;
             var unresolvedNames = new List<string>();
+
+            var builtSchedules = new List<ViewSchedule>();
+            TagSchedulePlacementResult placement = null;
 
             var progress = StingProgressDialog.Show("Schedule Tag Expander", byCategory.Count);
             try
@@ -161,14 +201,36 @@ namespace StingTools.Commands.TagStudio
                             var r = BuildSchedule(doc, cat, plan.CategoryDisplay, plan.SheetColumns,
                                 existing, isFull: false);
                             Tally(r, ref created, ref skippedExisting, ref notSchedulable, ref truncatedCols);
+                            if (r?.Schedule != null) builtSchedules.Add(r.Schedule);
                         }
                         if (doFull)
                         {
                             var r = BuildSchedule(doc, cat, plan.CategoryDisplay, plan.FullColumns,
                                 existing, isFull: true);
                             Tally(r, ref created, ref skippedExisting, ref notSchedulable, ref truncatedCols);
+                            if (r?.Schedule != null) builtSchedules.Add(r.Schedule);
                         }
                     }
+
+                    // Placement runs inside the same transaction so "build + place"
+                    // is a single undo step — a half-placed set is never left behind.
+                    if (placeOnSheets)
+                    {
+                        // Re-running after everything already exists builds nothing,
+                        // but the user still asked for sheets — fall back to the
+                        // tag-expander schedules already in the project so the
+                        // option is never a silent no-op.
+                        var toPlace = builtSchedules.Count > 0
+                            ? builtSchedules
+                            : CollectUnplacedExpanderSchedules(doc);
+
+                        if (toPlace.Count > 0)
+                        {
+                            progress.Increment($"Placing {toPlace.Count} schedule(s) on sheets…");
+                            placement = TagSchedulePlacer.Place(doc, toPlace);
+                        }
+                    }
+
                     tx.Commit();
                 }
             }
@@ -184,7 +246,18 @@ namespace StingTools.Commands.TagStudio
                 $"Not schedulable:         {notSchedulable}\n" +
                 $"Empty entries skipped:   {emptySkipped}\n" +
                 $"Unmatched families:      {unmatchedFamilies.Count}\n" +
+                (bundleSkipped > 0 ? $"Filtered out by bundle:  {bundleSkipped}\n" : "") +
                 (truncatedCols > 0 ? $"Column-capped categories: {truncatedCols} (>{MaxColumns} cols)\n" : "") +
+                (placement != null
+                    ? $"\nPlaced on sheets:        {placement.Placed}\n" +
+                      $"Sheets created:          {placement.SheetsCreated}\n" +
+                      (placement.Oversized > 0 ? $"Overrunning sheet border: {placement.Oversized}\n" : "") +
+                      (placement.Failed > 0 ? $"Placement failures:      {placement.Failed}\n" : "") +
+                      (placement.Warnings.Count > 0
+                          ? "\n" + string.Join("\n", placement.Warnings.Take(6)) +
+                            (placement.Warnings.Count > 6 ? $"\n… and {placement.Warnings.Count - 6} more (see log)" : "")
+                          : "")
+                    : "") +
                 (unresolvedNames.Count > 0
                     ? "\nNot in project: " + string.Join(", ", unresolvedNames.Take(12)) +
                       (unresolvedNames.Count > 12 ? " …" : "")
@@ -199,11 +272,54 @@ namespace StingTools.Commands.TagStudio
             return Result.Succeeded;
         }
 
+        /// <summary>
+        /// Tag-expander schedules that are not yet on any sheet. Used when a
+        /// re-run creates nothing new but the caller still asked for placement.
+        /// </summary>
+        private static List<ViewSchedule> CollectUnplacedExpanderSchedules(Document doc)
+        {
+            var placedIds = new HashSet<ElementId>(
+                new FilteredElementCollector(doc)
+                    .OfClass(typeof(ScheduleSheetInstance))
+                    .Cast<ScheduleSheetInstance>()
+                    .Select(s => s.ScheduleId));
+
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewSchedule))
+                .Cast<ViewSchedule>()
+                .Where(v => !v.IsTemplate
+                         && (v.Name ?? "").StartsWith(SchedulePrefix, StringComparison.OrdinalIgnoreCase)
+                         && !placedIds.Contains(v.Id))
+                .OrderBy(v => v.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Parse the comma-separated bundle filter. An empty or whitespace value
+        /// means "no filter" — every bundle in the spec is built.
+        /// </summary>
+        private static HashSet<string> ParseBundles(string csv)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(csv)) return set;
+            foreach (var part in csv.Split(','))
+            {
+                string t = part.Trim();
+                if (t.Length > 0) set.Add(t);
+            }
+            return set;
+        }
+
         // ──────────────────────────────────────────────────────────────────
         //  Schedule construction
         // ──────────────────────────────────────────────────────────────────
 
-        private class BuildOutcome { public bool Created; public bool SkippedExisting; public bool NotSchedulable; public bool Truncated; }
+        private class BuildOutcome
+        {
+            public bool Created; public bool SkippedExisting; public bool NotSchedulable; public bool Truncated;
+            /// <summary>The schedule just created — null unless Created is true.</summary>
+            public ViewSchedule Schedule;
+        }
 
         private static void Tally(BuildOutcome r, ref int created, ref int skippedExisting,
             ref int notSchedulable, ref int truncated)
@@ -284,6 +400,7 @@ namespace StingTools.Commands.TagStudio
 
             existingNames.Add(name);
             outcome.Created = true;
+            outcome.Schedule = sched;
             StingLog.Info($"ScheduleTagExpander: '{name}' created with {added} fields ({cat.Name})");
             return outcome;
         }

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -269,10 +269,9 @@ namespace StingTools.Commands.TagStudio
                 (placement != null
                     ? $"\nPlaced on sheets:        {placement.Placed}\n" +
                       $"Sheets created:          {placement.SheetsCreated}\n" +
-                      // Sizing read-out: if these heights are 0 or all identical,
-                      // the packing is running blind and tables will overlap.
+                      $"Layout:                  {(placement.Compacted ? "packed (several per sheet)" : "one schedule per sheet")}\n" +
+                      $"Measurable:              {placement.Measurable}\n" +
                       $"Table heights:           {placement.MinHeightMm:F0}–{placement.MaxHeightMm:F0} mm\n" +
-                      (placement.Unsized > 0 ? $"Unsized (own sheet):     {placement.Unsized}\n" : "") +
                       (placement.Oversized > 0 ? $"Overrunning sheet border: {placement.Oversized}\n" : "") +
                       (placement.Failed > 0 ? $"Placement failures:      {placement.Failed}\n" : "") +
                       (placement.Warnings.Count > 0

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -54,6 +54,13 @@ namespace StingTools.Commands.TagStudio
         internal const string ParamBundles = "TagSched_Bundles";  // CSV of ARCH,GEN,HEALTH,MEP,STR
         internal const string ParamPlace   = "TagSched_Place";    // "1" = place on sheets
 
+        /// <summary>
+        /// Sent when the caller ticked no bundles at all. An empty filter means
+        /// "build everything", so "build nothing" needs its own value — otherwise
+        /// clearing every checkbox would create the entire ~200-schedule set.
+        /// </summary>
+        internal const string NoBundlesSentinel = "__NONE__";
+
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
             var ctx = ParameterHelpers.GetContext(commandData);
@@ -158,6 +165,14 @@ namespace StingTools.Commands.TagStudio
 
             if (byCategory.Count == 0)
             {
+                if (bundleFilter.Contains(NoBundlesSentinel))
+                {
+                    TaskDialog.Show("Schedule Tag Expander",
+                        "No discipline bundles are ticked, so there is nothing to build.\n\n" +
+                        "Tick at least one bundle under SCHEDULER → TAG SCHEDULES → DISCIPLINE BUNDLES.");
+                    return Result.Cancelled;
+                }
+
                 TaskDialog.Show("Schedule Tag Expander",
                     $"No schedulable categories resolved from the spec.\n" +
                     $"Skipped empty entries: {emptySkipped}, unmatched families: {unmatchedFamilies.Count}" +
@@ -222,7 +237,7 @@ namespace StingTools.Commands.TagStudio
                         // option is never a silent no-op.
                         var toPlace = builtSchedules.Count > 0
                             ? builtSchedules
-                            : CollectUnplacedExpanderSchedules(doc);
+                            : CollectUnplacedExpanderSchedules(doc, byCategory.Keys, doSheet, doFull);
 
                         if (toPlace.Count > 0)
                         {
@@ -276,8 +291,22 @@ namespace StingTools.Commands.TagStudio
         /// Tag-expander schedules that are not yet on any sheet. Used when a
         /// re-run creates nothing new but the caller still asked for placement.
         /// </summary>
-        private static List<ViewSchedule> CollectUnplacedExpanderSchedules(Document doc)
+        private static List<ViewSchedule> CollectUnplacedExpanderSchedules(
+            Document doc, IEnumerable<string> categoryDisplays, bool doSheet, bool doFull)
         {
+            // Scope the fallback to exactly what this run asked for. Schedule
+            // names are deterministic, so the in-scope categories plus the
+            // chosen column set name the precise set — otherwise a "sheet
+            // columns, MEP only" re-run would place the wide (Full) tables and
+            // every other discipline alongside them.
+            var wanted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string cat in categoryDisplays)
+            {
+                if (doSheet) wanted.Add(SchedulePrefix + cat);
+                if (doFull)  wanted.Add(SchedulePrefix + cat + " (Full)");
+            }
+            if (wanted.Count == 0) return new List<ViewSchedule>();
+
             var placedIds = new HashSet<ElementId>(
                 new FilteredElementCollector(doc)
                     .OfClass(typeof(ScheduleSheetInstance))
@@ -288,7 +317,7 @@ namespace StingTools.Commands.TagStudio
                 .OfClass(typeof(ViewSchedule))
                 .Cast<ViewSchedule>()
                 .Where(v => !v.IsTemplate
-                         && (v.Name ?? "").StartsWith(SchedulePrefix, StringComparison.OrdinalIgnoreCase)
+                         && wanted.Contains(v.Name ?? "")
                          && !placedIds.Contains(v.Id))
                 .OrderBy(v => v.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -243,7 +243,7 @@ namespace StingTools.Commands.TagStudio
                     // option is never a silent no-op.
                     var toPlace = builtSchedules.Count > 0
                         ? builtSchedules
-                        : CollectUnplacedExpanderSchedules(doc, byCategory.Keys, doSheet, doFull);
+                        : CollectExpanderSchedules(doc, byCategory.Keys, doSheet, doFull);
 
                     if (toPlace.Count > 0)
                     {
@@ -269,6 +269,8 @@ namespace StingTools.Commands.TagStudio
                 (placement != null
                     ? $"\nPlaced on sheets:        {placement.Placed}\n" +
                       $"Sheets created:          {placement.SheetsCreated}\n" +
+                      (placement.ClearedSheets > 0
+                          ? $"Old sheets cleared:      {placement.ClearedSheets}\n" : "") +
                       $"Layout:                  {(placement.Compacted ? "packed (several per sheet)" : "one schedule per sheet")}\n" +
                       $"Measurable:              {placement.Measurable}\n" +
                       $"Table heights:           {placement.MinHeightMm:F0}–{placement.MaxHeightMm:F0} mm\n" +
@@ -294,10 +296,19 @@ namespace StingTools.Commands.TagStudio
         }
 
         /// <summary>
-        /// Tag-expander schedules that are not yet on any sheet. Used when a
-        /// re-run creates nothing new but the caller still asked for placement.
+        /// Every in-scope tag-expander schedule, whether or not it is already on
+        /// a sheet. Used when a re-run creates nothing new but the caller still
+        /// asked for placement.
+        ///
+        /// This deliberately does NOT skip schedules that are already placed.
+        /// It used to, and that made re-runs a no-op: the first run placed
+        /// everything, so every later run found nothing to do and left the
+        /// original sheets untouched — including a bad layout the user was
+        /// re-running specifically to fix. The placer clears its own previous
+        /// sheets first, so returning placed schedules is what makes a re-run
+        /// actually redo the layout.
         /// </summary>
-        private static List<ViewSchedule> CollectUnplacedExpanderSchedules(
+        private static List<ViewSchedule> CollectExpanderSchedules(
             Document doc, IEnumerable<string> categoryDisplays, bool doSheet, bool doFull)
         {
             // Scope the fallback to exactly what this run asked for. Schedule
@@ -313,18 +324,11 @@ namespace StingTools.Commands.TagStudio
             }
             if (wanted.Count == 0) return new List<ViewSchedule>();
 
-            var placedIds = new HashSet<ElementId>(
-                new FilteredElementCollector(doc)
-                    .OfClass(typeof(ScheduleSheetInstance))
-                    .Cast<ScheduleSheetInstance>()
-                    .Select(s => s.ScheduleId));
-
             return new FilteredElementCollector(doc)
                 .OfClass(typeof(ViewSchedule))
                 .Cast<ViewSchedule>()
                 .Where(v => !v.IsTemplate
-                         && wanted.Contains(v.Name ?? "")
-                         && !placedIds.Contains(v.Id))
+                         && wanted.Contains(v.Name ?? ""))
                 .OrderBy(v => v.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -227,26 +227,29 @@ namespace StingTools.Commands.TagStudio
                         }
                     }
 
-                    // Placement runs inside the same transaction so "build + place"
-                    // is a single undo step — a half-placed set is never left behind.
-                    if (placeOnSheets)
-                    {
-                        // Re-running after everything already exists builds nothing,
-                        // but the user still asked for sheets — fall back to the
-                        // tag-expander schedules already in the project so the
-                        // option is never a silent no-op.
-                        var toPlace = builtSchedules.Count > 0
-                            ? builtSchedules
-                            : CollectUnplacedExpanderSchedules(doc, byCategory.Keys, doSheet, doFull);
-
-                        if (toPlace.Count > 0)
-                        {
-                            progress.Increment($"Placing {toPlace.Count} schedule(s) on sheets…");
-                            placement = TagSchedulePlacer.Place(doc, toPlace);
-                        }
-                    }
-
                     tx.Commit();
+                }
+
+                // Placement must run AFTER this commit: a schedule's rendered
+                // size is not readable while the creating transaction is open,
+                // and packing against an unreadable size piles the tables on
+                // top of each other. TagSchedulePlacer owns its own
+                // transactions, so build and place are separate undo steps.
+                if (placeOnSheets)
+                {
+                    // Re-running after everything already exists builds nothing,
+                    // but the user still asked for sheets — fall back to the
+                    // tag-expander schedules already in the project so the
+                    // option is never a silent no-op.
+                    var toPlace = builtSchedules.Count > 0
+                        ? builtSchedules
+                        : CollectUnplacedExpanderSchedules(doc, byCategory.Keys, doSheet, doFull);
+
+                    if (toPlace.Count > 0)
+                    {
+                        progress.Increment($"Measuring and placing {toPlace.Count} schedule(s)…");
+                        placement = TagSchedulePlacer.Place(doc, toPlace);
+                    }
                 }
             }
             finally { progress.Close(); }

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -269,6 +269,10 @@ namespace StingTools.Commands.TagStudio
                 (placement != null
                     ? $"\nPlaced on sheets:        {placement.Placed}\n" +
                       $"Sheets created:          {placement.SheetsCreated}\n" +
+                      // Sizing read-out: if these heights are 0 or all identical,
+                      // the packing is running blind and tables will overlap.
+                      $"Table heights:           {placement.MinHeightMm:F0}–{placement.MaxHeightMm:F0} mm\n" +
+                      (placement.Unsized > 0 ? $"Unsized (own sheet):     {placement.Unsized}\n" : "") +
                       (placement.Oversized > 0 ? $"Overrunning sheet border: {placement.Oversized}\n" : "") +
                       (placement.Failed > 0 ? $"Placement failures:      {placement.Failed}\n" : "") +
                       (placement.Warnings.Count > 0

--- a/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
+++ b/StingTools/Commands/TagStudio/ScheduleDisciplineTagExpanderCommand.cs
@@ -255,7 +255,7 @@ namespace StingTools.Commands.TagStudio
             finally { progress.Close(); }
 
             var td = new TaskDialog("Schedule Tag Expander — done");
-            td.MainInstruction = $"Created {created} schedule(s)";
+            td.MainInstruction = $"Created {created} schedule(s)   [{BuildStamp()}]";
             td.MainContent =
                 $"Categories planned:      {byCategory.Count}\n" +
                 $"Schedules created:       {created}\n" +
@@ -293,6 +293,27 @@ namespace StingTools.Commands.TagStudio
             if (unmatchedFamilies.Count > 0)
                 StingLog.Info("ScheduleTagExpander unmatched families: " + string.Join(" | ", unmatchedFamilies));
             return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// Which build of the plugin is actually loaded, taken from the running
+        /// assembly's file time.
+        ///
+        /// Deploying a fix and being told the behaviour is unchanged is
+        /// ambiguous: the fix may be wrong, or Revit may still be running an
+        /// older DLL. Stamping the build into the report removes the guesswork —
+        /// the result identifies the code that produced it.
+        /// </summary>
+        private static string BuildStamp()
+        {
+            try
+            {
+                string path = typeof(ScheduleDisciplineTagExpanderCommand).Assembly.Location;
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    return "build " + File.GetLastWriteTime(path).ToString("MMM dd HH:mm");
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildStamp: {ex.Message}"); }
+            return "build unknown";
         }
 
         /// <summary>

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -53,6 +53,8 @@ namespace StingTools.Commands.TagStudio
         public bool Compacted;
         /// <summary>How many instances returned a usable measurement in pass 2.</summary>
         public int Measurable;
+        /// <summary>Sheets from a previous run that were removed before placing.</summary>
+        public int ClearedSheets;
         public readonly List<string> Warnings = new List<string>();
         public readonly List<ElementId> SheetIds = new List<ElementId>();
         /// <summary>Measured height range in mm — 0–0 means measurement failed.</summary>
@@ -104,6 +106,11 @@ namespace StingTools.Commands.TagStudio
                 return result;
             }
 
+            // ── PASS 0 — clear this tool's own previous sheets ──
+            // Without this a re-run stacks a second layout on top of the first,
+            // and any earlier bad layout survives every attempt to fix it.
+            result.ClearedSheets = ClearPreviousSheets(doc, result);
+
             // ── PASS 1 — one per sheet. Cannot overlap. ──
             var instances = PlaceOnePerSheet(doc, list, titleBlockId, result);
             if (instances.Count == 0) return result;
@@ -135,6 +142,77 @@ namespace StingTools.Commands.TagStudio
 
             Compact(doc, sized, titleBlockId, result);
             return result;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Pass 0 — clear this tool's own previous sheets
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Delete sheets this placer created on an earlier run, identified by
+        /// the sheet-name prefix. Only sheets carrying nothing but schedule
+        /// instances are removed, so a sheet someone has since put drawings on
+        /// is left alone.
+        /// </summary>
+        private static int ClearPreviousSheets(Document doc, TagSchedulePlacementResult result)
+        {
+            List<ViewSheet> mine;
+            try
+            {
+                mine = new FilteredElementCollector(doc)
+                    .OfClass(typeof(ViewSheet))
+                    .Cast<ViewSheet>()
+                    .Where(s => !s.IsTemplate
+                             && (s.Name ?? "").StartsWith(SheetNamePrefix, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: could not scan for previous sheets — {ex.Message}");
+                return 0;
+            }
+
+            if (mine.Count == 0) return 0;
+
+            int cleared = 0;
+            using (var tx = new Transaction(doc, "STING Clear Previous Tag Schedule Sheets"))
+            {
+                tx.Start();
+                try
+                {
+                    foreach (var sheet in mine)
+                    {
+                        // A sheet holding real viewports is somebody's drawing now,
+                        // whatever its name — never delete that.
+                        bool hasViewports;
+                        try { hasViewports = sheet.GetAllViewports().Count > 0; }
+                        catch { hasViewports = true; }   // unknown → treat as occupied
+
+                        if (hasViewports)
+                        {
+                            result.Warnings.Add(
+                                $"Sheet '{sheet.SheetNumber} {sheet.Name}' has viewports on it and was left alone.");
+                            continue;
+                        }
+
+                        try { doc.Delete(sheet.Id); cleared++; }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"TagSchedulePlacer: delete previous sheet '{sheet.Name}' — {ex.Message}");
+                        }
+                    }
+                    tx.Commit();
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: clearing previous sheets failed — {ex.Message}");
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                    return 0;
+                }
+            }
+
+            StingLog.Info($"TagSchedulePlacer: cleared {cleared} sheet(s) from a previous run.");
+            return cleared;
         }
 
         // ──────────────────────────────────────────────────────────────────

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -6,31 +6,22 @@
 // sheet is not a deliverable — it is a table nobody sees. With ~204 spec
 // entries carrying sheet_columns, hand-dragging is not a workable answer.
 //
-// MEASURE, THEN ARRANGE
-// ---------------------
-// Revit will not tell you how big a schedule renders until it exists, and
-// ScheduleSheetInstance.get_BoundingBox returns nothing usable while the
-// creating transaction is still open — regenerating is not enough. Packing
-// against that during the build therefore degrades to a guessed row height
-// and the tables land on top of each other.
+// SIZING
+// ------
+// Packing needs each table's size on paper. Two earlier attempts measured a
+// placed ScheduleSheetInstance's bounding box — inside the creating
+// transaction, then after committing it. Neither is reliable, and packing
+// against an unreliable size is what piled the tables on top of each other.
 //
-// So this runs in three transactions:
+// The dependable source is the schedule's own table data: TableSectionData
+// reports GetColumnWidth and GetRowHeight in sheet space (feet) directly,
+// with nothing placed and no transaction needed. Width is the widest
+// section's summed column widths; height is every section's summed row
+// heights. That is what this uses.
 //
-//   1. MEASURE   every schedule is dropped on one scratch sheet at the same
-//                point. Overlap is irrelevant — a bounding box is per element.
-//   2. (commit)  sizes become readable.
-//   3. ARRANGE   the scratch sheet is deleted and each schedule is re-placed
-//                with its true width and height into a packed column layout.
-//
-// The cost is that build+place is no longer a single undo step. Correct
-// output beats a tidy undo stack.
-//
-// ANCHORING
-// ---------
-// ScheduleSheetInstance.Point is not necessarily the table's visual top-left,
-// so the measure pass also records each instance's Point→bounding-box offset.
-// Placement subtracts it, which is what makes every table in a column share
-// an exact left edge instead of being within a few millimetres of one.
+// A schedule whose table data cannot be read is placed on a sheet of its own
+// rather than packed on a guess — an isolated sheet is easy to spot and fix,
+// a silent overlap is not.
 // ============================================================================
 
 using System;
@@ -49,8 +40,12 @@ namespace StingTools.Commands.TagStudio
         public int SheetsCreated;
         public int Oversized;
         public int Failed;
+        /// <summary>Schedules whose table data could not be read, so given their own sheet.</summary>
+        public int Unsized;
         public readonly List<string> Warnings = new List<string>();
         public readonly List<ElementId> SheetIds = new List<ElementId>();
+        /// <summary>Smallest and largest measured height, in mm — a sanity read-out for the report.</summary>
+        public double MinHeightMm, MaxHeightMm;
     }
 
     internal static class TagSchedulePlacer
@@ -58,22 +53,21 @@ namespace StingTools.Commands.TagStudio
         private const string SheetNamePrefix = "STING Tag Schedules";
         private const double GapMm = 10.0;
 
-        /// <summary>Measured geometry for one schedule, in feet, sheet space.</summary>
-        private sealed class Measured
+        /// <summary>Paper-space size of one schedule, in feet.</summary>
+        private sealed class Sized
         {
             public ViewSchedule Schedule;
             public double Width;
             public double Height;
-            /// <summary>bbox.Min.X - Point.X — subtracted so left edges line up exactly.</summary>
-            public double AnchorDx;
-            /// <summary>bbox.Max.Y - Point.Y — subtracted so top edges line up exactly.</summary>
-            public double AnchorDy;
+            /// <summary>True when the table data was unreadable — gets its own sheet.</summary>
+            public bool Unknown;
         }
 
         private static double MmToFt(double mm) => UnitUtils.ConvertToInternalUnits(mm, UnitTypeId.Millimeters);
+        private static double FtToMm(double ft) => UnitUtils.ConvertFromInternalUnits(ft, UnitTypeId.Millimeters);
 
         /// <summary>
-        /// Place the given schedules onto new sheets. Opens its own transactions,
+        /// Place the given schedules onto new sheets. Opens its own transaction,
         /// so the caller must NOT have one open.
         /// </summary>
         internal static TagSchedulePlacementResult Place(Document doc, IList<ViewSchedule> schedules)
@@ -89,151 +83,79 @@ namespace StingTools.Commands.TagStudio
                 return result;
             }
 
-            var measured = Measure(doc, schedules, titleBlockId, result);
-            if (measured.Count == 0) return result;
+            var sized = schedules.Where(s => s != null).Select(s => MeasureFromTableData(s, result)).ToList();
+            if (sized.Count == 0) return result;
 
-            Arrange(doc, measured, titleBlockId, result);
+            var real = sized.Where(s => !s.Unknown).ToList();
+            result.MinHeightMm = real.Count > 0 ? FtToMm(real.Min(s => s.Height)) : 0;
+            result.MaxHeightMm = real.Count > 0 ? FtToMm(real.Max(s => s.Height)) : 0;
+            result.Unsized = sized.Count - real.Count;
+
+            StingLog.Info($"TagSchedulePlacer: sizing {sized.Count} schedule(s) — " +
+                          $"heights {result.MinHeightMm:F0}..{result.MaxHeightMm:F0} mm, unsized={result.Unsized}");
+
+            Arrange(doc, sized, titleBlockId, result);
 
             StingLog.Info($"TagSchedulePlacer: placed={result.Placed}, sheets={result.SheetsCreated}, " +
-                          $"oversized={result.Oversized}, failed={result.Failed}");
+                          $"oversized={result.Oversized}, unsized={result.Unsized}, failed={result.Failed}");
             return result;
         }
 
         // ──────────────────────────────────────────────────────────────────
-        //  Pass 1 — measure on a scratch sheet
+        //  Sizing — straight from the schedule's table data
         // ──────────────────────────────────────────────────────────────────
-
-        private static List<Measured> Measure(Document doc, IList<ViewSchedule> schedules,
-            ElementId titleBlockId, TagSchedulePlacementResult result)
-        {
-            var measured = new List<Measured>();
-            ViewSheet scratch = null;
-            var probes = new List<(ScheduleSheetInstance Ssi, ViewSchedule Sched)>();
-
-            using (var tx = new Transaction(doc, "STING Measure Tag Schedules"))
-            {
-                tx.Start();
-                try
-                {
-                    scratch = ViewSheet.Create(doc, titleBlockId);
-                    if (scratch == null)
-                    {
-                        result.Warnings.Add("Could not create the scratch sheet used to measure schedule sizes.");
-                        tx.RollBack();
-                        return measured;
-                    }
-                    try { scratch.Name = "STING ~ measuring"; } catch { /* name clash is harmless here */ }
-
-                    foreach (var sched in schedules)
-                    {
-                        if (sched == null) continue;
-                        try
-                        {
-                            var ssi = ScheduleSheetInstance.Create(doc, scratch.Id, sched.Id, XYZ.Zero);
-                            if (ssi != null) probes.Add((ssi, sched));
-                        }
-                        catch (Exception ex)
-                        {
-                            StingLog.Warn($"TagSchedulePlacer: measure probe for '{sched.Name}' — {ex.Message}");
-                            result.Warnings.Add($"Could not measure '{sched.Name}': {ex.Message}");
-                            result.Failed++;
-                        }
-                    }
-                    tx.Commit();   // sizes only become readable once committed
-                }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"TagSchedulePlacer: measure pass failed — {ex.Message}");
-                    result.Warnings.Add($"Measuring schedule sizes failed: {ex.Message}");
-                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
-                    return measured;
-                }
-            }
-
-            foreach (var (ssi, sched) in probes)
-            {
-                double w = 0, h = 0, adx = 0, ady = 0;
-                try
-                {
-                    var bb = ssi.get_BoundingBox(scratch);
-                    if (bb != null)
-                    {
-                        w = Math.Abs(bb.Max.X - bb.Min.X);
-                        h = Math.Abs(bb.Max.Y - bb.Min.Y);
-                        adx = bb.Min.X - ssi.Point.X;
-                        ady = bb.Max.Y - ssi.Point.Y;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"TagSchedulePlacer: bounding box for '{sched.Name}' — {ex.Message}");
-                }
-
-                if (w <= 0 || h <= 0)
-                {
-                    // Never silently pack against a zero size — that is exactly
-                    // what produces a pile of overlapping tables. Fall back to a
-                    // row-count estimate and say so.
-                    (w, h) = EstimateSize(doc, sched, w, h);
-                    result.Warnings.Add($"'{sched.Name}' could not be measured; used an estimated size.");
-                    StingLog.Warn($"TagSchedulePlacer: '{sched.Name}' unmeasurable, estimated {w:F2}x{h:F2} ft.");
-                }
-
-                measured.Add(new Measured
-                {
-                    Schedule = sched, Width = w, Height = h, AnchorDx = adx, AnchorDy = ady
-                });
-            }
-
-            // Drop the scratch sheet — deleting the sheet takes its instances too.
-            using (var tx = new Transaction(doc, "STING Clear Measuring Sheet"))
-            {
-                tx.Start();
-                try { doc.Delete(scratch.Id); tx.Commit(); }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"TagSchedulePlacer: could not delete scratch sheet — {ex.Message}");
-                    result.Warnings.Add("The temporary measuring sheet could not be removed; delete 'STING ~ measuring' by hand.");
-                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
-                }
-            }
-
-            return measured;
-        }
 
         /// <summary>
-        /// Last-resort size when the bounding box is unreadable: derive height
-        /// from the schedule's actual row count and width from its column count.
+        /// Width and height on paper, in feet, summed from the schedule's own
+        /// column widths and row heights. No placement, no transaction.
         /// </summary>
-        private static (double Width, double Height) EstimateSize(Document doc, ViewSchedule sched,
-            double knownW, double knownH)
+        private static Sized MeasureFromTableData(ViewSchedule sched, TagSchedulePlacementResult result)
         {
-            const double RowMm = 8.0;      // default Revit schedule row
-            const double ColMm = 38.0;     // default column width
-            int rows = 8, cols = 6;
-            try
+            double width = 0, height = 0;
+            bool readAnything = false;
+
+            // Header carries the title and column-heading rows; Body the data.
+            // Both contribute height; width is the widest of them.
+            foreach (SectionType st in new[] { SectionType.Header, SectionType.Body, SectionType.Summary, SectionType.Footer })
             {
-                var body = sched.GetTableData().GetSectionData(SectionType.Body);
-                if (body != null)
+                TableSectionData sd;
+                try { sd = sched.GetTableData()?.GetSectionData(st); }
+                catch (Exception ex)
                 {
-                    rows = Math.Max(rows, body.NumberOfRows + 2);   // + header rows
-                    cols = Math.Max(1, body.NumberOfColumns);
+                    StingLog.Warn($"TagSchedulePlacer: section {st} of '{sched.Name}' — {ex.Message}");
+                    continue;
+                }
+                if (sd == null) continue;
+
+                try
+                {
+                    double sectionWidth = 0;
+                    for (int c = 0; c < sd.NumberOfColumns; c++) sectionWidth += sd.GetColumnWidth(c);
+                    for (int r = 0; r < sd.NumberOfRows; r++) height += sd.GetRowHeight(r);
+                    width = Math.Max(width, sectionWidth);
+                    readAnything = true;
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: sizing section {st} of '{sched.Name}' — {ex.Message}");
                 }
             }
-            catch (Exception ex)
+
+            if (!readAnything || width <= 0 || height <= 0)
             {
-                StingLog.Warn($"TagSchedulePlacer: row count for '{sched.Name}' — {ex.Message}");
+                StingLog.Warn($"TagSchedulePlacer: '{sched.Name}' has no readable table size — giving it its own sheet.");
+                result.Warnings.Add($"'{sched.Name}' could not be sized; placed on a sheet of its own.");
+                return new Sized { Schedule = sched, Width = 0, Height = 0, Unknown = true };
             }
-            double w = knownW > 0 ? knownW : MmToFt(ColMm * cols);
-            double h = knownH > 0 ? knownH : MmToFt(RowMm * rows);
-            return (w, h);
+
+            return new Sized { Schedule = sched, Width = width, Height = height };
         }
 
         // ──────────────────────────────────────────────────────────────────
-        //  Pass 2 — arrange onto real sheets
+        //  Arrange onto sheets
         // ──────────────────────────────────────────────────────────────────
 
-        private static void Arrange(Document doc, List<Measured> measured,
+        private static void Arrange(Document doc, List<Sized> sized,
             ElementId titleBlockId, TagSchedulePlacementResult result)
         {
             double gap = MmToFt(GapMm);
@@ -266,66 +188,93 @@ namespace StingTools.Commands.TagStudio
 
                     if (!NewSheet()) { tx.RollBack(); return; }
 
-                    // Tallest first packs columns far more tightly than name order,
+                    // Tallest first packs columns far more tightly than name order
                     // and keeps a column's left edge stable once it is set.
-                    foreach (var m in measured.OrderByDescending(x => x.Height)
-                                              .ThenBy(x => x.Schedule.Name, StringComparer.OrdinalIgnoreCase))
-                    {
-                        bool fitsInColumn = (cursorTop - m.Height) >= zone.Min.Y - 1e-9;
+                    // Unsized ones go last so they do not disturb the packed run.
+                    var order = sized.Where(s => !s.Unknown)
+                                     .OrderByDescending(s => s.Height)
+                                     .ThenBy(s => s.Schedule.Name, StringComparer.OrdinalIgnoreCase)
+                                     .Concat(sized.Where(s => s.Unknown)
+                                                  .OrderBy(s => s.Schedule.Name, StringComparer.OrdinalIgnoreCase))
+                                     .ToList();
 
+                    bool sheetIsFresh = true;   // nothing placed on the current sheet yet
+
+                    foreach (var s in order)
+                    {
+                        if (s.Unknown)
+                        {
+                            // Unknown size: give it a sheet to itself rather than
+                            // pack it against a guess and risk landing on a neighbour.
+                            if (!sheetIsFresh && !NewSheet()) { result.Failed++; break; }
+                            if (PlaceOne(doc, sheet, s.Schedule, new XYZ(zone.Min.X, zone.Max.Y, 0), result))
+                                result.Placed++;
+                            if (!NewSheet()) { result.Failed++; break; }
+                            sheetIsFresh = true;
+                            continue;
+                        }
+
+                        bool fitsInColumn = (cursorTop - s.Height) >= zone.Min.Y - 1e-9;
                         if (!fitsInColumn)
                         {
                             double nextLeft = colLeft + colWidth + gap;
-                            bool fitsNextColumn = (nextLeft + m.Width) <= zone.Max.X + 1e-9
-                                                  && m.Height <= zone.Height + 1e-9;
-
+                            bool fitsNextColumn = (nextLeft + s.Width) <= zone.Max.X + 1e-9
+                                                  && s.Height <= zone.Height + 1e-9;
                             if (fitsNextColumn)
                             {
                                 colLeft = nextLeft;
                                 cursorTop = zone.Max.Y;
                                 colWidth = 0;
                             }
+                            else if (sheetIsFresh)
+                            {
+                                // Does not fit even on an empty sheet — place it
+                                // anyway and flag it rather than drop it.
+                                result.Oversized++;
+                                result.Warnings.Add($"'{s.Schedule.Name}' is larger than the sheet and overruns its border.");
+                            }
                             else
                             {
                                 if (!NewSheet()) { result.Failed++; break; }
-                                if (m.Height > zone.Height + 1e-9)
-                                {
-                                    // Taller than any sheet we can make. Place it
-                                    // rather than drop it, and flag it.
-                                    result.Oversized++;
-                                    result.Warnings.Add(
-                                        $"'{m.Schedule.Name}' is taller than the sheet and overruns its border.");
-                                }
+                                sheetIsFresh = true;
                             }
                         }
 
-                        var point = new XYZ(colLeft - m.AnchorDx, cursorTop - m.AnchorDy, 0);
-                        try
+                        if (!PlaceOne(doc, sheet, s.Schedule, new XYZ(colLeft, cursorTop, 0), result))
                         {
-                            var ssi = ScheduleSheetInstance.Create(doc, sheet.Id, m.Schedule.Id, point);
-                            if (ssi == null) { result.Failed++; continue; }
-                            result.Placed++;
-                        }
-                        catch (Exception ex)
-                        {
-                            StingLog.Warn($"TagSchedulePlacer: place '{m.Schedule.Name}' — {ex.Message}");
-                            result.Warnings.Add($"Could not place '{m.Schedule.Name}': {ex.Message}");
                             result.Failed++;
                             continue;
                         }
 
-                        colWidth = Math.Max(colWidth, m.Width);
-                        cursorTop -= m.Height + gap;
+                        result.Placed++;
+                        sheetIsFresh = false;
+                        colWidth = Math.Max(colWidth, s.Width);
+                        cursorTop -= s.Height + gap;
                     }
 
                     tx.Commit();
                 }
                 catch (Exception ex)
                 {
-                    StingLog.Warn($"TagSchedulePlacer: arrange pass failed — {ex.Message}");
+                    StingLog.Warn($"TagSchedulePlacer: arrange failed — {ex.Message}");
                     result.Warnings.Add($"Placing schedules failed: {ex.Message}");
                     if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
                 }
+            }
+        }
+
+        private static bool PlaceOne(Document doc, ViewSheet sheet, ViewSchedule sched,
+            XYZ point, TagSchedulePlacementResult result)
+        {
+            try
+            {
+                return ScheduleSheetInstance.Create(doc, sheet.Id, sched.Id, point) != null;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: place '{sched.Name}' — {ex.Message}");
+                result.Warnings.Add($"Could not place '{sched.Name}': {ex.Message}");
+                return false;
             }
         }
 

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -6,18 +6,31 @@
 // sheet is not a deliverable — it is a table nobody sees. With ~204 spec
 // entries carrying sheet_columns, hand-dragging is not a workable answer.
 //
-// This placer packs schedules onto as many sheets as it takes:
+// MEASURE, THEN ARRANGE
+// ---------------------
+// Revit will not tell you how big a schedule renders until it exists, and
+// ScheduleSheetInstance.get_BoundingBox returns nothing usable while the
+// creating transaction is still open — regenerating is not enough. Packing
+// against that during the build therefore degrades to a guessed row height
+// and the tables land on top of each other.
 //
-//   • a cursor walks DOWN a column from the top-left of the drawable zone
-//   • when the next schedule would overflow the column, the cursor moves
-//     RIGHT by the widest table in that column (+ gap) and returns to the top
-//   • when a column would overflow the zone's right edge, a new sheet is minted
+// So this runs in three transactions:
 //
-// Revit gives no way to ask how big a schedule will render before it is
-// placed, so each ScheduleSheetInstance is created at the cursor, the document
-// is regenerated, and its bounding box is measured. A table that does not fit
-// even on an empty sheet is placed anyway (top-left of a fresh sheet) and
-// reported — dropping it silently would be worse than an oversized sheet.
+//   1. MEASURE   every schedule is dropped on one scratch sheet at the same
+//                point. Overlap is irrelevant — a bounding box is per element.
+//   2. (commit)  sizes become readable.
+//   3. ARRANGE   the scratch sheet is deleted and each schedule is re-placed
+//                with its true width and height into a packed column layout.
+//
+// The cost is that build+place is no longer a single undo step. Correct
+// output beats a tidy undo stack.
+//
+// ANCHORING
+// ---------
+// ScheduleSheetInstance.Point is not necessarily the table's visual top-left,
+// so the measure pass also records each instance's Point→bounding-box offset.
+// Placement subtracts it, which is what makes every table in a column share
+// an exact left edge instead of being within a few millimetres of one.
 // ============================================================================
 
 using System;
@@ -43,14 +56,25 @@ namespace StingTools.Commands.TagStudio
     internal static class TagSchedulePlacer
     {
         private const string SheetNamePrefix = "STING Tag Schedules";
-        private const double GapMm = 8.0;
+        private const double GapMm = 10.0;
+
+        /// <summary>Measured geometry for one schedule, in feet, sheet space.</summary>
+        private sealed class Measured
+        {
+            public ViewSchedule Schedule;
+            public double Width;
+            public double Height;
+            /// <summary>bbox.Min.X - Point.X — subtracted so left edges line up exactly.</summary>
+            public double AnchorDx;
+            /// <summary>bbox.Max.Y - Point.Y — subtracted so top edges line up exactly.</summary>
+            public double AnchorDy;
+        }
 
         private static double MmToFt(double mm) => UnitUtils.ConvertToInternalUnits(mm, UnitTypeId.Millimeters);
 
         /// <summary>
-        /// Place the given schedules onto newly-created sheets. Must be called
-        /// inside an open Transaction — the caller owns the transaction so a
-        /// build+place run commits as one undo step.
+        /// Place the given schedules onto new sheets. Opens its own transactions,
+        /// so the caller must NOT have one open.
         /// </summary>
         internal static TagSchedulePlacementResult Place(Document doc, IList<ViewSchedule> schedules)
         {
@@ -58,92 +82,17 @@ namespace StingTools.Commands.TagStudio
             if (doc == null || schedules == null || schedules.Count == 0) return result;
 
             ElementId titleBlockId = ResolveTitleBlock(doc);
-            if (titleBlockId == null || titleBlockId == ElementId.InvalidElementId)
+            if (titleBlockId == ElementId.InvalidElementId)
             {
                 result.Warnings.Add("No title block family is loaded — cannot create sheets to place schedules on.");
                 StingLog.Warn("TagSchedulePlacer: no title block type found; placement skipped.");
                 return result;
             }
 
-            double gap = MmToFt(GapMm);
+            var measured = Measure(doc, schedules, titleBlockId, result);
+            if (measured.Count == 0) return result;
 
-            ViewSheet sheet = null;
-            DrawableZone zone = null;
-            double cursorX = 0, cursorY = 0, columnWidth = 0;
-
-            // Start a fresh sheet and reset the packing cursor to its top-left.
-            bool NewSheet()
-            {
-                sheet = CreateSheet(doc, titleBlockId, result);
-                if (sheet == null) return false;
-                zone = SheetManagerEngine.GetDrawableZone(doc, sheet);
-                if (zone == null || zone.Width <= 0 || zone.Height <= 0)
-                {
-                    result.Warnings.Add($"Sheet '{sheet.SheetNumber}' has no usable drawable zone.");
-                    return false;
-                }
-                cursorX = zone.Min.X;
-                cursorY = zone.Max.Y;
-                columnWidth = 0;
-                result.SheetIds.Add(sheet.Id);
-                return true;
-            }
-
-            if (!NewSheet()) return result;
-
-            foreach (var sched in schedules)
-            {
-                if (sched == null) continue;
-
-                ScheduleSheetInstance ssi = TryCreate(doc, sheet, sched, new XYZ(cursorX, cursorY, 0), result);
-                if (ssi == null) { result.Failed++; continue; }
-
-                // Revit only knows the rendered extents once the instance exists.
-                doc.Regenerate();
-                var size = MeasureSize(ssi, sheet);
-                double w = size.Width, h = size.Height;
-
-                bool fitsColumn = h <= 0 || (cursorY - h) >= zone.Min.Y;
-                if (!fitsColumn)
-                {
-                    // Try the next column on this sheet.
-                    double nextX = cursorX + Math.Max(columnWidth, w) + gap;
-                    if (nextX + w <= zone.Max.X)
-                    {
-                        cursorX = nextX;
-                        cursorY = zone.Max.Y;
-                        columnWidth = 0;
-                        MoveTo(doc, ssi, new XYZ(cursorX, cursorY, 0), result, sched.Name);
-                    }
-                    else
-                    {
-                        // Column and sheet are both full — start a new sheet.
-                        // Delete the probe instance first so it does not linger
-                        // half-off the old sheet.
-                        try { doc.Delete(ssi.Id); }
-                        catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: could not remove probe instance for '{sched.Name}' — {ex.Message}"); }
-
-                        if (!NewSheet()) { result.Failed++; break; }
-
-                        ssi = TryCreate(doc, sheet, sched, new XYZ(cursorX, cursorY, 0), result);
-                        if (ssi == null) { result.Failed++; continue; }
-                        doc.Regenerate();
-                        size = MeasureSize(ssi, sheet);
-                        w = size.Width; h = size.Height;
-
-                        // Still too tall for an empty sheet: keep it, flag it.
-                        if (h > 0 && h > zone.Height)
-                        {
-                            result.Oversized++;
-                            result.Warnings.Add($"'{sched.Name}' is taller than the sheet and overruns its border.");
-                        }
-                    }
-                }
-
-                result.Placed++;
-                columnWidth = Math.Max(columnWidth, w);
-                cursorY -= (h > 0 ? h : MmToFt(40)) + gap;
-            }
+            Arrange(doc, measured, titleBlockId, result);
 
             StingLog.Info($"TagSchedulePlacer: placed={result.Placed}, sheets={result.SheetsCreated}, " +
                           $"oversized={result.Oversized}, failed={result.Failed}");
@@ -151,51 +100,236 @@ namespace StingTools.Commands.TagStudio
         }
 
         // ──────────────────────────────────────────────────────────────────
+        //  Pass 1 — measure on a scratch sheet
+        // ──────────────────────────────────────────────────────────────────
 
-        private static ScheduleSheetInstance TryCreate(Document doc, ViewSheet sheet,
-            ViewSchedule sched, XYZ pt, TagSchedulePlacementResult result)
+        private static List<Measured> Measure(Document doc, IList<ViewSchedule> schedules,
+            ElementId titleBlockId, TagSchedulePlacementResult result)
         {
+            var measured = new List<Measured>();
+            ViewSheet scratch = null;
+            var probes = new List<(ScheduleSheetInstance Ssi, ViewSchedule Sched)>();
+
+            using (var tx = new Transaction(doc, "STING Measure Tag Schedules"))
+            {
+                tx.Start();
+                try
+                {
+                    scratch = ViewSheet.Create(doc, titleBlockId);
+                    if (scratch == null)
+                    {
+                        result.Warnings.Add("Could not create the scratch sheet used to measure schedule sizes.");
+                        tx.RollBack();
+                        return measured;
+                    }
+                    try { scratch.Name = "STING ~ measuring"; } catch { /* name clash is harmless here */ }
+
+                    foreach (var sched in schedules)
+                    {
+                        if (sched == null) continue;
+                        try
+                        {
+                            var ssi = ScheduleSheetInstance.Create(doc, scratch.Id, sched.Id, XYZ.Zero);
+                            if (ssi != null) probes.Add((ssi, sched));
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"TagSchedulePlacer: measure probe for '{sched.Name}' — {ex.Message}");
+                            result.Warnings.Add($"Could not measure '{sched.Name}': {ex.Message}");
+                            result.Failed++;
+                        }
+                    }
+                    tx.Commit();   // sizes only become readable once committed
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: measure pass failed — {ex.Message}");
+                    result.Warnings.Add($"Measuring schedule sizes failed: {ex.Message}");
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                    return measured;
+                }
+            }
+
+            foreach (var (ssi, sched) in probes)
+            {
+                double w = 0, h = 0, adx = 0, ady = 0;
+                try
+                {
+                    var bb = ssi.get_BoundingBox(scratch);
+                    if (bb != null)
+                    {
+                        w = Math.Abs(bb.Max.X - bb.Min.X);
+                        h = Math.Abs(bb.Max.Y - bb.Min.Y);
+                        adx = bb.Min.X - ssi.Point.X;
+                        ady = bb.Max.Y - ssi.Point.Y;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: bounding box for '{sched.Name}' — {ex.Message}");
+                }
+
+                if (w <= 0 || h <= 0)
+                {
+                    // Never silently pack against a zero size — that is exactly
+                    // what produces a pile of overlapping tables. Fall back to a
+                    // row-count estimate and say so.
+                    (w, h) = EstimateSize(doc, sched, w, h);
+                    result.Warnings.Add($"'{sched.Name}' could not be measured; used an estimated size.");
+                    StingLog.Warn($"TagSchedulePlacer: '{sched.Name}' unmeasurable, estimated {w:F2}x{h:F2} ft.");
+                }
+
+                measured.Add(new Measured
+                {
+                    Schedule = sched, Width = w, Height = h, AnchorDx = adx, AnchorDy = ady
+                });
+            }
+
+            // Drop the scratch sheet — deleting the sheet takes its instances too.
+            using (var tx = new Transaction(doc, "STING Clear Measuring Sheet"))
+            {
+                tx.Start();
+                try { doc.Delete(scratch.Id); tx.Commit(); }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: could not delete scratch sheet — {ex.Message}");
+                    result.Warnings.Add("The temporary measuring sheet could not be removed; delete 'STING ~ measuring' by hand.");
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                }
+            }
+
+            return measured;
+        }
+
+        /// <summary>
+        /// Last-resort size when the bounding box is unreadable: derive height
+        /// from the schedule's actual row count and width from its column count.
+        /// </summary>
+        private static (double Width, double Height) EstimateSize(Document doc, ViewSchedule sched,
+            double knownW, double knownH)
+        {
+            const double RowMm = 8.0;      // default Revit schedule row
+            const double ColMm = 38.0;     // default column width
+            int rows = 8, cols = 6;
             try
             {
-                return ScheduleSheetInstance.Create(doc, sheet.Id, sched.Id, pt);
+                var body = sched.GetTableData().GetSectionData(SectionType.Body);
+                if (body != null)
+                {
+                    rows = Math.Max(rows, body.NumberOfRows + 2);   // + header rows
+                    cols = Math.Max(1, body.NumberOfColumns);
+                }
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"TagSchedulePlacer: ScheduleSheetInstance.Create('{sched.Name}') — {ex.Message}");
-                result.Warnings.Add($"Could not place '{sched.Name}': {ex.Message}");
-                return null;
+                StingLog.Warn($"TagSchedulePlacer: row count for '{sched.Name}' — {ex.Message}");
+            }
+            double w = knownW > 0 ? knownW : MmToFt(ColMm * cols);
+            double h = knownH > 0 ? knownH : MmToFt(RowMm * rows);
+            return (w, h);
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Pass 2 — arrange onto real sheets
+        // ──────────────────────────────────────────────────────────────────
+
+        private static void Arrange(Document doc, List<Measured> measured,
+            ElementId titleBlockId, TagSchedulePlacementResult result)
+        {
+            double gap = MmToFt(GapMm);
+
+            using (var tx = new Transaction(doc, "STING Place Tag Schedules On Sheets"))
+            {
+                tx.Start();
+                try
+                {
+                    ViewSheet sheet = null;
+                    DrawableZone zone = null;
+                    double colLeft = 0, cursorTop = 0, colWidth = 0;
+
+                    bool NewSheet()
+                    {
+                        sheet = CreateSheet(doc, titleBlockId, result);
+                        if (sheet == null) return false;
+                        zone = SheetManagerEngine.GetDrawableZone(doc, sheet);
+                        if (zone == null || zone.Width <= 0 || zone.Height <= 0)
+                        {
+                            result.Warnings.Add($"Sheet '{sheet.SheetNumber}' has no usable drawable zone.");
+                            return false;
+                        }
+                        colLeft = zone.Min.X;
+                        cursorTop = zone.Max.Y;
+                        colWidth = 0;
+                        result.SheetIds.Add(sheet.Id);
+                        return true;
+                    }
+
+                    if (!NewSheet()) { tx.RollBack(); return; }
+
+                    // Tallest first packs columns far more tightly than name order,
+                    // and keeps a column's left edge stable once it is set.
+                    foreach (var m in measured.OrderByDescending(x => x.Height)
+                                              .ThenBy(x => x.Schedule.Name, StringComparer.OrdinalIgnoreCase))
+                    {
+                        bool fitsInColumn = (cursorTop - m.Height) >= zone.Min.Y - 1e-9;
+
+                        if (!fitsInColumn)
+                        {
+                            double nextLeft = colLeft + colWidth + gap;
+                            bool fitsNextColumn = (nextLeft + m.Width) <= zone.Max.X + 1e-9
+                                                  && m.Height <= zone.Height + 1e-9;
+
+                            if (fitsNextColumn)
+                            {
+                                colLeft = nextLeft;
+                                cursorTop = zone.Max.Y;
+                                colWidth = 0;
+                            }
+                            else
+                            {
+                                if (!NewSheet()) { result.Failed++; break; }
+                                if (m.Height > zone.Height + 1e-9)
+                                {
+                                    // Taller than any sheet we can make. Place it
+                                    // rather than drop it, and flag it.
+                                    result.Oversized++;
+                                    result.Warnings.Add(
+                                        $"'{m.Schedule.Name}' is taller than the sheet and overruns its border.");
+                                }
+                            }
+                        }
+
+                        var point = new XYZ(colLeft - m.AnchorDx, cursorTop - m.AnchorDy, 0);
+                        try
+                        {
+                            var ssi = ScheduleSheetInstance.Create(doc, sheet.Id, m.Schedule.Id, point);
+                            if (ssi == null) { result.Failed++; continue; }
+                            result.Placed++;
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"TagSchedulePlacer: place '{m.Schedule.Name}' — {ex.Message}");
+                            result.Warnings.Add($"Could not place '{m.Schedule.Name}': {ex.Message}");
+                            result.Failed++;
+                            continue;
+                        }
+
+                        colWidth = Math.Max(colWidth, m.Width);
+                        cursorTop -= m.Height + gap;
+                    }
+
+                    tx.Commit();
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: arrange pass failed — {ex.Message}");
+                    result.Warnings.Add($"Placing schedules failed: {ex.Message}");
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                }
             }
         }
 
-        private static void MoveTo(Document doc, ScheduleSheetInstance ssi, XYZ target,
-            TagSchedulePlacementResult result, string schedName)
-        {
-            try
-            {
-                var delta = target - ssi.Point;
-                if (!delta.IsZeroLength()) ElementTransformUtils.MoveElement(doc, ssi.Id, delta);
-            }
-            catch (Exception ex)
-            {
-                StingLog.Warn($"TagSchedulePlacer: move '{schedName}' — {ex.Message}");
-                result.Warnings.Add($"Could not reposition '{schedName}': {ex.Message}");
-            }
-        }
-
-        private static (double Width, double Height) MeasureSize(ScheduleSheetInstance ssi, ViewSheet sheet)
-        {
-            try
-            {
-                var bb = ssi.get_BoundingBox(sheet);
-                if (bb != null)
-                    return (Math.Abs(bb.Max.X - bb.Min.X), Math.Abs(bb.Max.Y - bb.Min.Y));
-            }
-            catch (Exception ex)
-            {
-                StingLog.Warn($"TagSchedulePlacer: bounding box unavailable — {ex.Message}");
-            }
-            return (0, 0);
-        }
+        // ──────────────────────────────────────────────────────────────────
 
         private static ViewSheet CreateSheet(Document doc, ElementId titleBlockId, TagSchedulePlacementResult result)
         {

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -1,0 +1,250 @@
+// ============================================================================
+// TagSchedulePlacer.cs — put tag-expander schedules onto sheets.
+//
+// The tag-expander (ScheduleDisciplineTagExpanderCommand) builds one
+// ViewSchedule per model category, but a ViewSchedule that never reaches a
+// sheet is not a deliverable — it is a table nobody sees. With ~204 spec
+// entries carrying sheet_columns, hand-dragging is not a workable answer.
+//
+// This placer packs schedules onto as many sheets as it takes:
+//
+//   • a cursor walks DOWN a column from the top-left of the drawable zone
+//   • when the next schedule would overflow the column, the cursor moves
+//     RIGHT by the widest table in that column (+ gap) and returns to the top
+//   • when a column would overflow the zone's right edge, a new sheet is minted
+//
+// Revit gives no way to ask how big a schedule will render before it is
+// placed, so each ScheduleSheetInstance is created at the cursor, the document
+// is regenerated, and its bounding box is measured. A table that does not fit
+// even on an empty sheet is placed anyway (top-left of a fresh sheet) and
+// reported — dropping it silently would be worse than an oversized sheet.
+// ============================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+using StingTools.Docs;
+
+namespace StingTools.Commands.TagStudio
+{
+    /// <summary>Outcome of a sheet-placement run.</summary>
+    internal sealed class TagSchedulePlacementResult
+    {
+        public int Placed;
+        public int SheetsCreated;
+        public int Oversized;
+        public int Failed;
+        public readonly List<string> Warnings = new List<string>();
+        public readonly List<ElementId> SheetIds = new List<ElementId>();
+    }
+
+    internal static class TagSchedulePlacer
+    {
+        private const string SheetNamePrefix = "STING Tag Schedules";
+        private const double GapMm = 8.0;
+
+        private static double MmToFt(double mm) => UnitUtils.ConvertToInternalUnits(mm, UnitTypeId.Millimeters);
+
+        /// <summary>
+        /// Place the given schedules onto newly-created sheets. Must be called
+        /// inside an open Transaction — the caller owns the transaction so a
+        /// build+place run commits as one undo step.
+        /// </summary>
+        internal static TagSchedulePlacementResult Place(Document doc, IList<ViewSchedule> schedules)
+        {
+            var result = new TagSchedulePlacementResult();
+            if (doc == null || schedules == null || schedules.Count == 0) return result;
+
+            ElementId titleBlockId = ResolveTitleBlock(doc);
+            if (titleBlockId == null || titleBlockId == ElementId.InvalidElementId)
+            {
+                result.Warnings.Add("No title block family is loaded — cannot create sheets to place schedules on.");
+                StingLog.Warn("TagSchedulePlacer: no title block type found; placement skipped.");
+                return result;
+            }
+
+            double gap = MmToFt(GapMm);
+
+            ViewSheet sheet = null;
+            DrawableZone zone = null;
+            double cursorX = 0, cursorY = 0, columnWidth = 0;
+
+            // Start a fresh sheet and reset the packing cursor to its top-left.
+            bool NewSheet()
+            {
+                sheet = CreateSheet(doc, titleBlockId, result);
+                if (sheet == null) return false;
+                zone = SheetManagerEngine.GetDrawableZone(doc, sheet);
+                if (zone == null || zone.Width <= 0 || zone.Height <= 0)
+                {
+                    result.Warnings.Add($"Sheet '{sheet.SheetNumber}' has no usable drawable zone.");
+                    return false;
+                }
+                cursorX = zone.Min.X;
+                cursorY = zone.Max.Y;
+                columnWidth = 0;
+                result.SheetIds.Add(sheet.Id);
+                return true;
+            }
+
+            if (!NewSheet()) return result;
+
+            foreach (var sched in schedules)
+            {
+                if (sched == null) continue;
+
+                ScheduleSheetInstance ssi = TryCreate(doc, sheet, sched, new XYZ(cursorX, cursorY, 0), result);
+                if (ssi == null) { result.Failed++; continue; }
+
+                // Revit only knows the rendered extents once the instance exists.
+                doc.Regenerate();
+                var size = MeasureSize(ssi, sheet);
+                double w = size.Width, h = size.Height;
+
+                bool fitsColumn = h <= 0 || (cursorY - h) >= zone.Min.Y;
+                if (!fitsColumn)
+                {
+                    // Try the next column on this sheet.
+                    double nextX = cursorX + Math.Max(columnWidth, w) + gap;
+                    if (nextX + w <= zone.Max.X)
+                    {
+                        cursorX = nextX;
+                        cursorY = zone.Max.Y;
+                        columnWidth = 0;
+                        MoveTo(doc, ssi, new XYZ(cursorX, cursorY, 0), result, sched.Name);
+                    }
+                    else
+                    {
+                        // Column and sheet are both full — start a new sheet.
+                        // Delete the probe instance first so it does not linger
+                        // half-off the old sheet.
+                        try { doc.Delete(ssi.Id); }
+                        catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: could not remove probe instance for '{sched.Name}' — {ex.Message}"); }
+
+                        if (!NewSheet()) { result.Failed++; break; }
+
+                        ssi = TryCreate(doc, sheet, sched, new XYZ(cursorX, cursorY, 0), result);
+                        if (ssi == null) { result.Failed++; continue; }
+                        doc.Regenerate();
+                        size = MeasureSize(ssi, sheet);
+                        w = size.Width; h = size.Height;
+
+                        // Still too tall for an empty sheet: keep it, flag it.
+                        if (h > 0 && h > zone.Height)
+                        {
+                            result.Oversized++;
+                            result.Warnings.Add($"'{sched.Name}' is taller than the sheet and overruns its border.");
+                        }
+                    }
+                }
+
+                result.Placed++;
+                columnWidth = Math.Max(columnWidth, w);
+                cursorY -= (h > 0 ? h : MmToFt(40)) + gap;
+            }
+
+            StingLog.Info($"TagSchedulePlacer: placed={result.Placed}, sheets={result.SheetsCreated}, " +
+                          $"oversized={result.Oversized}, failed={result.Failed}");
+            return result;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+
+        private static ScheduleSheetInstance TryCreate(Document doc, ViewSheet sheet,
+            ViewSchedule sched, XYZ pt, TagSchedulePlacementResult result)
+        {
+            try
+            {
+                return ScheduleSheetInstance.Create(doc, sheet.Id, sched.Id, pt);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: ScheduleSheetInstance.Create('{sched.Name}') — {ex.Message}");
+                result.Warnings.Add($"Could not place '{sched.Name}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private static void MoveTo(Document doc, ScheduleSheetInstance ssi, XYZ target,
+            TagSchedulePlacementResult result, string schedName)
+        {
+            try
+            {
+                var delta = target - ssi.Point;
+                if (!delta.IsZeroLength()) ElementTransformUtils.MoveElement(doc, ssi.Id, delta);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: move '{schedName}' — {ex.Message}");
+                result.Warnings.Add($"Could not reposition '{schedName}': {ex.Message}");
+            }
+        }
+
+        private static (double Width, double Height) MeasureSize(ScheduleSheetInstance ssi, ViewSheet sheet)
+        {
+            try
+            {
+                var bb = ssi.get_BoundingBox(sheet);
+                if (bb != null)
+                    return (Math.Abs(bb.Max.X - bb.Min.X), Math.Abs(bb.Max.Y - bb.Min.Y));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: bounding box unavailable — {ex.Message}");
+            }
+            return (0, 0);
+        }
+
+        private static ViewSheet CreateSheet(Document doc, ElementId titleBlockId, TagSchedulePlacementResult result)
+        {
+            try
+            {
+                var sheet = ViewSheet.Create(doc, titleBlockId);
+                if (sheet == null) return null;
+
+                int index = result.SheetsCreated + 1;
+                try { sheet.Name = $"{SheetNamePrefix} {index:D2}"; }
+                catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: sheet name — {ex.Message}"); }
+
+                try
+                {
+                    string number = SheetManagerEngine.GetNextSheetNumber(doc, "TS");
+                    if (!string.IsNullOrEmpty(number)) sheet.SheetNumber = number;
+                }
+                catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: sheet number — {ex.Message}"); }
+
+                result.SheetsCreated++;
+                return sheet;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"TagSchedulePlacer: ViewSheet.Create — {ex.Message}");
+                result.Warnings.Add($"Could not create sheet: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Prefer an A1 title block when one is loaded (tag schedules are wide),
+        /// otherwise take whatever title block the project has.
+        /// </summary>
+        private static ElementId ResolveTitleBlock(Document doc)
+        {
+            var types = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_TitleBlocks)
+                .WhereElementIsElementType()
+                .Cast<FamilySymbol>()
+                .ToList();
+
+            if (types.Count == 0) return ElementId.InvalidElementId;
+
+            var a1 = types.FirstOrDefault(t =>
+                (t.Name ?? "").IndexOf("A1", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                (t.FamilyName ?? "").IndexOf("A1", StringComparison.OrdinalIgnoreCase) >= 0);
+
+            return (a1 ?? types[0]).Id;
+        }
+    }
+}

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -66,6 +66,14 @@ namespace StingTools.Commands.TagStudio
         private const string SheetNamePrefix = "STING Tag Schedules";
         private const double GapMm = 10.0;
 
+        /// <summary>
+        /// Schedule-name prefix minted by ScheduleDisciplineTagExpanderCommand.
+        /// Cleanup keys off this rather than the sheet name, because schedule
+        /// names are set on creation and known good, whereas sheet renaming is
+        /// best-effort.
+        /// </summary>
+        private const string ExpanderSchedulePrefix = "STING Tag Expander - ";
+
         /// <summary>Fraction of schedules that must measure sanely before packing is trusted.</summary>
         private const double CompactionThreshold = 0.9;
 
@@ -149,22 +157,50 @@ namespace StingTools.Commands.TagStudio
         // ──────────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Delete sheets this placer created on an earlier run, identified by
-        /// the sheet-name prefix. Only sheets carrying nothing but schedule
-        /// instances are removed, so a sheet someone has since put drawings on
-        /// is left alone.
+        /// Delete sheets this placer created on an earlier run.
+        ///
+        /// Identified by their CONTENTS, not their name. Sheet naming is
+        /// best-effort — ViewSheet.Name assignment is wrapped in a catch, so a
+        /// failed rename would leave a sheet that a name-based scan could never
+        /// find again, and a bad layout would survive every re-run. What is
+        /// reliable is what sits on the sheet: a sheet holding nothing but
+        /// tag-expander schedule instances is ours.
+        ///
+        /// A sheet carrying viewports, or any schedule that is not a
+        /// tag-expander one, belongs to somebody else and is left alone.
         /// </summary>
         private static int ClearPreviousSheets(Document doc, TagSchedulePlacementResult result)
         {
             List<ViewSheet> mine;
             try
             {
-                mine = new FilteredElementCollector(doc)
-                    .OfClass(typeof(ViewSheet))
-                    .Cast<ViewSheet>()
-                    .Where(s => !s.IsTemplate
-                             && (s.Name ?? "").StartsWith(SheetNamePrefix, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                // Group placed schedule instances by the sheet they sit on.
+                var bySheet = new Dictionary<ElementId, List<ScheduleSheetInstance>>();
+                foreach (var ssi in new FilteredElementCollector(doc)
+                             .OfClass(typeof(ScheduleSheetInstance))
+                             .Cast<ScheduleSheetInstance>())
+                {
+                    ElementId owner = ssi.OwnerViewId;
+                    if (owner == null || owner == ElementId.InvalidElementId) continue;
+                    if (!bySheet.TryGetValue(owner, out var list))
+                        bySheet[owner] = list = new List<ScheduleSheetInstance>();
+                    list.Add(ssi);
+                }
+
+                mine = new List<ViewSheet>();
+                foreach (var kv in bySheet)
+                {
+                    if (!(doc.GetElement(kv.Key) is ViewSheet sheet) || sheet.IsTemplate) continue;
+
+                    bool allOurs = kv.Value.Count > 0 && kv.Value.All(ssi =>
+                    {
+                        var sched = doc.GetElement(ssi.ScheduleId) as ViewSchedule;
+                        return sched != null
+                            && (sched.Name ?? "").StartsWith(ExpanderSchedulePrefix, StringComparison.OrdinalIgnoreCase);
+                    });
+
+                    if (allOurs) mine.Add(sheet);
+                }
             }
             catch (Exception ex)
             {
@@ -445,7 +481,14 @@ namespace StingTools.Commands.TagStudio
 
                 int index = result.SheetsCreated + 1;
                 try { sheet.Name = $"{SheetNamePrefix} {index:D2}"; }
-                catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: sheet name — {ex.Message}"); }
+                catch (Exception ex)
+                {
+                    // Not fatal — cleanup identifies our sheets by contents, not
+                    // name — but worth saying out loud, because an unnamed sheet
+                    // is confusing in the browser.
+                    StingLog.Warn($"TagSchedulePlacer: sheet name — {ex.Message}");
+                    result.Warnings.Add($"Could not name a sheet ('{SheetNamePrefix} {index:D2}'): {ex.Message}");
+                }
 
                 try
                 {

--- a/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
+++ b/StingTools/Commands/TagStudio/TagSchedulePlacer.cs
@@ -6,22 +6,31 @@
 // sheet is not a deliverable — it is a table nobody sees. With ~204 spec
 // entries carrying sheet_columns, hand-dragging is not a workable answer.
 //
-// SIZING
-// ------
-// Packing needs each table's size on paper. Two earlier attempts measured a
-// placed ScheduleSheetInstance's bounding box — inside the creating
-// transaction, then after committing it. Neither is reliable, and packing
-// against an unreliable size is what piled the tables on top of each other.
+// WHY THIS IS SHAPED THE WAY IT IS
+// --------------------------------
+// Packing several schedules onto one sheet needs each table's size on paper.
+// Three sources were tried and none proved dependable:
 //
-// The dependable source is the schedule's own table data: TableSectionData
-// reports GetColumnWidth and GetRowHeight in sheet space (feet) directly,
-// with nothing placed and no transaction needed. Width is the widest
-// section's summed column widths; height is every section's summed row
-// heights. That is what this uses.
+//   1. ScheduleSheetInstance.get_BoundingBox inside the creating transaction
+//      — returns nothing usable; Regenerate does not help.
+//   2. The same bounding box measured on a scratch sheet after committing.
+//   3. TableSectionData.GetColumnWidth / GetRowHeight — reported ~0 for these
+//      schedules, so packing ran on zero heights.
 //
-// A schedule whose table data cannot be read is placed on a sheet of its own
-// rather than packed on a guess — an isolated sheet is easy to spot and fix,
-// a silent overlap is not.
+// Each attempt packed against a size that was really unknown, and each one
+// piled the tables on top of each other.
+//
+// So correctness no longer depends on knowing the size:
+//
+//   PASS 1  every schedule goes on its OWN sheet, top-left. This cannot
+//           overlap, whatever the API reports. Commit.
+//   PASS 2  measure the now-placed, committed instances.
+//   PASS 3  ONLY if those measurements look sane, delete the one-per-sheet
+//           layout and re-place packed. If they do not, the one-per-sheet
+//           result stands.
+//
+// The worst case is therefore more sheets than strictly necessary — never
+// schedules on top of each other. The result says which layout you got.
 // ============================================================================
 
 using System;
@@ -40,11 +49,13 @@ namespace StingTools.Commands.TagStudio
         public int SheetsCreated;
         public int Oversized;
         public int Failed;
-        /// <summary>Schedules whose table data could not be read, so given their own sheet.</summary>
-        public int Unsized;
+        /// <summary>True when pass 3 ran and schedules share sheets.</summary>
+        public bool Compacted;
+        /// <summary>How many instances returned a usable measurement in pass 2.</summary>
+        public int Measurable;
         public readonly List<string> Warnings = new List<string>();
         public readonly List<ElementId> SheetIds = new List<ElementId>();
-        /// <summary>Smallest and largest measured height, in mm — a sanity read-out for the report.</summary>
+        /// <summary>Measured height range in mm — 0–0 means measurement failed.</summary>
         public double MinHeightMm, MaxHeightMm;
     }
 
@@ -53,27 +64,37 @@ namespace StingTools.Commands.TagStudio
         private const string SheetNamePrefix = "STING Tag Schedules";
         private const double GapMm = 10.0;
 
-        /// <summary>Paper-space size of one schedule, in feet.</summary>
+        /// <summary>Fraction of schedules that must measure sanely before packing is trusted.</summary>
+        private const double CompactionThreshold = 0.9;
+
         private sealed class Sized
         {
             public ViewSchedule Schedule;
             public double Width;
             public double Height;
-            /// <summary>True when the table data was unreadable — gets its own sheet.</summary>
-            public bool Unknown;
+            /// <summary>bbox.Min.X - Point.X, so left edges line up exactly.</summary>
+            public double AnchorDx;
+            /// <summary>bbox.Max.Y - Point.Y, so top edges line up exactly.</summary>
+            public double AnchorDy;
+            public bool Usable => Width > 0 && Height > 0;
         }
 
         private static double MmToFt(double mm) => UnitUtils.ConvertToInternalUnits(mm, UnitTypeId.Millimeters);
         private static double FtToMm(double ft) => UnitUtils.ConvertFromInternalUnits(ft, UnitTypeId.Millimeters);
 
         /// <summary>
-        /// Place the given schedules onto new sheets. Opens its own transaction,
+        /// Place the given schedules onto new sheets. Opens its own transactions,
         /// so the caller must NOT have one open.
         /// </summary>
         internal static TagSchedulePlacementResult Place(Document doc, IList<ViewSchedule> schedules)
         {
             var result = new TagSchedulePlacementResult();
             if (doc == null || schedules == null || schedules.Count == 0) return result;
+
+            var list = schedules.Where(s => s != null)
+                                .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+                                .ToList();
+            if (list.Count == 0) return result;
 
             ElementId titleBlockId = ResolveTitleBlock(doc);
             if (titleBlockId == ElementId.InvalidElementId)
@@ -83,91 +104,154 @@ namespace StingTools.Commands.TagStudio
                 return result;
             }
 
-            var sized = schedules.Where(s => s != null).Select(s => MeasureFromTableData(s, result)).ToList();
-            if (sized.Count == 0) return result;
+            // ── PASS 1 — one per sheet. Cannot overlap. ──
+            var instances = PlaceOnePerSheet(doc, list, titleBlockId, result);
+            if (instances.Count == 0) return result;
 
-            var real = sized.Where(s => !s.Unknown).ToList();
-            result.MinHeightMm = real.Count > 0 ? FtToMm(real.Min(s => s.Height)) : 0;
-            result.MaxHeightMm = real.Count > 0 ? FtToMm(real.Max(s => s.Height)) : 0;
-            result.Unsized = sized.Count - real.Count;
+            // ── PASS 2 — measure what is now placed and committed ──
+            var sized = MeasurePlaced(doc, instances, result);
+            var usable = sized.Where(s => s.Usable).ToList();
+            result.Measurable = usable.Count;
+            result.MinHeightMm = usable.Count > 0 ? FtToMm(usable.Min(s => s.Height)) : 0;
+            result.MaxHeightMm = usable.Count > 0 ? FtToMm(usable.Max(s => s.Height)) : 0;
 
-            StingLog.Info($"TagSchedulePlacer: sizing {sized.Count} schedule(s) — " +
-                          $"heights {result.MinHeightMm:F0}..{result.MaxHeightMm:F0} mm, unsized={result.Unsized}");
+            StingLog.Info($"TagSchedulePlacer: measured {usable.Count}/{sized.Count} — " +
+                          $"heights {result.MinHeightMm:F0}..{result.MaxHeightMm:F0} mm");
 
-            Arrange(doc, sized, titleBlockId, result);
+            // ── PASS 3 — pack, but only on trustworthy measurements ──
+            bool trustworthy = sized.Count > 0
+                            && usable.Count >= (int)Math.Ceiling(sized.Count * CompactionThreshold)
+                            && result.MaxHeightMm > 1.0;
 
-            StingLog.Info($"TagSchedulePlacer: placed={result.Placed}, sheets={result.SheetsCreated}, " +
-                          $"oversized={result.Oversized}, unsized={result.Unsized}, failed={result.Failed}");
+            if (!trustworthy)
+            {
+                result.Warnings.Add(
+                    $"Revit reported a usable size for only {usable.Count} of {sized.Count} schedules, " +
+                    "so they were left one per sheet rather than packed — packing on unknown sizes is what " +
+                    "makes them overlap.");
+                StingLog.Warn("TagSchedulePlacer: measurements untrustworthy; keeping one-per-sheet layout.");
+                return result;
+            }
+
+            Compact(doc, sized, titleBlockId, result);
             return result;
         }
 
         // ──────────────────────────────────────────────────────────────────
-        //  Sizing — straight from the schedule's table data
+        //  Pass 1 — one schedule per sheet
         // ──────────────────────────────────────────────────────────────────
 
-        /// <summary>
-        /// Width and height on paper, in feet, summed from the schedule's own
-        /// column widths and row heights. No placement, no transaction.
-        /// </summary>
-        private static Sized MeasureFromTableData(ViewSchedule sched, TagSchedulePlacementResult result)
+        private static List<(ScheduleSheetInstance Ssi, ViewSheet Sheet, ViewSchedule Sched)> PlaceOnePerSheet(
+            Document doc, List<ViewSchedule> list, ElementId titleBlockId, TagSchedulePlacementResult result)
         {
-            double width = 0, height = 0;
-            bool readAnything = false;
-
-            // Header carries the title and column-heading rows; Body the data.
-            // Both contribute height; width is the widest of them.
-            foreach (SectionType st in new[] { SectionType.Header, SectionType.Body, SectionType.Summary, SectionType.Footer })
-            {
-                TableSectionData sd;
-                try { sd = sched.GetTableData()?.GetSectionData(st); }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"TagSchedulePlacer: section {st} of '{sched.Name}' — {ex.Message}");
-                    continue;
-                }
-                if (sd == null) continue;
-
-                try
-                {
-                    double sectionWidth = 0;
-                    for (int c = 0; c < sd.NumberOfColumns; c++) sectionWidth += sd.GetColumnWidth(c);
-                    for (int r = 0; r < sd.NumberOfRows; r++) height += sd.GetRowHeight(r);
-                    width = Math.Max(width, sectionWidth);
-                    readAnything = true;
-                }
-                catch (Exception ex)
-                {
-                    StingLog.Warn($"TagSchedulePlacer: sizing section {st} of '{sched.Name}' — {ex.Message}");
-                }
-            }
-
-            if (!readAnything || width <= 0 || height <= 0)
-            {
-                StingLog.Warn($"TagSchedulePlacer: '{sched.Name}' has no readable table size — giving it its own sheet.");
-                result.Warnings.Add($"'{sched.Name}' could not be sized; placed on a sheet of its own.");
-                return new Sized { Schedule = sched, Width = 0, Height = 0, Unknown = true };
-            }
-
-            return new Sized { Schedule = sched, Width = width, Height = height };
-        }
-
-        // ──────────────────────────────────────────────────────────────────
-        //  Arrange onto sheets
-        // ──────────────────────────────────────────────────────────────────
-
-        private static void Arrange(Document doc, List<Sized> sized,
-            ElementId titleBlockId, TagSchedulePlacementResult result)
-        {
-            double gap = MmToFt(GapMm);
+            var placed = new List<(ScheduleSheetInstance, ViewSheet, ViewSchedule)>();
 
             using (var tx = new Transaction(doc, "STING Place Tag Schedules On Sheets"))
             {
                 tx.Start();
                 try
                 {
+                    foreach (var sched in list)
+                    {
+                        var sheet = CreateSheet(doc, titleBlockId, result);
+                        if (sheet == null) { result.Failed++; continue; }
+
+                        var zone = SheetManagerEngine.GetDrawableZone(doc, sheet);
+                        XYZ pt = zone != null ? new XYZ(zone.Min.X, zone.Max.Y, 0) : XYZ.Zero;
+
+                        try
+                        {
+                            var ssi = ScheduleSheetInstance.Create(doc, sheet.Id, sched.Id, pt);
+                            if (ssi == null) { result.Failed++; continue; }
+                            placed.Add((ssi, sheet, sched));
+                            result.SheetIds.Add(sheet.Id);
+                            result.Placed++;
+                        }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn($"TagSchedulePlacer: place '{sched.Name}' — {ex.Message}");
+                            result.Warnings.Add($"Could not place '{sched.Name}': {ex.Message}");
+                            result.Failed++;
+                        }
+                    }
+                    tx.Commit();
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: pass 1 failed — {ex.Message}");
+                    result.Warnings.Add($"Placing schedules failed: {ex.Message}");
+                    if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                    placed.Clear();
+                }
+            }
+
+            return placed;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Pass 2 — measure the committed instances
+        // ──────────────────────────────────────────────────────────────────
+
+        private static List<Sized> MeasurePlaced(Document doc,
+            List<(ScheduleSheetInstance Ssi, ViewSheet Sheet, ViewSchedule Sched)> instances,
+            TagSchedulePlacementResult result)
+        {
+            var sized = new List<Sized>();
+
+            foreach (var (ssi, sheet, sched) in instances)
+            {
+                var s = new Sized { Schedule = sched };
+                try
+                {
+                    var bb = ssi.get_BoundingBox(sheet);
+                    if (bb != null)
+                    {
+                        s.Width  = Math.Abs(bb.Max.X - bb.Min.X);
+                        s.Height = Math.Abs(bb.Max.Y - bb.Min.Y);
+                        s.AnchorDx = bb.Min.X - ssi.Point.X;
+                        s.AnchorDy = bb.Max.Y - ssi.Point.Y;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"TagSchedulePlacer: measuring '{sched.Name}' — {ex.Message}");
+                }
+                sized.Add(s);
+            }
+
+            return sized;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Pass 3 — re-place packed, replacing the one-per-sheet layout
+        // ──────────────────────────────────────────────────────────────────
+
+        private static void Compact(Document doc, List<Sized> sized,
+            ElementId titleBlockId, TagSchedulePlacementResult result)
+        {
+            double gap = MmToFt(GapMm);
+            var oldSheetIds = new List<ElementId>(result.SheetIds);
+
+            using (var tx = new Transaction(doc, "STING Pack Tag Schedules"))
+            {
+                tx.Start();
+                try
+                {
+                    // Drop the one-per-sheet layout; deleting a sheet takes its
+                    // schedule instances with it.
+                    foreach (var id in oldSheetIds)
+                    {
+                        try { doc.Delete(id); }
+                        catch (Exception ex) { StingLog.Warn($"TagSchedulePlacer: delete sheet — {ex.Message}"); }
+                    }
+                    result.SheetIds.Clear();
+                    result.SheetsCreated = 0;
+                    result.Placed = 0;
+
                     ViewSheet sheet = null;
                     DrawableZone zone = null;
                     double colLeft = 0, cursorTop = 0, colWidth = 0;
+                    bool sheetIsFresh = true;
 
                     bool NewSheet()
                     {
@@ -182,45 +266,38 @@ namespace StingTools.Commands.TagStudio
                         colLeft = zone.Min.X;
                         cursorTop = zone.Max.Y;
                         colWidth = 0;
+                        sheetIsFresh = true;
                         result.SheetIds.Add(sheet.Id);
                         return true;
                     }
 
                     if (!NewSheet()) { tx.RollBack(); return; }
 
-                    // Tallest first packs columns far more tightly than name order
-                    // and keeps a column's left edge stable once it is set.
-                    // Unsized ones go last so they do not disturb the packed run.
-                    var order = sized.Where(s => !s.Unknown)
+                    // Tallest first packs columns tightly and keeps a column's
+                    // left edge stable once set. Anything that failed to measure
+                    // goes last, on a sheet of its own.
+                    var order = sized.Where(s => s.Usable)
                                      .OrderByDescending(s => s.Height)
                                      .ThenBy(s => s.Schedule.Name, StringComparer.OrdinalIgnoreCase)
-                                     .Concat(sized.Where(s => s.Unknown)
+                                     .Concat(sized.Where(s => !s.Usable)
                                                   .OrderBy(s => s.Schedule.Name, StringComparer.OrdinalIgnoreCase))
                                      .ToList();
 
-                    bool sheetIsFresh = true;   // nothing placed on the current sheet yet
-
                     foreach (var s in order)
                     {
-                        if (s.Unknown)
+                        if (!s.Usable)
                         {
-                            // Unknown size: give it a sheet to itself rather than
-                            // pack it against a guess and risk landing on a neighbour.
                             if (!sheetIsFresh && !NewSheet()) { result.Failed++; break; }
                             if (PlaceOne(doc, sheet, s.Schedule, new XYZ(zone.Min.X, zone.Max.Y, 0), result))
                                 result.Placed++;
                             if (!NewSheet()) { result.Failed++; break; }
-                            sheetIsFresh = true;
                             continue;
                         }
 
-                        bool fitsInColumn = (cursorTop - s.Height) >= zone.Min.Y - 1e-9;
-                        if (!fitsInColumn)
+                        if ((cursorTop - s.Height) < zone.Min.Y - 1e-9)
                         {
                             double nextLeft = colLeft + colWidth + gap;
-                            bool fitsNextColumn = (nextLeft + s.Width) <= zone.Max.X + 1e-9
-                                                  && s.Height <= zone.Height + 1e-9;
-                            if (fitsNextColumn)
+                            if ((nextLeft + s.Width) <= zone.Max.X + 1e-9 && s.Height <= zone.Height + 1e-9)
                             {
                                 colLeft = nextLeft;
                                 cursorTop = zone.Max.Y;
@@ -228,23 +305,16 @@ namespace StingTools.Commands.TagStudio
                             }
                             else if (sheetIsFresh)
                             {
-                                // Does not fit even on an empty sheet — place it
-                                // anyway and flag it rather than drop it.
+                                // Bigger than any sheet we can make: place it and
+                                // flag it rather than drop it.
                                 result.Oversized++;
                                 result.Warnings.Add($"'{s.Schedule.Name}' is larger than the sheet and overruns its border.");
                             }
-                            else
-                            {
-                                if (!NewSheet()) { result.Failed++; break; }
-                                sheetIsFresh = true;
-                            }
+                            else if (!NewSheet()) { result.Failed++; break; }
                         }
 
-                        if (!PlaceOne(doc, sheet, s.Schedule, new XYZ(colLeft, cursorTop, 0), result))
-                        {
-                            result.Failed++;
-                            continue;
-                        }
+                        var pt = new XYZ(colLeft - s.AnchorDx, cursorTop - s.AnchorDy, 0);
+                        if (!PlaceOne(doc, sheet, s.Schedule, pt, result)) { result.Failed++; continue; }
 
                         result.Placed++;
                         sheetIsFresh = false;
@@ -253,15 +323,25 @@ namespace StingTools.Commands.TagStudio
                     }
 
                     tx.Commit();
+                    result.Compacted = true;
                 }
                 catch (Exception ex)
                 {
-                    StingLog.Warn($"TagSchedulePlacer: arrange failed — {ex.Message}");
-                    result.Warnings.Add($"Placing schedules failed: {ex.Message}");
+                    // Rolling back restores the one-per-sheet layout, which is
+                    // correct if verbose — far better than a half-packed pile.
+                    StingLog.Warn($"TagSchedulePlacer: packing failed, keeping one-per-sheet — {ex.Message}");
+                    result.Warnings.Add($"Packing failed; schedules left one per sheet: {ex.Message}");
                     if (tx.HasStarted() && !tx.HasEnded()) tx.RollBack();
+                    result.SheetIds.Clear();
+                    result.SheetIds.AddRange(oldSheetIds);
+                    result.SheetsCreated = oldSheetIds.Count;
+                    result.Placed = oldSheetIds.Count;
+                    result.Compacted = false;
                 }
             }
         }
+
+        // ──────────────────────────────────────────────────────────────────
 
         private static bool PlaceOne(Document doc, ViewSheet sheet, ViewSchedule sched,
             XYZ point, TagSchedulePlacementResult result)
@@ -277,8 +357,6 @@ namespace StingTools.Commands.TagStudio
                 return false;
             }
         }
-
-        // ──────────────────────────────────────────────────────────────────
 
         private static ViewSheet CreateSheet(Document doc, ElementId titleBlockId, TagSchedulePlacementResult result)
         {

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -2675,7 +2675,11 @@ namespace StingTools.Core
                 ("Fabrication_Open",     "Fabrication",   "FW", DrawingColor.Firebrick,    typeof(HubFabricationCommand).FullName),
                 ("Placement_Open",       "Placement",     "PC", DrawingColor.Goldenrod,    typeof(HubPlacementCommand).FullName),
                 ("StructuralDWGWizard",  "Struct Wizard", "SW", DrawingColor.SlateGray,    typeof(HubStructuralDwgWizardCommand).FullName),
-                ("Scheduling_Dashboard", "Scheduling",    "SD", DrawingColor.MidnightBlue, typeof(HubSchedulingDashboardCommand).FullName),
+                // Replaces the old "Scheduling" button, which opened the 4D/5D
+                // cost dashboard. That is programme management, not drawing
+                // schedules, and it stays reachable from the dock panel's BIM
+                // tab. The hub slot now opens the Scheduler.
+                ("Scheduler",            "Scheduler",     "SC", DrawingColor.ForestGreen,  typeof(HubSchedulerCommand).FullName),
                 ("Tag3D",                "3D Tag",        "T3", DrawingColor.Crimson,      typeof(HubTag3DCommand).FullName),
                 ("CreateTagFamilies",    "Tag Families",  "TF", DrawingColor.DarkCyan,     typeof(HubCreateTagFamiliesCommand).FullName),
                 ("AutoTag",              "Auto Tag",      "AT", DrawingColor.DarkGreen,      typeof(HubAutoTagCommand).FullName),
@@ -3203,6 +3207,19 @@ namespace StingTools.Core
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
             => HubDispatcher.Run(data, "SchedulingCostDashboard", ref message);
+    }
+
+    /// <summary>
+    /// STING Hub → Scheduler. A ribbon button rather than a dock-panel one so
+    /// it can be right-clicked onto the Quick Access Toolbar — the QAT only
+    /// accepts ribbon items.
+    /// </summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class HubSchedulerCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
+            => HubDispatcher.Run(data, "Scheduler", ref message);
     }
 
     [Transaction(TransactionMode.ReadOnly)]

--- a/StingTools/UI/ScheduleWizardDialog.cs
+++ b/StingTools/UI/ScheduleWizardDialog.cs
@@ -1122,7 +1122,9 @@ namespace StingTools.UI
                         // so an empty selection builds nothing rather than everything.
                         opts["TagSched_Bundles"] =
                             bundles.Count == 5 ? "" :
-                            bundles.Count == 0 ? "__NONE__" : string.Join(",", bundles);
+                            bundles.Count == 0
+                                ? Commands.TagStudio.ScheduleDisciplineTagExpanderCommand.NoBundlesSentinel
+                                : string.Join(",", bundles);
                         opts["TagSched_Place"]   = (ts.ChkPlace?.IsChecked == true) ? "1" : "0";
                     }
                     break;

--- a/StingTools/UI/ScheduleWizardDialog.cs
+++ b/StingTools/UI/ScheduleWizardDialog.cs
@@ -95,9 +95,9 @@ namespace StingTools.UI
 
             var win = new Window
             {
-                Title = "STING Scheduling Dashboard",
-                Width = 850,
-                Height = 620,
+                Title = "STING Scheduler",
+                Width = 880,
+                Height = 660,
                 MinWidth = 750,
                 MinHeight = 520,
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
@@ -126,7 +126,7 @@ namespace StingTools.UI
             var headerStack = new StackPanel();
             headerStack.Children.Add(new TextBlock
             {
-                Text = "Scheduling Dashboard",
+                Text = "Scheduler",
                 FontSize = 17,
                 FontWeight = FontWeights.SemiBold,
                 Foreground = BrWhite
@@ -203,7 +203,8 @@ namespace StingTools.UI
                 ("manage",    "MANAGE",            "Duplicate, delete, refresh, field manager"),
                 ("export",    "EXPORT",            "CSV/XLSX export, schedule-to-Excel"),
                 ("format",    "FORMAT",            "Column widths, alignment, visibility"),
-                ("corporate", "CORPORATE / MEP",   "Title block, register, MEP schedules")
+                ("corporate", "CORPORATE / MEP",   "Title block, register, MEP schedules"),
+                ("tag",       "TAG SCHEDULES",     "Per-category tag-expander schedules, placed on sheets")
             };
 
             // Content area
@@ -221,6 +222,7 @@ namespace StingTools.UI
             contentPanels["export"] = BuildExportTab(scheduleItems, statusText);
             contentPanels["format"] = BuildFormatTab(statusText);
             contentPanels["corporate"] = BuildCorporateMepTab(statusText);
+            contentPanels["tag"] = BuildTagSchedulesTab(statusText);
 
             foreach (var kvp in contentPanels)
             {
@@ -389,6 +391,27 @@ namespace StingTools.UI
             opGroup.Children.Add(rbReport);
             stack.Children.Add(opGroup);
 
+            // ── Consistency checks (were only reachable from DOCS / BIM) ──
+            stack.Children.Add(MakeSectionHeader("CONSISTENCY CHECKS"));
+            var checkGroup = new StackPanel { Margin = new Thickness(0, 0, 0, 12) };
+            var checkOps = new[]
+            {
+                ("ScheduleFieldRemapAudit",      "Deprecated Fields",   "Flag schedules still using renamed parameters (SCHEDULE_FIELD_REMAP.csv)"),
+                ("CheckScheduleFieldConsistency","Field Consistency",   "Check that shared fields agree across schedules"),
+                ("CrossScheduleValidate",        "Cross-Schedule Validate", "Validate values that must reconcile between schedules"),
+            };
+            foreach (var (tag, label, tip) in checkOps)
+            {
+                checkGroup.Children.Add(new RadioButton
+                {
+                    Content = $"{label} — {tip}",
+                    FontSize = 12, Foreground = BrFg,
+                    Margin = new Thickness(0, 3, 0, 3),
+                    GroupName = "AuditOp", Tag = tag
+                });
+            }
+            stack.Children.Add(checkGroup);
+
             // ── Schedule selection for audit/compare ─────────────────────
             stack.Children.Add(MakeSectionHeader("SELECT SCHEDULES"));
             var listPanel = BuildScheduleListPanel(items);
@@ -459,6 +482,23 @@ namespace StingTools.UI
             opGroup.Children.Add(rbExportCsv);
             opGroup.Children.Add(rbExportExcel);
             stack.Children.Add(opGroup);
+
+            // ── Excel round-trip (was only reachable from the INTEROP tab) ──
+            stack.Children.Add(MakeSectionHeader("EXCEL ROUND-TRIP"));
+            var rtGroup = new StackPanel { Margin = new Thickness(0, 0, 0, 12) };
+            rtGroup.Children.Add(new RadioButton
+            {
+                Content = "All Schedules → Excel — one worksheet per schedule, ready to edit",
+                FontSize = 12, Foreground = BrFg, Margin = new Thickness(0, 3, 0, 3),
+                GroupName = "ExportOp", Tag = "ExportSchedulesToExcel"
+            });
+            rtGroup.Children.Add(new RadioButton
+            {
+                Content = "Excel → Revit — write edited schedule values back into the model",
+                FontSize = 12, Foreground = BrFg, Margin = new Thickness(0, 3, 0, 3),
+                GroupName = "ExportOp", Tag = "ImportSchedulesFromExcel"
+            });
+            stack.Children.Add(rtGroup);
 
             // ── Output path ─────────────────────────────────────────────
             stack.Children.Add(MakeSectionHeader("OUTPUT"));
@@ -604,6 +644,10 @@ namespace StingTools.UI
                 ("CorporateTitleBlock",     "Corporate Title Block Schedule",  "Create title block schedule with project metadata"),
                 ("DrawingRegisterSchedule", "Drawing Register Schedule",       "Create ISO 19650 drawing register"),
                 ("MaterialSchedules",       "Material Schedules",              "Create BLE/MEP material quantity schedules"),
+                ("CreateTemplateSchedules", "Template Schedules",              "Create the standard schedule templates"),
+                ("RoomSchedule",            "Room Schedule",                   "Rooms with area, finishes and tags"),
+                ("RevisionSchedule",        "Revision Schedule",               "Revision history table for issue sheets"),
+                ("MaintenanceSchedule",     "Maintenance Schedule",            "Planned preventive maintenance with frequencies and priorities"),
             };
 
             RadioButton firstCorpRb = null;
@@ -658,6 +702,7 @@ namespace StingTools.UI
                 ("MEPScheduleElec",  "All Electrical Schedules", "Create all electrical schedules"),
                 ("MEPSchedulePlumb", "All Plumbing Schedules",   "Create all plumbing schedules"),
                 ("MEPScheduleFire",  "All Fire Schedules",       "Create all fire protection schedules"),
+                ("BatchMEPSchedules","Every MEP Schedule",       "Create the whole MEP set in one pass"),
             };
 
             foreach (var (tag, label, tip) in bulkOps)
@@ -676,6 +721,106 @@ namespace StingTools.UI
             stack.Tag = "corpmep_tab";
             scroll.Content = stack;
             return scroll;
+        }
+
+        // ════════════════════════════════════════════════════════════════
+        // TAB 7: TAG SCHEDULES
+        //
+        // The universal tag is discipline-agnostic, so the engineering data it
+        // no longer carries lives in a per-category schedule placed next to the
+        // drawing. This tab drives that builder: which column set, which
+        // discipline bundles, and whether the result reaches a sheet.
+        // ════════════════════════════════════════════════════════════════
+        private static UIElement BuildTagSchedulesTab(TextBlock status)
+        {
+            var scroll = new ScrollViewer { VerticalScrollBarVisibility = ScrollBarVisibility.Auto };
+            var stack = new StackPanel();
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = "Builds one schedule per model category: column 1 is the tag (ASS_TAG_1_TXT), " +
+                       "then the discipline parameters dropped from the universal tag, then Comments. " +
+                       "A reader sees the short tag on the drawing and the full properties in the schedule beside it.",
+                FontSize = 11, Foreground = BrFgDim, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 12)
+            });
+
+            // ── Column set ──────────────────────────────────────────────
+            stack.Children.Add(MakeSectionHeader("COLUMN SET"));
+            var modeGroup = new StackPanel { Margin = new Thickness(0, 0, 0, 12) };
+
+            // All three carry the same command tag — the column set travels as
+            // an option, so CollectOperation stays a simple "first checked wins".
+            const string TagCmd = "Schedule_DisciplineTagExpander";
+            var rbSheet = new RadioButton
+            {
+                Content = "Sheet columns — the curated set meant for drawings (recommended)",
+                FontSize = 12, Foreground = BrFg, IsChecked = true,
+                Margin = new Thickness(0, 3, 0, 3), GroupName = "TagSchedOp", Tag = TagCmd
+            };
+            var rbFull = new RadioButton
+            {
+                Content = "Full as-built columns — every discipline and fabrication parameter",
+                FontSize = 12, Foreground = BrFg,
+                Margin = new Thickness(0, 3, 0, 3), GroupName = "TagSchedOp", Tag = TagCmd
+            };
+            var rbBoth = new RadioButton
+            {
+                Content = "Both — a compact sheet schedule and a wide as-built schedule per category",
+                FontSize = 12, Foreground = BrFg,
+                Margin = new Thickness(0, 3, 0, 3), GroupName = "TagSchedOp", Tag = TagCmd
+            };
+            modeGroup.Children.Add(rbSheet);
+            modeGroup.Children.Add(rbFull);
+            modeGroup.Children.Add(rbBoth);
+            stack.Children.Add(modeGroup);
+
+            // ── Bundle filter ───────────────────────────────────────────
+            stack.Children.Add(MakeSectionHeader("DISCIPLINE BUNDLES"));
+            stack.Children.Add(new TextBlock
+            {
+                Text = "Leave all ticked to build the whole spec (~200 schedules). Untick to work one discipline at a time.",
+                FontSize = 10.5, Foreground = BrFgDim, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 6)
+            });
+            var bundleWrap = new WrapPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 12) };
+            var chkArch   = MakeCheckBox("ARCH — Architectural", true);
+            var chkGen    = MakeCheckBox("GEN — General", true);
+            var chkMep    = MakeCheckBox("MEP — Mechanical / Electrical / Plumbing", true);
+            var chkStr    = MakeCheckBox("STR — Structural", true);
+            var chkHealth = MakeCheckBox("HEALTH — Healthcare", true);
+            bundleWrap.Children.Add(chkArch); bundleWrap.Children.Add(chkGen); bundleWrap.Children.Add(chkMep);
+            bundleWrap.Children.Add(chkStr); bundleWrap.Children.Add(chkHealth);
+            stack.Children.Add(bundleWrap);
+
+            // ── Sheet placement ─────────────────────────────────────────
+            stack.Children.Add(MakeSectionHeader("SHEET PLACEMENT"));
+            var chkPlace = MakeCheckBox("Place the schedules on sheets after building", true);
+            stack.Children.Add(chkPlace);
+            stack.Children.Add(new TextBlock
+            {
+                Text = "Schedules are packed in columns onto as many new sheets as needed. " +
+                       "If nothing new gets built, any tag-expander schedules not yet on a sheet are placed instead.",
+                FontSize = 10.5, Foreground = BrFgDim, TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(20, 2, 0, 12)
+            });
+
+            stack.Tag = new TagSchedTabState
+            {
+                RbSheet = rbSheet, RbFull = rbFull, RbBoth = rbBoth,
+                ChkArch = chkArch, ChkGen = chkGen, ChkMep = chkMep, ChkStr = chkStr, ChkHealth = chkHealth,
+                ChkPlace = chkPlace
+            };
+
+            scroll.Content = stack;
+            return scroll;
+        }
+
+        private class TagSchedTabState
+        {
+            public RadioButton RbSheet, RbFull, RbBoth;
+            public CheckBox ChkArch, ChkGen, ChkMep, ChkStr, ChkHealth;
+            public CheckBox ChkPlace;
         }
 
         // ════════════════════════════════════════════════════════════════
@@ -954,6 +1099,31 @@ namespace StingTools.UI
                     {
                         opts["OutputPath"] = es.TxtPath?.Text ?? "";
                         opts["Format"]     = es.CmbFormat?.SelectedItem?.ToString() ?? "CSV";
+                    }
+                    break;
+
+                case "tag":
+                    if (stack.Tag is TagSchedTabState ts)
+                    {
+                        opts["TagSched_Mode"] =
+                            (ts.RbBoth?.IsChecked == true) ? "Both" :
+                            (ts.RbFull?.IsChecked == true) ? "Full" : "Sheet";
+
+                        var bundles = new List<string>();
+                        if (ts.ChkArch?.IsChecked   == true) bundles.Add("ARCH");
+                        if (ts.ChkGen?.IsChecked    == true) bundles.Add("GEN");
+                        if (ts.ChkMep?.IsChecked    == true) bundles.Add("MEP");
+                        if (ts.ChkStr?.IsChecked    == true) bundles.Add("STR");
+                        if (ts.ChkHealth?.IsChecked == true) bundles.Add("HEALTH");
+
+                        // All five ticked means "no filter" — send an empty value
+                        // so the command does not have to know the full bundle list.
+                        // Nothing ticked stays a real filter that matches nothing,
+                        // so an empty selection builds nothing rather than everything.
+                        opts["TagSched_Bundles"] =
+                            bundles.Count == 5 ? "" :
+                            bundles.Count == 0 ? "__NONE__" : string.Join(",", bundles);
+                        opts["TagSched_Place"]   = (ts.ChkPlace?.IsChecked == true) ? "1" : "0";
                     }
                     break;
 

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -3268,7 +3268,8 @@ namespace StingTools.UI
                         }
                         break;
                     }
-                    case "ScheduleWizard":
+                    case "Scheduler":        // current name
+                    case "ScheduleWizard":   // legacy tag — kept so saved workflows and MCP calls keep working
                     {
                         // Load CSV definitions and existing schedule names for the wizard
                         var doc = app.ActiveUIDocument?.Document;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -162,6 +162,7 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="28"/>
+                    <ColumnDefinition Width="34"/>
                 </Grid.ColumnDefinitions>
                 <Grid>
                     <TextBox x:Name="txtCommandBar"
@@ -234,6 +235,16 @@
                         Cursor="Hand"
                         ToolTip="Ask AI — design briefs, BIM knowledge, draft documents"
                         Click="AskAI_Click"/>
+                <!-- Schedules are needed from every tab, so the Scheduler lives
+                     in the header rather than inside one of them. -->
+                <Button x:Name="btnScheduler" Grid.Column="2"
+                        Content="SCH" Width="32" Height="23"
+                        Margin="2,0,0,0" FontSize="9" FontWeight="Bold"
+                        Background="#4CAF50" Foreground="White"
+                        BorderBrush="#388E3C" BorderThickness="1"
+                        Cursor="Hand"
+                        ToolTip="STING Scheduler — every view-schedule function in one dialog: create &amp; populate, audit, manage, export, format, corporate/MEP, and the per-category tag schedules with automatic sheet placement"
+                        Tag="Scheduler" Click="Cmd_Click"/>
             </Grid>
             </StackPanel>
         </Border>

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1581,6 +1581,7 @@
                                 </WrapPanel>
                                 <TextBlock Style="{StaticResource SubLabel}" Text="SCHEDULE MANAGEMENT"/>
                                 <WrapPanel>
+                                    <Button Style="{StaticResource GreenBtn}" Content="★ SCHEDULER" Tag="Scheduler" Click="Cmd_Click" ToolTip="STING Scheduler — every view-schedule function in one dialog. The buttons below are shortcuts into it." FontWeight="Bold"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Audit" Tag="ScheduleAudit" Click="Cmd_Click" ToolTip="Audit all schedules for issues and CSV coverage"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Refresh" Tag="ScheduleRefresh" Click="Cmd_Click" ToolTip="Re-apply formatting from CSV definitions"/>
                                 </WrapPanel>
@@ -2026,7 +2027,7 @@
                         <Border Style="{StaticResource GroupBorder}">
                             <StackPanel>
                                 <WrapPanel>
-                                    <Button Style="{StaticResource GreenBtn}" Content="★ Wizard" Tag="ScheduleWizard" Click="Cmd_Click" ToolTip="Schedule Wizard — unified schedule wizard: create, populate, audit, export in one dialog" FontWeight="Bold"/>
+                                    <Button Style="{StaticResource GreenBtn}" Content="★ SCHEDULER" Tag="Scheduler" Click="Cmd_Click" ToolTip="STING Scheduler — every view-schedule function in one dialog: create &amp; populate, audit, manage, export, format, corporate/MEP, and the per-category tag schedules with sheet placement" FontWeight="Bold"/>
                                     <Button Style="{StaticResource GreenBtn}" Content="★ Full AutoPop" Tag="FullAutoPopulate" Click="Cmd_Click" ToolTip="Full AutoPopulate — zero-input full pipeline" FontWeight="Bold"/>
                                     <Button Style="{StaticResource GreenBtn}" Content="★ Excel Link" Tag="ExcelLinkExport" Click="Cmd_Click" ToolTip="Excel Link — ExLink-style export: pick categories and properties, export to Excel" FontWeight="Bold"/>
                                 </WrapPanel>
@@ -2333,7 +2334,7 @@
                                             <Button Style="{StaticResource PurpleBtn}" Content="Propagate Universal" Tag="Propagate_UniversalTag" Click="Cmd_Click" ToolTip="Universal-tag pivot: clone the hand-built universal master label to loaded STING tag families — EditFamily → recategorise → rename → re-create type variants → SaveAs/LoadFamily. Re-run = safe re-sync. Smoke-test on Duct first."/>
                                             <Button Style="{StaticResource ActionBtn}" Content="Stamp Gates" Tag="Gate_StampStatus" Click="Cmd_Click" ToolTip="Compute + stamp STING_GATE_DATA_STATUS_INT / STING_GATE_QA_STATUS_INT (0=red/1=amber/2=green) on every taggable element. Binds the params first if needed."/>
                                             <Button Style="{StaticResource ActionBtn}" Content="Status Register" Tag="Status_Register" Click="Cmd_Click" ToolTip="Export a colour-coded data/QA status register to Excel (Register + Summary sheets) to share with modellers. Read-only — computes each element's data + QA gate fresh, reds sorted to top, auto-filtered."/>
-                                            <Button Style="{StaticResource ActionBtn}" Content="Tag Schedules" Tag="Schedule_DisciplineTagExpander" Click="Cmd_Click" ToolTip="Build one ViewSchedule per model category from SCHEDULE_SPEC_all_disciplines.json — col1 ASS_TAG_1_TXT + the discipline columns dropped from the universal tag + Comments. Sheet / Full as-built / Both. Skips empty entries + unresolved categories."/>
+                                            <Button Style="{StaticResource ActionBtn}" Content="Tag Schedules" Tag="Schedule_DisciplineTagExpander" Click="Cmd_Click" ToolTip="Build one ViewSchedule per model category from SCHEDULE_SPEC_all_disciplines.json — col1 ASS_TAG_1_TXT + the discipline columns dropped from the universal tag + Comments. Sheet / Full as-built / Both. For bundle filtering and automatic sheet placement, use SETUP → ★ SCHEDULER → TAG SCHEDULES."/>
                                             <Button Style="{StaticResource ActionBtn}" Content="Style Audit"  Tag="StyleAudit"               Click="Cmd_Click" ToolTip="Audit every tag family for missing params / variants and flag deviations from disciplinary defaults"/>
                                         </WrapPanel>
                                     </StackPanel>
@@ -2938,7 +2939,7 @@
                             <StackPanel>
                                 <TextBlock Text="WORKFLOW &amp; COORDINATION" FontWeight="Bold" FontSize="10" Foreground="{DynamicResource PanelFg}" Margin="0,0,0,6"/>
                                 <WrapPanel>
-                                    <Button Style="{StaticResource ActionBtn}" Content="Scheduler" Tag="WorkflowScheduler" Click="Cmd_Click" ToolTip="Manage scheduled workflow triggers (on-open, compliance-fall, SLA, periodic)"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="Workflow Triggers" Tag="WorkflowScheduler" Click="Cmd_Click" ToolTip="Manage scheduled workflow triggers (on-open, compliance-fall, SLA, periodic). Not related to view schedules — for those use SETUP → ★ SCHEDULER."/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Mid-Day" Tag="MidDayCoordination" Click="Cmd_Click" ToolTip="Mid-Day Check — quick coordination checkpoint before meetings (2-3 min)"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Review Prep" Tag="DesignReviewPrep" Click="Cmd_Click" ToolTip="Prepare model for design review (retag, fix, validate, report)"/>
                                 </WrapPanel>


### PR DESCRIPTION
## What this does

Schedule tooling was scattered across five tabs of the main hub with no single door: SETUP had a wizard, DOCS had ten management buttons, INTEROP owned the Excel round-trip, TAG STUDIO hid the tag-expander, and a button labelled "Scheduler" pointed at workflow triggers.

- **One entry point, shortcuts kept.** SETUP, DOCS, the panel header (green **SCH**), and the STING Hub ribbon all open the Scheduler. The legacy `ScheduleWizard` tag still dispatches, so saved workflows and MCP calls keep working. Existing per-function buttons remain as shortcuts.
- **STING Hub ribbon.** The `Scheduling` button (which opened the 4D/5D cost dashboard) is now `Scheduler`. It has to be a ribbon button because the Quick Access Toolbar only accepts ribbon items. The cost dashboard keeps its entry on the BIM tab — 4D/5D programme work stays separate from drawing schedules by design.
- **Renamed** the workflow-trigger button to "Workflow Triggers"; it was called "Scheduler" and is unrelated.
- **Folded in** functions that had no home in the dialog: deprecated-field / consistency / cross-schedule checks, the Excel round-trip, and template / room / revision / maintenance schedules.
- **New TAG SCHEDULES tab** driving the per-category tag-expander (`SCHEDULE_SPEC_all_disciplines.json`, 207 entries across ARCH/GEN/HEALTH/MEP/STR) with a column set, a discipline-bundle filter, and sheet placement. These are the schedules carrying the parameters removed from the universal tag.
- **`TagSchedulePlacer`** (new) puts them on sheets. The expander previously built ViewSchedules and stopped, so schedules meant to sit beside the drawing never got there.

## Known limitation — read before relying on packing

Packing several schedules per sheet needs each table's paper size. Three sources were tried and none proved dependable: `get_BoundingBox` inside the creating transaction, the same after committing, and `TableSectionData.GetColumnWidth`/`GetRowHeight` (reported ~0 in a live model). Each attempt packed against a size that was really unknown, and each produced overlapping tables.

So placement no longer depends on knowing the size: every schedule goes on **its own sheet** first, which cannot overlap; sizes are then measured, and packing only runs if at least 90% measure sanely. If they don't, the one-per-sheet layout stands and the report says so.

**Worst case is more sheets than necessary, not schedules on top of each other.**

## Verification status

Builds clean on Windows + Revit 2025 — 0 errors, 0 warnings.

**Not verified in Revit.** Revit's journals show no session on the test machine since before this work was deployed, so none of the placement code has executed against a real model. The completion report now stamps the loaded assembly's build time so any future run identifies the code that produced it.

Worth checking on first real run: `Old sheets cleared`, `Layout`, and `Measurable` in the report.