### PR TITLE
feat(planscape): R1 Phase A/1 — persist + emit the IFC GlobalId cross-host key

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
@@ -17,6 +17,7 @@ public class AdminController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
     private readonly Planscape.Infrastructure.Authorization.IPermissionRevocationStore _revocations;
+    private readonly Planscape.Core.Interfaces.IIdentityReconciliationService _identityReconcile;
 
     /// <summary>
     /// Can this account reach the admin surfaces? Mirrors
@@ -28,10 +29,12 @@ public class AdminController : ControllerBase
 
     public AdminController(
         PlanscapeDbContext db,
-        Planscape.Infrastructure.Authorization.IPermissionRevocationStore revocations)
+        Planscape.Infrastructure.Authorization.IPermissionRevocationStore revocations,
+        Planscape.Core.Interfaces.IIdentityReconciliationService identityReconcile)
     {
         _db = db;
         _revocations = revocations;
+        _identityReconcile = identityReconcile;
     }
 
     // ── Organization Management ──
@@ -244,6 +247,23 @@ public class AdminController : ControllerBase
 
     private static string HashPassword(string password)
         => BCrypt.Net.BCrypt.HashPassword(password, workFactor: 12);
+
+    // ── R1 identity reconciliation (Phase A / Increment 2) ──
+    // Backfill IfcGlobalId onto Revit rows from ExternalElementMapping, then merge
+    // each (ProjectId, IfcGlobalId) group down to one row. Human-triggered with a
+    // dry-run first, because it mutates element rows; re-running is a no-op once
+    // clean. Admin/Owner only (class-level [Authorize]). Optional ?projectId
+    // scopes to one project; omit to reconcile the whole tenant.
+
+    /// <summary>Dry-run: report what identity reconciliation WOULD do. Mutates nothing.</summary>
+    [HttpPost("identity/reconcile/analyze")]
+    public async Task<ActionResult> AnalyzeIdentityReconciliation([FromQuery] Guid? projectId, CancellationToken ct)
+        => Ok(await _identityReconcile.AnalyzeAsync(GetTenantId(), projectId, ct));
+
+    /// <summary>Apply identity reconciliation (backfill + merge). Idempotent.</summary>
+    [HttpPost("identity/reconcile/apply")]
+    public async Task<ActionResult> ApplyIdentityReconciliation([FromQuery] Guid? projectId, CancellationToken ct)
+        => Ok(await _identityReconcile.ApplyAsync(GetTenantId(), projectId, ct));
 }
 
 public record CreateUserRequest(string Email, string DisplayName, string Password, string? Role, string? Iso19650Role);

