### PR TITLE
fix(server): the per-folder ACL enforces again, and reports its own blast radius (#631)

### DIFF
--- a/Planscape.Server/src/Planscape.API/Authorization/ProjectMemberAcl.cs
+++ b/Planscape.Server/src/Planscape.API/Authorization/ProjectMemberAcl.cs
@@ -60,19 +60,36 @@ public static class ProjectMemberAcl
         if (!Guid.TryParse(subClaim, out var userId))
             return new AclSlice(null, null, null, BypassesAcl: true); // can't narrow what we can't identify
 
-        // Phase 177 — project only the columns that existed before the
-        // AddProjectMemberAcls migration so the query doesn't crash when
-        // the migration hasn't been applied yet (the three ACL columns are
-        // nullable and default to null = "all", so documents still load).
+        // #631 — read the three allow-list columns for real.
+        //
+        // These were hard-coded to null between cb503b024 (2026-05-16) and this
+        // commit, which meant ApplyTo could never narrow a query and the Phase
+        // 177 ACL restricted nothing for ~3 months. The stub was a deliberate
+        // crash workaround: a full entity fetch expands to SELECT *, which
+        // failed with "column p.AllowedCdeStates does not exist" on a database
+        // where migration 20260508000000_AddProjectMemberAcls had not been
+        // applied. Its comment said "until the migration is run".
+        //
+        // That reasoning is obsolete and must not be restored. This codebase
+        // does not run migrations: schema comes from OnModelCreating via
+        // EnsureCreated plus the idempotent patchers, and render.yaml sets
+        // PLANSCAPE_USE_ENSURE_CREATED=true on both the api and worker services
+        // (docs/adr/0001-schema-management.md). The three columns therefore
+        // exist wherever the model does — verified present on a live database.
+        //
+        // The explicit projection is kept, minus the null literals: it selects
+        // exactly the four columns this method needs, so the query cannot be
+        // widened by an unrelated entity change and cannot fetch a column that
+        // does not exist.
         var memberRow = await db.ProjectMembers
             .AsNoTracking()
             .Where(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive)
             .Select(m => new
             {
                 m.Id,
-                AllowedCdeStates    = (string?)null,
-                AllowedDisciplines  = (string?)null,
-                AllowedSuitabilities = (string?)null,
+                m.AllowedCdeStates,
+                m.AllowedDisciplines,
+                m.AllowedSuitabilities,
             })
             .FirstOrDefaultAsync(ct);
 

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1618,6 +1618,52 @@ app.MapHub<Planscape.Infrastructure.SignalR.DocumentSyncHub>("/hubs/document-syn
         // the EF migration set is incomplete). Idempotent CREATE TABLE IF NOT EXISTS.
         await Planscape.API.PlatformSchemaPatcher.ApplyAsync(patchConn);
 
+        // #631 — report the per-folder ACL population at boot.
+        //
+        // ProjectMemberAcl.ResolveAsync narrows what a member sees inside a
+        // project using three allow-list columns on ProjectMembers. Between
+        // cb503b024 (2026-05-16) and the fix for #631 those columns were
+        // hard-coded to null, so the ACL restricted nothing. Turning it back on
+        // is inert for a member whose allow-lists are empty (null = "all") and
+        // NARROWS access for a member whose are not.
+        //
+        // Nobody could answer "how many rows are populated in production?"
+        // without database access, so the server answers it itself, once per
+        // boot, before it matters.
+        //
+        // Deliberately logged at Warning in BOTH cases. render.yaml sets
+        // Serilog__MinimumLevel__Default=Warning in production, so an
+        // Information line would be invisible there — and "no line appeared"
+        // would then be indistinguishable between "zero rows" and "the check
+        // never ran". One line per deploy is a fair price for an unambiguous
+        // answer.
+        try
+        {
+            var aclScoped = await db.ProjectMembers
+                .IgnoreQueryFilters()
+                .CountAsync(m => m.IsActive && (
+                       (m.AllowedCdeStates     != null && m.AllowedCdeStates     != "")
+                    || (m.AllowedDisciplines   != null && m.AllowedDisciplines   != "")
+                    || (m.AllowedSuitabilities != null && m.AllowedSuitabilities != "")));
+
+            if (aclScoped > 0)
+                app.Logger.LogWarning(
+                    "[ACL] {Count} active ProjectMember row(s) carry a per-folder allow-list. " +
+                    "ProjectMemberAcl WILL narrow document visibility for them. To restore full " +
+                    "access for a member, set their AllowedCdeStates/AllowedDisciplines/" +
+                    "AllowedSuitabilities back to NULL (null = all). See #631.",
+                    aclScoped);
+            else
+                app.Logger.LogWarning(
+                    "[ACL] No active ProjectMember row carries a per-folder allow-list. " +
+                    "ProjectMemberAcl is active but narrows nothing for anyone. See #631.");
+        }
+        catch (Exception ex)
+        {
+            // Never let a diagnostic stop the boot — but never swallow it either.
+            app.Logger.LogWarning(ex, "[ACL] Could not read the per-folder ACL population.");
+        }
+
         // Postgres RLS policies (#545). OFF unless Database:RlsEnabled is set —
         // the same key that gates RlsConnectionInterceptor above, so the
         // session variable and the policies that read it turn on together

--- a/Planscape.Server/tests/Planscape.Tests/DocumentChangedSinceTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/DocumentChangedSinceTests.cs
@@ -176,13 +176,19 @@ public class DocumentChangedSinceTests : IClassFixture<PlanscapeWebApplicationFa
         // than as a hard-coded expectation: sync writes files to disk, so its
         // surface must be a SUBSET of what the same caller can already see.
         //
-        // Stated as a subset check on purpose. ProjectMemberAcl.ResolveAsync
-        // currently hard-codes its three allow-list columns to null (a deliberate
-        // migration-safety choice — see its comment), so no narrowing happens for
-        // anyone today. Asserting "PUBLISHED is filtered out" would therefore be
-        // asserting a behaviour that does not exist. This assertion holds now AND
-        // keeps holding the day those columns are read for real, because both
-        // endpoints route through the same helper.
+        // Stated as a subset check on purpose, and it is the right shape either
+        // way — both endpoints route through ProjectMemberAcl, so sync cannot
+        // outrun the list regardless of what the ACL allows.
+        //
+        // The previous version of this comment noted that ResolveAsync hard-coded
+        // its three allow-list columns to null, so no narrowing happened for
+        // anyone. That is no longer true: #631 restored the real column reads.
+        // The narrowing itself is asserted directly in ProjectMemberAclTests;
+        // this test deliberately does NOT duplicate it, because what it is here
+        // to protect is the subset relationship, not the filter.
+        //
+        // Note the seeded user is a tenant Owner and therefore bypasses the ACL
+        // entirely, which is why both documents are still expected below.
         SeedDocument("CS-SUBSET-WIP.pdf", DateTime.UtcNow.AddMinutes(-5), cdeStatus: "WIP");
         SeedDocument("CS-SUBSET-PUB.pdf", DateTime.UtcNow.AddMinutes(-5), cdeStatus: "PUBLISHED");
         var client = await _factory.CreateAuthenticatedClientAsync();

--- a/Planscape.Server/tests/Planscape.Tests/ProjectMemberAclTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectMemberAclTests.cs
@@ -1,0 +1,249 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// #631 — the Phase 177 per-folder ACL, exercised end to end over HTTP.
+///
+/// Between cb503b024 (2026-05-16) and the fix these tests cover,
+/// <c>ProjectMemberAcl.ResolveAsync</c> projected all three allow-list columns
+/// to <c>(string?)null</c>, so <c>ApplyTo</c> never added a predicate and the
+/// ACL restricted nothing for anyone. It was a deliberate crash workaround for
+/// an unapplied migration — a premise this codebase invalidated when it settled
+/// on EnsureCreated + patchers (docs/adr/0001-schema-management.md).
+///
+/// Two things these tests are careful about:
+///
+///   • They assert on NON-EMPTY results. "The member sees nothing" would pass a
+///     naive narrowing test just as well as correct filtering does, and it is
+///     also what a broken tenant filter produces. Every restriction test below
+///     names the documents that MUST still be visible as well as the one that
+///     must not.
+///
+///   • They pin <c>null = all</c> in both directions. That is the documented
+///     semantic and existing rows depend on it: a member with no allow-list
+///     must keep seeing the whole project, not suddenly see nothing.
+/// </summary>
+public class ProjectMemberAclTests : IClassFixture<PlanscapeWebApplicationFactory>
+{
+    private readonly PlanscapeWebApplicationFactory _factory;
+
+    public ProjectMemberAclTests(PlanscapeWebApplicationFactory factory) => _factory = factory;
+
+    // ── The restriction that had never actually restricted ────────────────────
+
+    [Fact]
+    public async Task Member_restricted_to_WIP_and_SHARED_cannot_see_PUBLISHED()
+    {
+        var project = NewProject();
+        SeedMember(project, cde: "WIP,SHARED");
+        SeedDocument(project, "ACL-WIP.pdf", cde: "WIP");
+        SeedDocument(project, "ACL-SHARED.pdf", cde: "SHARED");
+        SeedDocument(project, "ACL-PUBLISHED.pdf", cde: "PUBLISHED");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        // Non-empty, and specifically the two that are allowed. Asserting only
+        // the absence of PUBLISHED would pass if the member saw nothing at all.
+        Assert.Contains("ACL-WIP.pdf", names);
+        Assert.Contains("ACL-SHARED.pdf", names);
+        Assert.DoesNotContain("ACL-PUBLISHED.pdf", names);
+    }
+
+    [Fact]
+    public async Task Member_restricted_by_discipline_sees_only_that_discipline()
+    {
+        var project = NewProject();
+        SeedMember(project, disciplines: "M,E");
+        SeedDocument(project, "ACL-DISC-M.pdf", cde: "SHARED", discipline: "M");
+        SeedDocument(project, "ACL-DISC-E.pdf", cde: "SHARED", discipline: "E");
+        SeedDocument(project, "ACL-DISC-A.pdf", cde: "SHARED", discipline: "A");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        Assert.Contains("ACL-DISC-M.pdf", names);
+        Assert.Contains("ACL-DISC-E.pdf", names);
+        Assert.DoesNotContain("ACL-DISC-A.pdf", names);
+    }
+
+    [Fact]
+    public async Task Member_restricted_by_suitability_sees_only_those_codes()
+    {
+        var project = NewProject();
+        SeedMember(project, suitabilities: "S2,S3");
+        SeedDocument(project, "ACL-SUIT-S2.pdf", cde: "SHARED", suitability: "S2");
+        SeedDocument(project, "ACL-SUIT-S3.pdf", cde: "SHARED", suitability: "S3");
+        SeedDocument(project, "ACL-SUIT-S4.pdf", cde: "SHARED", suitability: "S4");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        Assert.Contains("ACL-SUIT-S2.pdf", names);
+        Assert.Contains("ACL-SUIT-S3.pdf", names);
+        Assert.DoesNotContain("ACL-SUIT-S4.pdf", names);
+    }
+
+    [Fact]
+    public async Task Axes_combine_with_AND_not_OR()
+    {
+        // A document must satisfy EVERY populated axis. A document that clears
+        // the CDE list but fails the discipline list must not slip through.
+        var project = NewProject();
+        SeedMember(project, cde: "WIP,SHARED", disciplines: "M");
+        SeedDocument(project, "ACL-AND-BOTH.pdf", cde: "SHARED", discipline: "M");
+        SeedDocument(project, "ACL-AND-CDE-ONLY.pdf", cde: "SHARED", discipline: "A");
+        SeedDocument(project, "ACL-AND-DISC-ONLY.pdf", cde: "PUBLISHED", discipline: "M");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        Assert.Contains("ACL-AND-BOTH.pdf", names);
+        Assert.DoesNotContain("ACL-AND-CDE-ONLY.pdf", names);
+        Assert.DoesNotContain("ACL-AND-DISC-ONLY.pdf", names);
+    }
+
+    // ── null = all, in both directions ────────────────────────────────────────
+
+    [Fact]
+    public async Task Member_with_no_allow_lists_still_sees_the_whole_project()
+    {
+        // The regression that would hurt most on deploy: turning the ACL back on
+        // must not restrict a member who was never given an allow-list. Every
+        // ProjectMember row in the local database is this shape.
+        var project = NewProject();
+        SeedMember(project); // all three columns null
+        SeedDocument(project, "ACL-NULL-WIP.pdf", cde: "WIP");
+        SeedDocument(project, "ACL-NULL-PUBLISHED.pdf", cde: "PUBLISHED");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        Assert.Contains("ACL-NULL-WIP.pdf", names);
+        Assert.Contains("ACL-NULL-PUBLISHED.pdf", names);
+    }
+
+    [Fact]
+    public async Task An_empty_string_allow_list_means_all_not_none()
+    {
+        // ParseAllowList treats "" and "   " as null. Worth pinning: a UI that
+        // clears every chip writes an empty string, and reading that as "allow
+        // nothing" would lock the member out of the entire project.
+        var project = NewProject();
+        SeedMember(project, cde: "", disciplines: "   ", suitabilities: "");
+        SeedDocument(project, "ACL-EMPTY-WIP.pdf", cde: "WIP");
+        SeedDocument(project, "ACL-EMPTY-PUBLISHED.pdf", cde: "PUBLISHED");
+
+        var names = await ListAsync(await MemberClientAsync(), project);
+
+        Assert.Contains("ACL-EMPTY-WIP.pdf", names);
+        Assert.Contains("ACL-EMPTY-PUBLISHED.pdf", names);
+    }
+
+    // ── Bypass ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Tenant_owner_bypasses_the_ACL()
+    {
+        // Admin / Owner / SecurityOfficer keep cross-project audit reach even
+        // where a member row would narrow them.
+        var project = NewProject();
+        SeedMember(project, cde: "WIP", userId: TestData.AdminUserId);
+        SeedDocument(project, "ACL-BYPASS-WIP.pdf", cde: "WIP");
+        SeedDocument(project, "ACL-BYPASS-PUBLISHED.pdf", cde: "PUBLISHED");
+
+        var names = await ListAsync(await _factory.CreateAuthenticatedClientAsync(), project);
+
+        Assert.Contains("ACL-BYPASS-WIP.pdf", names);
+        Assert.Contains("ACL-BYPASS-PUBLISHED.pdf", names);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Task<HttpClient> MemberClientAsync() =>
+        _factory.CreateAuthenticatedClientAsync("member@test.org", "Password123!");
+
+    private static async Task<HashSet<string>> ListAsync(HttpClient client, Guid projectId)
+    {
+        var res = await client.GetAsync($"/api/projects/{projectId}/documents?pageSize=500");
+        res.EnsureSuccessStatusCode();
+        var json = await res.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("items").EnumerateArray()
+            .Select(i => i.GetProperty("fileName").GetString()!)
+            .ToHashSet();
+    }
+
+    /// <summary>A fresh project per test so allow-lists cannot leak between them.</summary>
+    private Guid NewProject()
+    {
+        var id = Guid.NewGuid();
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        db.Projects.Add(new Project
+        {
+            Id = id,
+            TenantId = TestData.TenantId,
+            Name = $"ACL Project {id:N}",
+            Code = $"ACL-{id.ToString("N")[..6]}",
+            Status = ProjectStatus.Active,
+        });
+        db.SaveChanges();
+        return id;
+    }
+
+    private void SeedMember(
+        Guid projectId,
+        string? cde = null,
+        string? disciplines = null,
+        string? suitabilities = null,
+        Guid? userId = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        db.ProjectMembers.Add(new ProjectMember
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestData.TenantId,
+            ProjectId = projectId,
+            UserId = userId ?? TestData.MemberUserId,
+            ProjectRole = "Contributor",
+            Iso19650Role = "E",
+            IsActive = true,
+            AllowedCdeStates = cde,
+            AllowedDisciplines = disciplines,
+            AllowedSuitabilities = suitabilities,
+        });
+        db.SaveChanges();
+    }
+
+    private void SeedDocument(
+        Guid projectId,
+        string fileName,
+        string cde = "SHARED",
+        string? discipline = null,
+        string? suitability = null)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+        db.Documents.Add(new DocumentRecord
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TestData.TenantId,
+            ProjectId = projectId,
+            FileName = fileName,
+            DocumentType = "DR",
+            CdeStatus = cde,
+            Discipline = discipline,
+            SuitabilityCode = suitability ?? (cde == "PUBLISHED" ? "S4" : "S3"),
+            Revision = "P01",
+            UploadedBy = "Test Admin",
+            UploadedAt = DateTime.UtcNow.AddMinutes(-5),
+            ScanStatus = "CLEAN",
+        });
+        db.SaveChanges();
+    }
+}


