### PR TITLE
fix(bcc): a refused site-photo action no longer reports the system as broken — and the review queue stops inventing an empty one

### DIFF
--- a/StingTools.SitePhotos.Tests/CapabilityStateTests.cs
+++ b/StingTools.SitePhotos.Tests/CapabilityStateTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using StingTools.BIMManager;
+using Xunit;
+
+namespace StingTools.SitePhotos.Tests;
+
+/// <summary>
+/// The three-state capability rule (#547 / #558 / #634), pinned.
+///
+/// WHY THESE EXIST. The BCC now disables controls from the server's answer to
+/// GET members/capabilities. The entire correctness of that hinges on one
+/// distinction that is invisible in the type system and easy to "tidy" away:
+///
+///     Denied   the server said no                 → disable, name the capability
+///     Unknown  we never got an answer             → LEAVE IT ENABLED
+///
+/// Collapsing Unknown into Denied — "absence of an explicit true is false" —
+/// locks legitimate users out of a working system whenever the network hiccups,
+/// and shows them a permissions message while doing it. It is the same failure
+/// as an empty list standing in for a failed load, one layer up: an absent
+/// answer rendered as a definite one.
+///
+/// A 404 is the one exception and is asserted as such: it says the caller cannot
+/// see the project at all, which IS an answer.
+///
+/// Every case below is driven through the real client against a real socket, so
+/// what is pinned is the shipped behaviour and not a re-statement of the rule.
+/// </summary>
+public class CapabilityStateTests
+{
+    private static PlanscapeServerClient Client => PlanscapeServerClient.Instance;
+
+    private static async Task<CaptureServer> AuthedServerAsync()
+    {
+        var srv = new CaptureServer();
+        var ok = await Client.LoginAsync(srv.BaseUrl, "harness@test", "pw");
+        Assert.True(ok, $"harness login failed against the capture server: {Client.LastError}");
+        return srv;
+    }
+
+    private static void ServeCapabilities(CaptureServer srv, int status, string body)
+    {
+        srv.Routes.Add((p => p.EndsWith("/members/capabilities", StringComparison.OrdinalIgnoreCase),
+            _ => (status, "application/json", Encoding.UTF8.GetBytes(body))));
+    }
+
+    // ── The happy path, both directions ──────────────────────────────────
+
+    [Fact]
+    public async Task Explicit_true_is_Allowed_and_explicit_false_is_Denied()
+    {
+        using var srv = await AuthedServerAsync();
+        ServeCapabilities(srv, 200,
+            "{\"canCurateProject\":true,\"canApproveSitePhotos\":false}");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        Assert.Equal(CapabilityState.Allowed, caps.CurateProject);
+        Assert.Equal(CapabilityState.Denied, caps.ApproveSitePhotos);
+    }
+
+    // ── 404 is authoritative-false ───────────────────────────────────────
+
+    [Fact]
+    public async Task Not_found_denies_everything_because_the_project_is_invisible()
+    {
+        using var srv = await AuthedServerAsync();
+        ServeCapabilities(srv, 404, "");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        // A 404 from this endpoint means the caller cannot see the project.
+        // Nothing is possible on it, so Denied is the honest answer — this is
+        // the ONE status that may narrow the UI.
+        Assert.Equal(CapabilityState.Denied, caps.CurateProject);
+        Assert.Equal(CapabilityState.Denied, caps.ApproveSitePhotos);
+    }
+
+    // ── Everything else is Unknown ───────────────────────────────────────
+
+    [Fact]
+    public async Task Server_down_is_Unknown_not_Denied()
+    {
+        var srv = await AuthedServerAsync();
+        srv.Kill(); // session established, then the API goes away
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        // The regression this file exists to catch. Denied here would disable
+        // Approve / Reject for a user who has every right to them, and tell
+        // them it was a permissions problem.
+        Assert.Equal(CapabilityState.Unknown, caps.CurateProject);
+        Assert.Equal(CapabilityState.Unknown, caps.ApproveSitePhotos);
+    }
+
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(401)]
+    public async Task Non_404_error_statuses_are_Unknown(int status)
+    {
+        using var srv = await AuthedServerAsync();
+        ServeCapabilities(srv, status, "{\"error\":\"boom\"}");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        Assert.Equal(CapabilityState.Unknown, caps.CurateProject);
+        Assert.Equal(CapabilityState.Unknown, caps.ApproveSitePhotos);
+    }
+
+    [Fact]
+    public async Task Unparseable_body_is_Unknown()
+    {
+        using var srv = await AuthedServerAsync();
+        ServeCapabilities(srv, 200, "<html>proxy error</html>");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        Assert.Equal(CapabilityState.Unknown, caps.CurateProject);
+        Assert.Equal(CapabilityState.Unknown, caps.ApproveSitePhotos);
+    }
+
+    [Fact]
+    public async Task Missing_field_is_Unknown_not_Denied()
+    {
+        using var srv = await AuthedServerAsync();
+        // A 200 that carries one flag and not the other — a shape change, or a
+        // partial rollout. The field that IS there is honoured; the one that is
+        // not stays unknown rather than silently disabling half the pane.
+        ServeCapabilities(srv, 200, "{\"canCurateProject\":true}");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        Assert.Equal(CapabilityState.Allowed, caps.CurateProject);
+        Assert.Equal(CapabilityState.Unknown, caps.ApproveSitePhotos);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("\"true\"")]   // string, not boolean
+    [InlineData("1")]          // number, not boolean
+    public async Task Non_boolean_values_are_Unknown(string literal)
+    {
+        using var srv = await AuthedServerAsync();
+        ServeCapabilities(srv, 200,
+            "{\"canCurateProject\":" + literal + ",\"canApproveSitePhotos\":" + literal + "}");
+
+        var caps = await Client.GetProjectCapabilitiesAsync(Guid.NewGuid());
+
+        // "true" the STRING is not true the BOOLEAN. Coercing it would mean a
+        // contract drift silently granted a capability; reading it as false
+        // would silently remove one. Neither is an answer we were given.
+        Assert.Equal(CapabilityState.Unknown, caps.CurateProject);
+        Assert.Equal(CapabilityState.Unknown, caps.ApproveSitePhotos);
+    }
+
+    // ── LastStatus, which the forbidden-vs-failure split depends on ──────
+
+    [Fact]
+    public async Task LastStatus_carries_403_so_a_refusal_is_not_reported_as_an_outage()
+    {
+        using var srv = await AuthedServerAsync();
+        srv.Routes.Add((p => p.Contains("/photo-albums", StringComparison.OrdinalIgnoreCase),
+            _ => (403, "application/json", Encoding.UTF8.GetBytes(""))));
+
+        var albums = await Client.ListPhotoAlbumsAsync(Guid.NewGuid());
+
+        Assert.Null(albums);              // still the failure channel
+        Assert.Equal(403, Client.LastStatus);
+    }
+
+    [Fact]
+    public async Task LastStatus_is_null_when_there_was_no_response_at_all()
+    {
+        var srv = await AuthedServerAsync();
+        srv.Kill();
+
+        await Client.ListPhotoAlbumsAsync(Guid.NewGuid());
+
+        // Null, not 0 and not a stale 200 from the login that preceded it.
+        // The UI branches on == 403; a stale value would misroute the report.
+        Assert.Null(Client.LastStatus);
+    }
+
+    // ── The list that used to lie ────────────────────────────────────────
+
+    [Fact]
+    public async Task ListSitePhotos_returns_null_on_failure_not_an_empty_list()
+    {
+        var srv = await AuthedServerAsync();
+        srv.Kill();
+
+        var photos = await Client.ListSitePhotosAsync(Guid.NewGuid());
+
+        // Until #558 this returned `new List<SitePhotoDto>()` on every failure
+        // path, and the BCC review queue rendered "✓ No photos awaiting review."
+        // over an unreachable server. Same fabrication #550 removed elsewhere.
+        Assert.Null(photos);
+        Assert.False(string.IsNullOrWhiteSpace(Client.LastError));
+    }
+
+    [Fact]
+    public async Task ListSitePhotos_still_returns_an_empty_list_when_the_project_really_has_none()
+    {
+        using var srv = await AuthedServerAsync();
+        srv.Routes.Add((p => p.Contains("/photos", StringComparison.OrdinalIgnoreCase),
+            _ => (200, "application/json",
+                  Encoding.UTF8.GetBytes("{\"items\":[],\"total\":0,\"page\":1,\"pageSize\":50}"))));
+
+        var photos = await Client.ListSitePhotosAsync(Guid.NewGuid());
+
+        // The other half of the distinction: empty must stay empty, or the fix
+        // would have replaced one wrong answer with another.
+        Assert.NotNull(photos);
+        Assert.Empty(photos);
+    }
+}

