### PR TITLE
fix(mobile): migrate the last status-from-message tests — and make the class unable to return

### DIFF
--- a/Planscape/.eslintrc.json
+++ b/Planscape/.eslintrc.json
@@ -32,6 +32,43 @@
     "no-empty": "warn",
     "no-inner-declarations": "off",
     "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error"
-  }
+    "react-hooks/rules-of-hooks": "error",
+
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "CallExpression[callee.property.name=/^(includes|indexOf|lastIndexOf|search|startsWith|endsWith|match|matchAll)$/] > Literal[value=/HTTP[ _-]?[0-9]/]",
+        "message": "Do not recover an HTTP status from an error message. ApiError carries it as `err.status` (src/api/client.ts). Its `message` is the response BODY and only falls back to the literal `HTTP <status>` when that body is EMPTY — so a message test silently matches empty-body responses and nothing else. That is #646, and it had already produced #624, #625 and three more latent sites. Read `err.status`."
+      },
+      {
+        "selector": "MemberExpression[property.name=/^(test|exec)$/] > Literal[regex.pattern=/HTTP[ _-]?[0-9\\\\[]/]",
+        "message": "Do not recover an HTTP status by matching a regex against an error message. ApiError carries it as `err.status` (src/api/client.ts); `message` is the response BODY and only falls back to `HTTP <status>` when that body is EMPTY, so this regex can only ever match empty-body responses. See #646. Read `err.status`."
+      },
+      {
+        "selector": "CallExpression[callee.property.name=/^(match|matchAll|search|replace|replaceAll|split)$/] > Literal[regex.pattern=/HTTP[ _-]?[0-9\\\\[]/]",
+        "message": "Do not recover an HTTP status by matching a regex against an error message. ApiError carries it as `err.status` (src/api/client.ts); `message` is the response BODY and only falls back to `HTTP <status>` when that body is EMPTY, so this regex can only ever match empty-body responses. See #646. Read `err.status`."
+      }
+    ]
+  },
+  "overrides": [
+    // TEMPORARY — remove once #628 and #629 have merged.
+    //
+    // These two files carry the last remaining status-from-message tests.
+    // Both are already being removed in open PRs (#628 documents.tsx,
+    // #629 issues.tsx), so fixing them here too would duplicate that work.
+    // Downgraded to "warn" rather than "off" so they stay visible.
+    //
+    // When both have merged, DELETE this block — the rule is then error-level
+    // everywhere with no exemptions, which is the point of adding it.
+    {
+      "files": ["app/(tabs)/documents.tsx", "app/(tabs)/issues.tsx"],
+      "rules": { "no-restricted-syntax": "warn" }
+    },
+    // The lint-rule fixture deliberately contains every banned form so that
+    // tests/lintRule.test.mjs can prove the rule fires on each one.
+    {
+      "files": ["tests/**"],
+      "rules": { "no-restricted-syntax": "off" }
+    }
+  ]
 }

--- a/Planscape/.gitignore
+++ b/Planscape/.gitignore
@@ -6,3 +6,6 @@ web-build/
 .DS_Store
 ios/Pods/
 android/.gradle/
+
+# Materialised by tests/lintRule.test.mjs; deleted again in its finally block.
+lint-rule-fixture.tmp.ts