### PR DESCRIPTION
Closes #631. Security. Independent of #663/#664 — server-side only, branched from `main`.

## The bug

`ProjectMemberAcl.ResolveAsync` projected all three allow-list columns to `(string?)null`:

```csharp
.Select(m => new {
    m.Id,
    AllowedCdeStates     = (string?)null,
    AllowedDisciplines   = (string?)null,
    AllowedSuitabilities = (string?)null,
})
```

`null` means "allow all", so `ApplyTo` never added a predicate and `AllowsDocument` never returned false. The Phase 177 per-folder ACL has restricted **nothing, for anyone**. Seven call sites depend on it — six in `DocumentsController`, one in `MyActionsController`.

## This is not a feature that never worked

That distinction changes what the fix means, so I traced it rather than assuming:

- **`a417ed646`** (Phase 177) shipped `ResolveAsync` reading the real columns. The ACL worked.
- **`cb503b024`** (**2026-05-16**) replaced them with `null`. Its own commit message is explicit:

  > The Phase 177 ResolveAsync query did a full entity fetch on ProjectMembers, which EF Core expands to SELECT * … When that migration hasn't been applied the PostgreSQL query fails with "column p.AllowedCdeStates does not exist", crashing the documents page. Fixed by … hardcoding the three ACL fields to null … **until the migration is run.**