--- a/StingTools/BIMManager/PlanscapeServerClient.Capabilities.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Capabilities.cs
@@ -1,0 +1,158 @@
+// PlanscapeServerClient — project capabilities (#547 consumer, #558).
+//
+// WHAT THIS IS FOR
+// ----------------
+// The BCC used to have no idea what the signed-in user is allowed to do on a
+// project, so every refused action arrived as a generic red failure that was
+// indistinguishable from the server being unreachable. An operator who lacks a
+// capability was told the system was broken rather than told they lack
+// permission — and those warrant different actions ("call IT" vs "ask your PM").
+//
+// The fix is NOT for the client to re-derive the rule from projectRole /
+// iso19650Role. Three surfaces each holding their own copy of the role rules is
+// exactly how the eleven dead `ProjectRole == "PM"` gates happened. The server
+// resolves it and serves the answer; this client renders what it returns.
+//
+// THREE STATES, NOT TWO
+// ---------------------
+//   Allowed  — the server said true.        Offer the control.
+//   Denied   — the server said false, or    Disable it, and name the capability.
+//              answered 404 (the caller
+//              cannot see this project).
+//   Unknown  — no answer at all: transport  LEAVE THE CONTROL ENABLED and let
+//              failure, timeout, 5xx, or a  the attempt report what happens.
+//              body that will not parse.
+//
+// Unknown is deliberately NOT rendered as denied. Capabilities drive
+// AFFORDANCE; the server remains the gate, and every action still attempts and
+// reports. Failing closed on a dropped connection locks out legitimate users and
+// looks identical to a permissions problem — the precise confusion #558 exists
+// to remove. It is also the house anti-pattern in a new costume: an absent
+// answer displayed as a definite one, the same mistake as an empty list standing
+// in for a failed load.
+//
+// A 404 IS authoritative-false: it says the caller cannot see the project at
+// all, so nothing is possible on it. A dropped connection says nothing about
+// permissions.
+//
+// See #634 for the correction to the #547 docstring, which originally said
+// absence of an explicit `true` was `false` including network errors.
+
+#nullable enable annotations
+#nullable disable warnings
+
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.BIMManager
+{
+    /// <summary>One capability's answer. See the file header for why there are
+    /// three of these and not two.</summary>
+    public enum CapabilityState
+    {
+        /// <summary>No answer — leave the control enabled and let the attempt report.</summary>
+        Unknown = 0,
+        /// <summary>The server said yes.</summary>
+        Allowed,
+        /// <summary>The server said no, authoritatively.</summary>
+        Denied,
+    }
+
+    /// <summary>
+    /// The caller's capabilities on one project, as resolved by
+    /// <c>GET /api/projects/{id}/members/capabilities</c>.
+    ///
+    /// Deliberately two fields, matching the two predicates that exist on the
+    /// server's <c>ProjectRoles</c>. A third does not get added here first — it
+    /// gets proposed on the server, the same way these two did.
+    /// </summary>
+    public sealed class ProjectCapabilities
+    {
+        /// <summary>Albums, checklists, distribution groups.</summary>
+        public CapabilityState CurateProject { get; set; } = CapabilityState.Unknown;
+
+        /// <summary>Photo approve / reject, share-link issuance, photo policy.</summary>
+        public CapabilityState ApproveSitePhotos { get; set; } = CapabilityState.Unknown;
+
+        /// <summary>Why the answer is what it is — shown in diagnostics, never
+        /// used as a gate. Null when the server answered normally.</summary>
+        public string? Note { get; set; }
+
+        /// <summary>The safe default: we know nothing, so nothing is disabled.</summary>
+        public static ProjectCapabilities Unknown(string? note = null)
+            => new ProjectCapabilities { Note = note };
+
+        /// <summary>Every capability authoritatively false. Only for a 404 —
+        /// the caller cannot see this project at all.</summary>
+        public static ProjectCapabilities AllDenied(string? note = null)
+            => new ProjectCapabilities
+            {
+                CurateProject     = CapabilityState.Denied,
+                ApproveSitePhotos = CapabilityState.Denied,
+                Note              = note,
+            };
+    }
+
+    public sealed partial class PlanscapeServerClient
+    {
+        /// <summary>
+        /// <c>GET /api/projects/{projectId}/members/capabilities</c>.
+        /// Never returns null and never throws — an unreachable server yields
+        /// all-Unknown, which leaves every control enabled.
+        /// </summary>
+        public async Task<ProjectCapabilities> GetProjectCapabilitiesAsync(Guid projectId)
+        {
+            if (projectId == Guid.Empty)
+                return ProjectCapabilities.Unknown("No project selected.");
+
+            if (!await EnsureAuthenticatedAsync().ConfigureAwait(false))
+                return ProjectCapabilities.Unknown(LastError ?? "Not connected to Planscape.");
+
+            try
+            {
+                var resp = await GetAsync($"/api/projects/{projectId}/members/capabilities")
+                    .ConfigureAwait(false);
+
+                // 404 = the caller cannot see this project. Authoritative false.
+                if (resp.status == 404)
+                    return ProjectCapabilities.AllDenied("You do not have access to this project.");
+
+                if (!resp.ok)
+                {
+                    // 5xx, 401 after a token race, a proxy error page — the server
+                    // did not answer the question. Not a denial.
+                    StingLog.Warn($"Capabilities: HTTP {resp.status} for {projectId}");
+                    return ProjectCapabilities.Unknown($"Capabilities unavailable (HTTP {resp.status}).");
+                }
+
+                var j = JObject.Parse(resp.body);
+
+                // Read only an EXPLICIT boolean. A missing or non-boolean field is
+                // a contract mismatch, not a "no" — the server would have to have
+                // changed shape for this to happen, and guessing on a shape change
+                // is how a client silently disables half its own UI.
+                return new ProjectCapabilities
+                {
+                    CurateProject     = ReadFlag(j, "canCurateProject"),
+                    ApproveSitePhotos = ReadFlag(j, "canApproveSitePhotos"),
+                };
+            }
+            catch (Exception ex)
+            {
+                // Includes transport failures and unparseable bodies. Unknown.
+                StingLog.Warn($"GetProjectCapabilitiesAsync: {ex.Message}");
+                return ProjectCapabilities.Unknown(ex.Message);
+            }
+        }
+
+        private static CapabilityState ReadFlag(JObject j, string field)
+        {
+            var tok = j[field];
+            if (tok == null || tok.Type == JTokenType.Null) return CapabilityState.Unknown;
+            if (tok.Type != JTokenType.Boolean) return CapabilityState.Unknown;
+            return tok.Value<bool>() ? CapabilityState.Allowed : CapabilityState.Denied;
+        }
+    }
+}

--- a/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.SitePhotos.cs
@@ -583,6 +583,11 @@ namespace StingTools.BIMManager
             if (ExportSelectionRejected(albumId, photoIds, isPdf)) return null;
 
             var http = SnapshotHttpClient();
+            // This path streams the response, so it does NOT go through
+            // GetAsync/PostJsonAsync and has to record LastStatus itself.
+            // Missing it would make a refused export report as a transport
+            // failure — the exact confusion #558 removes.
+            LastStatus = null;
             if (http == null) { LastError = "Not connected."; return null; }
 
             try
@@ -599,6 +604,8 @@ namespace StingTools.BIMManager
                 using var resp = await http
                     .SendAsync(req, HttpCompletionOption.ResponseHeadersRead)
                     .ConfigureAwait(false);