--- a/Planscape/app/project-settings/index.tsx
+++ b/Planscape/app/project-settings/index.tsx
@@ -20,6 +20,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { ApiError } from '@/api/client';
 import { theme } from '@/utils/theme';
 import {
   getProjectSettings,
@@ -82,7 +83,10 @@ export default function ProjectSettingsScreen() {
       setSettings((s) => s ? { ...s, admin: { ...s.admin, [key]: previous } } : s);
       const msg = err instanceof Error ? err.message : 'Update failed';
       // 403 is expected for non-admin members — be specific so they understand.
-      if (msg.includes('HTTP 403')) {
+      // Read the status off the error. `msg` is the response BODY (ApiError
+      // only falls back to "HTTP <status>" for an empty body), so testing the
+      // message recognised empty-body refusals only — see #646.
+      if (err instanceof ApiError && err.status === 403) {
         Alert.alert(
           'Permission denied',
           'Only BIM Managers (role K) and Coordinators (role C) can change admin settings on this project.',

--- a/Planscape/app/project-settings/members.tsx
+++ b/Planscape/app/project-settings/members.tsx
@@ -19,6 +19,7 @@ import {
   ActivityIndicator,
   Alert,
 } from 'react-native';
+import { ApiError } from '@/api/client';
 import { theme } from '@/utils/theme';
 import {
   listProjectMembersFull,
@@ -171,7 +172,10 @@ function MemberCard({
       await onSaved();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('HTTP 403')) {
+      // Read the status off the error. `msg` is the response BODY (ApiError
+      // only falls back to "HTTP <status>" for an empty body), so testing the
+      // message recognised empty-body refusals only — see #646.
+      if (err instanceof ApiError && err.status === 403) {
         Alert.alert('Permission denied', 'You do not have permission to edit project members.');
       } else {
         Alert.alert('Save failed', msg);

--- a/Planscape/package.json
+++ b/Planscape/package.json
@@ -16,7 +16,9 @@
     "web": "expo start --web",
     "lint": "eslint . --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
-    "test:queue": "node --experimental-transform-types tests/offlineQueue.terminal.test.mjs"
+    "test:queue": "node --experimental-transform-types tests/offlineQueue.terminal.test.mjs",
+    "test:lint-rule": "node tests/lintRule.test.mjs",
+    "test": "npm run test:queue && npm run test:lint-rule && npm run typecheck"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",

--- a/Planscape/tests/fixtures/status-from-message.fixture.ts.txt
+++ b/Planscape/tests/fixtures/status-from-message.fixture.ts.txt
@@ -1,0 +1,61 @@
+// Fixture for the `no-status-from-message` lint rule.
+//
+// Every BAD form below is a real shape that existed in this repo (or is one
+// keystroke away from one). Every GOOD form must NOT be flagged. Verified by
+// tests/lint-rule.test.mjs, which lints this file and compares the reported
+// lines against the expectations recorded there.
+//
+// Kept as .ts.txt so it is not itself compiled or linted by the project gates.
+
+declare const msg: string;
+declare const err: { status?: number; message: string };
+declare function alert(a: string, b?: string): void;
+
+export function bad() {
+  // BAD 1 — documents.tsx:172 / project-settings/index.tsx:85 / members.tsx:174
+  if (msg.includes('HTTP 403')) alert('denied');
+
+  // BAD 2 — issues.tsx:550
+  if (msg.includes('HTTP 400') && msg.toLowerCase().includes('latitude')) alert('bad latitude');
+
+  // BAD 3 — offlineQueue.ts:531, regex-literal receiver
+  const permanent = /HTTP 4(0[0-79]|1[013-9])/.test(msg);
+
+  // BAD 4 — offlineQueue.ts:532
+  const conflict = /HTTP 409/.test(msg);
+
+  // BAD 5 — regex literal as an argument
+  const m = msg.match(/HTTP 403/);
+
+  // BAD 6 — indexOf form
+  if (msg.indexOf('HTTP 401') >= 0) alert('expired');
+
+  // BAD 7 — startsWith form
+  if (msg.startsWith('HTTP 500')) alert('server');
+
+  // BAD 8 — \d escape rather than a literal number
+  const any4xx = /HTTP \d{3}/.test(msg);
+
+  return { permanent, conflict, m, any4xx };
+}
+
+export function good() {
+  // GOOD 1 — read the status off the error, which is where it lives
+  if (err.status === 403) alert('denied');
+
+  // GOOD 2 — the template literal that CONSTRUCTS the fallback message in
+  // client.ts. Must never be flagged: it is the producer, not a status test.
+  const fallback = `HTTP ${err.status}`;
+
+  // GOOD 3 — a status test against a numeric range
+  const permanent = err.status != null && err.status >= 400 && err.status < 500;
+
+  // GOOD 4 — matching on the server's own reason text is legitimate; it is
+  // only the STATUS that must not be recovered from prose.
+  const geofence = msg.toLowerCase().includes('geofence');
+
+  // GOOD 5 — an unrelated string that happens to contain digits
+  const label = 'Error 403 pages are configured in nginx';
+
+  return { fallback, permanent, geofence, label };
+}

--- a/Planscape/tests/lintRule.test.mjs
+++ b/Planscape/tests/lintRule.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * Proves the `no-restricted-syntax` guard against status-from-message actually
+ * fires — on every banned form, and on none of the allowed ones.
+ *
+ * A lint rule nobody has tested is a lint rule nobody knows the shape of. The
+ * whole point of adding it is that this defect class is invisible to the
+ * compiler, the type-checker and CI; if the selectors are subtly wrong it is
+ * invisible to the linter too, and we are back where we started.
+ *
+ * Run: npm run test:lint-rule
+ */
+
+import assert from 'node:assert/strict';
+import { ESLint } from 'eslint';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..');
+const fixtureSrc = path.join(here, 'fixtures', 'status-from-message.fixture.ts.txt');
+
+// The fixture is kept as .ts.txt so the project gates never compile or lint it
+// as part of the app. Materialise it as a real .ts next to the app so eslint
+// picks up the project's own .eslintrc.json — the rule under test must be the
+// SHIPPED config, not a copy of it.
+// NB: no leading dot in the filename — ESLint silently ignores dotfiles, which
+// would make every assertion below pass vacuously by reporting nothing.
+const tmp = path.join(projectRoot, 'lint-rule-fixture.tmp.ts');
+fs.writeFileSync(tmp, fs.readFileSync(fixtureSrc, 'utf8'));
+
+let messages;
+try {
+  // `overrides` in .eslintrc.json turns the rule off under tests/, so the
+  // fixture is linted from the project root where the rule is error-level.
+  const eslint = new ESLint({ cwd: projectRoot });
+  const [result] = await eslint.lintFiles([tmp]);
+  messages = result.messages.filter((m) => m.ruleId === 'no-restricted-syntax');
+} finally {
+  fs.unlinkSync(tmp);
+}
+
+const flagged = new Set(messages.map((m) => m.line));
+const source = fs.readFileSync(fixtureSrc, 'utf8').split(/\r?\n/);
+
+// Derive expectations from the fixture itself: a line is expected to be
+// flagged iff the comment two lines above it starts with "// BAD".
+const expected = new Set();
+const allowed = new Set();
+source.forEach((line, i) => {
+  const marker = /^\s*\/\/ (BAD|GOOD) (\d+)/.exec(line);
+  if (!marker) return;
+  // The statement follows the comment block; find the next non-comment,
+  // non-blank line.
+  for (let j = i + 1; j < source.length; j++) {
+    const l = source[j].trim();
+    if (!l || l.startsWith('//')) continue;
+    (marker[1] === 'BAD' ? expected : allowed).add(j + 1);
+    break;
+  }
+});
+
+const results = [];
+const check = (name, fn) => {
+  try { fn(); results.push([true, name]); }
+  catch (e) { results.push([false, `${name}\n      ${e.message.split('\n')[0]}`]); }
+};
+
+check('the fixture declares both banned and allowed forms', () => {
+  assert.ok(expected.size >= 8, `expected >=8 BAD forms, fixture has ${expected.size}`);
+  assert.ok(allowed.size >= 5, `expected >=5 GOOD forms, fixture has ${allowed.size}`);
+});
+
+for (const line of [...expected].sort((a, b) => a - b)) {
+  check(`fires on the banned form at fixture line ${line}: ${source[line - 1].trim().slice(0, 62)}`,
+    () => assert.ok(flagged.has(line), 'rule did NOT fire — this form would slip through'));
+}
+
+for (const line of [...allowed].sort((a, b) => a - b)) {
+  check(`stays quiet on the allowed form at fixture line ${line}: ${source[line - 1].trim().slice(0, 62)}`,
+    () => assert.ok(!flagged.has(line), 'rule fired on legitimate code — false positive'));
+}
+
+check('the rule flags nothing outside the declared forms', () => {
+  const unexpected = [...flagged].filter((l) => !expected.has(l));
+  assert.equal(unexpected.length, 0, `unexpected reports on line(s) ${unexpected.join(', ')}`);
+});
+
+console.log('');
+let bad = 0;
+for (const [ok, name] of results) {
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}`);
+  if (!ok) bad++;
+}
+console.log(`\n  ${results.length - bad}/${results.length} passed, ${bad} failed\n`);
+process.exit(bad ? 1 : 0);

--- a/Planscape/tests/types/apiError.contract.ts
+++ b/Planscape/tests/types/apiError.contract.ts
@@ -1,0 +1,61 @@
+/**
+ * Type-level contract for `ApiError`.
+ *
+ * This app has no jest runner, so `tsc --noEmit` is the strongest compile-time
+ * guarantee available. Every assertion below is a compile error if the contract
+ * breaks — `npm run typecheck` already covers this file via tsconfig's
+ * `"include": ["**\/*.ts"]`.
+ *
+ * What is being pinned, and why:
+ *
+ *   The status-from-message defect class (#646, and #624/#625 before it) was
+ *   possible because callers reconstructed the HTTP status by matching prose
+ *   against `err.message`. The number was on the object the whole time. These
+ *   assertions make `status` a load-bearing part of the type, so that removing
+ *   it, renaming it, widening it to `number | undefined`, or turning it into a
+ *   string cannot land silently.
+ *
+ *   It also pins the *negative* half — that `message` is a plain `string` and
+ *   carries no status guarantee — because that is the half people forget.
+ */
+
+import { ApiError } from '@/api/client';
+
+/** Compile-time assertion helper. `Expect<false>` is an error. */
+type Expect<T extends true> = T;
+/** Invariant (not merely assignable) type equality. */
+type Exact<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+// ── 1. `status` exists, is exactly `number`, and is not optional ────────────
+// `Exact` rather than `extends` so `number | undefined`, `403`, `any` and
+// `unknown` all fail. A widened status is the failure mode that would let the
+// old prose-matching creep back in as a "safe" fallback.
+export type _StatusIsExactlyNumber = Expect<Exact<ApiError['status'], number>>;
+
+// Not optional: `Partial` of the field must not be assignable back to it.
+export type _StatusIsRequired = Expect<Exact<undefined extends ApiError['status'] ? true : false, false>>;
+
+// ── 2. `status` is reachable on a constructed instance ─────────────────────
+// Guards against `status` becoming a getter that is dropped, or the
+// constructor parameter property being replaced by something private.
+const _instanceStatus: number = new ApiError(403, 'forbidden').status;
+
+// ── 3. The constructor still takes (status, message) in that order ─────────
+export type _CtorShape = Expect<Exact<ConstructorParameters<typeof ApiError>, [number, string]>>;
+
+// ── 4. `message` is a plain string and promises nothing about the status ───
+// This is the assertion that documents the trap: `message` is the response
+// BODY, falling back to `HTTP <status>` only when that body is empty. Nothing
+// in the type says otherwise, so nothing may be inferred from it.
+export type _MessageIsPlainString = Expect<Exact<ApiError['message'], string>>;
+
+// ── 5. `ApiError` is a real class, so `instanceof` narrowing works ─────────
+// The narrowing in offlineQueue.statusOf and in the project-settings screens
+// depends on this; an interface or a plain object factory would break it.
+declare const maybe: unknown;
+if (maybe instanceof ApiError) {
+  const _narrowed: number = maybe.status;
+  void _narrowed;
+}
+
+void _instanceStatus;


### PR DESCRIPTION
**Stacked on #663** — base is `claude/offline-queue-status-not-prose`, not `main`. The lint rule added here fails on `main` until #663 lands, because `offlineQueue.ts:531` is one of the sites it catches. Merge #663 first; this PR's base will retarget automatically.

## Inventory first

Measured on `origin/main` before changing anything — **6 sites in 4 files**, all the same mistake:

| Site | Form | Owner |
|---|---|---|
| `src/utils/offlineQueue.ts:531` | `/HTTP 4(0[0-79]…)/.test(msg)` | #663 (parent commit) |
| `src/utils/offlineQueue.ts:532` | `/HTTP 409/.test(msg)` | #663 (parent commit) |
| `app/(tabs)/documents.tsx:172` | `msg.includes('HTTP 403')` | **open PR #628** |
| `app/(tabs)/issues.tsx:547` | `msg.includes('HTTP 403')` | **open PR #629** |
| `app/(tabs)/issues.tsx:550` | `msg.includes('HTTP 400')` | **open PR #629** |
| `app/(tabs)/issues.tsx:552` | `msg.includes('HTTP 400')` | **open PR #629** |
| `app/project-settings/index.tsx:85` | `msg.includes('HTTP 403')` | **this PR** |
| `app/project-settings/members.tsx:174` | `msg.includes('HTTP 403')` | **this PR** |

Two search passes, both recorded in the commit: a targeted one for matcher-call forms, and a broad one for any 3-digit status inside a string literal anywhere under `Planscape/`. They returned the same set, which is the reason I believe the inventory is complete rather than merely large.

I did **not** touch `documents.tsx` or `issues.tsx` — #628 and #629 already remove those and #628 additionally extracts `ApiError` into `src/api/apiError.ts` with a shared reason helper. Fixing them here would collide with both.

## The sweep is not the fix

This class is invisible to the compiler, invisible to the type checker, **and invisible to CI**. Nothing in the build could tell the difference between a test that worked and a test that could only ever match an empty response body. That is why it reached five sites one at a time, producing #624, #625 and #646 as separate incidents rather than one.

So the sweep is the smaller half. Two guards close the door.

### 1. A lint rule — the only gate the compiler cannot skip

Three `no-restricted-syntax` selectors in `.eslintrc.json`, covering the three shapes this can take:

- the string-literal form — `msg.includes('HTTP 403')`, `.indexOf`, `.startsWith`, `.match`, …
- the regex-receiver form — `/HTTP 409/.test(msg)`
- the regex-argument form — `msg.match(/HTTP 403/)`

No new dependency, no plugin, no `--rulesdir` flag. It runs under the existing `npm run lint`, so it cannot be bypassed by forgetting to pass something.

The message teaches rather than scolds:

> Do not recover an HTTP status from an error message. ApiError carries it as `err.status` (src/api/client.ts). Its `message` is the response BODY and only falls back to the literal `HTTP <status>` when that body is EMPTY — so a message test silently matches empty-body responses and nothing else. That is #646, and it had already produced #624, #625 and three more latent sites. Read `err.status`.

**A lint rule nobody has tested is a lint rule nobody knows the shape of.** `tests/lintRule.test.mjs` lints a fixture through the **shipped** `.eslintrc.json` (not a copy of it) and derives its expectations from the fixture's own `// BAD` / `// GOOD` markers:

```
  PASS  fires on the banned form at fixture line 16: if (msg.includes('HTTP 403')) alert('denied');
  PASS  fires on the banned form at fixture line 22: const permanent = /HTTP 4(0[0-79]|1[013-9])/.test(msg);
  PASS  fires on the banned form at fixture line 37: const any4xx = /HTTP \d{3}/.test(msg);
  ...
  PASS  stays quiet on the allowed form at line 48: const fallback = `HTTP ${err.status}`;
  PASS  stays quiet on the allowed form at line 55: const geofence = msg.toLowerCase().includes('geofence');
  PASS  the rule flags nothing outside the declared forms

  15/15 passed, 0 failed
```

Two of the allowed forms matter especially:

- `` `HTTP ${err.status}` `` — the template literal in `client.ts` that **constructs** the fallback. Flagging the producer would be absurd; it isn't flagged.
- `msg.toLowerCase().includes('geofence')` — matching the server's own *reason text* stays legal. It is only the **status** that must not be recovered from prose.

**The harness was RED at 7/15 first, and the reason is worth recording**: ESLint silently ignores dot-prefixed filenames, so my first temp fixture was never linted at all and every assertion passed vacuously by reporting nothing. That is the same failure shape as the bug being fixed — an empty result standing in for a real answer. The fix is a filename without a leading dot, and a comment in the harness saying why.

### 2. A type-level pin on `ApiError.status`

`tests/types/apiError.contract.ts`. Same technique as #645, same reason: this app has no jest runner, so `tsc --noEmit` is the strongest compile-time guarantee available.

It uses invariant equality rather than `extends`, so **widening** fails too — `number | undefined`, `403`, `any` and `unknown` are all rejected, not just deletion. It pins the constructor arity/order, that `instanceof` narrowing works (both `offlineQueue.statusOf` and the two screens here depend on it), and the negative half — that `message` is a plain `string` and promises nothing about the status, because that is the half people forget.

**Proven RED.** Widening `status` to `number | undefined` in `client.ts`:

```
tests/types/apiError.contract.ts(33,45): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/types/apiError.contract.ts(36,40): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/types/apiError.contract.ts(41,7):  error TS2322: Type 'number | undefined' is not assignable to type 'number'.
tests/types/apiError.contract.ts(44,33): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/types/apiError.contract.ts(57,9):  error TS2322: Type 'number | undefined' is not assignable to type 'number'.
src/utils/offlineQueue.ts(499,32):       error TS2322: Type 'number | undefined' is not assignable to type 'number | null'.
```

Five contract errors plus one in the real caller. Restored, `git diff` clean.

## The temporary override, and how it retires

`documents.tsx` and `issues.tsx` are downgraded to `"warn"` — not `"off"`, so they stay visible — via an `overrides` block that names #628 and #629 and says to delete itself:

```jsonc
// TEMPORARY — remove once #628 and #629 have merged.
// ...
// When both have merged, DELETE this block — the rule is then error-level
// everywhere with no exemptions, which is the point of adding it.
```

This is the one loose end in the PR and I would rather name it than hide it: an allowlist that everyone forgets is how a closed door reopens. The four warnings it produces are the reminder.

## Gates

| | |
|---|---|
| `npm run test:lint-rule` | **15/15** |
| `npm run test:queue` | **16/16** (from #663) |
| `npm run typecheck` | clean; RED under the widening probe above |
| `npm run lint` | **0 errors**, 126 warnings — 122 pre-existing (`no-explicit-any` 98, `exhaustive-deps` 19, `no-empty` 4, `no-var-requires` 1) + the 4 owned by #628/#629 |

Also adds `npm test` as `test:queue && test:lint-rule && typecheck`, so the app has one command that runs everything it can run.

## Scope I did not take

The same defect class may exist in the **web** app and in the **C#** BCC, which I have not swept — this PR is scoped to `Planscape/` as asked, and this lint rule protects `Planscape/` only. I would rather say that than imply repo-wide coverage.

Do not merge — owner merges.