The migration was never run. A deliberate temporary workaround became permanent, and a security control has been silently inert for roughly three months.

## Why the guard must not come back

The comment in the code now says this, so the next reader doesn't restore it:

This codebase **does not run migrations**. Schema comes from `OnModelCreating` via `EnsureCreated` plus the idempotent patchers — `docs/adr/0001-schema-management.md` — and `render.yaml` sets `PLANSCAPE_USE_ENSURE_CREATED=true` on **both** the api and worker services. The columns exist wherever the model does. Verified against a live database:

```
AllowedCdeStates|text
AllowedDisciplines|text
AllowedSuitabilities|text
```

I kept the explicit projection (minus the null literals). It still selects exactly the four columns this method needs, so the query can't be widened by an unrelated entity change — which was the legitimate half of the original concern.

## Blast radius — the part that needed a decision

Turning an ACL back on is inert for a member with empty allow-lists and **narrows access** for a member without. Nobody could answer *"how many production rows are populated?"* without database access, which I don't have.

**What I could measure — local database, read-only `SELECT`:**

| | |
|---|---|
| `ProjectMembers` total / active | 34 / 34 |
| Rows with **any** allow-list populated | **0** |
| CDE / discipline / suitability individually | 0 / 0 / 0 |
| `AccessProfiles` (second path to the same columns) | **0** |

