### PR TITLE
fix(mobile): a refused queued action is classified by its status, not its prose (#646)

### DIFF
--- a/Planscape/package.json
+++ b/Planscape/package.json
@@ -15,7 +15,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "eslint . --ext .ts,.tsx",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:queue": "node --experimental-transform-types tests/offlineQueue.terminal.test.mjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",

--- a/Planscape/src/utils/offlineQueue.ts
+++ b/Planscape/src/utils/offlineQueue.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as FileSystem from 'expo-file-system/legacy';
+import { ApiError } from '@/api/client';
 import { createIssue, updateIssue, transitionCDE, uploadIssueAttachment, captureSitePhoto } from '@/api/endpoints';
 import type { DeliverableUpsertArgs, CreateSiteDiaryRequest } from '@/api/endpoints';
 import type { OfflineAction, SitePhotoCaptureMeta } from '@/types/api';
@@ -479,6 +480,46 @@ const MAX_RETRIES_PER_ACTION = 3;
 const MAX_QUEUE_SIZE = 200;
 
 /**
+ * #646 — 4xx statuses that are NOT the client's fault and so stay retryable.
+ * Everything else in 4xx means replaying the same payload can never succeed.
+ * 5xx and transport failures are always retryable.
+ */
+const RETRYABLE_4XX = new Set([408, 429]);
+
+/**
+ * Read the HTTP status off a replay failure.
+ *
+ * `ApiError` (src/api/client.ts — the only place the app constructs one)
+ * carries `status` as a public field. Returns null when the error has no
+ * numeric status, which is the transport-failure case: a network drop, a DNS
+ * failure, an aborted request. Those must stay retryable, so null is treated
+ * as "not permanent" by every caller below.
+ */
+function statusOf(err: unknown): number | null {
+  if (err instanceof ApiError) return err.status;
+  // Endpoints that call `fetch` directly rather than through `apiFetch` can
+  // reject with their own status-bearing error; accept those too.
+  const s = (err as { status?: unknown } | null | undefined)?.status;
+  return typeof s === 'number' && Number.isFinite(s) ? s : null;
+}
+
+/**
+ * Is this failure permanent — i.e. will replaying the identical payload
+ * always be refused?
+ *
+ * Read the status the error already carries. Do NOT test the message: an
+ * `ApiError`'s message is the response *body*, and only falls back to
+ * `HTTP <status>` when that body is empty. Matching /HTTP 4xx/ against it
+ * therefore recognises empty-body refusals only, and silently misclassifies
+ * every refusal that explains itself — which is most of them (#646).
+ */
+function isPermanentFailure(err: unknown): boolean {
+  const status = statusOf(err);
+  if (status === null) return false;
+  return status >= 400 && status < 500 && !RETRYABLE_4XX.has(status);
+}
+
+/**
  * N-G17 — compute exponential-backoff delay in milliseconds.
  * Sequence: 2s → 4s → 8s → 16s (capped), with ±20% jitter so reconnect
  * storms across many devices don't hammer the server simultaneously.
@@ -527,9 +568,8 @@ export async function syncQueue(): Promise<SyncResult> {
       // Permanent errors — move to failed side-queue immediately rather than
       // retry. 4xx (except 408/429) indicate the client payload is the problem
       // so retrying will never succeed.
-      const isPermanent = /HTTP 4(0[0-79]|1[013-9]|2[013-9])/.test(msg)
-        || /HTTP 40[0137]/.test(msg); // 400, 401, 403, 407
-      const isConflict = /HTTP 409/.test(msg);
+      const isPermanent = isPermanentFailure(err);
+      const isConflict = statusOf(err) === 409;
       if (isConflict) result.conflicts++;
 
       if (isPermanent || (action.retryCount >= MAX_RETRIES_PER_ACTION)) {

--- a/Planscape/tests/offlineQueue.terminal.test.mjs
+++ b/Planscape/tests/offlineQueue.terminal.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * offlineQueue terminal-failure classification.
+ *
+ * Regression cover for #646. The queue used to decide whether a failure was
+ * permanent by running a regex over the error *message*. ApiError.message is
+ * the response BODY (falling back to `HTTP <status>` only when the body is
+ * empty), so the regex only ever matched empty-body responses — and a refused
+ * mutation that came back with a body was classified transient and retried.
+ *
+ * These assertions are written against `err.status`, which is what the class
+ * has always carried. They exercise the real syncQueue and the real ApiError.
+ *
+ * Run: npm run test:queue
+ */
+
+import assert from 'node:assert/strict';
+import './register.mjs';
+
+const { ApiError } = await import('../src/api/client.ts');
+const queue = await import('../src/utils/offlineQueue.ts');
+const endpoints = await import('./stubs/endpoints.mjs');
+const AsyncStorage = (await import('./stubs/async-storage.mjs')).default;
+
+const QUEUE_KEY = 'planscape_offline_queue';
+const FAILED_KEY = 'planscape_offline_failed';
+
+// A real refusal body, as the server actually sends it. This is the case the
+// old regex could not see.
+const FORBIDDEN_BODY = JSON.stringify({
+  error: 'forbidden',
+  reason: 'Your role does not permit transitioning documents to PUBLISHED.',
+});
+
+async function reset() {
+  await AsyncStorage.removeItem(QUEUE_KEY);
+  await AsyncStorage.removeItem(FAILED_KEY);
+}
+
+/** Simulate the backoff window elapsing so the next drain is not gated. */
+async function advancePastBackoff() {
+  const raw = await AsyncStorage.getItem(QUEUE_KEY);
+  if (!raw) return;
+  const q = JSON.parse(raw).map((a) => ({ ...a, nextRetryAt: undefined }));
+  await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(q));
+}
+
+async function counts() {
+  const live = JSON.parse((await AsyncStorage.getItem(QUEUE_KEY)) ?? '[]');
+  const failed = JSON.parse((await AsyncStorage.getItem(FAILED_KEY)) ?? '[]');
+  return { live: live.length, failed: failed.length };
+}
+
+/**
+ * Queue one action, make the endpoint reject with `status`/`body`, drain once,
+ * and report whether the action was retained for retry or moved to the failed
+ * side-queue.
+ */
+async function drainOnce(status, body) {
+  await reset();
+  await queue.enqueue('TRANSITION_CDE', { projectId: 'p', docId: 'd', newStatus: 'PUBLISHED' });
+  endpoints.__setBehaviour(async () => { throw new ApiError(status, body || `HTTP ${status}`); });
+  const result = await queue.syncQueue();
+  return { result, ...(await counts()) };
+}
+
+const results = [];
+function check(name, fn) {
+  try { fn(); results.push([true, name]); }
+  catch (e) { results.push([false, `${name}\n      ${e.message.split('\n')[0]}`]); }
+}
+
+// ── The class of bug, stated directly ────────────────────────────────────────
+{
+  const err = new ApiError(403, FORBIDDEN_BODY);
+  check('ApiError carries the status as a field', () => assert.equal(err.status, 403));
+  check('ApiError.message is the body, NOT "HTTP 403"', () => {
+    assert.equal(err.message, FORBIDDEN_BODY);
+    assert.ok(!/HTTP \d{3}/.test(err.message),
+      'the message contains no status text — any regex over it cannot classify this error');
+  });
+}
+
+// ── Terminal statuses: must move to the failed side-queue on attempt 1 ───────
+for (const [status, body, label] of [
+  [403, FORBIDDEN_BODY, '403 WITH a response body (#646)'],
+  [403, '', '403 with an empty body'],
+  [400, JSON.stringify({ error: 'bad latitude' }), '400 with a body'],
+  [401, '', '401'],
+  [404, '', '404'],
+  [409, JSON.stringify({ error: 'conflict' }), '409 with a body'],
+  [412, '', '412 Precondition Failed'],
+  [422, '', '422 Unprocessable Entity'],
+]) {
+  const r = await drainOnce(status, body);
+  check(`terminal: ${label} moves to failed queue on the first attempt`, () => {
+    assert.equal(r.result.moved, 1, `expected moved=1, got ${r.result.moved}`);
+    assert.equal(r.failed, 1, `expected 1 action in the failed side-queue, got ${r.failed}`);
+    assert.equal(r.live, 0, `expected the live queue drained, got ${r.live}`);
+  });
+}
+
+// ── Retryable statuses: must stay in the live queue ──────────────────────────
+for (const [status, label] of [[408, '408 Request Timeout'], [429, '429 Too Many Requests'], [500, '500'], [503, '503']]) {
+  const r = await drainOnce(status, '');
+  check(`retryable: ${label} stays in the live queue`, () => {
+    assert.equal(r.result.moved, 0, `expected moved=0, got ${r.result.moved}`);
+    assert.equal(r.live, 1, `expected the action retained for retry, got live=${r.live}`);
+    assert.equal(r.failed, 0, `expected nothing in the failed side-queue, got ${r.failed}`);
+  });
+}
+
+// ── A non-ApiError (genuine network drop) must stay retryable ────────────────
+{
+  await reset();
+  await queue.enqueue('TRANSITION_CDE', { projectId: 'p', docId: 'd', newStatus: 'SHARED' });
+  endpoints.__setBehaviour(async () => { throw new TypeError('Network request failed'); });
+  const result = await queue.syncQueue();
+  const c = await counts();
+  check('retryable: a network TypeError stays in the live queue', () => {
+    assert.equal(result.moved, 0);
+    assert.equal(c.live, 1);
+  });
+}
+
+// ── Measure the cost of the misclassification ───────────────────────────────
+// How many drains does a refused-with-a-body action survive? Every drain it
+// survives is a wasted request AND a drain in which it blocks the FIFO head.
+{
+  await reset();
+  await queue.enqueue('TRANSITION_CDE', { projectId: 'p', docId: 'd', newStatus: 'PUBLISHED' });
+  endpoints.__setBehaviour(async () => { throw new ApiError(403, FORBIDDEN_BODY); });
+  let drains = 0;
+  for (let i = 0; i < 12; i++) {
+    const r = await queue.syncQueue();
+    if (r.total === 0) break;
+    drains++;
+    if (r.moved > 0) break;
+    await advancePastBackoff();
+  }
+  console.log(`\n  measured: a 403-with-a-body survives ${drains} drain(s) before reaching the failed queue`);
+  check('a refused action costs exactly one request', () =>
+    assert.equal(drains, 1, `it took ${drains} drains — ${drains - 1} wasted request(s), and the FIFO head was blocked for ${drains - 1} extra drain(s)`));
+}
+
+// ── Report ──────────────────────────────────────────────────────────────────
+console.log('');
+let bad = 0;
+for (const [ok, name] of results) {
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}`);
+  if (!ok) bad++;
+}
+console.log(`\n  ${results.length - bad}/${results.length} passed, ${bad} failed\n`);
+process.exit(bad ? 1 : 0);

--- a/Planscape/tests/register.mjs
+++ b/Planscape/tests/register.mjs
@@ -1,0 +1,53 @@
+// Node module-resolution hooks so the offline-queue harness can load the REAL
+// TypeScript sources (src/utils/offlineQueue.ts, src/api/client.ts) outside
+// React Native.
+//
+// Two jobs:
+//   1. Resolve the `@/*` -> `src/*` tsconfig path alias, which Node does not
+//      know about.
+//   2. Redirect the handful of native-only modules (SecureStore, AsyncStorage,
+//      expo-file-system) and the endpoint layer to in-memory stubs.
+//
+// Everything else — including offlineQueue's classification logic and the
+// ApiError class under test — is loaded from real source.
+
+import { registerHooks } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..');
+const stub = (f) => pathToFileURL(path.join(here, 'stubs', f)).href;
+
+const REDIRECTS = new Map([
+  ['@react-native-async-storage/async-storage', stub('async-storage.mjs')],
+  ['expo-secure-store', stub('expo-secure-store.mjs')],
+  ['expo-file-system/legacy', stub('expo-file-system-legacy.mjs')],
+  ['@/api/endpoints', stub('endpoints.mjs')],
+]);
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    const redirect = REDIRECTS.get(specifier);
+    if (redirect) return { url: redirect, shortCircuit: true };
+
+    // `../i18n` / `@/i18n` — imported by client.ts for the X-Language header.
+    if (specifier === '../i18n' || specifier === '@/i18n') {
+      return { url: stub('i18n.mjs'), shortCircuit: true };
+    }
+
+    // tsconfig path alias: @/foo -> <root>/src/foo(.ts)
+    if (specifier.startsWith('@/')) {
+      const rel = specifier.slice(2);
+      const candidate = path.join(projectRoot, 'src', rel);
+      for (const ext of ['.ts', '.tsx', '/index.ts', '']) {
+        const full = candidate + ext;
+        try {
+          return { url: pathToFileURL(full).href, shortCircuit: true };
+        } catch { /* try next extension */ }
+      }
+    }
+
+    return nextResolve(specifier, context);
+  },
+});

