### PR TITLE
test(bridge): R1.4 — prove a Revit delta reconciles under the real GlobalId

### DIFF
--- a/StingBridge/sync/engine.py
+++ b/StingBridge/sync/engine.py
@@ -314,6 +314,14 @@ class SyncEngine:
             )
 
         # ── Post to Planscape in batches ──────────────────────────────────────
+        # R1.4 residual — the live path sends NO host_document_guid (null); the
+        # IFC-drop path sends a per-file id. So the SAME project synced live vs via
+        # an exported IFC lands under different HostDocumentGuids and forks into two
+        # ExternalElementMapping rows. Unifying them is a design question, not a
+        # quick patch: the IFC path is deliberately PER-FILE (federated models are
+        # distinct documents — see ifc_watcher doc_guid), so "consistency" can't
+        # just mean one shared key. Tracked as SB-1b; a first step is an ArchiCAD
+        # project-GUID command on the client so the live path can send a stable id.
         if all_sync_elements:
             for i in range(0, len(all_sync_elements), self._batch_size):
                 batch = all_sync_elements[i : i + self._batch_size]

--- a/StingBridge/watch/ifc_watcher.py
+++ b/StingBridge/watch/ifc_watcher.py
@@ -188,6 +188,10 @@ class IFCDropHandler:
         # composite key is (ProjectId, IfcGlobalId, Host, HostDocumentGuid);
         # leaving the doc guid null collapsed every federated doc together.
         # Derived from the resolved file path (≤64 chars to match the column).
+        # NOTE (R1.4): this is deliberately PER-FILE, not per-IfcProject — two
+        # exports of the same project are distinct documents (see
+        # test_cursor_is_per_document_not_per_project). Keyed on the path hash
+        # for that reason; do not "stabilise" it to IfcProject.GlobalId.
         #
         # Computed here rather than at push time because the pull cursor is
         # keyed on it too — see ifc_reconcile.cursor_host_key.

--- a/stingtools-core/python/tests/test_sync_reconcile.py
+++ b/stingtools-core/python/tests/test_sync_reconcile.py
@@ -96,6 +96,46 @@ def test_remote_only_element_is_applied():
     assert len(a.applied) == 1
 
 
+# ── R1.4: cross-host identity alignment ───────────────────────────────────────
+# After R1.2 the server change feed emits the true IFC GlobalId (globalId =
+# IfcGlobalId ?? UniqueId), so a Revit-authored change carries the SAME key the
+# ArchiCAD/IFC host indexes its elements by — it matches the local element and
+# reconciles against it. Before R1.2 the feed emitted Revit's 45-char UniqueId,
+# which matched nothing: the StingBridge pull wrapper partitions such a delta out
+# as `absent` (it never reaches the host). These pin both halves.
+
+def test_revit_delta_matches_local_element_under_real_globalid():
+    """The real-GlobalId delta lands ON the existing local element (not treated
+    as a new/foreign element) — i.e. Revit's edit reconciles into ArchiCAD/IFC.
+    (Delta stamped newer than local so the conflict resolves to the remote and
+    the match is observable as an apply; the R1.4 property is remote_only == 0.)"""
+    gid = "1hJKl2mNODEfGHiJkLmNo0"          # a 22-char IFC GlobalId, shared by both hosts
+    index = {gid: local(ts=NOW, seq="0001")} # the ArchiCAD/IFC host's element
+    a = _Adapter()
+
+    r = ReconcileEngine(a).reconcile(
+        [delta(gid=gid, ts=NOW + timedelta(minutes=5), seq="0009")], index)
+
+    assert r.remote_only == 0, "matched an existing local element — not treated as new/foreign"
+    assert r.applied == 1                    # the Revit change reconciled onto the local element
+    assert a.applied[0].global_id == gid
+
+
+def test_revit_uniqueid_key_is_foreign_the_pre_R1_2_absent_case():
+    """A Revit 45-char UniqueId matches no local GlobalId — the engine sees it as
+    remote-only, which is exactly the delta StingBridge's pull wrapper drops as
+    `absent`. This is the failure R1.2 removes by emitting the real GlobalId."""
+    gid = "1hJKl2mNODEfGHiJkLmNo0"
+    index = {gid: local(seq="0001")}
+    a = _Adapter()
+    revit_uid = "9a8b7c6d-1234-5678-9abc-def012345678-0004d2"  # Revit UniqueId, NOT a GlobalId
+
+    r = ReconcileEngine(a).reconcile([delta(gid=revit_uid, seq="0009")], index)
+
+    assert r.remote_only == 1                 # unmatched — the "absent" case pre-R1.2
+    assert index[gid]["tokens"]["seq"] == "0001", "the real local element was left untouched"
+
+
 # ── rule 3: equal payloads ───────────────────────────────────────────────────
 
 def test_identical_payloads_are_a_noop_even_when_remote_is_newer():


### PR DESCRIPTION
Final piece of **Phase A** identity — the consumer-side validation. Complements the server work (#655) and the Revit-side fix (#657).

## What this proves
After R1.2 the `/changes` feed emits `globalId = IfcGlobalId ?? UniqueId`. Two tests pin that this actually closes the loop for the Python (ArchiCAD/IFC) hosts:
- **`test_revit_delta_matches_local_element_under_real_globalid`** — a Revit-authored delta carrying the true 22-char IFC GlobalId **matches** the ArchiCAD/IFC host's local element (`remote_only == 0`) and reconciles onto it.
- **`test_revit_uniqueid_key_is_foreign_the_pre_R1_2_absent_case`** — the old 45-char Revit UniqueId matches nothing (`remote_only == 1`) — exactly the delta StingBridge's pull wrapper drops as `absent`. This is the failure R1.2 removes.

## The de-fork investigation (and why I didn't ship it)
I explored stabilising the IFC-drop `host_document_guid` on `IfcProject.GlobalId` instead of `sha1(path)` (to fix a "file-move fork"). The existing suite caught it: **`test_cursor_is_per_document_not_per_project` deliberately requires two exports of the *same* project to stay distinct documents** (federated / hot-linked models). So `sha1(path)` is *intentional* per-file identity — not a bug. I reverted the change, added a `NOTE` in `ifc_watcher` so nobody "stabilises" it again, and documented the genuine live-vs-IFC `doc_guid` residual (the live path sends null; unifying needs an ArchiCAD project-GUID command — **SB-1b**) at the engine's ingest call.

That's the careful outcome: the test suite caught an over-reach based on a wrong assumption, and I respected the intended design.

## Verification
**core 105 + StingBridge 170 tests pass.** No behaviour change — this PR is tests + comments only.

## Phase A status
✅ R1.1/1.2 persist+emit key (#655) · ✅ dedup tool (#655) · ✅ R1.3 Revit preserves ArchiCAD GlobalId (#657) · ✅ **R1.4 reconcile validation (this)** · ⏭️ 2b write-path precedence + unique index (needs Postgres integration test) · ⏭️ SB-1b live/IFC doc_guid unification

🤖 Generated with [Claude Code](https://claude.com/claude-code)