+
+                LastStatus = (int)resp.StatusCode;
 
                 if (!resp.IsSuccessStatusCode)
                 {

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -66,6 +66,27 @@ public sealed partial class PlanscapeServerClient : IDisposable
     public bool   MimEnabled    { get; private set; }
     public string? LastError    { get; private set; }
 
+    /// <summary>
+    /// HTTP status of the most recent request, or <c>null</c> when the request
+    /// never produced one (transport failure, timeout, client not initialised).
+    ///
+    /// WHY THIS EXISTS. The UI needs to tell a REFUSAL (403) apart from a
+    /// FAILURE (unreachable server, 500), because those warrant different
+    /// actions — "ask your PM" vs "call IT". Before this, the only signal was
+    /// <see cref="LastError"/>, a human string. Substring-matching a status out
+    /// of a message is how mobile ended up reporting "HTTP 403" for an empty
+    /// body (#624); the status is carried as a number so nobody has to.
+    ///
+    /// Set in the three HTTP helpers, so every call site gets it without
+    /// touching ninety failure branches. Same lifetime and same caveat as
+    /// <see cref="LastError"/>: it describes the LAST request on this shared
+    /// singleton, so read it immediately after the await that set it.
+    ///
+    /// <c>null</c> is deliberately NOT "denied". It is "we do not know" — the
+    /// three-state rule this surface is built on.
+    /// </summary>
+    public int? LastStatus { get; private set; }
+
     /// <summary>C2 — tenant + user IDs parsed from the login response's JWT payload
     /// so the real-time client can join the right SignalR groups.</summary>
     public Guid TenantId { get; private set; }
@@ -1623,7 +1644,21 @@ public sealed partial class PlanscapeServerClient : IDisposable
     /// paginated envelope: { items, total, page, pageSize }. We surface the
     /// items list directly; callers can re-paginate by passing page/pageSize.
     /// </summary>
-    public async Task<List<SitePhotoDto>> ListSitePhotosAsync(
+    /// <returns>
+    /// The photos, an EMPTY list when the project genuinely has none, or
+    /// <c>null</c> when the request FAILED.
+    ///
+    /// This method used to return an empty list on every failure path — HTTP
+    /// error, exception, missing envelope. Both callers then rendered "✓ No
+    /// photos awaiting review." over an unreachable server or a refusal: a
+    /// confident, wrong, empty answer. That is the same fabrication #550
+    /// removed from the album and distribution-group panes, still live in the
+    /// review queue and the grid, and it is why neither surface could show a
+    /// forbidden state — nothing reached them saying anything had gone wrong.
+    /// Null is the failure channel; <see cref="LastError"/> and
+    /// <see cref="LastStatus"/> carry the reason.
+    /// </returns>
+    public async Task<List<SitePhotoDto>?> ListSitePhotosAsync(
         Guid projectId,
         string? reason     = null,
         string? audience   = null,
@@ -1634,8 +1669,11 @@ public sealed partial class PlanscapeServerClient : IDisposable
         int page           = 1,
         int pageSize       = 50)
     {
-        var empty = new List<SitePhotoDto>();
-        if (!await EnsureAuthenticatedAsync()) return empty;
+        if (!await EnsureAuthenticatedAsync())
+        {
+            LastError = "Not connected to Planscape.";
+            return null;
+        }
         try
         {
             var qs = new List<string>();
@@ -1650,12 +1688,19 @@ public sealed partial class PlanscapeServerClient : IDisposable
             var path = $"/api/projects/{projectId}/photos?{string.Join("&", qs)}";
 
             var resp = await GetAsync(path);
-            if (!resp.ok) { LastError = $"ListSitePhotos: HTTP {resp.status}"; return empty; }
+            if (!resp.ok) { LastError = $"ListSitePhotos: HTTP {resp.status}"; return null; }
 
             // Envelope: { items: [...], total, page, pageSize }
             var json = JObject.Parse(resp.body);
             var items = json["items"] as JArray;
-            if (items == null) return empty;
+            // A 200 with no `items` array is a contract mismatch, not an empty
+            // project. Returning [] here would have re-introduced the same
+            // fabrication one layer down.
+            if (items == null)
+            {
+                LastError = "ListSitePhotos: response had no 'items' array.";
+                return null;
+            }
             var list = items.ToObject<List<SitePhotoDto>>();
             // Phase 180 — surface ndaRequiredIds so callers can render
             // a 🔒 lock badge on photos awaiting NDA acceptance.
@@ -1671,9 +1716,9 @@ public sealed partial class PlanscapeServerClient : IDisposable
             else
             {
             }
-            return list ?? empty;
+            return list ?? new List<SitePhotoDto>();
         }
-        catch (Exception ex) { LastError = ex.Message; StingLog.Warn($"ListSitePhotosAsync: {ex.Message}"); return empty; }
+        catch (Exception ex) { LastError = ex.Message; StingLog.Warn($"ListSitePhotosAsync: {ex.Message}"); return null; }
     }
 
 
@@ -1817,10 +1862,14 @@ public sealed partial class PlanscapeServerClient : IDisposable
             Encoding.UTF8, "application/json");
 
         var http = SnapshotHttpClient();
+        // Cleared FIRST so a throw below leaves LastStatus null — "no status",
+        // which the capability layer reads as unknown rather than as denied.
+        LastStatus = null;
         if (http == null) throw new InvalidOperationException("HttpClient not initialised — call LoginAsync first.");
         var resp = await http.PostAsync(path, content).ConfigureAwait(false);
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
         var ok = (int)resp.StatusCode >= 200 && (int)resp.StatusCode < 300;
+        LastStatus = (int)resp.StatusCode;
         if (ok) TouchActivity(); // SEC-EA-08
         return (ok, (int)resp.StatusCode, body);
     }
@@ -1838,10 +1887,12 @@ public sealed partial class PlanscapeServerClient : IDisposable
             Encoding.UTF8, "application/json");
 
         var http = SnapshotHttpClient();
+        LastStatus = null;
         if (http == null) throw new InvalidOperationException("HttpClient not initialised — call LoginAsync first.");
         var resp = await http.PutAsync(path, content).ConfigureAwait(false);
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
         var ok = (int)resp.StatusCode >= 200 && (int)resp.StatusCode < 300;
+        LastStatus = (int)resp.StatusCode;
         if (ok) TouchActivity(); // SEC-EA-08
         return (ok, (int)resp.StatusCode, body);
     }
@@ -1849,10 +1900,12 @@ public sealed partial class PlanscapeServerClient : IDisposable
     private async Task<(bool ok, int status, string body)> GetAsync(string path)
     {
         var http = SnapshotHttpClient();
+        LastStatus = null;
         if (http == null) throw new InvalidOperationException("HttpClient not initialised — call LoginAsync first.");
         var resp = await http.GetAsync(path).ConfigureAwait(false);
         var body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
         var ok = (int)resp.StatusCode >= 200 && (int)resp.StatusCode < 300;
+        LastStatus = (int)resp.StatusCode;
         if (ok) TouchActivity(); // SEC-EA-08
         return (ok, (int)resp.StatusCode, body);
     }