--- a/Planscape/tests/stubs/async-storage.mjs
+++ b/Planscape/tests/stubs/async-storage.mjs
@@ -1,0 +1,9 @@
+// Test stub for @react-native-async-storage/async-storage — in-memory.
+const store = new Map();
+const AsyncStorage = {
+  async getItem(k) { return store.has(k) ? store.get(k) : null; },
+  async setItem(k, v) { store.set(k, String(v)); },
+  async removeItem(k) { store.delete(k); },
+  async clear() { store.clear(); },
+};
+export default AsyncStorage;

--- a/Planscape/tests/stubs/endpoints.mjs
+++ b/Planscape/tests/stubs/endpoints.mjs
@@ -1,0 +1,50 @@
+// Test stub for @/api/endpoints.
+//
+// Every endpoint offlineQueue.replayAction can reach delegates to a single
+// programmable behaviour so a test can make the *next* replay throw a chosen
+// error. The error thrown is the REAL ApiError from src/api/client.ts — the
+// point of the harness is to exercise the real class, not a look-alike.
+
+let behaviour = async () => undefined;
+let calls = 0;
+
+/** Install the behaviour used by every stubbed endpoint. */
+export function __setBehaviour(fn) { behaviour = fn; calls = 0; }
+/** How many times any endpoint was invoked since __setBehaviour. */
+export function __callCount() { return calls; }
+
+const NAMES = [
+  'createIssue', 'updateIssue', 'transitionCDE', 'uploadIssueAttachment',
+  'captureSitePhoto', 'addIssueComment', 'addMeetingAction',
+  'updateMeetingAction', 'createSiteDiary', 'updateSiteDiary',
+  'signOffStageCriterion', 'uploadAudioNote', 'uploadModelMarkup',
+  'fulfilChecklistItem', 'createDeliverable', 'updateDeliverable',
+  'transitionDeliverable', 'postMgasVerification', 'postPressureLog',
+  'postAntiLigatureAudit',
+];
+
+const impl = {};
+for (const n of NAMES) {
+  impl[n] = async (...args) => { calls++; return behaviour(n, args); };
+}
+
+export const createIssue = impl.createIssue;
+export const updateIssue = impl.updateIssue;
+export const transitionCDE = impl.transitionCDE;
+export const uploadIssueAttachment = impl.uploadIssueAttachment;
+export const captureSitePhoto = impl.captureSitePhoto;
+export const addIssueComment = impl.addIssueComment;
+export const addMeetingAction = impl.addMeetingAction;
+export const updateMeetingAction = impl.updateMeetingAction;
+export const createSiteDiary = impl.createSiteDiary;
+export const updateSiteDiary = impl.updateSiteDiary;
+export const signOffStageCriterion = impl.signOffStageCriterion;
+export const uploadAudioNote = impl.uploadAudioNote;
+export const uploadModelMarkup = impl.uploadModelMarkup;
+export const fulfilChecklistItem = impl.fulfilChecklistItem;
+export const createDeliverable = impl.createDeliverable;
+export const updateDeliverable = impl.updateDeliverable;
+export const transitionDeliverable = impl.transitionDeliverable;
+export const postMgasVerification = impl.postMgasVerification;
+export const postPressureLog = impl.postPressureLog;
+export const postAntiLigatureAudit = impl.postAntiLigatureAudit;

