### PR TITLE
test(web): render the four states and prove they are four, not one (verifies #643)

### DIFF
--- a/planscape-web/app/projects/[id]/documents/page.tsx
+++ b/planscape-web/app/projects/[id]/documents/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { describeFailure } from '@/lib/api';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
@@ -124,7 +125,14 @@ export default function DocumentsPage() {
       toast(`${d.fileName} → ${n.to}`, 'success');
       load();
     } catch (e) {
-      toast(e instanceof Error ? e.message : 'Transition failed', 'error');
+      // This gate DOES send a reason ("Insufficient role for WIP->SHARED…"),
+      // so describeFailure shows the server's sentence rather than a client
+      // copy of the rule. The fallback only fires if it ever stops.
+      const d = describeFailure(e, {
+        forbidden: 'You do not have the role required for this CDE transition.',
+        fallback: 'Transition failed',
+      });
+      toast(d.message, d.tone);
     }
   }
 

--- a/planscape-web/app/projects/[id]/members/page.tsx
+++ b/planscape-web/app/projects/[id]/members/page.tsx
@@ -15,12 +15,19 @@ import {
   useToast,
   type Column,
 } from '@/components/ui';
+import { describeFailure } from '@/lib/api';
 import { inviteMember, listMembers, listProjectRoles, removeMember, updateMemberRole } from '@/lib/data';
 import type { Iso19650Role, ProjectMember } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
 const PROJECT_ROLES = ['Viewer', 'Contributor', 'Coordinator', 'Manager', 'Owner', 'Admin'];
+
+// Invite and remove share one server gate (ProjectMembersController.
+// AuthorizeManageAsync), so they share one sentence. Two hand-typed copies of
+// the same rule is how these drift.
+const MEMBER_MANAGE_FORBIDDEN =
+  "Only a project Manager/Owner/Admin, the project's author, or a tenant Owner/Admin can manage this project's members.";
 
 /**
  * U4 — Members grid. Editable columns are `projectRole` + `iso19650Role`, which
@@ -74,7 +81,11 @@ export default function MembersPage() {
       setInviteOpen(false);
       load();
     } catch (e) {
-      toast(e instanceof Error ? e.message : 'Invite failed', 'error');
+      const d = describeFailure(e, {
+        forbidden: MEMBER_MANAGE_FORBIDDEN,
+        fallback: 'Invite failed',
+      });
+      toast(d.message, d.tone);
     } finally {
       setBusy(false);
     }
@@ -87,7 +98,11 @@ export default function MembersPage() {
       toast(`${m.displayName || m.email} removed`, 'success');
       load();
     } catch (e) {
-      toast(e instanceof Error ? e.message : 'Remove failed', 'error');
+      const d = describeFailure(e, {
+        forbidden: MEMBER_MANAGE_FORBIDDEN,
+        fallback: 'Remove failed',
+      });
+      toast(d.message, d.tone);
     }
   }
 

--- a/planscape-web/app/projects/[id]/models/page.tsx
+++ b/planscape-web/app/projects/[id]/models/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
+import { ErrorNote, ForbiddenNote } from '@/components/ui';
+import { describeFailure } from '@/lib/api';
 import { listModels, uploadModel } from '@/lib/data';
 import type { ProjectModel } from '@/lib/types';
 
@@ -17,6 +19,7 @@ export default function ModelsPage() {
 
   const [models, setModels] = useState<ProjectModel[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -38,6 +41,7 @@ export default function ModelsPage() {
     if (!file) return;
     setBusy(true);
     setError(null);
+    setForbidden(false);
     setNotice(null);
     try {
       const r = await uploadModel(projectId, file, {
@@ -57,7 +61,15 @@ export default function ModelsPage() {
       if (fileRef.current) fileRef.current.value = '';
       refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Upload failed');
+      // POST models is [Authorize(Roles = "Admin,Owner,Coordinator")] and
+      // Forbid() sends an EMPTY body, so this used to render the literal
+      // "Request failed (HTTP 403)". Name the roles instead.
+      const d = describeFailure(err, {
+        forbidden: 'Only an Admin, Owner or Coordinator can upload a model to this project.',
+        fallback: 'Upload failed',
+      });
+      setError(d.message);
+      setForbidden(d.tone === 'forbidden');
     } finally {
       setBusy(false);
     }
@@ -116,7 +128,11 @@ export default function ModelsPage() {
         </p>
       </form>
 
-      {error && <p className="mb-3 rounded bg-danger-subtle px-3 py-2 text-sm text-danger">{error}</p>}
+      {error && (
+        <div className="mb-3">
+          {forbidden ? <ForbiddenNote>{error}</ForbiddenNote> : <ErrorNote>{error}</ErrorNote>}
+        </div>
+      )}
       {notice && <p className="mb-3 rounded bg-success-subtle px-3 py-2 text-sm text-success">{notice}</p>}
 
       {/* List */}

--- a/planscape-web/app/projects/[id]/photos/page.tsx
+++ b/planscape-web/app/projects/[id]/photos/page.tsx
@@ -4,7 +4,9 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
-import { LoadingBlock } from '@/components/ui';
+import { ErrorNote, ForbiddenNote, LoadingBlock } from '@/components/ui';
+import { describeFailure } from '@/lib/api';
+import { CAPABILITY_COPY, useProjectCapabilities } from '@/lib/capabilities';
 import { listSitePhotos, photoFileUrl, approvePhoto, rejectPhoto } from '@/lib/data';
 import type { SitePhoto } from '@/lib/types';
 
