### PR TITLE
feat(bridge): SB-1b — stable per-project HostDocumentGuid for the live sync

### DIFF
--- a/StingBridge/sync/engine.py
+++ b/StingBridge/sync/engine.py
@@ -31,6 +31,17 @@ from .property_writer import PropertyWriter
 
 log = logging.getLogger(__name__)
 
+# SB-1b — the live ArchiCAD sync's HostDocumentGuid. A live session is ONE
+# document per Planscape project, so a stable constant (scoped per-project by the
+# ProjectId already in the mapping key) is the right identity — not null. Null
+# left the (ProjectId, IfcGlobalId, Host, HostDocumentGuid) UNIQUE index unable to
+# enforce for live rows (Postgres treats NULLs as distinct), so a concurrent
+# double-sync could slip two mapping rows past it; a constant closes that. It is
+# deliberately DISTINCT from the IFC-drop path's per-file id: a live model and an
+# exported IFC file are genuinely different documents, and ArchiCAD exposes no
+# project GUID to unify them (only a Tapir add-on path, itself move-fragile).
+LIVE_DOCUMENT_GUID = "archicad-live"
+
 
 def _ifc_global_id_from_acguid(ac_guid: str) -> str:
     """Convert an ArchiCAD element GUID to the IFC GlobalId ArchiCAD assigns
@@ -314,19 +325,18 @@ class SyncEngine:
             )
 
         # ── Post to Planscape in batches ──────────────────────────────────────
-        # R1.4 residual — the live path sends NO host_document_guid (null); the
-        # IFC-drop path sends a per-file id. So the SAME project synced live vs via
-        # an exported IFC lands under different HostDocumentGuids and forks into two
-        # ExternalElementMapping rows. Unifying them is a design question, not a
-        # quick patch: the IFC path is deliberately PER-FILE (federated models are
-        # distinct documents — see ifc_watcher doc_guid), so "consistency" can't
-        # just mean one shared key. Tracked as SB-1b; a first step is an ArchiCAD
-        # project-GUID command on the client so the live path can send a stable id.
+        # SB-1b — send a stable per-project document id (see LIVE_DOCUMENT_GUID)
+        # instead of null, so the cross-host mapping's unique index can enforce for
+        # live rows. (Investigated unifying this with the IFC-drop path's id: not
+        # achievable or desirable — different documents, and ArchiCAD has no project
+        # GUID. The live path's null was already deduped by the server upsert's
+        # null-matching; this hardens the concurrent case.)
         if all_sync_elements:
             for i in range(0, len(all_sync_elements), self._batch_size):
                 batch = all_sync_elements[i : i + self._batch_size]
                 try:
-                    self._ps.ingest_ifc_data(batch, host="archicad")
+                    self._ps.ingest_ifc_data(
+                        batch, host="archicad", host_document_guid=LIVE_DOCUMENT_GUID)
                     result.planscape_synced += len(batch)
                 except (PlanscapeError, Exception) as e:
                     msg = f"Planscape sync failed for batch {i//self._batch_size}: {e}"

--- a/StingBridge/tests/test_live_document_guid.py
+++ b/StingBridge/tests/test_live_document_guid.py
@@ -1,0 +1,34 @@
+"""SB-1b — the live ArchiCAD sync sends a stable, non-null HostDocumentGuid.
+
+A live session is one document per project, so a constant (scoped per-project by
+the ProjectId already in the mapping key) is the right identity. Null left the
+cross-host mapping's unique index unable to enforce for live rows (Postgres
+treats NULLs as distinct); a stable value closes that. It must be non-empty and
+fit the HostDocumentGuid column (<=64 chars).
+
+Run from the repo root:  python StingBridge/tests/test_live_document_guid.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from StingBridge.sync.engine import LIVE_DOCUMENT_GUID  # noqa: E402
+
+
+def test_live_document_guid_is_a_stable_nonempty_id():
+    assert isinstance(LIVE_DOCUMENT_GUID, str)
+    assert LIVE_DOCUMENT_GUID.strip(), "must be non-empty — null is exactly what SB-1b removes"
+    assert len(LIVE_DOCUMENT_GUID) <= 64, "must fit the HostDocumentGuid column"
+    # Stable constant, not a path/hash — the live doc identity must not change when
+    # the .pln is moved or renamed (unlike the IFC-drop path's per-file id).
+    assert LIVE_DOCUMENT_GUID == "archicad-live"
+
+
+if __name__ == "__main__":
+    test_live_document_guid_is_a_stable_nonempty_id()
+    print("OK")


### PR DESCRIPTION
**Stacked on #658.** The last open item from the whole round-trip review.

## Research first (the original framing was wrong)
"Unify the live vs IFC-drop `doc_guid`" turned out to be neither achievable nor desirable:
- **ArchiCAD exposes no project GUID** — only a project *path*, and only via a **Tapir add-on** (`AdditionalJSONCommands.GetProjectInfo`), which is move-fragile and a dependency.
- A **live model and an exported IFC file are genuinely different documents** (the IFC path is deliberately per-file for federated models).
- The live path's `null` was **already deduped** by the server's mapping upsert (`HostDocumentGuid == null` matches via EF null-semantics), so repeated live syncs already converge.

## The real gap, and the fix
`null` left the cross-host mapping's **UNIQUE `(ProjectId, IfcGlobalId, Host, HostDocumentGuid)` index unable to enforce** for live rows (Postgres treats NULLs as distinct) — a concurrent double-sync could slip two rows past it. Fix: the live path now sends a **stable constant** `LIVE_DOCUMENT_GUID = "archicad-live"`. A live session is one document per project (already scoped by `ProjectId` in the key), so a constant is the correct identity — **no ArchiCAD API/Tapir dependency, no move-fragility** (a path hash would fork when the `.pln` moves), fully deterministic. It stays deliberately distinct from the IFC-drop per-file id.

## Verification
The engine's live pipeline has no unit harness (only the IFC watcher does), so this is a self-evident 1-line config change + a lock-test on the constant. **Full StingBridge suite: 171 pass** (no regression).

## Round-trip review: fully closed
R1.1–R1.4 + 2b (identity) · R3 (compliance) · **SB-1b (this)**. Every gap from the review is now addressed. See `docs/ROADMAP.md` and `docs/ROUND_TRIP_R1_R2_SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)