--- a/Planscape/tests/stubs/expo-file-system-legacy.mjs
+++ b/Planscape/tests/stubs/expo-file-system-legacy.mjs
@@ -1,0 +1,10 @@
+// Test stub for expo-file-system/legacy — no filesystem in the harness.
+export async function getInfoAsync() { return { exists: true, size: 1 }; }
+export async function deleteAsync() { /* no-op */ }
+export async function copyAsync() { /* no-op */ }
+export async function moveAsync() { /* no-op */ }
+export async function makeDirectoryAsync() { /* no-op */ }
+export async function readAsStringAsync() { return ''; }
+export async function writeAsStringAsync() { /* no-op */ }
+export const documentDirectory = '/tmp/';
+export const cacheDirectory = '/tmp/';

--- a/Planscape/tests/stubs/expo-secure-store.mjs
+++ b/Planscape/tests/stubs/expo-secure-store.mjs
@@ -1,0 +1,5 @@
+// Test stub for expo-secure-store — in-memory, no native module.
+const store = new Map();
+export async function getItemAsync(k) { return store.has(k) ? store.get(k) : null; }
+export async function setItemAsync(k, v) { store.set(k, v); }
+export async function deleteItemAsync(k) { store.delete(k); }

--- a/Planscape/tests/stubs/i18n.mjs
+++ b/Planscape/tests/stubs/i18n.mjs
@@ -1,0 +1,4 @@
+// Test stub for src/i18n — the harness never renders copy.
+export function getLanguage() { return 'en'; }
+export function t(k) { return k; }
+export default { getLanguage, t };


