### PR TITLE
feat(revit): R1.3 — preserve the ArchiCAD-origin GlobalId across the Revit hop

### DIFF
--- a/StingTools/Commands/Interop/ArchiCadIfcImportCommand.cs
+++ b/StingTools/Commands/Interop/ArchiCadIfcImportCommand.cs
@@ -2052,6 +2052,19 @@ namespace StingTools.Commands.Interop
                   ?? el.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
             p1?.Set("AC:" + src.GlobalId);
 
+            // R1 — carry the ArchiCAD-origin IFC GlobalId as the canonical
+            // cross-host key so it SURVIVES the Revit hop. Without this the element
+            // travels with only ARCHICAD_GUID; StabilizeIfcGuids then stamps Revit's
+            // own re-minted IfcGUID into IFC_GLOBAL_ID_TXT and the Planscape push
+            // keys on that Revit-local value — so the element can never be matched
+            // back to its ArchiCAD twin. StabilizeIfcGuids now treats an
+            // ArchiCAD-origin element's GlobalId as authoritative and preserves it.
+            if (!string.IsNullOrEmpty(src.GlobalId))
+            {
+                var pg = el.LookupParameter("IFC_GLOBAL_ID_TXT");
+                if (pg != null && !pg.IsReadOnly) pg.Set(src.GlobalId);
+            }
+
             if (!string.IsNullOrEmpty(src.Name))
             {
                 var p2 = el.LookupParameter("ARCHICAD_ELEMENT_NAME")

--- a/StingTools/Commands/Interop/StabilizeIfcGuidsCommand.cs
+++ b/StingTools/Commands/Interop/StabilizeIfcGuidsCommand.cs
@@ -51,6 +51,7 @@ namespace StingTools.Commands.Interop
             // Pre-check: can we even write IFC_GLOBAL_ID_TXT on any element?
             // If the shared param is not bound, we skip silently and report.
             int written = 0, skippedNoParam = 0, skippedReadOnly = 0, unchanged = 0, skippedNotExported = 0;
+            int healedExternal = 0; // R1 — ArchiCAD-origin GlobalIds preserved/healed (not overwritten by Revit's)
             int total = 0;
             var conflicts = new List<string>(); // existing GUID ≠ current Revit GUID
 
@@ -78,6 +79,33 @@ namespace StingTools.Commands.Interop
                             bic == BuiltInCategory.OST_Grids    ||
                             bic == BuiltInCategory.OST_Levels)
                             continue;
+
+                        // R1 — ArchiCAD-origin elements FIRST. Their canonical
+                        // cross-host key is the ArchiCAD IFC GlobalId (recoverable
+                        // from ARCHICAD_GUID), independent of whether Revit ever
+                        // assigned this element its own IfcGUID. Ensure
+                        // IFC_GLOBAL_ID_TXT holds that GlobalId and NEVER overwrite
+                        // it with Revit's re-minted one — that would replace the
+                        // key with a Revit-local value and sever the element from
+                        // its ArchiCAD twin across the round-trip. Self-healing: if
+                        // a prior run clobbered it, this restores it.
+                        string? acGid = TryReadArchiCadGlobalId(el);
+                        if (acGid != null)
+                        {
+                            total++;
+                            var acParam = el.LookupParameter(StingIfcGuidParam);
+                            if (acParam == null) { skippedNoParam++; continue; }
+                            if (acParam.IsReadOnly) { skippedReadOnly++; continue; }
+
+                            string acExisting = acParam.AsString() ?? "";
+                            if (acExisting == acGid) { unchanged++; continue; }
+                            if (!string.IsNullOrEmpty(acExisting) && acExisting != acGid)
+                                conflicts.Add($"  [{el.Id.Value}] {el.Category?.Name ?? "?"}: " +
+                                              $"healed ArchiCAD GlobalId (was {acExisting} → {acGid})");
+                            acParam.Set(acGid);
+                            healedExternal++;
+                            continue;
+                        }
 
                         // Read the current Revit-side IfcGUID.
                         string? revitIfcGuid = ReadRevitIfcGuid(el);