On that data this change is completely inert.

**What I did instead of guessing about production.** The server now answers the question itself, once per boot, **before it can affect anyone**:

```
[ACL] 3 active ProjectMember row(s) carry a per-folder allow-list. ProjectMemberAcl
      WILL narrow document visibility for them. To restore full access for a member,
      set their AllowedCdeStates/AllowedDisciplines/AllowedSuitabilities back to NULL
      (null = all). See #631.
```

…or, in the inert case:

```
[ACL] No active ProjectMember row carries a per-folder allow-list. ProjectMemberAcl
      is active but narrows nothing for anyone. See #631.
```

Logged at **Warning in both cases**, deliberately. `render.yaml` pins `Serilog__MinimumLevel__Default=Warning` in production, so an Information line would be invisible there — and "no line appeared" would then be indistinguishable between *zero rows* and *the check never ran*. That is the same absence-as-answer trap as the bug in #646. One line per deploy is a fair price for an unambiguous answer.

## The undo, and the switch I deliberately did not add

`null` already means "all", so the escape hatch exists in data and needs no code:

```sql
UPDATE "ProjectMembers"
SET "AllowedCdeStates" = NULL, "AllowedDisciplines" = NULL, "AllowedSuitabilities" = NULL
WHERE "UserId" = '…' AND "ProjectId" = '…';
```