### PR DESCRIPTION
Closes #646.

## The bug

`Planscape/src/utils/offlineQueue.ts` decided whether a replay failure was permanent by running a regex over the error **message**:

```ts
const isPermanent = /HTTP 4(0[0-79]|1[013-9]|2[013-9])/.test(msg)
  || /HTTP 40[0137]/.test(msg);
const isConflict = /HTTP 409/.test(msg);
```

`ApiError.message` is the **response body**. It only falls back to `HTTP <status>` when that body is empty:

```ts
// src/api/client.ts:159
throw new ApiError(res.status, body || `HTTP ${res.status}`);
```

So the regex matched empty-body refusals and nothing else. Every refusal that explained itself — which is most of them — was classified transient and retried.

Meanwhile `ApiError` has carried the number as a public field since it was written:

```ts
// src/api/client.ts:110
export class ApiError extends Error {
  constructor(public status: number, message: string) { ... }
}
```

The regex was reconstructing from prose a value that was already on the object.

## Correction to the reported symptom

The issue describes unbounded retry. **It is not unbounded** — I measured it rather than assuming it. `MAX_RETRIES_PER_ACTION = 3`, and `retryCount` is mutated on the live queue objects and persisted by `saveQueue`, so a poison-pill action does reach the failed side-queue after three attempts.