--- a/Planscape.Server/src/Planscape.API/Controllers/ChangesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ChangesController.cs
@@ -98,7 +98,12 @@ public class ChangesController : ControllerBase
         var items = rows.Select(t => new
         {
             kind = "tag",
-            globalId = t.UniqueId,
+            // R1 — emit the canonical cross-host key. For non-Revit rows UniqueId
+            // already IS the GlobalId; for Revit rows IfcGlobalId (once populated)
+            // is the true GlobalId a Python/ArchiCAD host keys on — without this a
+            // Revit edit reached those hosts with the 45-char Revit UniqueId and
+            // was dropped as `absent`. Falls back to UniqueId when unknown.
+            globalId = t.IfcGlobalId ?? t.UniqueId,
             lastModifiedUtc = t.LastModifiedUtc,
             payload = new
             {

--- a/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/TagSyncController.cs
@@ -573,6 +573,12 @@ public class TagSyncController : ControllerBase
     {
         entity.RevitElementId = dto.RevitElementId;
         entity.UniqueId = dto.UniqueId;
+        // R1 — persist the canonical cross-host key the DTO already carries (was
+        // previously dropped), and stamp origin so a Revit-authored row is
+        // distinguishable from its ArchiCAD/IFC twin. Only overwrite with a
+        // non-empty value so a push that omits it can't blank an existing key.
+        if (!string.IsNullOrWhiteSpace(dto.IfcGlobalId)) entity.IfcGlobalId = dto.IfcGlobalId;
+        entity.Source = "revit";
         entity.Disc = dto.Disc; entity.Loc = dto.Loc; entity.Zone = dto.Zone;
         entity.Lvl = dto.Lvl; entity.Sys = dto.Sys; entity.Func = dto.Func;
         entity.Prod = dto.Prod; entity.Seq = dto.Seq;

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -738,6 +738,8 @@ builder.Services.AddScoped<Planscape.Core.Interfaces.IIdentityResolverService,
 // TagSyncController + ArchiCADController (mapping upsert).
 builder.Services.AddScoped<Planscape.Core.Interfaces.IIfcIngestService,
     Planscape.Infrastructure.Services.IfcIngestService>();
+builder.Services.AddScoped<Planscape.Core.Interfaces.IIdentityReconciliationService,
+    Planscape.Infrastructure.Services.IdentityReconciliationService>();
 // K2 — Platform event spine (durable cross-surface channel → STING plugin).
 builder.Services.AddScoped<Planscape.Core.Interfaces.IPlatformEventService,
     Planscape.Infrastructure.Services.PlatformEventService>();

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -2021,6 +2021,19 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // they did before.
         "ALTER TABLE \"TaggedElements\" ADD COLUMN IF NOT EXISTS \"DeletedAtUtc\" timestamp with time zone NULL",
         "CREATE INDEX IF NOT EXISTS \"IX_TaggedElements_ProjectId_DeletedAtUtc\" ON \"TaggedElements\" (\"ProjectId\", \"DeletedAtUtc\")",
+        // R1 — TaggedElements.IfcGlobalId (the canonical cross-host key). Same
+        // idempotent-patch rationale as DeletedAtUtc above: fresh DBs get it from
+        // the EF model via CreateTables; pre-existing DBs get it here. Nullable so
+        // existing rows read as "unknown GlobalId" until the next push populates
+        // it. NON-unique index for now (Increment 1) — the unique constraint +
+        // dedup lands in Increment 2.
+        "ALTER TABLE \"TaggedElements\" ADD COLUMN IF NOT EXISTS \"IfcGlobalId\" text NULL",
+        "CREATE INDEX IF NOT EXISTS \"IX_TaggedElements_ProjectId_IfcGlobalId\" ON \"TaggedElements\" (\"ProjectId\", \"IfcGlobalId\") WHERE \"IfcGlobalId\" IS NOT NULL",
+        // Safe backfill: non-Revit rows (RevitElementId = 0) already carry the
+        // IFC GlobalId in UniqueId, so copy it across. Revit rows are backfilled
+        // from ExternalElementMapping during the Increment-2 merge; until then
+        // they populate IfcGlobalId on their next push (MapDtoToEntity).
+        "UPDATE \"TaggedElements\" SET \"IfcGlobalId\" = \"UniqueId\" WHERE \"RevitElementId\" = 0 AND (\"IfcGlobalId\" IS NULL OR \"IfcGlobalId\" = '') AND \"UniqueId\" <> ''",
     };
     int applied = 0, failed = 0;
     foreach (var sql in patches)

--- a/Planscape.Server/src/Planscape.Core/Entities/TaggedElement.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/TaggedElement.cs
@@ -12,6 +12,14 @@ public class TaggedElement : ITenantScoped, ISoftDeletable
     public long RevitElementId { get; set; }
     public string UniqueId { get; set; } = ""; // Revit UniqueId for cross-session tracking
 
+    // The 22-char IFC GlobalId — the canonical CROSS-HOST identity (R1). Every
+    // host can produce it: Revit sends it (stabilised into IFC_GLOBAL_ID_TXT),
+    // Bonsai/ArchiCAD send it natively. It is what unifies a Revit-authored row
+    // and its ArchiCAD/IFC twin — unlike UniqueId, which is Revit's local
+    // 45-char id for Revit rows but carries the GlobalId for non-Revit rows.
+    // Nullable: pre-existing rows and pushes that omit it read as null.
+    public string? IfcGlobalId { get; set; }
+
     // 8 source tokens
     public string Disc { get; set; } = "";
     public string Loc { get; set; } = "";

--- a/Planscape.Server/src/Planscape.Core/Interfaces/IIdentityReconciliationService.cs
+++ b/Planscape.Server/src/Planscape.Core/Interfaces/IIdentityReconciliationService.cs
@@ -1,0 +1,49 @@
+namespace Planscape.Core.Interfaces;
+
+/// <summary>
+/// R1 (Phase A, Increment 2) — dedup/backfill tool for the cross-host identity.
+///
+/// The same physical element can exist as TWO <c>TaggedElement</c> rows: one
+/// from the Revit door (keyed on RevitElementId) and one from the /ifc/data door
+/// (keyed on the IFC GlobalId in UniqueId). This service (a) backfills
+/// <c>IfcGlobalId</c> onto Revit rows from <c>ExternalElementMapping</c>, then
+/// (b) merges each <c>(ProjectId, IfcGlobalId)</c> group down to one row.
+///
+/// Deliberately human-triggered (admin endpoint) with a dry-run mode — a
+/// data-mutating merge must be reviewed before it runs, and re-running is a
+/// cheap no-op once clean (idempotent).
+/// </summary>
+public interface IIdentityReconciliationService
+{
+    /// <summary>Dry-run: report what a merge WOULD do; mutates nothing.</summary>
+    Task<IdentityReconciliationReport> AnalyzeAsync(Guid tenantId, Guid? projectId = null, CancellationToken ct = default);
+
+    /// <summary>Apply the backfill + merge. Idempotent.</summary>
+    Task<IdentityReconciliationReport> ApplyAsync(Guid tenantId, Guid? projectId = null, CancellationToken ct = default);
+}
+
+/// <summary>Counts from an identity-reconciliation analyze/apply pass.</summary>
+public sealed record IdentityReconciliationReport
+{
+    /// <summary>False for a dry-run (AnalyzeAsync), true for ApplyAsync.</summary>
+    public bool Applied { get; init; }
+
+    /// <summary>Revit rows (RevitElementId &gt; 0) that got an IfcGlobalId from ExternalElementMapping.</summary>
+    public int RevitRowsBackfilled { get; init; }
+
+    /// <summary>Distinct (ProjectId, IfcGlobalId) groups holding more than one row.</summary>
+    public int DuplicateGroups { get; init; }
+
+    /// <summary>Total surplus rows across those groups (rows that would be / were removed).</summary>
+    public int DuplicateRows { get; init; }
+
+    /// <summary>Rows actually removed by the merge (0 on a dry-run; equals DuplicateRows on apply).</summary>
+    public int RowsMerged { get; init; }
+
+    /// <summary>
+    /// Groups that carried more than one DISTINCT RevitElementId &gt; 0 — a data
+    /// anomaly (two Revit elements claiming one GlobalId). The primary keeps one;
+    /// surfaced so an operator can investigate.
+    /// </summary>
+    public int RevitIdConflicts { get; init; }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -659,6 +659,13 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(t => new { t.ProjectId, t.UniqueId })
                 .IsUnique()
                 .HasFilter("\"UniqueId\" <> ''");
+            // R1 — the canonical cross-host key. NON-unique for now: today the
+            // same physical element still lives as two rows (Revit + IFC), so a
+            // unique constraint would reject the second. Increment 2 merges the
+            // duplicates and swaps this to unique + makes it the primary upsert
+            // key. This index also serves the Revit pull-back reverse lookup (R2).
+            e.HasIndex(t => new { t.ProjectId, t.IfcGlobalId })
+                .HasFilter("\"IfcGlobalId\" IS NOT NULL");
             e.HasIndex(t => t.Tag1);
             e.HasIndex(t => t.Disc);
             e.HasIndex(t => t.IsStale);

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IdentityReconciliationService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IdentityReconciliationService.cs
@@ -1,0 +1,164 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Constants;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <inheritdoc />
+public sealed class IdentityReconciliationService : IIdentityReconciliationService
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<IdentityReconciliationService>? _logger;
+
+    public IdentityReconciliationService(PlanscapeDbContext db, ILogger<IdentityReconciliationService>? logger = null)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public Task<IdentityReconciliationReport> AnalyzeAsync(Guid tenantId, Guid? projectId = null, CancellationToken ct = default)
+        => RunAsync(tenantId, projectId, apply: false, ct);
+
+    public Task<IdentityReconciliationReport> ApplyAsync(Guid tenantId, Guid? projectId = null, CancellationToken ct = default)
+        => RunAsync(tenantId, projectId, apply: true, ct);
+
+    private async Task<IdentityReconciliationReport> RunAsync(
+        Guid tenantId, Guid? projectId, bool apply, CancellationToken ct)
+    {
+        // IgnoreQueryFilters + explicit tenant: this runs from an admin request
+        // whose ambient tenant is the caller's, but the operation is inherently
+        // cross-project/whole-tenant, and tombstoned rows must be visible so a
+        // live row can win over a tombstoned duplicate.
+        IQueryable<TaggedElement> elementsQ = _db.TaggedElements
+            .IgnoreQueryFilters().Where(t => t.TenantId == tenantId);
+        IQueryable<ExternalElementMapping> mapQ = _db.ExternalElementMappings
+            .IgnoreQueryFilters().Where(m => m.TenantId == tenantId);
+        if (projectId is Guid pid)
+        {
+            elementsQ = elementsQ.Where(t => t.ProjectId == pid);
+            mapQ = mapQ.Where(m => m.ProjectId == pid);
+        }
+
+        // ── 1. Backfill: Revit rows (RevitElementId > 0) with no IfcGlobalId, from
+        //       ExternalElementMapping (host=revit, HostElementId = RevitElementId). ──
+        var revitMap = (await mapQ.ToListAsync(ct))
+            .Where(m => MappingHosts.Normalize(m.Host) == MappingHosts.Revit
+                        && !string.IsNullOrWhiteSpace(m.IfcGlobalId)
+                        && !string.IsNullOrWhiteSpace(m.HostElementId))
+            .GroupBy(m => (m.ProjectId, m.HostElementId))
+            .ToDictionary(g => g.Key, g => g.First().IfcGlobalId);
+
+        var backfillCandidates = await elementsQ
+            .Where(t => t.RevitElementId > 0 && (t.IfcGlobalId == null || t.IfcGlobalId == ""))
+            .ToListAsync(ct);
+
+        int backfilled = 0;
+        foreach (var t in backfillCandidates)
+        {
+            if (revitMap.TryGetValue((t.ProjectId, t.RevitElementId.ToString()), out var gid))
+            {
+                if (apply) t.IfcGlobalId = gid;
+                backfilled++;
+            }
+        }
+        // Persist the backfill FIRST so the grouping below sees the newly-keyed rows.
+        if (apply && backfilled > 0) await _db.SaveChangesAsync(ct);
+
+        // ── 2. Merge: collapse each (ProjectId, IfcGlobalId) group to one row. ──
+        var withGid = await elementsQ
+            .Where(t => t.IfcGlobalId != null && t.IfcGlobalId != "")
+            .ToListAsync(ct);
+
+        var groups = withGid
+            .GroupBy(t => (t.ProjectId, t.IfcGlobalId))
+            .Where(g => g.Count() > 1)
+            .ToList();
+
+        int dupGroups = groups.Count;
+        int dupRows = groups.Sum(g => g.Count() - 1);
+        int merged = 0, revitIdConflicts = 0;
+
+        foreach (var g in groups)
+        {
+            if (g.Where(t => t.RevitElementId > 0).Select(t => t.RevitElementId).Distinct().Count() > 1)
+                revitIdConflicts++;
+
+            if (!apply) continue;
+
+            var members = g.ToList();
+            var freshest = members
+                .OrderByDescending(t => t.LastModifiedUtc ?? DateTime.MinValue)
+                .ThenBy(t => t.Id)
+                .First();
+
+            // Primary = the Revit row when one exists, so RevitElementId / UniqueId
+            // (both under filtered-UNIQUE indexes) are NEVER mutated while a
+            // to-be-deleted sibling still holds the same value — which would risk
+            // a transient unique violation inside the SaveChanges transaction on
+            // Postgres. Data is taken from the freshest row instead.
+            var primary = members
+                .Where(t => t.RevitElementId > 0)
+                .OrderByDescending(t => t.LastModifiedUtc ?? DateTime.MinValue)
+                .ThenBy(t => t.Id)
+                .FirstOrDefault() ?? freshest;
+
+            if (!ReferenceEquals(primary, freshest))
+                CopyDataFrom(primary, freshest);
+
+            // Keep the newest modification stamp + highest version across the group,
+            // and let a live row win over a tombstoned duplicate.
+            primary.LastModifiedUtc = members.Max(t => t.LastModifiedUtc) ?? primary.LastModifiedUtc;
+            primary.Version = members.Max(t => t.Version);
+            if (members.Any(t => t.DeletedAtUtc == null)) primary.DeletedAtUtc = null;
+
+            var others = members.Where(t => !ReferenceEquals(t, primary)).ToList();
+            _db.TaggedElements.RemoveRange(others);
+            merged += others.Count;
+        }
+
+        if (apply && merged > 0) await _db.SaveChangesAsync(ct);
+
+        var report = new IdentityReconciliationReport
+        {
+            Applied = apply,
+            RevitRowsBackfilled = backfilled,
+            DuplicateGroups = dupGroups,
+            DuplicateRows = dupRows,
+            RowsMerged = apply ? merged : 0,
+            RevitIdConflicts = revitIdConflicts,
+        };
+        _logger?.LogInformation(
+            "[identity-reconcile] {Mode} tenant={Tenant} project={Project} backfilled={Backfilled} " +
+            "dupGroups={Groups} dupRows={Rows} merged={Merged} revitIdConflicts={Conflicts}",
+            apply ? "APPLY" : "ANALYZE", tenantId, projectId?.ToString() ?? "(all)",
+            backfilled, dupGroups, dupRows, report.RowsMerged, revitIdConflicts);
+        return report;
+    }
+
+    /// <summary>
+    /// Copy every NON-identity field from <paramref name="src"/> onto
+    /// <paramref name="dst"/>. Identity + row keys (Id, TenantId, ProjectId,
+    /// RevitElementId, UniqueId, IfcGlobalId) are deliberately left untouched.
+    /// </summary>
+    private static void CopyDataFrom(TaggedElement dst, TaggedElement src)
+    {
+        dst.Disc = src.Disc; dst.Loc = src.Loc; dst.Zone = src.Zone; dst.Lvl = src.Lvl;
+        dst.Sys = src.Sys; dst.Func = src.Func; dst.Prod = src.Prod; dst.Seq = src.Seq;
+        dst.Tag1 = src.Tag1; dst.Tag7 = src.Tag7;
+        dst.Tag7A = src.Tag7A; dst.Tag7B = src.Tag7B; dst.Tag7C = src.Tag7C;
+        dst.Tag7D = src.Tag7D; dst.Tag7E = src.Tag7E; dst.Tag7F = src.Tag7F;
+        dst.CategoryName = src.CategoryName; dst.FamilyName = src.FamilyName; dst.TypeName = src.TypeName;
+        dst.Status = src.Status; dst.Rev = src.Rev; dst.GridRef = src.GridRef;
+        dst.RoomName = src.RoomName; dst.Level = src.Level;
+        dst.IsStale = src.IsStale; dst.IsComplete = src.IsComplete; dst.IsFullyResolved = src.IsFullyResolved;
+        dst.ValidationErrors = src.ValidationErrors;
+        dst.PreviousTag = src.PreviousTag; dst.TagModifiedAt = src.TagModifiedAt;
+        dst.SyncedAt = src.SyncedAt; dst.SyncedBy = src.SyncedBy;
+        dst.Source = src.Source;
+        dst.P6ActivityId = src.P6ActivityId; dst.PercentComplete = src.PercentComplete;
+        dst.ActualStart = src.ActualStart; dst.ActualFinish = src.ActualFinish;
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcIngestService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcIngestService.cs
@@ -133,6 +133,10 @@ public sealed class IfcIngestService : IIfcIngestService
                         continue;
                     }
 
+                    // R1 — stamp the canonical key explicitly (not only via
+                    // UniqueId) + record origin, so the changes feed and cross-host
+                    // matching key on IfcGlobalId regardless of ingest door.
+                    t.IfcGlobalId = el.IfcGlobalId; t.Source = host;
                     t.Disc = el.Discipline; t.Loc = el.Location; t.Zone = el.Zone; t.Lvl = el.Level;
                     t.Sys = el.System; t.Func = el.Function; t.Prod = el.Product; t.Seq = el.Sequence;
                     t.Tag1 = el.FullTag;
@@ -157,6 +161,8 @@ public sealed class IfcIngestService : IIfcIngestService
                         TenantId = tenantId,
                         ProjectId = projectId,
                         UniqueId = el.IfcGlobalId,
+                        IfcGlobalId = el.IfcGlobalId,  // R1 — explicit canonical key
+                        Source = host,                 // R1 — origin (archicad/bonsai/tekla/…)
                         RevitElementId = 0,  // host-agnostic — IFC GlobalId is the key
                         Disc = el.Discipline, Loc = el.Location, Zone = el.Zone, Lvl = el.Level,
                         Sys = el.System, Func = el.Function, Prod = el.Product, Seq = el.Sequence,

--- a/Planscape.Server/tests/Planscape.Tests/IdentityReconciliationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/IdentityReconciliationTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Constants;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+using Xunit;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// R1 (Phase A, Increment 2) — the identity dedup/backfill tool. Merges the
+/// two-row duplication (a Revit row + its ArchiCAD/IFC twin) into one, keeping
+/// the Revit identity and the freshest data, and backfills IfcGlobalId onto
+/// Revit rows from ExternalElementMapping. EF InMemory (unique indexes are not
+/// enforced there, so duplicates can be seeded).
+/// </summary>
+public class IdentityReconciliationTests
+{
+    private static readonly Guid TenantId  = Guid.Parse("aaaaaaaa-0000-0000-0000-0000000000c1");
+    private static readonly Guid ProjectId = Guid.Parse("bbbbbbbb-0000-0000-0000-0000000000c2");
+    private const string Gid  = "0aBcDeFgHiJkLmNoPqRsT1";
+    private const string Gid2 = "0aBcDeFgHiJkLmNoPqRsT2";
+    private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime T1 = new(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static PlanscapeDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<PlanscapeDbContext>()
+            .UseInMemoryDatabase($"reconcile-{Guid.NewGuid():N}")
+            .Options);
+
+    private static TaggedElement El(long revitId, string uniqueId, string? gid, string tag1,
+        DateTime? lastMod, string source) => new()
+    {
+        Id = Guid.NewGuid(), TenantId = TenantId, ProjectId = ProjectId,
+        RevitElementId = revitId, UniqueId = uniqueId, IfcGlobalId = gid,
+        Tag1 = tag1, Disc = "A", LastModifiedUtc = lastMod, Source = source, Version = 1,
+    };
+
+    // ── Merge: Revit row + IFC row for the same GlobalId collapse to one, keeping
+    //    the Revit identity (as primary) and the freshest data. ──
+    [Fact]
+    public async Task Apply_MergesDuplicate_KeepsRevitIdentityAndFreshestData()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(42, "revit-uid-42", Gid, "A-OLD", T0, "revit")); // Revit, older
+        db.TaggedElements.Add(El(0,  Gid,           Gid, "A-NEW", T1, "bonsai")); // IFC twin, fresher
+        await db.SaveChangesAsync();
+
+        var report = await new IdentityReconciliationService(db).ApplyAsync(TenantId);
+
+        Assert.Equal(1, report.DuplicateGroups);
+        Assert.Equal(1, report.RowsMerged);
+
+        var rows = await db.TaggedElements.IgnoreQueryFilters().Where(t => t.IfcGlobalId == Gid).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal(42, rows[0].RevitElementId);          // Revit identity preserved (primary)
+        Assert.Equal("revit-uid-42", rows[0].UniqueId);    // …UniqueId never mutated
+        Assert.Equal("A-NEW", rows[0].Tag1);               // …data taken from the freshest row
+        Assert.Equal(T1, rows[0].LastModifiedUtc);         // …newest modification stamp wins
+    }
+
+    // ── Backfill: a Revit row with no IfcGlobalId gets it from ExternalElementMapping. ──
+    [Fact]
+    public async Task Apply_BackfillsRevitIfcGlobalIdFromMapping()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(7, "revit-uid-7", null, "A", T0, "revit"));
+        db.ExternalElementMappings.Add(new ExternalElementMapping
+        {
+            Id = Guid.NewGuid(), TenantId = TenantId, ProjectId = ProjectId,
+            IfcGlobalId = Gid, Host = MappingHosts.Revit, HostElementId = "7",
+        });
+        await db.SaveChangesAsync();
+
+        var report = await new IdentityReconciliationService(db).ApplyAsync(TenantId);
+
+        Assert.Equal(1, report.RevitRowsBackfilled);
+        var row = await db.TaggedElements.IgnoreQueryFilters().FirstAsync(t => t.RevitElementId == 7);
+        Assert.Equal(Gid, row.IfcGlobalId);
+    }
+
+    // ── Backfill THEN merge: the realistic case — a Revit row (unkeyed) + an IFC
+    //    twin; backfill keys the Revit row, then the two merge. ──
+    [Fact]
+    public async Task Apply_BackfillThenMerge_CollapsesToOne()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(9, "revit-uid-9", null, "A-OLD", T0, "revit")); // no GlobalId yet
+        db.TaggedElements.Add(El(0, Gid,           Gid,  "A-NEW", T1, "bonsai"));
+        db.ExternalElementMappings.Add(new ExternalElementMapping
+        {
+            Id = Guid.NewGuid(), TenantId = TenantId, ProjectId = ProjectId,
+            IfcGlobalId = Gid, Host = MappingHosts.Revit, HostElementId = "9",
+        });
+        await db.SaveChangesAsync();
+
+        var report = await new IdentityReconciliationService(db).ApplyAsync(TenantId);
+
+        Assert.Equal(1, report.RevitRowsBackfilled);
+        Assert.Equal(1, report.RowsMerged);
+        var rows = await db.TaggedElements.IgnoreQueryFilters().Where(t => t.IfcGlobalId == Gid).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal(9, rows[0].RevitElementId);   // the (now-keyed) Revit row is primary
+        Assert.Equal("A-NEW", rows[0].Tag1);        // freshest data
+    }
+
+    // ── Analyze is a pure dry-run: reports the counts, mutates nothing. ──
+    [Fact]
+    public async Task Analyze_ReportsButDoesNotMutate()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(42, "revit-uid-42", Gid, "A-OLD", T0, "revit"));
+        db.TaggedElements.Add(El(0,  Gid,           Gid, "A-NEW", T1, "bonsai"));
+        await db.SaveChangesAsync();
+
+        var report = await new IdentityReconciliationService(db).AnalyzeAsync(TenantId);
+
+        Assert.False(report.Applied);
+        Assert.Equal(1, report.DuplicateGroups);
+        Assert.Equal(1, report.DuplicateRows);
+        Assert.Equal(0, report.RowsMerged);                                   // nothing removed
+        Assert.Equal(2, await db.TaggedElements.IgnoreQueryFilters().CountAsync()); // both rows intact
+    }
+
+    // ── Idempotent: a second apply is a no-op. ──
+    [Fact]
+    public async Task Apply_Twice_IsNoOpSecondTime()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(42, "revit-uid-42", Gid, "A-OLD", T0, "revit"));
+        db.TaggedElements.Add(El(0,  Gid,           Gid, "A-NEW", T1, "bonsai"));
+        await db.SaveChangesAsync();
+        var svc = new IdentityReconciliationService(db);
+
+        await svc.ApplyAsync(TenantId);
+        var second = await svc.ApplyAsync(TenantId);
+
+        Assert.Equal(0, second.DuplicateGroups);
+        Assert.Equal(0, second.RowsMerged);
+        Assert.Equal(0, second.RevitRowsBackfilled);
+    }
+
+    // ── Clean project: distinct elements are left alone. ──
+    [Fact]
+    public async Task Apply_NoDuplicates_IsNoOp()
+    {
+        using var db = NewDb();
+        db.TaggedElements.Add(El(1, "revit-uid-1", Gid,  "A", T0, "revit"));
+        db.TaggedElements.Add(El(2, "revit-uid-2", Gid2, "A", T0, "revit"));
+        await db.SaveChangesAsync();
+
+        var report = await new IdentityReconciliationService(db).ApplyAsync(TenantId);
+
+        Assert.Equal(0, report.DuplicateGroups);
+        Assert.Equal(0, report.RowsMerged);
+        Assert.Equal(2, await db.TaggedElements.IgnoreQueryFilters().CountAsync());
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/TaggedElementIdentityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/TaggedElementIdentityTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Planscape.Core.DTOs;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+using Xunit;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// R1 (Phase A, Increment 1) — the canonical cross-host key (IFC GlobalId) is now
+/// persisted on TaggedElement and the ingest origin is stamped, so the changes
+/// feed and cross-host matching can key on the GlobalId regardless of ingest door.
+/// Exercised against EF InMemory (no host boot → no Jwt/Hangfire).
+/// </summary>
+public class TaggedElementIdentityTests
+{
+    private static readonly Guid TenantId  = Guid.Parse("aaaaaaaa-0000-0000-0000-0000000000a1");
+    private static readonly Guid ProjectId = Guid.Parse("bbbbbbbb-0000-0000-0000-0000000000b2");
+    private const string Gid = "0aBcDeFgHiJkLmNoPqRsT1";
+
+    private static PlanscapeDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<PlanscapeDbContext>()
+            .UseInMemoryDatabase($"identity-{Guid.NewGuid():N}")
+            .Options);
+
+    private static IfcIngestRequest Request(string host, string fullTag = "A-BLD1-Z01-GF-ARC-WAL-WAL-0001") => new()
+    {
+        Host = host,
+        HostDocumentGuid = "doc-1",
+        Elements = new()
+        {
+            new IfcElementDto
+            {
+                IfcGlobalId = Gid, HostElementId = "AC-1",
+                Discipline = "A", Location = "BLD1", Zone = "Z01", Level = "GF",
+                System = "ARC", Function = "WAL", Product = "WAL", Sequence = "0001",
+                FullTag = fullTag, IsComplete = true,
+            },
+        },
+    };
+
+    [Fact]
+    public async Task IfcIngest_Insert_PersistsIfcGlobalIdAndSource()
+    {
+        using var db = NewDb();
+
+        await new IfcIngestService(db).IngestAsync(TenantId, ProjectId, Request("archicad"));
+
+        var row = await db.TaggedElements.IgnoreQueryFilters().FirstAsync(t => t.UniqueId == Gid);
+        Assert.Equal(Gid, row.IfcGlobalId);   // R1 — explicit canonical key persisted
+        Assert.Equal(Gid, row.UniqueId);      // non-Revit rows still carry the GlobalId in UniqueId
+        Assert.Equal("archicad", row.Source); // R1 — origin stamped
+        Assert.Equal(0, row.RevitElementId);
+    }
+
+    [Fact]
+    public async Task IfcIngest_Update_KeepsIfcGlobalIdAndSource()
+    {
+        using var db = NewDb();
+        var ingest = new IfcIngestService(db);
+
+        await ingest.IngestAsync(TenantId, ProjectId, Request("archicad", "A-OLD"));
+        // Re-ingest the same GlobalId (update branch) from a different host.
+        await ingest.IngestAsync(TenantId, ProjectId, Request("bonsai", "A-NEW"));
+
+        var rows = await db.TaggedElements.IgnoreQueryFilters().Where(t => t.UniqueId == Gid).ToListAsync();
+        Assert.Single(rows);                       // matched + updated, not duplicated
+        Assert.Equal("A-NEW", rows[0].Tag1);       // update applied
+        Assert.Equal(Gid, rows[0].IfcGlobalId);    // canonical key preserved
+        Assert.Equal("bonsai", rows[0].Source);    // origin reflects the latest writer
+    }
+}