--- a/StingTools/UI/PlanscapeForbidden.cs
+++ b/StingTools/UI/PlanscapeForbidden.cs
@@ -1,0 +1,215 @@
+// ══════════════════════════════════════════════════════════════════════
+//  PlanscapeForbidden — the BCC's single forbidden treatment (#558).
+//
+//  THE FOUR STATES. Every server-backed pane in this client owes the user
+//  four visually distinct answers:
+//
+//    loading    — a spinner / "Loading…"
+//    empty      — grey italic, "No albums yet…"
+//    error      — SitePhotosTabHelpers.BuildLoadFailure, red, the server's
+//                 own reason, plus "this is not an empty result"
+//    forbidden  — THIS FILE. Amber, a lock, and the capability named.
+//
+//  Before this, the BCC had three. A 403 fell through the generic failure
+//  path and rendered as the couldn't-load treatment, so someone who simply
+//  lacks a capability was told the system was broken. "Call IT" and "ask
+//  your PM" are different actions; a UI that cannot tell them apart sends
+//  people to the wrong one.
+//
+//  ONE TREATMENT, NOT ONE PER SCREEN. Every string here lives in
+//  Describe() so the wording is changed in one place. Hand-rolling the
+//  copy at each call site is what produced three clients that disagree
+//  about who is allowed to do what.
+//
+//  THE ROLE NAMES BELOW ARE COPY, NOT A GATE. They exist to tell the user
+//  who to ask. Nothing in this file decides anything — the server decides,
+//  and CapabilityState carries its answer. If the server's rule changes,
+//  this copy is stale text, not a broken permission check.
+//
+//  THREE STATES. Unknown is not denied. See
+//  PlanscapeServerClient.Capabilities.cs for why, and #634.
+// ══════════════════════════════════════════════════════════════════════
+
+#nullable enable
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using StingTools.BIMManager;
+
+namespace StingTools.UI
+{
+    /// <summary>The capabilities this client knows how to talk about. One
+    /// entry per boolean the server serves.</summary>
+    internal enum PlanscapeCapability
+    {
+        CurateProject,
+        ApproveSitePhotos,
+    }
+
+    internal static class PlanscapeForbidden
+    {
+        // Amber, deliberately NOT the crimson used by BuildLoadFailure. The
+        // two states must be distinguishable at a glance, not only by reading.
+        private static readonly Brush Amber     = new SolidColorBrush(Color.FromRgb(0xB2, 0x6A, 0x00));
+        private static readonly Brush AmberFill = new SolidColorBrush(Color.FromRgb(0xFF, 0xF5, 0xE5));
+        private static readonly Brush AmberLine = new SolidColorBrush(Color.FromRgb(0xF0, 0xD5, 0xA8));
+
+        /// <summary>
+        /// The user-facing sentence for a capability. Names the capability and
+        /// who holds it — never the HTTP status.
+        /// </summary>
+        internal static string Describe(PlanscapeCapability cap) => cap switch
+        {
+            PlanscapeCapability.CurateProject =>
+                "Only a project manager or BIM coordinator can curate albums, checklists and distribution groups.",
+            PlanscapeCapability.ApproveSitePhotos =>
+                "Only a project manager can approve site photos, issue share links, or change the photo policy.",
+            _ => "You do not have this capability on this project.",
+        };
+
+        /// <summary>Short form for a tooltip on a disabled control.</summary>
+        internal static string Tooltip(PlanscapeCapability cap)
+            => Describe(cap) + "\n\nAsk a project manager to grant it.";
+
+        /// <summary>
+        /// The inline forbidden panel — use where a list or detail pane cannot
+        /// be shown at all.
+        /// </summary>
+        internal static UIElement BuildPanel(string headline, PlanscapeCapability cap, string? serverDetail = null)
+        {
+            var border = new Border
+            {
+                Background      = AmberFill,
+                BorderBrush     = AmberLine,
+                BorderThickness = new Thickness(1),
+                CornerRadius    = new CornerRadius(4),
+                Padding         = new Thickness(10, 8, 10, 8),
+                Margin          = new Thickness(6),
+            };
+            var sp = new StackPanel();
+
+            sp.Children.Add(new TextBlock
+            {
+                Text            = "🔒 " + headline,
+                Foreground      = Amber,
+                FontWeight      = FontWeights.SemiBold,
+                TextWrapping    = TextWrapping.Wrap,
+            });
+            sp.Children.Add(new TextBlock
+            {
+                Text            = Describe(cap),
+                Foreground      = Amber,
+                Opacity         = 0.9,
+                TextWrapping    = TextWrapping.Wrap,
+                Margin          = new Thickness(0, 3, 0, 0),
+            });
+            sp.Children.Add(new TextBlock
+            {
+                // Says plainly that this is a permission answer, not a fault.
+                // Without this line the pane reads like something went wrong.
+                Text            = "This is not a failure — the server refused the request because of your role on this project.",
+                FontStyle       = FontStyles.Italic,
+                Foreground      = Brushes.Gray,
+                TextWrapping    = TextWrapping.Wrap,
+                Margin          = new Thickness(0, 6, 0, 0),
+            });
+            if (!string.IsNullOrWhiteSpace(serverDetail))
+            {
+                sp.Children.Add(new TextBlock
+                {
+                    Text         = serverDetail,
+                    FontSize     = 10,
+                    Foreground   = Brushes.Gray,
+                    TextWrapping = TextWrapping.Wrap,
+                    Margin       = new Thickness(0, 4, 0, 0),
+                });
+            }
+
+            border.Child = sp;
+            return border;
+        }
+
+        /// <summary>
+        /// Report a refused ACTION (as opposed to a refused pane). Same wording,
+        /// delivered through the dialog the action would have used anyway.
+        /// </summary>
+        internal static void ShowDialog(string title, PlanscapeCapability cap, string? serverDetail = null)
+        {
+            var body = Describe(cap)
+                     + "\n\nThis is not a failure — the server refused the request because of your role on this project."
+                     + (string.IsNullOrWhiteSpace(serverDetail) ? "" : "\n\n" + serverDetail);
+            Autodesk.Revit.UI.TaskDialog.Show(title, body);
+        }
+
+        /// <summary>
+        /// Route a failed call to the right report. Call it immediately after
+        /// the await that failed, while <see cref="PlanscapeServerClient.LastStatus"/>
+        /// still describes that call.
+        ///
+        /// A 403 is a refusal and gets the forbidden treatment. Anything else —
+        /// including a transport failure, where LastStatus is null — is a
+        /// failure and keeps the red couldn't-load treatment. Unknown is never
+        /// dressed up as denied.
+        /// </summary>
+        internal static UIElement BuildFailureOrForbidden(
+            string failureHeadline, string forbiddenHeadline, PlanscapeCapability cap)
+        {
+            var client = PlanscapeServerClient.Instance;
+            return client.LastStatus == 403
+                ? BuildPanel(forbiddenHeadline, cap)
+                : SitePhotosTabHelpers.BuildLoadFailure(failureHeadline, client.LastError);
+        }
+
+        /// <summary>Dialog counterpart of <see cref="BuildFailureOrForbidden"/>.</summary>
+        internal static void ShowFailureOrForbidden(string title, PlanscapeCapability cap)
+        {
+            var client = PlanscapeServerClient.Instance;
+            if (client.LastStatus == 403) { ShowDialog(title, cap); return; }
+            Autodesk.Revit.UI.TaskDialog.Show(title, client.LastError ?? "(no detail)");
+        }
+
+        /// <summary>
+        /// Apply a KNOWN-denied capability to a control: disable it and attach
+        /// the reason.
+        ///
+        /// Deliberately does nothing when the state is Allowed **or Unknown**.
+        /// Unknown leaves the control enabled so the attempt can report — the
+        /// three-state rule. Callers must not pre-compute a boolean and pass it
+        /// here, because that collapses the third state on the way in.
+        /// </summary>
+        internal static void ApplyIfDenied(Control control, CapabilityState state, PlanscapeCapability cap)
+        {
+            if (state != CapabilityState.Denied) return;
+            control.IsEnabled = false;
+            control.ToolTip   = Tooltip(cap);
+            control.Opacity   = 0.55;
+        }
+
+        /// <summary>
+        /// A one-line banner naming a capability the user is known to lack, for
+        /// the top of a pane whose controls have just been disabled. Returns
+        /// null for Allowed and for Unknown — there is nothing honest to say
+        /// about a capability we could not determine.
+        /// </summary>
+        internal static UIElement? BuildBannerIfDenied(CapabilityState state, PlanscapeCapability cap)
+        {
+            if (state != CapabilityState.Denied) return null;
+            return new Border
+            {
+                Background      = AmberFill,
+                BorderBrush     = AmberLine,
+                BorderThickness = new Thickness(1),
+                CornerRadius    = new CornerRadius(4),
+                Padding         = new Thickness(8, 5, 8, 5),
+                Margin          = new Thickness(0, 0, 0, 8),
+                Child = new TextBlock
+                {
+                    Text         = "🔒 " + Describe(cap),
+                    Foreground   = Amber,
+                    FontSize     = 11,
+                    TextWrapping = TextWrapping.Wrap,
+                },
+            };
+        }
+    }
+}