The real cost is smaller but still worth fixing:

- **2 wasted requests** per refused action.
- **2 extra drains of head-of-line blocking.** `syncQueue` `break`s on the first failure to preserve FIFO ordering, so while the refused action is still considered retryable it sits at the head and stalls every action queued behind it.
- **The user gets no signal for 3 drains.** The failed side-queue is the surface a coordinator reviews; a dead action stays invisible until the cap is hit.

Nothing here retries forever. I would rather the issue be right than dramatic.

## What I found auditing the regex against its own comment

The comment above it promises "4xx (except 408/429)". The code did not do that:

| Status | Comment says | Regex did | Why |
|---|---|---|---|
| 408 | retryable | retryable ✅ | `0[0-79]` correctly excludes `8` |
| 429 | retryable | **permanent** ❌ | `2[013-9]` excludes `2`, not `9` — wrong digit |
| 412 | permanent | **retryable** ❌ | `1[013-9]` excludes `2` |
| 422 | permanent | **retryable** ❌ | `2[013-9]` excludes `2` |

The author excluded the correct digit in the `40x` arm and then excluded the *first* digit rather than the intended one in both later arms.

The second arm, `/HTTP 40[0137]/`, is entirely subsumed by `0[0-79]` in the first. It matched nothing the first arm did not. Dead code.