### PR DESCRIPTION
First increment of **Phase A** from the round-trip identity spec ([`docs/ROUND_TRIP_R1_R2_SPEC.md`](../blob/main/docs/ROUND_TRIP_R1_R2_SPEC.md)). Makes the canonical cross-host key (the 22-char IFC GlobalId) **present and correct everywhere**, without yet changing how rows are matched — additive and low-risk. The risky dedup + unique constraint is Increment 2.

## Why
The wire DTO already carries `IfcGlobalId` (documented as "the canonical cross-host key"), and `ExternalElementMapping` already stores it — but the `TaggedElement` projection neither stored nor keyed on it, and the changes feed emitted `t.UniqueId`. So a Revit edit reached Python/ArchiCAD hosts under the 45-char Revit UniqueId and was **dropped as `absent`**.

## Changes
- **`TaggedElement.IfcGlobalId`** — new nullable column (the canonical key).
- **Both ingest doors persist it + stamp `Source`:**
  - `/tagsync` (Revit): `MapDtoToEntity` copies `dto.IfcGlobalId` (only when non-empty) + `Source="revit"`.
  - `/ifc/data` (ArchiCAD/Bonsai/Tekla): sets `IfcGlobalId` + `Source=host` on insert **and** update. (Side-effect: closes **R5/provenance**.)
- **`ChangesController`** emits `globalId = IfcGlobalId ?? UniqueId` → Revit edits now reach Python/ArchiCAD hosts under the real GlobalId (**unblocks R1.4**).
- **Schema:** column added to the EF model (fresh DBs via `CreateTables`) **and** the idempotent `PlatformSchemaPatcher` (pre-existing DBs) — `SchemaDriftChecker` stays green. NON-unique index on `(ProjectId, IfcGlobalId)` + a safe backfill (non-Revit rows already hold the GlobalId in `UniqueId`).

## Tests
`TaggedElementIdentityTests` (EF InMemory, no host boot): insert + update persist `IfcGlobalId`/`Source`; re-ingesting the same GlobalId updates one row. API build clean (0 errors).

## Deferred to Increment 2 (the dedup)
Match on `IfcGlobalId` first · merge the existing two-row duplicates · swap the index to **unique** · backfill Revit rows from `ExternalElementMapping`. Then R1.3 (Revit stops re-minting the ArchiCAD GlobalId) and R1.4 (StingBridge de-fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)