@@ -19,6 +21,13 @@ export default function PhotosPage() {
   const [reason, setReason] = useState<(typeof REASONS)[number]>('ALL');
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+
+  // Approve / reject are gated on canApproveSitePhotos. This starts 'unknown',
+  // which leaves both buttons live — correct, because the server is still the
+  // gate and an unanswered question must not render as a "no".
+  const caps = useProjectCapabilities(projectId);
+  const cannotApprove = caps.approveSitePhotos === 'denied';
 
   const load = useCallback(() => {
     setPhotos(null);
@@ -33,13 +42,19 @@ export default function PhotosPage() {
     const caption = prompt('Caption (required, min 3 chars):', p.caption ?? '');
     if (caption == null) return;
     setError(null);
+    setForbidden(false);
     setNotice(null);
     try {
       await approvePhoto(projectId, p.id, caption);
       setNotice('Photo approved.');
       load();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Approve failed');
+      const d = describeFailure(e, {
+        forbidden: CAPABILITY_COPY.approveSitePhotos,
+        fallback: 'Approve failed',
+      });
+      setError(d.message);
+      setForbidden(d.tone === 'forbidden');
     }
   }
 
@@ -47,13 +62,19 @@ export default function PhotosPage() {
     const reasonText = prompt('Rejection reason:');
     if (!reasonText) return;
     setError(null);
+    setForbidden(false);
     setNotice(null);
     try {
       await rejectPhoto(projectId, p.id, reasonText);
       setNotice('Photo rejected.');
       load();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Reject failed');
+      const d = describeFailure(e, {
+        forbidden: CAPABILITY_COPY.approveSitePhotos,
+        fallback: 'Reject failed',
+      });
+      setError(d.message);
+      setForbidden(d.tone === 'forbidden');
     }
   }
 
@@ -80,7 +101,14 @@ export default function PhotosPage() {
         ))}
       </div>
 
-      {error && <p className="mb-3 rounded bg-danger-subtle px-3 py-2 text-sm text-danger">{error}</p>}
+      {error && (
+        <div className="mb-3">{forbidden ? <ForbiddenNote>{error}</ForbiddenNote> : <ErrorNote>{error}</ErrorNote>}</div>
+      )}
+      {cannotApprove && (
+        <div className="mb-3">
+          <ForbiddenNote>{CAPABILITY_COPY.approveSitePhotos}</ForbiddenNote>
+        </div>
+      )}
       {notice && <p className="mb-3 rounded bg-success-subtle px-3 py-2 text-sm text-success">{notice}</p>}
       {!photos && !error && <LoadingBlock />}
       {photos && photos.length === 0 && (
@@ -112,13 +140,17 @@ export default function PhotosPage() {
                   <div className="mt-2 flex gap-1">
                     <button
                       onClick={() => onApprove(p)}
-                      className="flex-1 rounded bg-success px-2 py-1 text-[11px] font-medium text-fg-on-accent hover:opacity-90"
+                      disabled={cannotApprove}
+                      title={cannotApprove ? CAPABILITY_COPY.approveSitePhotos : undefined}
+                      className="flex-1 rounded bg-success px-2 py-1 text-[11px] font-medium text-fg-on-accent hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Approve
                     </button>
                     <button
                       onClick={() => onReject(p)}
-                      className="flex-1 rounded border border-border-strong px-2 py-1 text-[11px] text-danger hover:bg-danger-subtle"
+                      disabled={cannotApprove}
+                      title={cannotApprove ? CAPABILITY_COPY.approveSitePhotos : undefined}
+                      className="flex-1 rounded border border-border-strong px-2 py-1 text-[11px] text-danger hover:bg-danger-subtle disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Reject
                     </button>

--- a/planscape-web/app/settings/team/page.tsx
+++ b/planscape-web/app/settings/team/page.tsx
@@ -26,6 +26,8 @@ import {
   Card,
   DataGrid,
   ErrorNote,
+  ForbiddenNote,
+  ForbiddenPanel,
   Input,
   Modal,
   PageHeader,
@@ -33,7 +35,7 @@ import {
   useToast,
   type Column,
 } from '@/components/ui';
-import { ApiError } from '@/lib/api';
+import { ApiError, isForbidden } from '@/lib/api';
 import { getTenantDashboard, inviteTenantMember } from '@/lib/data';
 import type { QuotaExceeded, TenantDashboard, TenantUser } from '@/lib/types';
 
@@ -53,6 +55,10 @@ export default function TeamPage() {
   const [role, setRole] = useState('Coordinator');
   const [busy, setBusy] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
+  // Kept alongside the message rather than derived from it: deciding the
+  // treatment by matching the sentence would be exactly the string-sniffing
+  // #624 was filed for.
+  const [inviteForbidden, setInviteForbidden] = useState(false);
 
   const load = useCallback(() => {
     getTenantDashboard()
@@ -62,7 +68,7 @@ export default function TeamPage() {
         setError(null);
       })
       .catch((e) => {
-        if (e instanceof ApiError && e.status === 403) {
+        if (isForbidden(e)) {
           setForbidden(true);
           return;
         }
@@ -77,6 +83,7 @@ export default function TeamPage() {
     if (!addr) return;
     setBusy(true);
     setInviteError(null);
+    setInviteForbidden(false);
     try {
       await inviteTenantMember({ email: addr, displayName: displayName.trim() || addr, role });
       toast(`${addr} invited as ${role}.`, 'success');
@@ -86,6 +93,7 @@ export default function TeamPage() {
       load();
     } catch (e) {
       setInviteError(inviteMessage(e));
+      setInviteForbidden(isForbidden(e));
     } finally {
       setBusy(false);
     }
@@ -130,15 +138,16 @@ export default function TeamPage() {
   ];
 
   if (forbidden) {
+    // Same two sentences as before, in the shared treatment. This page was the
+    // model implementation for #558 — the point of moving it is that the other
+    // surfaces stop re-inventing the treatment, not that this one changes.
     return (
       <AppShell>
         <PageHeader title="Team" />
-        <Card>
-          <p className="text-sm text-fg">You need the Owner or Admin role to manage your firm&rsquo;s team.</p>
-          <p className="mt-1 text-sm text-fg-muted">
-            Project-level membership is managed per project, under Members — that does not require Admin.
-          </p>
-        </Card>
+        <ForbiddenPanel
+          message={<>You need the Owner or Admin role to manage your firm&rsquo;s team.</>}
+          hint="Project-level membership is managed per project, under Members — that does not require Admin."
+        />
       </AppShell>
     );
   }
@@ -233,11 +242,16 @@ export default function TeamPage() {
               Authors and Coordinators are capped separately by your plan.
             </span>
           </label>
-          {inviteError && (
-            <p role="alert" className="rounded bg-danger-subtle px-3 py-2 text-sm text-danger">
-              {inviteError}
-            </p>
-          )}
+          {inviteError &&
+            (inviteForbidden ? (
+              // Same sentence as before, in the forbidden treatment. It was
+              // rendering in the danger colours, which said "something broke"
+              // about the one branch of inviteMessage() that is a permission
+              // answer rather than a failure.
+              <ForbiddenNote>{inviteError}</ForbiddenNote>
+            ) : (
+              <ErrorNote>{inviteError}</ErrorNote>
+            ))}
         </div>
       </Modal>
     </AppShell>
@@ -257,7 +271,9 @@ function inviteMessage(e: unknown): string {
     return `Your plan's seat limit is full.${detail} Upgrade your plan to invite more people.`;
   }
   if (e.status === 409) return 'Someone already has an account with that email.';
-  if (e.status === 403) return 'You need the Owner or Admin role to invite people to the firm.';
+  // Wording unchanged (#558). What changed is the treatment it renders in —
+  // see `inviteForbidden` at the call site.
+  if (isForbidden(e)) return 'You need the Owner or Admin role to invite people to the firm.';
   return e.message;
 }
 

--- a/planscape-web/components/ArchiveProjectDialog.tsx
+++ b/planscape-web/components/ArchiveProjectDialog.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Button, Input, Modal } from '@/components/ui';
-import { ApiError } from '@/lib/api';
+import { Button, ErrorNote, ForbiddenNote, Input, Modal } from '@/components/ui';
+import { ApiError, isForbidden } from '@/lib/api';
 import { archiveProject } from '@/lib/data';
 
 /**
@@ -36,6 +36,8 @@ export function ArchiveProjectDialog({
   const [typed, setTyped] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tracked next to the message, not sniffed back out of it (#624).
+  const [forbidden, setForbidden] = useState(false);
 
   // Re-opening the dialog must not inherit the previous attempt's typed code or
   // its error banner.
@@ -43,6 +45,7 @@ export function ArchiveProjectDialog({
     if (open) {
       setTyped('');
       setError(null);
+      setForbidden(false);
     }
   }, [open]);
 
@@ -54,6 +57,7 @@ export function ArchiveProjectDialog({
     if (!matches) return;
     setBusy(true);
     setError(null);
+    setForbidden(false);
     try {
       await archiveProject(projectId, typed.trim());
       onOpenChange(false);
@@ -61,7 +65,11 @@ export function ArchiveProjectDialog({
     } catch (e) {
       // 403 is a real, expected answer — the caller is neither the project author
       // nor a tenant admin. Name that instead of dropping a generic toast.
-      if (e instanceof ApiError && e.status === 403) {
+      if (isForbidden(e)) {
+        // Wording unchanged (#558) — it already named who can. What changed is
+        // that it now renders in the forbidden treatment instead of the danger
+        // one, so it does not read as "the archive failed".
+        setForbidden(true);
         setError(
           'You do not have permission to archive this project. Only the person who created it, or a tenant Owner/Admin, can.',
         );
@@ -111,11 +119,7 @@ export function ArchiveProjectDialog({
             autoComplete="off"
           />
         </label>
-        {error && (
-          <p role="alert" className="rounded bg-danger-subtle px-3 py-2 text-sm text-danger">
-            {error}
-          </p>
-        )}
+        {error && (forbidden ? <ForbiddenNote>{error}</ForbiddenNote> : <ErrorNote>{error}</ErrorNote>)}
       </div>
     </Modal>
   );

--- a/planscape-web/components/ui/index.ts
+++ b/planscape-web/components/ui/index.ts
@@ -5,6 +5,8 @@ export {
   Card,
   EmptyState,
   ErrorNote,
+  ForbiddenNote,
+  ForbiddenPanel,
   Input,
   LoadingBlock,
   PageHeader,

--- a/planscape-web/components/ui/primitives.tsx
+++ b/planscape-web/components/ui/primitives.tsx
@@ -192,3 +192,65 @@ export function ErrorNote({ children }: { children: ReactNode }) {
     </div>
   );
 }
+
+/**
+ * Inline FORBIDDEN state — the app's fourth answer, alongside loading, empty
+ * and error (#558).
+ *
+ * WHY IT IS NOT AN ErrorNote. A refusal is a correct answer to a legitimate
+ * request. Rendering it in the error treatment tells the user something went
+ * wrong and sends them to IT, when what they need is to ask whoever holds the
+ * role. The two must be distinguishable at a glance, not only by reading the
+ * sentence — hence `warning` rather than `danger`, and the lock.
+ *
+ * `role="status"` rather than `role="alert"` for the same reason: assertive
+ * announcement is for things that have gone wrong.
+ *
+ * The MESSAGE is the caller's, and it should name the capability or role
+ * ("You need the Owner or Admin role to invite people to the firm."), never
+ * the HTTP status. What this component owns is the treatment, so the app has
+ * one instead of one per screen.
+ */
+export function ForbiddenNote({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="status"
+      className="flex gap-2 rounded border border-warning/40 bg-warning-subtle px-3 py-2 text-sm text-warning"
+    >
+      <span aria-hidden="true">🔒</span>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Whole-pane forbidden state, for a page whose entire content was refused.
+ *
+ * `hint` is where "here is what you CAN do" goes — the team page's pointer to
+ * project-level membership is the model. A forbidden state that only says no
+ * leaves the user with nowhere to go.
+ */
+export function ForbiddenPanel({
+  message,
+  hint,
+}: {
+  message: ReactNode;
+  hint?: ReactNode;
+}) {
+  return (
+    <Card>
+      <div role="status" className="flex gap-2">
+        <span aria-hidden="true" className="text-warning">
+          🔒
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm text-fg">{message}</p>
+          {hint && <p className="mt-1 text-sm text-fg-muted">{hint}</p>}
+          <p className="mt-2 text-xs text-fg-subtle">
+            This is not a failure — the server refused the request because of your role.
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/planscape-web/components/ui/state-treatments.test.tsx
+++ b/planscape-web/components/ui/state-treatments.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * The four answers, rendered — LOADING / EMPTY / ERROR / FORBIDDEN.
+ *
+ * #558 added FORBIDDEN as the app's fourth answer. #643 wired it through the
+ * web surfaces. Neither had been SEEN. Component rendering was available and
+ * already in use elsewhere (`Menu.test.tsx`, `DataGrid.test.tsx`), but every
+ * test #643 itself shipped was a `lib/*` logic test — `api.test.ts` and
+ * `capabilities.test.ts`. Those prove `isForbidden()` returns true for a 403.
+ * They do not prove a user can tell a refusal from a failure, which is the
+ * entire claim of the change.
+ *
+ * The specific risk this file exists to rule out: four states that all render
+ * the same. A forbidden state that inherits the error treatment is not a fourth
+ * answer, it is an error message with different words — it still tells the user
+ * the system is broken and still sends them to IT, when what they need is to
+ * ask whoever holds the role.
+ *
+ * So these assertions are about DISTINGUISHABILITY, not prettiness: each state
+ * must differ from the other three in the channels a user actually perceives —
+ * the accessibility role, the colour family, and the presence of an icon —
+ * and every assertion below is made against the real rendered DOM.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { EmptyState, ErrorNote, ForbiddenNote, ForbiddenPanel, LoadingBlock } from './primitives';
+
+afterEach(cleanup);
+
+/** The outermost element a state primitive renders. */
+function rootOf(container: HTMLElement): HTMLElement {
+  return container.firstElementChild as HTMLElement;
+}
+
+/** Colour family carried by the Tailwind classes actually applied. */
+function toneOf(el: HTMLElement): 'danger' | 'warning' | 'neutral' {
+  const cls = el.className;
+  if (/\bborder-danger|bg-danger|text-danger\b/.test(cls)) return 'danger';
+  if (/\bborder-warning|bg-warning|text-warning\b/.test(cls)) return 'warning';
+  return 'neutral';
+}
+
+describe('the four states are actually four', () => {
+  it('renders each state and reports what it looks like', () => {
+    const seen: Record<string, { role: string | null; busy: string | null; tone: string; lock: boolean; text: string }> = {};
+
+    const capture = (name: string, ui: React.ReactElement) => {
+      const { container } = render(ui);
+      const root = rootOf(container);
+      seen[name] = {
+        role: root.getAttribute('role'),
+        busy: root.getAttribute('aria-busy'),
+        tone: toneOf(root),
+        lock: (root.textContent ?? '').includes('🔒'),
+        text: (root.textContent ?? '').replace(/\s+/g, ' ').trim().slice(0, 70),
+      };
+      cleanup();
+    };
+
+    capture('LOADING', <LoadingBlock rows={3} />);
+    capture('EMPTY', <EmptyState title="No documents yet" description="Upload one to get started." />);
+    capture('ERROR', <ErrorNote>The server did not respond.</ErrorNote>);
+    capture('FORBIDDEN', <ForbiddenNote>You need the Coordinator role to publish.</ForbiddenNote>);
+
+    // Printed so the four states can be READ, not just asserted. This is the
+    // "capture" half of the verification.
+    // eslint-disable-next-line no-console
+    console.log('\n  ── the four states, as rendered ──');
+    for (const [name, s] of Object.entries(seen)) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `  ${name.padEnd(10)} role=${String(s.role).padEnd(7)} busy=${String(s.busy).padEnd(5)} ` +
+        `tone=${s.tone.padEnd(8)} lock=${s.lock ? 'yes' : 'no '}  "${s.text}"`,
+      );
+    }
+
+    // ── ERROR and FORBIDDEN must not look the same ──────────────────────────
+    // This is the assertion the whole file is for.
+    expect(seen.ERROR.tone).toBe('danger');
+    expect(seen.FORBIDDEN.tone).toBe('warning');
+    expect(seen.FORBIDDEN.tone).not.toBe(seen.ERROR.tone);
+
+    // Different a11y roles: a failure is an alert (interrupt me), a refusal is
+    // a status (tell me). A screen-reader user gets a different signal too, not
+    // just a different colour — colour alone would fail anyone who cannot see it.
+    expect(seen.ERROR.role).toBe('alert');
+    expect(seen.FORBIDDEN.role).toBe('status');
+
+    // A third, non-colour, non-role channel: the lock glyph. Present on the
+    // refusal only.
+    expect(seen.FORBIDDEN.lock).toBe(true);
+    expect(seen.ERROR.lock).toBe(false);
+
+    // ── LOADING vs FORBIDDEN share role="status" ────────────────────────────
+    // They are separated by aria-busy. Pinned deliberately: if aria-busy were
+    // dropped from LoadingBlock these two would be indistinguishable to a
+    // screen reader, and that regression is otherwise invisible.
+    expect(seen.LOADING.role).toBe('status');
+    expect(seen.FORBIDDEN.role).toBe('status');
+    expect(seen.LOADING.busy).toBe('true');
+    expect(seen.FORBIDDEN.busy).toBeNull();
+
+    // ── EMPTY is neither an error nor a refusal ─────────────────────────────
+    // An empty list is a true answer. It must not borrow either alarm colour —
+    // this is the "empty result standing in for a failure" trap, in CSS.
+    expect(seen.EMPTY.tone).toBe('neutral');
+    expect(seen.EMPTY.role).toBeNull();
+
+    // ── All four differ pairwise on (role, aria-busy, tone, lock) ───────────
+    const fingerprints = Object.entries(seen).map(
+      ([n, s]) => [n, `${s.role}|${s.busy}|${s.tone}|${s.lock}`] as const,
+    );
+    const unique = new Set(fingerprints.map(([, f]) => f));
+    expect(unique.size, `states collide: ${fingerprints.map(([n, f]) => `${n}=${f}`).join('  ')}`).toBe(4);
+  });
+
+  // ── The states carry real content, not placeholders ───────────────────────
+
+  // NB: plain DOM assertions rather than jest-dom matchers. This repo has
+  // @testing-library/jest-dom installed but `vitest.config.ts` declares no
+  // `setupFiles`, so its matchers are not registered and `toBeInTheDocument()`
+  // fails with "Invalid Chai property" — further evidence that the component
+  // testing path was set up and never walked. Keeping these assertions
+  // self-contained means this file does not depend on a shared-config change.
+
+  it('FORBIDDEN shows the reason it was given, not a status code', () => {
+    render(<ForbiddenNote>You need the Coordinator role to publish this document.</ForbiddenNote>);
+    const text = screen.getByRole('status').textContent ?? '';
+    expect(text).toContain('You need the Coordinator role to publish this document.');
+    // The literal strings users were shown before #643.
+    expect(text).not.toMatch(/HTTP\s*\d{3}/);
+    expect(text).not.toMatch(/Request failed/i);
+  });
+
+  it('LOADING announces itself to a screen reader', () => {
+    render(<LoadingBlock rows={2} label="Loading documents" />);
+    const el = screen.getByRole('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+    expect(el.textContent ?? '').toContain('Loading documents');
+  });
+
+  it('EMPTY states the answer rather than implying a failure', () => {
+    const { container } = render(
+      <EmptyState title="No documents yet" description="Upload one to get started." />,
+    );
+    expect(screen.getByText('No documents yet')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+    // and it does not borrow the failure colour
+    expect(toneOf(rootOf(container))).toBe('neutral');
+  });
+
+  it('ForbiddenPanel — the whole-pane refusal — is also a status, not an alert', () => {
+    render(<ForbiddenPanel message="You cannot see this project's members." hint="Ask a project Admin." />);
+    const text = screen.getByRole('status').textContent ?? '';
+    expect(text).toContain("You cannot see this project's members.");
+    expect(text).toContain('Ask a project Admin.');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/planscape-web/components/ui/toast.tsx
+++ b/planscape-web/components/ui/toast.tsx
@@ -11,7 +11,15 @@ import { cn } from '@/lib/cn';
  * disappears on its own.
  */
 
-export type ToastTone = 'success' | 'error' | 'info';
+/**
+ * `forbidden` is the fourth answer, added in #558: the server REFUSED a
+ * legitimate request. It is deliberately not `error` — an error says something
+ * went wrong and sends the user to IT; a refusal means they need to ask
+ * whoever holds the role. Like `error` it does NOT auto-dismiss, because a
+ * permission answer that vanishes after four seconds leaves the user believing
+ * the action worked.
+ */
+export type ToastTone = 'success' | 'error' | 'info' | 'forbidden';
 
 interface ToastItem {
   id: number;
@@ -38,7 +46,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       setItems((xs) => [...xs, { id, tone, message }]);
       // Errors persist until dismissed — a failed save that vanishes after four
       // seconds is how a user ends up believing a value saved when it didn't.
-      if (tone !== 'error') setTimeout(() => dismiss(id), 4000);
+      if (tone !== 'error' && tone !== 'forbidden') setTimeout(() => dismiss(id), 4000);
     },
     [dismiss],
   );
@@ -60,9 +68,11 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               'pointer-events-auto flex items-start gap-2 rounded-md border px-3 py-2 text-sm shadow-lg animate-fade-in',
               t.tone === 'success' && 'border-success/40 bg-success-subtle text-success',
               t.tone === 'error' && 'border-danger/40 bg-danger-subtle text-danger',
+              t.tone === 'forbidden' && 'border-warning/40 bg-warning-subtle text-warning',
               t.tone === 'info' && 'border-border bg-surface text-fg',
             )}
           >
+            {t.tone === 'forbidden' && <span aria-hidden="true">🔒</span>}
             <span className="flex-1">{t.message}</span>
             <button
               type="button"

--- a/planscape-web/lib/api.test.ts
+++ b/planscape-web/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { api, ApiError, getToken, setToken } from './api';
+import { api, ApiError, describeFailure, getToken, isForbidden, setToken } from './api';
 
 function mockFetch(status: number, body: unknown, ok = status < 400) {
   return vi.fn().mockResolvedValue({
@@ -81,5 +81,101 @@ describe('api()', () => {
     vi.stubGlobal('fetch', f);
     await expect(api('/api/secure')).rejects.toMatchObject({ status: 401 });
     expect(getToken()).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #558 — a refusal is not a failure.
+//
+// Every 403 site in this app used to retype the status check and decide for
+// itself whether to render a permission answer in the error treatment. These
+// pin the one predicate and the one describe helper they now share, plus the
+// distinction that makes them useful: whether the server sent a reason at all.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('isForbidden()', () => {
+  it('is true only for a 403 ApiError', () => {
+    expect(isForbidden(new ApiError(403, 'nope'))).toBe(true);
+    expect(isForbidden(new ApiError(500, 'boom'))).toBe(false);
+    expect(isForbidden(new ApiError(404, 'gone'))).toBe(false);
+  });
+
+  it('is false for a transport failure, which says nothing about permissions', () => {
+    // A dropped fetch rejects with a TypeError. Treating it as forbidden would
+    // tell a user with every right that they lack a role.
+    expect(isForbidden(new TypeError('Failed to fetch'))).toBe(false);
+    expect(isForbidden(undefined)).toBe(false);
+  });
+
+  it('does not read the status out of the message', () => {
+    // ApiError.message is the response BODY. A 200-shaped error whose body
+    // happens to mention 403 is not a refusal (#624).
+    expect(isForbidden(new ApiError(400, 'the string HTTP 403 appears here'))).toBe(false);
+  });
+});
+
+describe('ApiError.serverMessage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('is undefined when the response body carried nothing', async () => {
+    // ASP.NET Forbid() sends an empty body, so `message` falls back to our own
+    // placeholder. Four call sites were showing that placeholder to users.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => {
+          throw new Error('no body');
+        },
+      } as unknown as Response),
+    );
+
+    const e = (await api('/api/thing').catch((x) => x)) as ApiError;
+    expect(e).toBeInstanceOf(ApiError);
+    expect(e.serverMessage).toBeUndefined();
+    expect(e.message).toBe('Request failed (HTTP 403)');
+  });
+
+  it('carries the sentence when the server did send one', async () => {
+    vi.stubGlobal('fetch', mockFetch(403, { message: 'Insufficient role for WIP->SHARED transition.' }, false));
+
+    const e = (await api('/api/thing').catch((x) => x)) as ApiError;
+    expect(e.serverMessage).toBe('Insufficient role for WIP->SHARED transition.');
+  });
+});
+
+describe('describeFailure()', () => {
+  it('prefers the server sentence over the caller copy — the server owns the rule', () => {
+    const e = new ApiError(403, 'Insufficient role.', undefined, 'Insufficient role.');
+    expect(describeFailure(e, { forbidden: 'client copy', fallback: 'failed' })).toEqual({
+      message: 'Insufficient role.',
+      tone: 'forbidden',
+    });
+  });
+
+  it('names the capability when the server sent an empty body', () => {
+    const e = new ApiError(403, 'Request failed (HTTP 403)');
+    expect(describeFailure(e, { forbidden: 'Only an Admin can do that.', fallback: 'failed' })).toEqual({
+      message: 'Only an Admin can do that.',
+      tone: 'forbidden',
+    });
+  });
+
+  it('never shows the raw placeholder for a refusal', () => {
+    const e = new ApiError(403, 'Request failed (HTTP 403)');
+    expect(describeFailure(e, { forbidden: 'Only an Admin can do that.', fallback: 'failed' }).message).not.toContain(
+      'HTTP 403',
+    );
+  });
+
+  it('keeps the error tone for everything that is not a 403', () => {
+    expect(describeFailure(new ApiError(500, 'boom'), { forbidden: 'f', fallback: 'failed' }).tone).toBe('error');
+    expect(describeFailure(new TypeError('Failed to fetch'), { forbidden: 'f', fallback: 'failed' }).tone).toBe(
+      'error',
+    );
   });
 });

--- a/planscape-web/lib/api.ts
+++ b/planscape-web/lib/api.ts
@@ -29,12 +29,75 @@ export class ApiError extends Error {
    * whose useful sentence is `reason`, not `error`.
    */
   body?: unknown;
-  constructor(status: number, message: string, body?: unknown) {
+  /**
+   * The sentence the SERVER actually sent, when it sent one. Undefined when the
+   * response had no usable body and `message` is our own generic placeholder.
+   *
+   * WHY THE DISTINCTION MATTERS (#558). ASP.NET `Forbid()` returns an EMPTY
+   * body, so on a 403 `message` is the literal string
+   * `"Request failed (HTTP 403)"` — which four call sites were showing to users
+   * verbatim. A forbidden state has to know whether it has a real reason to
+   * show or should fall back to naming the capability itself. Recording it as a
+   * separate field is the alternative to matching `"Request failed (HTTP "` out
+   * of the message, which is the string-sniffing #624 was filed for.
+   */
+  serverMessage?: string;
+  constructor(status: number, message: string, body?: unknown, serverMessage?: string) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
     this.body = body;
+    this.serverMessage = serverMessage;
   }
+}
+
+/**
+ * Is this thrown value the server REFUSING a legitimate request, as opposed to
+ * the request failing? (#558)
+ *
+ * Every 403 site in this app used to retype `e instanceof ApiError && e.status
+ * === 403`, and each one decided independently whether to treat it as an error.
+ * One predicate, so the answer is the same everywhere.
+ *
+ * Note what this is NOT: a substring test on the message. `ApiError.message` is
+ * the response BODY, so `message.includes('HTTP 403')` is an empty-body test and
+ * never a status test — the defect #624 was filed for. The status is a number
+ * and is read as one.
+ *
+ * Anything that is not an ApiError — a TypeError from a dropped fetch, an abort
+ * — is deliberately NOT forbidden. A transport failure says nothing about
+ * permissions, and rendering it as one would tell a user with every right that
+ * they lack a role.
+ */
+// Returns a plain boolean, deliberately not an `e is ApiError` type predicate:
+// narrowing an already-ApiError value with that predicate makes the ELSE branch
+// `never`, which broke inviteMessage()'s final `return e.message`.
+export function isForbidden(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 403;
+}
+
+/**
+ * Turn a caught value into the sentence to show and the treatment to show it
+ * in — so every call site stops deciding independently whether a refusal is an
+ * error (#558).
+ *
+ * @param forbidden What to say when the server refused and sent no reason of
+ *   its own. Name the capability or the role — "Only a project manager can…" —
+ *   never the status. Four sites were showing users the literal string
+ *   "Request failed (HTTP 403)" because ASP.NET `Forbid()` sends an empty body.
+ *   When the server DOES send a sentence (the CDE transition gates do), that
+ *   sentence wins: the server owns the rule, and a client copy would drift.
+ * @param fallback What to say when the request genuinely failed and there is no
+ *   server message either.
+ */
+export function describeFailure(
+  e: unknown,
+  { forbidden, fallback }: { forbidden: string; fallback: string },
+): { message: string; tone: 'error' | 'forbidden' } {
+  if (e instanceof ApiError && e.status === 403) {
+    return { message: e.serverMessage?.trim() || forbidden, tone: 'forbidden' };
+  }
+  return { message: e instanceof Error ? e.message : fallback, tone: 'error' };
 }
 
 export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
@@ -54,16 +117,19 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   }
 
   if (!res.ok) {
-    let message = `Request failed (HTTP ${res.status})`;
+    const generic = `Request failed (HTTP ${res.status})`;
+    let message = generic;
+    let serverMessage: string | undefined;
     let parsed: unknown;
     try {
       const body = await res.json();
       parsed = body;
-      message = body.message || body.error || message;
+      serverMessage = body.message || body.error || undefined;
+      message = serverMessage || generic;
     } catch {
       /* non-JSON error body — keep the generic message */
     }
-    throw new ApiError(res.status, message, parsed);
+    throw new ApiError(res.status, message, parsed, serverMessage);
   }
 
   if (res.status === 204) return undefined as T;

--- a/planscape-web/lib/capabilities.test.ts
+++ b/planscape-web/lib/capabilities.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getProjectCapabilities } from './capabilities';
+
+/**
+ * The three-state capability rule (#547 / #558 / #634), pinned.
+ *
+ * The whole correctness of a disabled Approve button hinges on one distinction
+ * that is invisible in the type system and easy to "tidy" away:
+ *
+ *   'denied'   the server said no        → disable, name the capability
+ *   'unknown'  we never got an answer    → LEAVE IT ENABLED
+ *
+ * Collapsing unknown into denied locks legitimate users out on a network blip
+ * *while showing them a permissions message*. A 404 is the one exception, and
+ * is asserted as such.
+ */
+
+function mockJson(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+describe('getProjectCapabilities()', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('maps explicit booleans in both directions', async () => {
+    vi.stubGlobal('fetch', mockJson(200, { canCurateProject: true, canApproveSitePhotos: false }));
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'allowed',
+      approveSitePhotos: 'denied',
+    });
+  });
+
+  it('treats 404 as authoritative-false — the caller cannot see the project', async () => {
+    vi.stubGlobal('fetch', mockJson(404, {}));
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'denied',
+      approveSitePhotos: 'denied',
+    });
+  });
+
+  it('is unknown when the fetch never completes — NOT denied', async () => {
+    // The regression this file exists to catch.
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'unknown',
+      approveSitePhotos: 'unknown',
+    });
+  });
+
+  it.each([500, 502, 403])('is unknown for HTTP %i', async (status) => {
+    vi.stubGlobal('fetch', mockJson(status, { error: 'boom' }));
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'unknown',
+      approveSitePhotos: 'unknown',
+    });
+  });
+
+  it('is unknown when the body will not parse', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error('<html>proxy error</html>');
+        },
+      } as unknown as Response),
+    );
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'unknown',
+      approveSitePhotos: 'unknown',
+    });
+  });
+
+  it('leaves a missing field unknown while honouring the one that is present', async () => {
+    vi.stubGlobal('fetch', mockJson(200, { canCurateProject: true }));
+
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'allowed',
+      approveSitePhotos: 'unknown',
+    });
+  });
+
+  it.each(['"true"', 'null', '1'])('treats the non-boolean %s as unknown', async (literal) => {
+    const v = JSON.parse(literal);
+    vi.stubGlobal('fetch', mockJson(200, { canCurateProject: v, canApproveSitePhotos: v }));
+
+    // "true" the STRING is not true the BOOLEAN. Coercing it would mean a
+    // contract drift silently granted a capability; reading it as false would
+    // silently remove one. Neither is an answer we were given.
+    expect(await getProjectCapabilities('p1')).toEqual({
+      curateProject: 'unknown',
+      approveSitePhotos: 'unknown',
+    });
+  });
+});

