### PR TITLE
docs(marketing-site): Pages secrets need a redeploy — the file said they did not

### DIFF
--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -19,6 +19,18 @@ compatibility_date = "2026-05-01"
 [vars]
 SITE_URL = "https://planscape.build"
 
+# SETTING A SECRET IS NOT ENOUGH — YOU MUST REDEPLOY. Pages Functions capture
+# their bindings at DEPLOYMENT time. An existing deployment keeps the bindings it
+# was created with, so a newly-added secret does not reach the running Functions
+# until the next `npm run deploy`. `wrangler pages secret list` showing the name
+# proves it is STORED, not that it is BOUND.
+#
+# Measured 2026-08-16 (#674): LICENSE_PRIVATE_KEY was set and appeared in
+# `secret list`, yet POST /api/license/present kept returning 500 "Licensing is
+# not configured". A redeploy of a byte-identical tree — no code change at all —
+# flipped it to 400. Diagnostic: an endpoint 500ing on a guard for a secret that
+# `secret list` shows means "not deployed since it was set".
+#
 # Auth core (B1) secrets — DO NOT put real values here. Set them as encrypted
 # environment variables / secrets in the Cloudflare dashboard:
 #   Pages → planscape-marketing → Settings → Environment variables (Production).
@@ -29,6 +41,26 @@ SITE_URL = "https://planscape.build"
 #   EMAIL_FROM      Plain var (optional). Override the From: address.
 #                   Default: "Planscape <noreply@planscape.build>"
 # The auth Functions reuse the WAITLIST_DB D1 binding below — no new binding needed.
+
+# Licensing (functions/api/license/*).
+#   LICENSE_PRIVATE_KEY  Secret. PKCS#8 PEM of the RSA key whose PUBLIC half is
+#                        compiled into the plugin at
+#                        StingTools/Core/Licensing/LicensePublicKey.cs.
+#                        issue.ts signs with it; present.ts re-signs to verify
+#                        (see _lib/crypto.ts for why there is no public-key
+#                        binding). Set from the issuer's key:
+#                          wrangler pages secret put LICENSE_PRIVATE_KEY \
+#                            --project-name planscape-marketing \
+#                            < StingTools.LicenseIssuer/private.pem
+#                        THEN REDEPLOY. Production only — preview shares this
+#                        project's D1 (#652), so a preview binding would let a
+#                        preview branch mint real licences.
+#                        Uploading a MISMATCHED key is the dangerous failure:
+#                        issuing and presentation both succeed, and only the
+#                        plugin rejects the licence, offline, at the customer.
+#                        Verify the pair before setting:
+#                          openssl rsa -in private.pem -pubout
+#                        must equal the PEM in LicensePublicKey.cs.
 
 # Cloud handoff (functions/api/cloud/handoff.ts) — where "sign in" hands a
 # logged-in planscape.build user off to the coordinator app.
@@ -46,8 +78,8 @@ SITE_URL = "https://planscape.build"
 #                       echo "<new origin>" | \
 #                         wrangler pages secret put CLOUD_APP_ORIGIN \
 #                         --project-name planscape-marketing
-#                     No redeploy required either way — Pages secrets are
-#                     runtime bindings.
+#                     A REDEPLOY IS REQUIRED — see the note above the secrets
+#                     list. This line previously claimed the opposite.
 
 # D1 binding for the waitlist Function (functions/api/waitlist.ts)
 # Created via: wrangler d1 create planscape-waitlist


### PR DESCRIPTION
Comments only. No code, no bindings, no behaviour change.

Closes #674.

## What was wrong

`wrangler.toml` stated:

> No redeploy required either way — Pages secrets are runtime bindings.

## Measured false (2026-08-16)

Setting `LICENSE_PRIVATE_KEY` on production:

| Step | Result |
|---|---|
| `wrangler pages secret put LICENSE_PRIVATE_KEY` | `✨ Success! Uploaded secret` |
| `wrangler pages secret list` | `LICENSE_PRIVATE_KEY: Value Encrypted` |
| `POST /api/license/present` `{}` | **500** `Licensing is not configured.` |
| re-probed minutes later | **500** — not propagation lag |
| `npm run deploy` | new deployment |
| `POST /api/license/present` `{}` | **400** `No licence supplied.` |

The deployed tree was byte-identical — `git diff a227528 HEAD -- marketing-site` was empty. No code changed; only the deployment did.

Pages Functions capture their bindings at deployment time, so an existing deployment keeps the bindings it was created with. `secret list` showing a name proves the secret is **stored**, not that it is **bound**.

## Why it is worth more than a comment fix

It is read at exactly the moment it misleads — you open `wrangler.toml` to find out how to set a secret. And it compounds #651 rather than duplicating it:

- #651 — **merged ≠ live**: the code you wrote is not the code serving.
- This — **set ≠ bound**: the config you set is not the config serving.

Both fail silently and they stack. A 500 on a guard for a secret that `secret list` clearly shows reads as "wrong value" or "broken guard", and sends the investigation into the code. That diagnostic is now written down beside the claim it corrects.

## Also added

`LICENSE_PRIVATE_KEY` was never documented in this file at all, despite `JWT_SECRET`, `RESEND_API_KEY` and `CLOUD_APP_ORIGIN` being. It now is, including:

- production-only, because preview shares this project's D1 (#652)
- the **mismatched-key failure mode**, which is the dangerous one: issuing and presentation both succeed, and only the plugin rejects the licence — offline, at the customer, with no server-side signal. The `openssl rsa -pubout` check against `LicensePublicKey.cs` that catches it is written down.

## Verification

Comments only; the diff touches no key/value line. Confirmed no stray non-comment lines were introduced.