--- a/StingTools/UI/SitePhotosAdminSubTab.cs
+++ b/StingTools/UI/SitePhotosAdminSubTab.cs
@@ -9,9 +9,13 @@
 //    * Re-redact         — re-run the blur worker on a single photo
 //    * Audit log probe   — last 50 audit events for site photos on this project
 //
-//  All operations route through PlanscapeServerClient. Server enforces
-//  the actual permission gate (PM / Admin / Owner only); the desktop
-//  surface just hides the UI from non-curators on a best-effort basis.
+//  All operations route through PlanscapeServerClient. The SERVER remains
+//  the gate. What the desktop surface adds (#558) is affordance: it asks
+//  the server what this user can do (GET members/capabilities) and
+//  disables only what the server has explicitly said no to, naming the
+//  capability. A capability we could not determine — unreachable server,
+//  timeout, unparseable body — leaves the control enabled and lets the
+//  attempt report. Unknown is not denied.
 // ══════════════════════════════════════════════════════════════════════
 
 #nullable enable
@@ -45,6 +49,7 @@ namespace StingTools.UI
             root.Children.Add(sel);
 
             var bulkBar = new WrapPanel { Margin = new Thickness(0, 0, 0, 10) };
+            var bulkButtons = new List<Button>();
             foreach (var (label, code) in SitePhotosTab.Reasons.Select(r => (r.Label, r.Code)))
             {
                 var b = new Button {
@@ -62,11 +67,17 @@ namespace StingTools.UI
                     if (state.SelectedIds.Count == 0) return;
                     var n = await PlanscapeServerClient.Instance.BulkReclassifyPhotosAsync(
                         state.ProjectId, state.SelectedIds.ToList(), code);
-                    Autodesk.Revit.UI.TaskDialog.Show("Reclassify",
-                        n > 0 ? $"Reclassified {n} photo(s) to {code}." :
-                        (PlanscapeServerClient.Instance.LastError ?? "(no detail)"));
+                    if (n > 0)
+                    {
+                        Autodesk.Revit.UI.TaskDialog.Show("Reclassify",
+                            $"Reclassified {n} photo(s) to {code}.");
+                        return;
+                    }
+                    PlanscapeForbidden.ShowFailureOrForbidden(
+                        "Reclassify", PlanscapeCapability.ApproveSitePhotos);
                 };
                 bulkBar.Children.Add(b);
+                bulkButtons.Add(b);
             }
             root.Children.Add(bulkBar);
 
@@ -90,9 +101,13 @@ namespace StingTools.UI
                 if (lvl == null && zn == null) return;
                 var n = await PlanscapeServerClient.Instance.BulkReanchorPhotosAsync(
                     state.ProjectId, state.SelectedIds.ToList(), levelCode: lvl, zoneCode: zn);
-                Autodesk.Revit.UI.TaskDialog.Show("Re-anchor",
-                    n > 0 ? $"Re-anchored {n} photo(s)." :
-                    (PlanscapeServerClient.Instance.LastError ?? "(no detail)"));
+                if (n > 0)
+                {
+                    Autodesk.Revit.UI.TaskDialog.Show("Re-anchor", $"Re-anchored {n} photo(s).");
+                    return;
+                }
+                PlanscapeForbidden.ShowFailureOrForbidden(
+                    "Re-anchor", PlanscapeCapability.ApproveSitePhotos);
             };
             reanchorBar.Children.Add(reanchorBtn);
             root.Children.Add(reanchorBar);
@@ -137,9 +152,10 @@ namespace StingTools.UI
                 var groups = await PlanscapeServerClient.Instance.ListDistributionGroupsAsync(state.ProjectId);
                 if (groups == null)
                 {
-                    dgPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                    dgPanel.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
                         "Could not load distribution groups.",
-                        PlanscapeServerClient.Instance.LastError));
+                        "Distribution groups are not available to you on this project.",
+                        PlanscapeCapability.CurateProject));
                     return;
                 }
                 if (groups.Count == 0)
@@ -186,8 +202,10 @@ namespace StingTools.UI
                         // pane: an operator would conclude nobody is on distribution and
                         // re-add recipients who are already there.
                         memberLine.Text = mem == null
-                            ? "Could not load members — "
-                              + (PlanscapeServerClient.Instance.LastError ?? "(no detail)")
+                            ? (PlanscapeServerClient.Instance.LastStatus == 403
+                                ? "🔒 " + PlanscapeForbidden.Describe(PlanscapeCapability.CurateProject)
+                                : "Could not load members — "
+                                  + (PlanscapeServerClient.Instance.LastError ?? "(no detail)"))
                             : mem.Count == 0
                                 ? "No members yet."
                                 : string.Join(", ", mem.Select(m =>
@@ -249,8 +267,8 @@ namespace StingTools.UI
 
                         if (!ok)
                         {
-                            Autodesk.Revit.UI.TaskDialog.Show("Add member",
-                                PlanscapeServerClient.Instance.LastError ?? "(no detail)");
+                            PlanscapeForbidden.ShowFailureOrForbidden(
+                                "Add member", PlanscapeCapability.CurateProject);
                             return;
                         }
                         await LoadMembersAsync();
@@ -273,8 +291,8 @@ namespace StingTools.UI
                     state.ProjectId, name.Trim(), kind: "Internal");
                 if (grp == null)
                 {
-                    Autodesk.Revit.UI.TaskDialog.Show("New group",
-                        PlanscapeServerClient.Instance.LastError ?? "(no detail)");
+                    PlanscapeForbidden.ShowFailureOrForbidden(
+                        "New group", PlanscapeCapability.CurateProject);
                     return;
                 }
                 // Non-null with LastError set is partial success: the group exists but
@@ -290,10 +308,41 @@ namespace StingTools.UI
 
             _ = LoadGroupsAsync();
 
+            // ── Affordance from capabilities (#547 / #558) ──────────
+            // Two different capabilities on one pane, and they are NOT the
+            // same set of people: bulk reclassify / re-anchor rewrite the
+            // audience machine and need ApproveSitePhotos, while distribution
+            // groups are curation. Gating both on one flag would tell a
+            // coordinator they cannot do something they can.
+            bool bannerShown = false;
+            void ApplyCaps()
+            {
+                foreach (var b in bulkButtons)
+                    PlanscapeForbidden.ApplyIfDenied(b, state.Caps.ApproveSitePhotos,
+                        PlanscapeCapability.ApproveSitePhotos);
+                PlanscapeForbidden.ApplyIfDenied(reanchorBtn, state.Caps.ApproveSitePhotos,
+                    PlanscapeCapability.ApproveSitePhotos);
+                PlanscapeForbidden.ApplyIfDenied(dgNew, state.Caps.CurateProject,
+                    PlanscapeCapability.CurateProject);
+
+                if (bannerShown) return;
+                var banner = PlanscapeForbidden.BuildBannerIfDenied(
+                    state.Caps.ApproveSitePhotos, PlanscapeCapability.ApproveSitePhotos)
+                    ?? PlanscapeForbidden.BuildBannerIfDenied(
+                        state.Caps.CurateProject, PlanscapeCapability.CurateProject);
+                if (banner == null) return;
+                bannerShown = true;
+                root.Children.Insert(0, banner);
+            }
+            state.CapabilitiesResolved += ApplyCaps;
+            ApplyCaps();
+
             // ── Section: Help ───────────────────────────────────────
             root.Children.Add(SectionHeader("Notes"));
             root.Children.Add(new TextBlock {
-                Text = "• Bulk operations require PM, Admin, or Owner role on the server.\n" +
+                // Sourced from the shared helper rather than retyped — this line
+                // and the forbidden panels must never drift apart.
+                Text = "• " + PlanscapeForbidden.Describe(PlanscapeCapability.ApproveSitePhotos) + "\n" +
                        "• Force-state and audit-log endpoints are reachable via the web admin only.\n" +
                        "• The watermark / retention / digest hour are edited under the project's\n" +
                        "  Photo Policy (PUT /api/projects/{id}/photo-policy) — a future BCC slice\n" +

--- a/StingTools/UI/SitePhotosAlbumsSubTab.cs
+++ b/StingTools/UI/SitePhotosAlbumsSubTab.cs
@@ -75,6 +75,7 @@ namespace StingTools.UI
             grid.Children.Add(rightSv);
 
             PhotoAlbumDto? selected = null;
+            bool bannerShown = false;
 
             async Task LoadListAsync()
             {
@@ -100,9 +101,12 @@ namespace StingTools.UI
                 }
                 if (albums == null)
                 {
-                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                    // A refusal and a failure are different answers and need
+                    // different actions — "ask your PM" vs "call IT".
+                    listPanel.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
                         "Could not load albums.",
-                        PlanscapeServerClient.Instance.LastError));
+                        "Albums are not available to you on this project.",
+                        PlanscapeCapability.CurateProject));
                     return;
                 }
                 if (albums.Count == 0)