--- a/planscape-web/lib/capabilities.ts
+++ b/planscape-web/lib/capabilities.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { api, ApiError } from './api';
+
+/**
+ * Project capabilities, resolved server-side (#547) and consumed here (#558).
+ *
+ * WHY THIS EXISTS. Clients were re-deriving authority from `projectRole` /
+ * `iso19650Role`. Three surfaces re-implementing one rule is how the eleven dead
+ * `ProjectRole == "PM"` gates happened. The server owns the rule; this renders
+ * what it returns.
+ *
+ * THREE STATES, NOT TWO
+ * ---------------------
+ *   'allowed'  the server said true            offer the control
+ *   'denied'   the server said false, or 404   disable it, name the capability
+ *   'unknown'  no answer at all — transport    LEAVE IT ENABLED and let the
+ *              failure, timeout, 5xx, or a     attempt report
+ *              body that will not parse
+ *
+ * Unknown is deliberately NOT rendered as denied. Capabilities drive
+ * AFFORDANCE; the server remains the gate. Failing closed on a dropped
+ * connection locks out legitimate users and looks identical to a permissions
+ * problem — an absent answer displayed as a definite one, the same mistake as
+ * an empty list standing in for a failed load.
+ *
+ * A 404 IS authoritative-false: it says the caller cannot see the project at
+ * all. A dropped connection says nothing about permissions. See #634 for the
+ * correction to the #547 docstring that originally said otherwise.
+ */
+export type CapabilityState = 'allowed' | 'denied' | 'unknown';
+
+export interface ProjectCapabilities {
+  /** Albums, checklists, distribution groups. */
+  curateProject: CapabilityState;
+  /** Photo approve / reject, share-link issuance, photo policy. */
+  approveSitePhotos: CapabilityState;
+}
+
+export const UNKNOWN_CAPABILITIES: ProjectCapabilities = {
+  curateProject: 'unknown',
+  approveSitePhotos: 'unknown',
+};
+
+const ALL_DENIED: ProjectCapabilities = {
+  curateProject: 'denied',
+  approveSitePhotos: 'denied',
+};
+
+/**
+ * Read only an EXPLICIT boolean. A missing field, a null, or a string `"true"`
+ * is a contract mismatch, not a "no" — coercing it would silently grant a
+ * capability and reading it as false would silently remove one. Neither is an
+ * answer we were given.
+ */
+function flag(v: unknown): CapabilityState {
+  if (v === true) return 'allowed';
+  if (v === false) return 'denied';
+  return 'unknown';
+}
+
+/**
+ * `GET /api/projects/{id}/members/capabilities`.
+ * Never throws — every failure mode yields all-`unknown`, which disables
+ * nothing.
+ */
+export async function getProjectCapabilities(projectId: string): Promise<ProjectCapabilities> {
+  try {
+    const raw = await api<Record<string, unknown>>(`/api/projects/${projectId}/members/capabilities`);
+    return {
+      curateProject: flag(raw?.canCurateProject),
+      approveSitePhotos: flag(raw?.canApproveSitePhotos),
+    };
+  } catch (e) {
+    // The caller cannot see this project at all — nothing is possible on it.
+    // This is the ONE status that may narrow the UI.
+    if (e instanceof ApiError && e.status === 404) return ALL_DENIED;
+    // 5xx, a proxy error page, a dropped fetch: the server did not answer the
+    // question. Not a denial.
+    return UNKNOWN_CAPABILITIES;
+  }
+}
+
+/**
+ * Hook form. Starts all-`unknown`, so a component renders with every control
+ * live and only ever loses one to an explicit answer. A fetch that never
+ * returns leaves the surface in its honest default.
+ */
+export function useProjectCapabilities(projectId: string | undefined): ProjectCapabilities {
+  const [caps, setCaps] = useState<ProjectCapabilities>(UNKNOWN_CAPABILITIES);
+
+  useEffect(() => {
+    if (!projectId) return;
+    let live = true;
+    void getProjectCapabilities(projectId).then((c) => {
+      if (live) setCaps(c);
+    });
+    return () => {
+      live = false;
+    };
+  }, [projectId]);
+
+  return caps;
+}
+
+/**
+ * The user-facing sentence for a capability — named here so it is written once
+ * rather than at each control.
+ *
+ * THE ROLE NAMES ARE COPY, NOT A GATE. They tell the user who to ask. Nothing
+ * in this file decides anything; the server decides and `CapabilityState`
+ * carries its answer. If the server's rule changes this is stale text, not a
+ * broken permission check.
+ */
+export const CAPABILITY_COPY = {
+  curateProject: 'Only a project manager or BIM coordinator can curate albums, checklists and distribution groups.',
+  approveSitePhotos: 'Only a project manager can approve site photos, issue share links, or change the photo policy.',
+} as const;

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -241,14 +241,18 @@ export async function uploadModel(
     throw new ApiError(401, 'Session expired — please sign in again.');
   }
   if (!res.ok) {
-    let message = `Upload failed (HTTP ${res.status})`;
+    // `serverMessage` stays undefined when the body carried nothing, so a
+    // forbidden state can tell "the server explained why" from "the server said
+    // nothing and this is our placeholder". See ApiError in lib/api.ts.
+    const generic = `Upload failed (HTTP ${res.status})`;
+    let serverMessage: string | undefined;
     try {
       const b = await res.json();
-      message = b.message || b.error || message;
+      serverMessage = b.message || b.error || undefined;
     } catch {
       /* non-JSON */
     }
-    throw new ApiError(res.status, message);
+    throw new ApiError(res.status, serverMessage || generic, undefined, serverMessage);
   }
   if (res.status === 204) return {};
   return (await res.json()) as UploadModelResult;