I considered a `Security:ProjectMemberAclEnabled` config kill-switch and **rejected it**. An untested config flag guarding a security control is exactly what `Database:RlsEnabled` already is in this repo — a switch that reads as protection and isn't. Adding a second one would make the codebase less trustworthy, not more. The data-level undo is real, already documented by the null semantic, and cannot rot.

## null = all is preserved, and now pinned

This is the regression that would hurt most on deploy, so it is asserted in both directions:

- a member with **no** allow-list keeps the whole project;
- an **empty or whitespace** string reads as "all", not "none". `ParseAllowList` already does this, but it was unpinned — and a UI that clears every chip writes `""`. Reading that as "allow nothing" would lock a member out of the entire project.

## Proof — RED before GREEN

`ProjectMemberAclTests`, 7 cases over the **full HTTP path** (`GET /api/projects/{id}/documents`), not just the helper — so it proves the controller chain narrows, not merely that a function returns the right array.

**RED, against the stub:**

```
Planscape.Tests.ProjectMemberAclTests.Member_restricted_to_WIP_and_SHARED_cannot_see_PUBLISHED [FAIL]
Planscape.Tests.ProjectMemberAclTests.Member_restricted_by_discipline_sees_only_that_discipline [FAIL]
Planscape.Tests.ProjectMemberAclTests.Member_restricted_by_suitability_sees_only_those_codes [FAIL]
Planscape.Tests.ProjectMemberAclTests.Axes_combine_with_AND_not_OR [FAIL]

Failed!  -  Failed: 4,  Passed: 3,  Total: 7
```