@@ -165,8 +169,8 @@ namespace StingTools.UI
                         .AddPhotosToAlbumAsync(state.ProjectId, selected!.Id, ids);
                     if (!ok)
                     {
-                        Autodesk.Revit.UI.TaskDialog.Show("Add to album",
-                            $"Failed.\n\n{PlanscapeServerClient.Instance.LastError}");
+                        PlanscapeForbidden.ShowFailureOrForbidden(
+                            "Add to album", PlanscapeCapability.CurateProject);
                     }
                     else
                     {
@@ -189,7 +193,7 @@ namespace StingTools.UI
                 {
                     var ok = await PlanscapeServerClient.Instance
                         .LockPhotoAlbumAsync(state.ProjectId, selected!.Id, !selected.IsLocked);
-                    if (!ok) Autodesk.Revit.UI.TaskDialog.Show("Lock", PlanscapeServerClient.Instance.LastError ?? "(no detail)");
+                    if (!ok) PlanscapeForbidden.ShowFailureOrForbidden("Lock", PlanscapeCapability.CurateProject);
                     else { await LoadListAsync(); selected.IsLocked = !selected.IsLocked; await RenderRightAsync(); }
                 };
                 actions.Children.Add(lockBtn);
@@ -208,7 +212,13 @@ namespace StingTools.UI
                         state.ProjectId, albumId: selected!.Id, label: selected.Name + " (BCC)");
                     if (link == null)
                     {
-                        Autodesk.Revit.UI.TaskDialog.Show("Share link", PlanscapeServerClient.Instance.LastError ?? "(no detail)");
+                        // Share links are gated on ApproveSitePhotos, NOT on
+                        // CurateProject — a coordinator who can curate albums
+                        // deliberately cannot release imagery outside the
+                        // project. Naming the wrong capability here would send
+                        // them to argue about the wrong permission.
+                        PlanscapeForbidden.ShowFailureOrForbidden(
+                            "Share link", PlanscapeCapability.ApproveSitePhotos);
                         return;
                     }
                     var full = $"/api/share/{link.Token}";
@@ -242,6 +252,18 @@ namespace StingTools.UI
                 };
                 actions.Children.Add(exportBtn);
 
+                // Disable only what the server has said no to. Unknown leaves
+                // the button live so the attempt reports.
+                PlanscapeForbidden.ApplyIfDenied(addSelected, state.Caps.CurateProject,
+                    PlanscapeCapability.CurateProject);
+                PlanscapeForbidden.ApplyIfDenied(lockBtn, state.Caps.CurateProject,
+                    PlanscapeCapability.CurateProject);
+                PlanscapeForbidden.ApplyIfDenied(shareBtn, state.Caps.ApproveSitePhotos,
+                    PlanscapeCapability.ApproveSitePhotos);
+                // exportBtn is deliberately NOT gated: POST photo-export carries
+                // [Authorize] and no capability check on the server, so disabling
+                // it here would invent a restriction that does not exist.
+
                 rightPanel.Children.Add(actions);
 
                 // Photo strip — load detail + render thumbnails.
@@ -250,9 +272,12 @@ namespace StingTools.UI
                 {
                     // Failed to load — NOT an empty album. Saying "Album is empty"
                     // here would invite someone to re-add photos that are already in it.
-                    rightPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                    // A 403 is a third answer again: the album exists and is not
+                    // visible to this audience.
+                    rightPanel.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
                         "Could not load this album's photos.",
-                        PlanscapeServerClient.Instance.LastError));
+                        "This album is not visible to you.",
+                        PlanscapeCapability.CurateProject));
                     return;
                 }
                 if (detail.Photos == null || detail.Photos.Count == 0)
@@ -310,7 +335,8 @@ namespace StingTools.UI
                     state.ProjectId, name.Trim(), visibility: "Members");
                 if (album == null)
                 {
-                    Autodesk.Revit.UI.TaskDialog.Show("New album", PlanscapeServerClient.Instance.LastError ?? "(no detail)");
+                    PlanscapeForbidden.ShowFailureOrForbidden(
+                        "New album", PlanscapeCapability.CurateProject);
                     return;
                 }
                 await LoadListAsync();
@@ -318,6 +344,33 @@ namespace StingTools.UI
                 await RenderRightAsync();
             };
             refreshBtn.Click += (_, _) => _ = LoadListAsync();
+
+            // ── Affordance from capabilities (#547 / #558) ──────────────
+            // Runs when (and only when) the server answers. Until then every
+            // control stays enabled, which is correct: capabilities drive
+            // affordance, the server remains the gate, and an unanswered
+            // question must not be rendered as a "no". Nothing here re-derives
+            // permission from a role — it renders the server's own answer.
+            void ApplyCaps()
+            {
+                PlanscapeForbidden.ApplyIfDenied(newBtn, state.Caps.CurateProject,
+                    PlanscapeCapability.CurateProject);
+
+                var banner = PlanscapeForbidden.BuildBannerIfDenied(
+                    state.Caps.CurateProject, PlanscapeCapability.CurateProject);
+                if (banner != null && !bannerShown)
+                {
+                    bannerShown = true;
+                    leftDock.Children.Insert(0, banner);
+                    DockPanel.SetDock(banner, Dock.Top);
+                }
+
+                // The detail pane is rebuilt on every selection, so its buttons
+                // are re-gated there rather than captured here.
+                _ = RenderRightAsync();
+            }
+            state.CapabilitiesResolved += ApplyCaps;
+            if (state.Caps.CurateProject != CapabilityState.Unknown) ApplyCaps();
 
             _ = LoadListAsync();
             return grid;

--- a/StingTools/UI/SitePhotosChecklistsSubTab.cs
+++ b/StingTools/UI/SitePhotosChecklistsSubTab.cs
@@ -84,10 +84,12 @@ namespace StingTools.UI
                 }
                 if (rows == null)
                 {
-                    status.Text = "load failed";
-                    listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                    var refused = PlanscapeServerClient.Instance.LastStatus == 403;
+                    status.Text = refused ? "not permitted" : "load failed";
+                    listPanel.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
                         "Could not load checklists.",
-                        PlanscapeServerClient.Instance.LastError));
+                        "Checklists are not available to you on this project.",
+                        PlanscapeCapability.CurateProject));
                     return;
                 }
                 status.Text = $"{rows.Count} checklist{(rows.Count == 1 ? "" : "s")}";
@@ -105,6 +107,24 @@ namespace StingTools.UI
             }
             refreshBtn.Click += (_, _) => _ = LoadAsync();
             statusCb.SelectionChanged += (_, _) => _ = LoadAsync();
+
+            // Checklist WRITES are curator-gated on the server; the list itself
+            // is not. There is no create button on this pane yet, so the only
+            // honest affordance is to say plainly that curation is unavailable
+            // — and only once the server has actually said so.
+            bool bannerShown = false;
+            void ApplyCaps()
+            {
+                if (bannerShown) return;
+                var banner = PlanscapeForbidden.BuildBannerIfDenied(
+                    state.Caps.CurateProject, PlanscapeCapability.CurateProject);
+                if (banner == null) return;
+                bannerShown = true;
+                DockPanel.SetDock(banner, Dock.Top);
+                dock.Children.Insert(0, banner);
+            }
+            state.CapabilitiesResolved += ApplyCaps;
+            ApplyCaps();
 
             _ = LoadAsync();
             return dock;