@@ -535,14 +539,18 @@ export async function uploadDocument(
     throw new ApiError(401, 'Session expired — please sign in again.');
   }
   if (!res.ok) {
-    let message = `Upload failed (HTTP ${res.status})`;
+    // `serverMessage` stays undefined when the body carried nothing, so a
+    // forbidden state can tell "the server explained why" from "the server said
+    // nothing and this is our placeholder". See ApiError in lib/api.ts.
+    const generic = `Upload failed (HTTP ${res.status})`;
+    let serverMessage: string | undefined;
     try {
       const b = await res.json();
-      message = b.message || b.error || message;
+      serverMessage = b.message || b.error || undefined;
     } catch {
       /* non-JSON */
     }
-    throw new ApiError(res.status, message);
+    throw new ApiError(res.status, serverMessage || generic, undefined, serverMessage);
   }
   return (await res.json()) as ProjectDocument;
 }


### PR DESCRIPTION
Verification owed on #643. Targets that PR's branch.

Renders LOADING / EMPTY / ERROR / FORBIDDEN and captures each:

```
LOADING    role=status  busy=true  tone=neutral  lock=no   "Loading"
EMPTY      role=null    busy=null  tone=neutral  lock=no   "No documents yet…"
ERROR      role=alert   busy=null  tone=danger   lock=no   "The server did not respond."
FORBIDDEN  role=status  busy=null  tone=warning  lock=yes  "🔒You need the Coordinator role…"
```

**They are four.** ERROR and FORBIDDEN differ on three independent channels — colour family, a11y role, and the lock glyph — so the distinction survives for a user who cannot see colour.

**Proven RED**: giving `ForbiddenNote` the danger classes fails with `expected 'danger' to be 'warning'`.

Also pins that LOADING and FORBIDDEN, which share `role="status"`, are separated only by `aria-busy` — dropping it would make them identical to a screen reader.

Finding, not fixed here: `@testing-library/jest-dom` is installed but `vitest.config.ts` has no `setupFiles`, so its matchers throw "Invalid Chai property". One line of config would fix it for every component test in the repo.

Full web suite: 105 passed, 9 files. Do not merge — owner merges.