@@ -128,6 +156,8 @@ namespace StingTools.Commands.Interop
             sb.AppendLine();
             sb.AppendLine($"Elements scanned : {total}");
             sb.AppendLine($"GUIDs written    : {written}");
+            if (healedExternal > 0)
+                sb.AppendLine($"ArchiCAD GlobalId : {healedExternal}  (preserved/healed — Revit's GUID NOT applied)");
             sb.AppendLine($"Already current  : {unchanged}");
             if (skippedNoParam > 0)
                 sb.AppendLine($"No STING param   : {skippedNoParam}  (bind IFC_GLOBAL_ID_TXT shared param first)");
@@ -180,6 +210,28 @@ namespace StingTools.Commands.Interop
             // Return null so the caller skips it rather than storing a Revit UniqueId
             // (which is NOT the 22-character IFC GloballyUniqueId and would cause
             // Planscape drift detection to compare apples to oranges).
+            return null;
+        }
+
+        // R1 — recover the ArchiCAD-origin IFC GlobalId. ArchiCadIfcImportCommand
+        // stamps "AC:<globalid>" into ARCHICAD_GUID (or the Comments fallback when
+        // that shared param wasn't bound). A non-null return means "this element is
+        // ArchiCAD-origin and its authoritative cross-host key is <globalid>". The
+        // "AC:" prefix requirement avoids false positives on unrelated Comments.
+        private static string? TryReadArchiCadGlobalId(Element el)
+        {
+            try
+            {
+                string? v = el.LookupParameter("ARCHICAD_GUID")?.AsString();
+                if (string.IsNullOrWhiteSpace(v))
+                    v = el.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.AsString();
+                if (!string.IsNullOrWhiteSpace(v) && v!.StartsWith("AC:", StringComparison.Ordinal))
+                {
+                    string gid = v.Substring(3).Trim();
+                    return string.IsNullOrEmpty(gid) ? null : gid;
+                }
+            }
+            catch { /* parameter not accessible on this element */ }
             return null;
         }
     }


### PR DESCRIPTION
Third piece of **Phase A** identity (spec: `docs/ROUND_TRIP_R1_R2_SPEC.md`). Complements the server work in #655.

## Why
When an ArchiCAD element is imported into Revit and later pushed to Planscape, Revit **re-mints its own IfcGUID** and the push keys on that Revit-local value — so the element can never be matched back to its ArchiCAD twin. IFC GlobalId is the *only* identity Revit and ArchiCAD share; re-minting it defeats the whole round-trip.

## Changes
- **`ArchiCadIfcImportCommand.Stamp`** — in addition to `ARCHICAD_GUID` (`"AC:<gid>"`), write the **raw GlobalId** into `IFC_GLOBAL_ID_TXT`, the canonical cross-host key the Planscape push already sends (`PlatformLinkCommands` reads it into `IfcGlobalId`).
- **`StabilizeIfcGuidsCommand`** — process ArchiCAD-origin elements **first** (detected by the `"AC:"` prefix on `ARCHICAD_GUID`/Comments) and treat their ArchiCAD GlobalId as **authoritative**: ensure `IFC_GLOBAL_ID_TXT` holds it, **never** overwrite it with Revit's re-minted IfcGUID. Self-healing — restores the GlobalId if a prior run clobbered it or an old import never captured it, and works even for ArchiCAD elements Revit never IFC-exported. Revit-native elements keep the existing snapshot/drift behaviour unchanged.

## Verification
Plugin builds clean against the Revit 2025 API (**0 warnings / 0 errors**). Per repo convention, command logic that walks live Revit `Element`s is verified by build + in-Revit load (there's no Revit-API unit harness) — worth a manual smoke: import an ArchiCAD IFC → run `IFC_StabilizeGuids` → confirm the ArchiCAD elements' `IFC_GLOBAL_ID_TXT` equals their ArchiCAD GlobalId (not a Revit GUID), and the report shows an "ArchiCAD GlobalId" count.

## Phase A status
✅ R1.1/1.2 persist+emit key (#655) · ✅ R1.2 dedup tool (#655) · ✅ **R1.3 (this)** · ⏭️ 2b write-path precedence + unique index · ⏭️ R1.4 StingBridge de-fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)