**GREEN, with the fix:**

```
Passed!  -  Failed: 0,  Passed: 7,  Total: 7
```

The 4/3 split is itself the signal. The three that pass in **both** states are precisely the ones asserting *preserved* behaviour — null = all, empty = all, owner bypass. If any of those had flipped, the fix would be over-reaching.

**Every restriction test asserts on NON-EMPTY results**, naming the documents that must still be visible as well as the one that must not:

```csharp
Assert.Contains("ACL-WIP.pdf", names);
Assert.Contains("ACL-SHARED.pdf", names);
Assert.DoesNotContain("ACL-PUBLISHED.pdf", names);
```

Asserting only the absence would pass just as well if the member saw nothing at all — which is also what a broken tenant filter produces. Each test seeds its own project so allow-lists can't leak between them.

`Axes_combine_with_AND_not_OR` covers the case a single-axis test would miss: a document that clears the CDE list but fails the discipline list must not slip through.

## Regression check

```
Passed!  -  Failed: 0,  Passed: 640,  Skipped: 11,  Total: 651
```

`tests/known-failing-tests.txt` is deliberately empty — the baseline is a true zero-failure gate, so this is a clean run.

One stale comment corrected: `DocumentChangedSinceTests` explicitly documented the ACL as inert ("*no narrowing happens for anyone today*"). That is now false and would have misled the next reader.

## Before merging

The local count is 0. If you want certainty about production, this is the query:

```sql
SELECT count(*) FROM "ProjectMembers"
WHERE coalesce(btrim("AllowedCdeStates"),'')     <> ''
   OR coalesce(btrim("AllowedDisciplines"),'')   <> ''
   OR coalesce(btrim("AllowedSuitabilities"),'') <> '';
```

If it returns 0, this is a pure inert security repair. If it returns non-zero, those members' access narrows on deploy — and the boot log will name the count either way.

Do not merge — owner merges.