--- a/StingTools/UI/SitePhotosGridSubTab.cs
+++ b/StingTools/UI/SitePhotosGridSubTab.cs
@@ -102,7 +102,7 @@ namespace StingTools.UI
                     return;
                 }
                 status.Text = "Loading…";
-                List<SitePhotoDto> photos;
+                List<SitePhotoDto>? photos;
                 try
                 {
                     photos = await PlanscapeServerClient.Instance.ListSitePhotosAsync(
@@ -112,6 +112,21 @@ namespace StingTools.UI
                 {
                     StingLog.Warn($"GridSubTab.Load: {ex.Message}");
                     status.Text = "Failed — see log";
+                    wrap.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                        "Could not load photos.", ex.Message));
+                    return;
+                }
+
+                if (photos == null)
+                {
+                    // Was "0 photos" + "No photos to show." over every failure,
+                    // including a refusal. Both are answers the grid did not have.
+                    var refused = PlanscapeServerClient.Instance.LastStatus == 403;
+                    status.Text = refused ? "not permitted" : "load failed";
+                    wrap.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
+                        "Could not load photos.",
+                        "Site photos are not available to you on this project.",
+                        PlanscapeCapability.ApproveSitePhotos));
                     return;
                 }
 

--- a/StingTools/UI/SitePhotosTab.cs
+++ b/StingTools/UI/SitePhotosTab.cs
@@ -99,6 +99,26 @@ namespace StingTools.UI
 
             // Auto-refresh timer (null if not started)
             public DispatcherTimer? RefreshTimer;
+
+            // ── Capabilities (#547 / #558) ─────────────────────────────
+            // Starts all-Unknown, which means "nothing is disabled". The tab
+            // is built synchronously and the answer arrives later; a control
+            // that is enabled while we do not yet know is CORRECT — the
+            // server is still the gate and the attempt still reports. Only an
+            // explicit Denied ever disables anything.
+            public ProjectCapabilities Caps = ProjectCapabilities.Unknown();
+
+            /// <summary>Raised once, on the UI thread, when the capabilities
+            /// answer lands. Sub-tabs subscribe to disable what is now known
+            /// to be denied. Never raised with an Unknown-only result treated
+            /// as denial — handlers must gate on Denied, not on !Allowed.</summary>
+            public event Action? CapabilitiesResolved;
+
+            internal void PublishCapabilities(ProjectCapabilities caps)
+            {
+                Caps = caps;
+                CapabilitiesResolved?.Invoke();
+            }
         }
 
         /// <summary>UI-bindable photo row. Wraps the DTO so we can add a
@@ -197,7 +217,29 @@ namespace StingTools.UI
             });
 
             owner.Closed += (_, _) => state.RefreshTimer?.Stop();
+
+            // Fire-and-forget: the sub-tabs above are already built and
+            // enabled. This can only ever take controls AWAY, never grant
+            // them, so a fetch that never returns leaves the surface in its
+            // honest default — offer the control, let the server answer.
+            _ = LoadCapabilitiesAsync(state);
+
             return tabs;
+        }
+
+        /// <summary>
+        /// Resolve the caller's capabilities on this project and publish them
+        /// to the sub-tabs.
+        ///
+        /// Deliberately has no failure branch that disables anything: the
+        /// client returns all-Unknown for every failure mode, and Unknown
+        /// disables nothing. See PlanscapeServerClient.Capabilities.cs.
+        /// </summary>
+        private static async Task LoadCapabilitiesAsync(TabState state)
+        {
+            var caps = await PlanscapeServerClient.Instance
+                .GetProjectCapabilitiesAsync(state.ProjectId);
+            state.PublishCapabilities(caps);
         }
 
         /// <summary>The Phase 178 review queue, factored out as a sub-tab
@@ -224,6 +266,26 @@ namespace StingTools.UI
             footer.Visibility = Visibility.Collapsed;
             footer.Tag = "BulkFooter";
             root.Children.Add(footer);
+
+            // The queue is built before the capabilities answer lands, so the
+            // rows come up with Approve / Reject live. That is the correct
+            // default (unknown ≠ denied); when the answer arrives, re-render
+            // so a *known* denial actually disables them and says why.
+            bool capsBannerShown = false;
+            state.CapabilitiesResolved += () =>
+            {
+                if (!capsBannerShown)
+                {
+                    var banner = PlanscapeForbidden.BuildBannerIfDenied(
+                        state.Caps.ApproveSitePhotos, PlanscapeCapability.ApproveSitePhotos);
+                    if (banner != null)
+                    {
+                        capsBannerShown = true;
+                        root.Children.Insert(0, banner);
+                    }
+                }
+                _ = ReloadAsync(owner, state, listPanel, footer);
+            };
 
             async Task BootAsync()
             {
@@ -556,7 +618,7 @@ namespace StingTools.UI
                 _           => null,
             };
 
-            List<SitePhotoDto> dtos;
+            List<SitePhotoDto>? dtos;
             try
             {
                 dtos = await PlanscapeServerClient.Instance.ListSitePhotosAsync(
@@ -572,8 +634,23 @@ namespace StingTools.UI
             {
                 StingLog.Warn($"SitePhotosTab.ReloadAsync: {ex.Message}");
                 listPanel.Children.Clear();
-                listPanel.Children.Add(new TextBlock { Text = "Failed to load photos — see log.",
-                    FontSize = 12, Foreground = Brushes.Crimson, Margin = new Thickness(8) });
+                listPanel.Children.Add(SitePhotosTabHelpers.BuildLoadFailure(
+                    "Could not load photos.", ex.Message));
+                return;
+            }
+
+            if (dtos == null)
+            {
+                // Until now this path did not exist: the client answered every
+                // failure with an empty list and the queue rendered "✓ No photos
+                // awaiting review." over it. A refusal and an outage now each
+                // say what they are.
+                listPanel.Children.Clear();
+                listPanel.Children.Add(PlanscapeForbidden.BuildFailureOrForbidden(
+                    "Could not load photos.",
+                    "Site photos are not available to you on this project.",
+                    PlanscapeCapability.ApproveSitePhotos));
+                UpdateFooterVisibility(footer, state);
                 return;
             }
 
@@ -856,6 +933,12 @@ namespace StingTools.UI
                 var wBtn = MakeRowButton("↶ Withdraw", Color.FromRgb(0xC6, 0x28, 0x28),
                     "Withdraw this photo from the client portal");
                 wBtn.Click += async (_, _) => await WithdrawAsync(owner, state, row, listPanel, footer);
+                // Rows are rebuilt on every reload, so reading state.Caps here is
+                // enough — no subscription needed. Denied disables; Unknown does
+                // not, so a user whose capabilities never resolved keeps the
+                // button and finds out from the server.
+                PlanscapeForbidden.ApplyIfDenied(wBtn, state.Caps.ApproveSitePhotos,
+                    PlanscapeCapability.ApproveSitePhotos);
                 actions.Children.Add(wBtn);
             }
             else
@@ -864,11 +947,15 @@ namespace StingTools.UI
                 var aBtn = MakeRowButton("✓ Approve", owner.GreenColourPub,
                     "Approve with caption (defaults to current bulk caption)");
                 aBtn.Click += async (_, _) => await ApproveSingleAsync(owner, state, row, listPanel, footer);
+                PlanscapeForbidden.ApplyIfDenied(aBtn, state.Caps.ApproveSitePhotos,
+                    PlanscapeCapability.ApproveSitePhotos);
                 actions.Children.Add(aBtn);
 
                 var rBtn = MakeRowButton("✗ Reject", Color.FromRgb(0xC6, 0x28, 0x28),
                     "Reject with reason — sender will see the reason in mobile");
                 rBtn.Click += async (_, _) => await RejectAsync(owner, state, row, listPanel, footer);
+                PlanscapeForbidden.ApplyIfDenied(rBtn, state.Caps.ApproveSitePhotos,
+                    PlanscapeCapability.ApproveSitePhotos);
                 actions.Children.Add(rBtn);
             }
 