I did not extend the regex. Adding characters to it would have reproduced the mistake more precisely.

## The fix

```ts
const RETRYABLE_4XX = new Set([408, 429]);

function statusOf(err: unknown): number | null {
  if (err instanceof ApiError) return err.status;
  const s = (err as { status?: unknown } | null | undefined)?.status;
  return typeof s === 'number' && Number.isFinite(s) ? s : null;
}

function isPermanentFailure(err: unknown): boolean {
  const status = statusOf(err);
  if (status === null) return false;
  return status >= 400 && status < 500 && !RETRYABLE_4XX.has(status);
}
```

`statusOf` returns `null` for an error with no numeric status — a network drop, DNS failure, aborted request. That is the transport-failure case and it stays **retryable**, which is the safe direction: an unknown failure is never treated as a refusal.

`instanceof ApiError` is the primary path (it is the only place in the app that constructs one — verified by grep, single site). The duck-typed fallback covers the three endpoints that call `fetch` directly rather than through `apiFetch`.

I kept the retryable set to exactly 408 and 429, matching the contract the comment already stated. 425 Too Early is arguably retryable too, but adding it would be an unrequested behaviour change and I have no evidence the server emits it.

## Proof

This app has **no jest runner** — `lint` and `typecheck` were its only gates, which is a large part of why this class of bug survived in five places. `Planscape/tests/` adds a Node 24 harness that loads the **real** `offlineQueue.ts` and the **real** `ApiError`, with only the native-only modules (AsyncStorage, SecureStore, expo-file-system) and the endpoint layer stubbed. The classification logic under test is untouched production source.

```
npm run test:queue
```

**RED on origin/main — 9/16:**

```
  measured: a 403-with-a-body survives 3 drain(s) before reaching the failed queue

  FAIL  terminal: 403 WITH a response body (#646) moves to failed queue on the first attempt
  FAIL  terminal: 400 with a body moves to failed queue on the first attempt
  FAIL  terminal: 409 with a body moves to failed queue on the first attempt
  FAIL  terminal: 412 Precondition Failed moves to failed queue on the first attempt
  FAIL  terminal: 422 Unprocessable Entity moves to failed queue on the first attempt
  FAIL  retryable: 429 Too Many Requests stays in the live queue
  FAIL  a refused action costs exactly one request
        it took 3 drains — 2 wasted request(s), and the FIFO head was blocked for 2 extra drain(s)
```

Note which ones **passed** on main: 403-with-an-empty-body, 401, 404. That is the tell — the old code worked only for the empty-body case, exactly as predicted.

**GREEN with this change — 16/16:**

```
  measured: a 403-with-a-body survives 1 drain(s) before reaching the failed queue
  16/16 passed, 0 failed
```

Two assertions state the class of bug directly, so the next reader does not have to rediscover it:

```
  PASS  ApiError carries the status as a field
  PASS  ApiError.message is the body, NOT "HTTP 403"
```

## Gates

- `npx tsc --noEmit` — clean
- `npx eslint src/utils/offlineQueue.ts` — clean
- `npm run test:queue` — 16/16

## Scope

This PR fixes **one site**. The same defect exists in four more places (`documents.tsx`, `issues.tsx`, `project-settings/index.tsx`, `project-settings/members.tsx`). Those are a follow-up PR, together with an eslint rule that fails on `/HTTP \d{3}/` matched against an error message — because the sweep is not the fix. The lint rule is. This class is invisible to the compiler, the type-checker and CI, which is precisely why it reached five sites unnoticed.

Do not merge — owner merges.