@@ -995,8 +1082,11 @@ namespace StingTools.UI
                 .ApproveSitePhotoAsync(state.ProjectId, row.Dto.Id, caption.Trim());
             if (dto == null)
             {
-                Autodesk.Revit.UI.TaskDialog.Show("Approve photo",
-                    $"Server rejected the approval.\n\n{PlanscapeServerClient.Instance.LastError ?? "(no detail)"}");
+                // "Server rejected the approval" was true of a 403 and a 500
+                // alike, and told the user nothing about which. Approval is
+                // gated on ApproveSitePhotos; say so when that is the reason.
+                PlanscapeForbidden.ShowFailureOrForbidden(
+                    "Approve photo", PlanscapeCapability.ApproveSitePhotos);
                 return;
             }
             await ReloadAsync(owner, state, listPanel, footer);
@@ -1022,8 +1112,8 @@ namespace StingTools.UI
                 .RejectSitePhotoAsync(state.ProjectId, row.Dto.Id, reason.Trim());
             if (dto == null)
             {
-                Autodesk.Revit.UI.TaskDialog.Show("Reject photo",
-                    $"Server rejected the call.\n\n{PlanscapeServerClient.Instance.LastError ?? "(no detail)"}");
+                PlanscapeForbidden.ShowFailureOrForbidden(
+                    "Reject photo", PlanscapeCapability.ApproveSitePhotos);
                 return;
             }
             await ReloadAsync(owner, state, listPanel, footer);
@@ -1043,8 +1133,8 @@ namespace StingTools.UI
                 .WithdrawSitePhotoAsync(state.ProjectId, row.Dto.Id);
             if (!ok)
             {
-                Autodesk.Revit.UI.TaskDialog.Show("Withdraw photo",
-                    $"Server rejected the withdrawal.\n\n{PlanscapeServerClient.Instance.LastError ?? "(no detail)"}");
+                PlanscapeForbidden.ShowFailureOrForbidden(
+                    "Withdraw photo", PlanscapeCapability.ApproveSitePhotos);
                 return;
             }
             await ReloadAsync(owner, state, listPanel, footer);
@@ -1082,6 +1172,16 @@ namespace StingTools.UI
 
             var (approved, skipped) = await PlanscapeServerClient.Instance
                 .BulkApproveSitePhotosAsync(state.ProjectId, ids, caption);
+
+            // Nothing approved AND the server refused: that is a permission
+            // answer, not a "0 approved, 0 skipped" outcome. Reporting counts
+            // for a call that never ran reads as a successful no-op.
+            if (approved == 0 && PlanscapeServerClient.Instance.LastStatus == 403)
+            {
+                PlanscapeForbidden.ShowDialog("Bulk approve", PlanscapeCapability.ApproveSitePhotos);
+                return;
+            }
+
             Autodesk.Revit.UI.TaskDialog.Show("Bulk approve",
                 $"Approved: {approved}\nSkipped: {skipped}\n\n" +
                 (skipped > 0


### PR DESCRIPTION
First of three surfaces for **#558** (BCC → web → mobile). Depends on **#547** (merged) and **#634** (open — docstring correction; this PR implements what #634 says and does not amend it).

## Two things, and the second one is the bigger one

**1. The BCC had no forbidden state.** `grep -rc "403\|Forbidden" StingTools/UI/SitePhotos*.cs` was `0` across every file. A 403 fell through the generic failure path and rendered as the red couldn't-load treatment. An operator who lacks a capability was told the system was broken. "Call IT" and "ask your PM" are different actions; the UI could not tell them apart.

**2. `ListSitePhotosAsync` returned an empty list on every failure — and that BLOCKED the fix.** HTTP error, exception, missing envelope: all answered `new List<SitePhotoDto>()`. The review queue then rendered **"✓ No photos awaiting review."** over an unreachable server or a refusal, and the grid rendered **"No photos to show."** with a `0 photos` counter.

This is the same fabrication #550 removed from the album and distribution-group panes, still live in the two busiest panes — and it is *why* neither could show a forbidden state: nothing ever reached them saying anything had gone wrong. It now returns `null` on failure and `[]` only when the project genuinely has none. Both callers (the only two) updated. **This is a behaviour correction on the review queue and the grid, not a wording change.**

## The rule

| | | |
|---|---|---|
| **allowed** | explicit `true` | offer the control |
| **denied** | explicit `false`, **or 404** | disable it, name the capability |
| **unknown** | transport error / timeout / 5xx / unparseable body | **leave it enabled**, let the attempt report |

404 stays authoritative-false — it says the caller cannot see the project at all. A dropped connection says nothing about permissions. Rendering unknown as denied locks legitimate users out on a network blip *while showing them a permissions message*: an absent answer displayed as a definite one, same shape as an empty list standing in for a failed load.

## What landed

| File | |
|---|---|
| `PlanscapeServerClient.Capabilities.cs` **(new)** | `GET members/capabilities` as a tri-state. Never throws, never returns null; every failure mode yields all-`Unknown`, which disables nothing. Reads only an **explicit boolean** — `"true"` the string is not `true` the boolean, and neither coercing it nor reading it as false is an answer we were given. |
| `PlanscapeForbidden.cs` **(new)** | **One** treatment for this client, not one per screen. Amber + lock, deliberately not the crimson error state, so the two are distinguishable at a glance and not only by reading. Every string lives in `Describe()`. `ApplyIfDenied` does nothing on `Unknown` **by construction**, and takes a `CapabilityState` rather than a `bool` so a caller cannot collapse the third state on the way in. |
| `LastStatus` on the client | Set in the three HTTP helpers **and** the streaming export path, which bypasses them. Carries the status as a **number** so nobody substring-matches it out of a message — that is exactly how mobile ended up reporting `HTTP 403` for an empty body (#624). `null` when there was no response at all, deliberately not `0`. |
| Five sub-tabs | Failure vs refusal routed to the right report; controls disabled only on an explicit `Denied`, with the capability named. |

### Two details worth review

- **Share links are gated on `ApproveSitePhotos`, not `CurateProject`.** A coordinator who can curate albums deliberately cannot release imagery outside the project. Naming the wrong capability would send them to argue about the wrong permission.
- **Export is deliberately NOT gated.** `POST photo-export` carries `[Authorize]` and *no* capability check on the server. Disabling it here would invent a restriction that does not exist.

The Admin tab's hand-typed "Bulk operations require PM, Admin, or Owner role on the server" now reads from `Describe()`. The role names in that helper are **copy, not a gate** — they tell the user who to ask; nothing in the file decides anything.

## Verification

- `dotnet build` — **0 errors, 0 warnings**.
- **15 new tests** (`CapabilityStateTests.cs`) drive the real client against a real socket via the existing `CaptureServer` harness: explicit true/false, 404, killed server mid-session, 500/502/401, an HTML proxy body, a missing field, `null` / `"true"` / `1`, `LastStatus` == 403 on a refusal and `null` on no-response, plus both halves of the list distinction (null on failure, `[]` when genuinely empty).
- Full project: **31 passed, 1 skipped, 0 failed** — no regression from the `ListSitePhotosAsync` signature change.
- The capabilities wire shape (`canCurateProject`, `canApproveSitePhotos`, 404 for an invisible project) is pinned server-side by `ProjectCapabilitiesEndpointTests.cs`; this client reads exactly those fields.

**Not verified on screen.** These are WPF panels and no Revit session has rendered the amber forbidden panel or a disabled-with-tooltip button. The logic is covered headlessly; the pixels are not. The local docker API image predates #547 (built 2026-07-31, #547 merged 2026-08-06) so it answers 405 on that route — I did not rebuild it rather than restart a stack another agent may be measuring against.

Web and mobile follow in their own PRs; the `docs/CHANGELOG.md` entry lands with the third so the three branches do not conflict on it.

Refs #558, #547, #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)