### PR TITLE
Security: gate the federation controllers on project membership, not just tenant

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AlignmentController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AlignmentController.cs
@@ -4,15 +4,29 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
 using Planscape.Infrastructure.Services;
 using Planscape.Infrastructure.SignalR;
 
+/// <remarks>
+/// <c>[ProjectAccess]</c> gates reads (404). The two POSTs both mutate or run
+/// expensive work against the project's alignment state, so each also takes the
+/// member gate (403) — the auto-align POST in particular writes a
+/// ProjectModelTransform.
+///
+/// The auto-align action overrides the class route with an absolute
+/// <c>~/api/projects/{projectId:guid}/...</c> template; that template still
+/// carries <c>{projectId}</c>, so the attribute resolves it from route data as
+/// normal.
+/// </remarks>
 [ApiController]
 [Route("api/projects/{projectId:guid}/alignment")]
 [Authorize]
+[ProjectAccess]
 public class AlignmentController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
@@ -57,6 +71,8 @@ public class AlignmentController : ControllerBase
         [FromServices] IFederatedCoherenceJob coherenceJob,
         CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var report = await coherenceJob.RunAsync(projectId, _tenant.TenantId, ct);
         return Ok(report);
     }
@@ -72,6 +88,8 @@ public class AlignmentController : ControllerBase
         [FromServices] IHubContext<NotificationHub> notificationHub,
         CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         // #12 — pass both hubs so a successful auto-align broadcasts ModelUpdated:
         // FederatedModelHub for any /hubs/model client + NotificationHub
         // (project-{id}) which is where the dashboard + Revit plugin actually

--- a/Planscape.Server/src/Planscape.API/Controllers/CoordinateSystemController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/CoordinateSystemController.cs
@@ -3,6 +3,8 @@ namespace Planscape.API.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -15,9 +17,17 @@ using Planscape.Infrastructure.Data;
 /// this definition.
 /// Route: /api/projects/{projectId}/coordinate-system
 /// </summary>
+/// <remarks>
+/// The CRS is the frame every model in the project is aligned against, so an
+/// unauthorised edit silently mis-places the whole federation. Gated like
+/// <see cref="IfcIngestController"/>: <c>[ProjectAccess]</c> for read (404) and
+/// <see cref="ControllerProjectMembershipExtensions.RequireProjectMemberAsync"/>
+/// on every mutation (403).
+/// </remarks>
 [ApiController]
 [Route("api/projects/{projectId:guid}/coordinate-system")]
 [Authorize]
+[ProjectAccess]
 public class CoordinateSystemController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
@@ -51,6 +61,8 @@ public class CoordinateSystemController : ControllerBase
         [FromBody] CoordinateSystemDto dto,
         CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var existing = await _db.ProjectCoordinateSystems
             .AnyAsync(x => x.ProjectId == projectId && x.TenantId == _tenant.TenantId, ct);
 
@@ -92,6 +104,8 @@ public class CoordinateSystemController : ControllerBase
         [FromBody] CoordinateSystemDto dto,
         CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var entity = await _db.ProjectCoordinateSystems
             .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == _tenant.TenantId, ct);
 
@@ -122,6 +136,8 @@ public class CoordinateSystemController : ControllerBase
     [HttpDelete]
     public async Task<IActionResult> Delete(Guid projectId, CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var entity = await _db.ProjectCoordinateSystems
             .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == _tenant.TenantId, ct);
 

--- a/Planscape.Server/src/Planscape.API/Controllers/GlobalIdRegistryController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/GlobalIdRegistryController.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 
 namespace Planscape.API.Controllers;
 
@@ -27,6 +29,7 @@ namespace Planscape.API.Controllers;
 [ApiController]
 [Route("api/projects/{projectId:guid}/global-id-registry")]
 [Authorize]
+[ProjectAccess]   // cross-project read gate (404 for a project the caller cannot see)
 public class GlobalIdRegistryController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
@@ -121,6 +124,10 @@ public class GlobalIdRegistryController : ControllerBase
         [FromBody] RegistryCreateDto dto,
         CancellationToken ct)
     {
+        // Cross-project write gate: only a member of THIS project (or a tenant
+        // Admin/Owner) may create an identity mapping in it.
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var row = new ElementGlobalIdRegistry
         {
             TenantId            = _tenant.TenantId,
@@ -162,6 +169,9 @@ public class GlobalIdRegistryController : ControllerBase
         [FromBody] RegistryUpdateDto dto,
         CancellationToken ct)
     {
+        // Cross-project write gate: members (or Admin/Owner) only.
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var row = await _db.GlobalIdRegistry
             .FirstOrDefaultAsync(r => r.Id == registryId
                 && r.ProjectId == projectId
@@ -192,6 +202,9 @@ public class GlobalIdRegistryController : ControllerBase
         Guid registryId,
         CancellationToken ct)
     {
+        // Cross-project write gate: members (or Admin/Owner) only.
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var row = await _db.GlobalIdRegistry
             .FirstOrDefaultAsync(r => r.Id == registryId
                 && r.ProjectId == projectId
@@ -218,6 +231,10 @@ public class GlobalIdRegistryController : ControllerBase
     [HttpPost("auto-match")]
     public async Task<ActionResult> AutoMatch(Guid projectId, CancellationToken ct)
     {
+        // Cross-project write gate: auto-match creates registry rows — members
+        // (or Admin/Owner) only.
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var elements = await _db.FederatedElements.AsNoTracking()
             .Where(e => e.ProjectId == projectId && !e.IsDeleted && e.IfcGuid != null)
             .Select(e => new { e.IfcGuid, e.Category })

--- a/Planscape.Server/src/Planscape.API/Controllers/IfcController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcController.cs
@@ -7,6 +7,8 @@ using Planscape.Core.DTOs;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 
 namespace Planscape.API.Controllers;
 
@@ -38,6 +40,7 @@ namespace Planscape.API.Controllers;
 [ApiController]
 [Route("api/projects/{projectId:guid}/ifc")]
 [Authorize]
+[ProjectAccess]   // cross-project read gate (404 for a project the caller cannot see)
 [EnableRateLimiting("mobile")]
 public class IfcController : ControllerBase
 {
@@ -63,6 +66,9 @@ public class IfcController : ControllerBase
         Guid projectId,
         [FromBody] IfcIngestRequest request)
     {
+        // Cross-project write gate: only a member of THIS project (or a tenant
+        // Admin/Owner) may ingest into it — mirrors IfcIngestController/tagsync.
+        if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
         if (request is null) return BadRequest("missing body");
         if (request.Elements is null || request.Elements.Count == 0)
             return BadRequest("Elements is empty");
@@ -164,6 +170,9 @@ public class IfcController : ControllerBase
         [FromBody] IotBindingRequest request,
         CancellationToken ct = default)
     {
+        // Cross-project write gate: binding an IoT device mutates this project's
+        // cross-host identity table — members (or Admin/Owner) only.
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
         if (request is null) return BadRequest("missing body");
         if (string.IsNullOrWhiteSpace(request.IfcGlobalId)) return BadRequest("ifcGlobalId is required");
         if (string.IsNullOrWhiteSpace(request.DeviceId)) return BadRequest("deviceId is required");

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelDiffController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelDiffController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Authorization;
 using Planscape.Infrastructure.Data;
 
 namespace Planscape.API.Controllers;
@@ -12,8 +13,17 @@ namespace Planscape.API.Controllers;
 /// the viewer renders with one applyOverlay() call. No bespoke diff render
 /// path — the diff IS just another overlay feed.
 /// </summary>
+/// <remarks>
+/// Read-only, so <c>[ProjectAccess]</c> alone is the gate. The existing
+/// tenant-only check below (<c>Projects.AnyAsync(p.TenantId == tenantId)</c>)
+/// admitted any authenticated user in the tenant to any project's element-level
+/// change history; the attribute narrows that to admin / author / active member.
+/// The action's absolute route carries <c>{projectId}</c>, which is what the
+/// attribute resolves.
+/// </remarks>
 [ApiController]
 [Authorize]
+[ProjectAccess]
 public class ModelDiffController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
@@ -3,6 +3,8 @@ namespace Planscape.API.Controllers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Authorization;
+using Planscape.API.Services;
 using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
@@ -13,9 +15,19 @@ using Planscape.Infrastructure.Services;
 /// Gap E — REST API for managing per-model coordinate transforms.
 /// Route: api/projects/{projectId}/models/{modelId}/transform
 /// </summary>
+/// <remarks>
+/// Authorization mirrors <see cref="ModelsController"/> / <see cref="IfcIngestController"/>:
+/// <c>[ProjectAccess]</c> is the read gate (404 for a project the caller cannot
+/// see) and <see cref="ControllerProjectMembershipExtensions.RequireProjectMemberAsync"/>
+/// is the write gate (403 for a caller who can see the project but is not a
+/// member). Tenant scope alone is NOT sufficient — without these, a member of
+/// any project in the tenant could read and overwrite every other project's
+/// model transforms.
+/// </remarks>
 [ApiController]
 [Route("api/projects/{projectId:guid}/models/{modelId:guid}/transform")]
 [Authorize]
+[ProjectAccess]
 public class ModelTransformController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
@@ -91,6 +103,8 @@ public class ModelTransformController : ControllerBase
         [FromBody] TransformUpsertDto dto,
         CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         // Validate ownership
         var projectExists = await _db.ProjectModels.AsNoTracking()
             .AnyAsync(m => m.Id        == modelId
@@ -199,6 +213,8 @@ public class ModelTransformController : ControllerBase
     [HttpDelete]
     public async Task<IActionResult> Delete(Guid projectId, Guid modelId, CancellationToken ct)
     {
+        if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
+
         var xf = await _db.Set<ProjectModelTransform>()
             .FirstOrDefaultAsync(
                 t => t.ProjectModelId == modelId

--- a/Planscape.Server/src/Planscape.API/Controllers/SceneNodesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SceneNodesController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Planscape.API.Authorization;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
 
 namespace Planscape.API.Controllers;
 
@@ -19,8 +21,26 @@ namespace Planscape.API.Controllers;
 ///          chunk after it splits + uploads. Auth via shared bearer
 ///          token; converter is internal-only.
 /// </summary>
+/// <remarks>
+/// Authorization is per-endpoint because the three routes carry different
+/// identifiers:
+/// <list type="bullet">
+/// <item><c>projects/{projectId}/scene</c> — <c>[ProjectAccess]</c> resolves
+/// <c>{projectId}</c> from route data and 404s a caller who cannot see the
+/// project.</item>
+/// <item><c>scene-nodes/{nodeId}/file</c> — no <c>{projectId}</c> in the route,
+/// so the attribute falls through by design. The project is resolved from the
+/// node itself and checked explicitly in
+/// <see cref="GetChunkFile"/>; without that, any authenticated user in the
+/// tenant could download any other project's geometry given a node id.</item>
+/// <item><c>scene-nodes/ingest</c> — <c>[AllowAnonymous]</c>, authenticated by
+/// the converter's shared bearer. It has no <c>{projectId}</c> route value
+/// either, so the attribute is a no-op there and the bearer check stands.</item>
+/// </list>
+/// </remarks>
 [ApiController]
 [Route("api")]
+[ProjectAccess]
 public class SceneNodesController : ControllerBase
 {
     private readonly PlanscapeDbContext _db;
@@ -86,6 +106,14 @@ public class SceneNodesController : ControllerBase
     {
         var node = await _db.SceneNodes.AsNoTracking().FirstOrDefaultAsync(n => n.Id == nodeId && n.DeletedAt == null, ct);
         if (node == null) return NotFound();
+
+        // The route addresses the chunk, not the project, so [ProjectAccess]
+        // cannot gate this one — resolve the owning project off the node and
+        // apply the same decision by hand. 404 (not 403) to match the
+        // attribute: telling a non-member the node exists leaks the project.
+        if (!await ProjectVisibility.CanSeeProjectAsync(_db, node.ProjectId, User, ct))
+            return NotFound();
+
         var stream = await _storage.GetAsync(node.StoragePath, ct);
         if (stream == null) return NotFound();
         Response.Headers["Cache-Control"] = "public, max-age=31536000, immutable";

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
@@ -185,6 +185,39 @@ public sealed class AutoAlignService : IAutoAlignService
                   && t.TenantId       == tenantId,
                 ct);
 
+        // ── 6a. Never overwrite a manually-confirmed transform ────────────────
+        // A coordinator who has confirmed an alignment has made a judgement the
+        // survey data does not capture (a mis-stated IfcMapConversion, a model
+        // deliberately parked off-site, a base point agreed on site). The IFC
+        // ingest path has always respected that (IfcIngestController: "Only
+        // auto-update if not manually confirmed by a coordinator") — this path
+        // did not, so any auto-align run silently destroyed the confirmed
+        // alignment and the coordinator's only signal was the model jumping.
+        //
+        // Unlike the ingest path, which skips quietly because it is a side
+        // effect of an upload, this one is an explicit user action: report the
+        // refusal AND the transform that would have been applied, so the
+        // coordinator can compare it against the one they confirmed and decide
+        // deliberately (delete the transform, or PUT a new one).
+        if (existing is { IsConfirmed: true })
+        {
+            _logger.LogInformation(
+                "AutoAlign skipped for model {ModelId}: an existing transform is manually confirmed (confirmed by {AppliedBy} at {AppliedAt}).",
+                targetModelId, existing.AppliedBy ?? "unknown", existing.AppliedAt);
+
+            return new AutoAlignResult(
+                Success         : false,
+                TranslationX    : tx,
+                TranslationY    : ty,
+                TranslationZ    : tz,
+                RotationDeg     : rotDeg,
+                ScaleFactor     : scaleFactor,
+                ReferenceModelId: referenceModelId,
+                Message         : "This model's transform was manually confirmed by a coordinator and will not be "
+                                + "overwritten automatically. The transform auto-align computed is returned for "
+                                + "comparison; delete the existing transform or PUT a new one to change it.");
+        }
+
         if (existing == null)
         {
             existing = new ProjectModelTransform

--- a/Planscape.Server/src/Planscape.Infrastructure/SignalR/FederatedModelHub.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/SignalR/FederatedModelHub.cs
@@ -1,5 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Infrastructure.Authorization;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
 
 namespace Planscape.Infrastructure.SignalR;
 
@@ -14,9 +19,74 @@ namespace Planscape.Infrastructure.SignalR;
 [Authorize]
 public class FederatedModelHub : Hub
 {
-    /// <summary>Join the model-update stream for a project.</summary>
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public FederatedModelHub(IServiceScopeFactory scopeFactory)
+        => _scopeFactory = scopeFactory;
+
+    /// <summary>
+    /// Join the model-update stream for a project.
+    ///
+    /// <c>[Authorize]</c> alone only proves the caller is signed in — it says
+    /// nothing about WHICH project they may watch. Without the membership check
+    /// below, any authenticated user could join <c>model:{anyProjectId}</c> and
+    /// receive that project's ModelUpdated stream (element ids of everything
+    /// being edited, across tenants — the group name is the only key).
+    /// <see cref="NotificationHub.JoinProject"/> has validated membership since
+    /// NEW-LOGIC-15; this hub was missed.
+    ///
+    /// The membership decision goes through <see cref="ProjectMembershipGuard"/>
+    /// so it matches the REST gate on the same resources (ModelTransform /
+    /// Alignment / Scene), including the tenant Admin / Owner bypass.
+    ///
+    /// <para><b>Why the tenant check is explicit here.</b> Everywhere else the
+    /// ambient global query filter supplies tenant scope, but it reads
+    /// <c>ITenantContext.TenantId</c>, which resolves off
+    /// <c>IHttpContextAccessor</c> — and that is not reliably populated inside a
+    /// SignalR hub method (the documented accessor for a hub is
+    /// <c>Context.GetHttpContext()</c>). An unresolved tenant makes
+    /// <c>CurrentTenantId</c> <see cref="Guid.Empty"/>, which the filter treats
+    /// as "matches no rows": fail-closed, but it would deny every legitimate
+    /// member too. So this reads the tenant straight off the connection's JWT
+    /// principal — always present under <c>[Authorize]</c> — bypasses the
+    /// ambient filter for the one query, and re-applies tenant scope by hand.
+    /// The result is a gate that does not depend on whether HttpContext flows.
+    /// The scope (and therefore the bypass) is local to this call.</para>
+    /// </summary>
+    /// <exception cref="HubException">
+    /// Thrown for a malformed id, an unauthenticated caller, a cross-tenant
+    /// project, or a non-member. SignalR surfaces this to the caller and the
+    /// group is not joined.
+    /// </exception>
     public async Task JoinProject(string projectId)
     {
+        if (!Guid.TryParse(projectId, out var pid) || pid == Guid.Empty)
+            throw new HubException("Invalid project id");
+
+        var user = Context.User;
+        if (user == null) throw new HubException("Not authenticated");
+
+        var userId = ProjectVisibility.GetUserId(user);
+        var tenantId = ProjectVisibility.GetTenantId(user);
+        if (userId == Guid.Empty || tenantId == Guid.Empty)
+            throw new HubException("Not authenticated");
+
+        // The DbContext is scoped; a hub instance is per-invocation but may
+        // outlive a request scope, so resolve one per call.
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlanscapeDbContext>();
+        db.BypassTenantFilter = true;
+
+        // Cross-tenant first: the project must live in the caller's tenant.
+        var sameTenant = await db.Projects.AsNoTracking()
+            .AnyAsync(p => p.Id == pid && p.TenantId == tenantId);
+        if (!sameTenant)
+            throw new HubException("Not a member of this project");
+
+        var isAdmin = ProjectVisibility.IsTenantAdmin(user);
+        if (!await ProjectMembershipGuard.IsProjectMemberAsync(db, userId, pid, isAdmin))
+            throw new HubException("Not a member of this project");
+
         await Groups.AddToGroupAsync(Context.ConnectionId, ModelGroup(projectId));
     }
 

--- a/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK A3 — auto-align silently destroyed a manually-confirmed alignment.
+///
+/// THE DEFECT
+/// ----------
+/// <c>AutoAlignService.ComputeAsync</c> persisted its result with a bare
+/// "overwrite if exists": it loaded any existing ProjectModelTransform and
+/// stamped the computed values over it, ignoring <c>IsConfirmed</c>. The IFC
+/// ingest path has always respected the flag ("Only auto-update if not manually
+/// confirmed by a coordinator") — this path did not. A coordinator who had
+/// aligned a model by hand, against survey data that was wrong or absent, lost
+/// that work the moment anyone ran auto-align, and the only signal was the model
+/// jumping in the viewer.
+///
+/// WHY IsConfirmed IS THE RIGHT FLAG
+/// ---------------------------------
+/// It is set only by a human path: ModelTransformController.Upsert takes it from
+/// the request body and forces IsAutoComputed=false alongside. Both automatic
+/// writers (ingest, auto-align) store IsConfirmed=false. So "confirmed" means
+/// exactly "a coordinator asserted this", which is the thing an automatic
+/// process must not overrule.
+/// </summary>
+public class AutoAlignConfirmedTransformTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Target, Guid Reference);
+
+    /// <summary>
+    /// A project with two georeferenced models: a reference at survey origin
+    /// (1000, 2000) and a target at (1500, 2500). Auto-align therefore has real
+    /// work to do — a fixture where it fails for lack of data would make the
+    /// "did not overwrite" assertion pass for the wrong reason.
+    /// </summary>
+    private static World NewWorld(bool targetTransformConfirmed)
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var target = Guid.NewGuid();
+        var reference = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "acme@example.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Tower",
+                Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            // Both models must exist: ProjectModelTransform and
+            // IfcAlignmentReport carry real FKs to ProjectModel, and SQLite
+            // (unlike EF InMemory) enforces them.
+            foreach (var (id, name) in new[] { (reference, "Reference ARCH"), (target, "Target MEP") })
+                ctx.ProjectModels.Add(new ProjectModel
+                {
+                    Id = id, TenantId = tenant, ProjectId = project,
+                    Name = name, FileName = $"{name}.glb", StoragePath = $"t_x/{id:N}.glb",
+                });
+
+            ctx.IfcAlignmentReports.Add(new IfcAlignmentReport
+            {
+                TenantId = tenant, ProjectId = project, ProjectModelId = reference,
+                HasMapConversion = true,
+                SurveyEasting = 1000, SurveyNorthing = 2000, SurveyElevation = 0,
+                MapConversionRotationDeg = 0,
+                Verdict = "PASS", ValidatedAt = DateTime.UtcNow.AddMinutes(-5),
+            });
+            ctx.IfcAlignmentReports.Add(new IfcAlignmentReport
+            {
+                TenantId = tenant, ProjectId = project, ProjectModelId = target,
+                HasMapConversion = true,
+                SurveyEasting = 1500, SurveyNorthing = 2500, SurveyElevation = 0,
+                MapConversionRotationDeg = 0,
+                Verdict = "PASS", ValidatedAt = DateTime.UtcNow,
+            });
+
+            ctx.Set<ProjectModelTransform>().Add(new ProjectModelTransform
+            {
+                TenantId = tenant, ProjectId = project, ProjectModelId = target,
+                // A hand-set alignment that the survey data does NOT agree with.
+                TranslationX = 42.0, TranslationY = 43.0, TranslationZ = 44.0,
+                RotationDeg = 7.0, ScaleFactor = 2.0,
+                IsConfirmed = targetTransformConfirmed,
+                IsAutoComputed = !targetTransformConfirmed,
+                AppliedBy = targetTransformConfirmed ? "coordinator@example.com" : "auto-align-service",
+                AppliedAt = DateTime.UtcNow.AddDays(-1),
+                Notes = "site-agreed base point",
+            });
+
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, project, target, reference);
+    }
+
+    private static AutoAlignService NewService(World w)
+        => new(NewContext(w.Conn, w.Tenant), NullLogger<AutoAlignService>.Instance);
+
+    [Fact]
+    public async Task A_confirmed_transform_is_not_overwritten()
+    {
+        var w = NewWorld(targetTransformConfirmed: true);
+        using (w.Conn)
+        {
+            var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
+
+            Assert.False(result.Success);
+            Assert.Contains("manually confirmed", result.Message ?? "", StringComparison.OrdinalIgnoreCase);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.Set<ProjectModelTransform>().SingleAsync();
+            Assert.Equal(42.0, xf.TranslationX);
+            Assert.Equal(43.0, xf.TranslationY);
+            Assert.Equal(44.0, xf.TranslationZ);
+            Assert.Equal(7.0, xf.RotationDeg);
+            Assert.Equal(2.0, xf.ScaleFactor);
+            Assert.True(xf.IsConfirmed);
+            Assert.Equal("coordinator@example.com", xf.AppliedBy);
+        }
+    }
+
+    [Fact]
+    public async Task The_refusal_still_reports_what_auto_align_would_have_applied()
+    {
+        // The coordinator asked an explicit question and deserves the answer,
+        // so they can compare it with the transform they confirmed. A bare
+        // "refused" would make the feature useless at exactly the moment it
+        // matters.
+        var w = NewWorld(targetTransformConfirmed: true);
+        using (w.Conn)
+        {
+            var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
+
+            // reference(1000, 2000) - target(1500, 2500), in metres → mm.
+            Assert.Equal(-500_000.0, result.TranslationX, 3);
+            Assert.Equal(-500_000.0, result.TranslationY, 3);
+        }
+    }
+
+    [Fact]
+    public async Task An_unconfirmed_transform_is_still_overwritten()
+    {
+        // The mirror case. A guard that refused unconditionally would satisfy
+        // the tests above while disabling auto-align entirely.
+        var w = NewWorld(targetTransformConfirmed: false);
+        using (w.Conn)
+        {
+            var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
+
+            Assert.True(result.Success, result.Message);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.Set<ProjectModelTransform>().SingleAsync();
+            Assert.Equal(-500_000.0, xf.TranslationX, 3);
+            Assert.Equal(-500_000.0, xf.TranslationY, 3);
+            Assert.True(xf.IsAutoComputed);
+            Assert.False(xf.IsConfirmed);
+            Assert.Equal("auto-align-service", xf.AppliedBy);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/FederatedModelHubAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederatedModelHubAuthorizationTests.cs
@@ -1,0 +1,259 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.SignalR;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK A2 — <see cref="FederatedModelHub.JoinProject"/> had no membership
+/// check at all.
+///
+/// THE DEFECT
+/// ----------
+/// The hub carried <c>[Authorize]</c>, which proves only that the caller is
+/// signed in. JoinProject took a project id off the wire and added the caller
+/// straight into <c>model:{projectId}</c> — the group name was the ONLY key.
+/// Any authenticated user could therefore subscribe to any project's
+/// ModelUpdated stream (the element ids of everything being edited), including
+/// projects in other tenants, because a group name carries no tenant scope.
+/// <see cref="NotificationHub.JoinProject"/> has validated membership since
+/// NEW-LOGIC-15; this sibling hub was missed.
+///
+/// WHY THE TENANT CHECK IS ASSERTED SEPARATELY
+/// -------------------------------------------
+/// Everywhere else the ambient global query filter supplies tenant scope, but it
+/// reads ITenantContext.TenantId off IHttpContextAccessor, which is not reliably
+/// populated inside a SignalR hub method. If the fix had leaned on the ambient
+/// filter it would have failed CLOSED — denying every legitimate member — so
+/// <see cref="Outsider_from_another_tenant_is_rejected"/> and
+/// <see cref="Member_is_admitted"/> are both required: one proves the gate
+/// denies, the other proves it does not deny everyone.
+/// </summary>
+public class FederatedModelHubAuthorizationTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(
+        SqliteConnection Conn,
+        Guid Tenant, Guid OtherTenant,
+        Guid VictimProject,
+        Guid Insider, Guid Neighbour, Guid Outsider);
+
+    private static World NewWorld()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var otherTenant = Guid.NewGuid();
+        var victim = Guid.NewGuid();
+        var sibling = Guid.NewGuid();
+        var insider = Guid.NewGuid();
+        var neighbour = Guid.NewGuid();
+        var outsider = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+
+            foreach (var (id, slug) in new[] { (tenant, "acme"), (otherTenant, "rival") })
+                ctx.Tenants.Add(new Tenant
+                {
+                    Id = id, Name = slug, Slug = $"{slug}-{Guid.NewGuid():N}"[..14],
+                    ContactEmail = $"{slug}@example.com", Tier = LicenseTier.Professional,
+                    Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+                });
+
+            ctx.Projects.Add(new Project
+            {
+                Id = victim, TenantId = tenant, Name = "Victim Tower",
+                Code = $"VT-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = sibling, TenantId = tenant, Name = "Sibling Tower",
+                Code = $"ST-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            // ProjectMember FKs to AppUser; SQLite enforces it.
+            foreach (var (id, tid, name) in new[]
+                     {
+                         (insider, tenant, "Insider"),
+                         (neighbour, tenant, "Neighbour"),
+                         (outsider, otherTenant, "Outsider"),
+                     })
+                ctx.Users.Add(new AppUser
+                {
+                    Id = id, TenantId = tid, Email = $"{name}-{Guid.NewGuid():N}@example.com",
+                    DisplayName = name, PasswordHash = "x", IsActive = true,
+                });
+
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = victim, UserId = insider,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+            // Same tenant, real membership — on the OTHER project.
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = sibling, UserId = neighbour,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, otherTenant, victim, insider, neighbour, outsider);
+    }
+
+    /// <summary>Records group joins so a silent no-op cannot pass for a denial.</summary>
+    private sealed class SpyGroups : IGroupManager
+    {
+        public List<string> Joined { get; } = new();
+        public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken ct = default)
+        {
+            Joined.Add(groupName);
+            return Task.CompletedTask;
+        }
+        public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class FakeCallerContext : HubCallerContext
+    {
+        private readonly ClaimsPrincipal? _user;
+        public FakeCallerContext(ClaimsPrincipal? user) => _user = user;
+
+        public override string ConnectionId => "conn-1";
+        public override string? UserIdentifier => null;
+        public override ClaimsPrincipal? User => _user;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted => CancellationToken.None;
+        public override void Abort() { }
+    }
+
+    private static (FederatedModelHub hub, SpyGroups groups) NewHub(World w, Guid userId, Guid tenantId)
+    {
+        var services = new ServiceCollection();
+        // Scoped, so the hub's CreateScope() hands back a fresh context each call.
+        services.AddScoped(_ => NewContext(w.Conn, tenantId));
+
+        var groups = new SpyGroups();
+        var hub = new FederatedModelHub(services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>())
+        {
+            Groups = groups,
+            Context = new FakeCallerContext(new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim("user_id", userId.ToString()),
+                new Claim("tenant_id", tenantId.ToString()),
+                new Claim("role", "Contributor"),   // deliberately NOT Admin/Owner
+            }, "test"))),
+        };
+        return (hub, groups);
+    }
+
+    [Fact]
+    public async Task Same_tenant_non_member_is_rejected()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (hub, groups) = NewHub(w, w.Neighbour, w.Tenant);
+
+            await Assert.ThrowsAsync<HubException>(
+                () => hub.JoinProject(w.VictimProject.ToString()));
+
+            Assert.Empty(groups.Joined);
+        }
+    }
+
+    [Fact]
+    public async Task Outsider_from_another_tenant_is_rejected()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (hub, groups) = NewHub(w, w.Outsider, w.OtherTenant);
+
+            await Assert.ThrowsAsync<HubException>(
+                () => hub.JoinProject(w.VictimProject.ToString()));
+
+            Assert.Empty(groups.Joined);
+        }
+    }
+
+    [Fact]
+    public async Task Member_is_admitted()
+    {
+        // The load-bearing mirror case: the gate must not deny everyone. See the
+        // class remarks on why that is a live risk for a hub specifically.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (hub, groups) = NewHub(w, w.Insider, w.Tenant);
+
+            await hub.JoinProject(w.VictimProject.ToString());
+
+            Assert.Equal(new[] { $"model:{w.VictimProject}" }, groups.Joined);
+        }
+    }
+
+    [Fact]
+    public async Task A_malformed_project_id_is_rejected_not_joined()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (hub, groups) = NewHub(w, w.Insider, w.Tenant);
+
+            await Assert.ThrowsAsync<HubException>(() => hub.JoinProject("not-a-guid"));
+            await Assert.ThrowsAsync<HubException>(() => hub.JoinProject(Guid.Empty.ToString()));
+
+            Assert.Empty(groups.Joined);
+        }
+    }
+
+    [Fact]
+    public async Task An_unauthenticated_caller_is_rejected()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var services = new ServiceCollection();
+            services.AddScoped(_ => NewContext(w.Conn, w.Tenant));
+            var groups = new SpyGroups();
+            var hub = new FederatedModelHub(
+                services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>())
+            {
+                Groups = groups,
+                Context = new FakeCallerContext(user: null),
+            };
+
+            await Assert.ThrowsAsync<HubException>(
+                () => hub.JoinProject(w.VictimProject.ToString()));
+
+            Assert.Empty(groups.Joined);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
@@ -1,0 +1,620 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.API.Authorization;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK A1 — cross-PROJECT access control on the federation controllers.
+///
+/// THE DEFECT
+/// ----------
+/// ModelTransformController, CoordinateSystemController, AlignmentController,
+/// SceneNodesController and ModelDiffController carried <c>[Authorize]</c> and
+/// filtered by TENANT only. Tenant isolation is sound — the global ITenantScoped
+/// filter sees to that — but tenant is not the unit of authorization here:
+/// a user invited to ANY ONE project in a tenant could read and overwrite EVERY
+/// OTHER project's coordinate system, model transforms and geometry in the same
+/// tenant. ModelsController and IfcIngestController already applied the
+/// documented gate; these five were missed.
+///
+/// WHY THE TESTS ATTACK WITHIN A TENANT
+/// ------------------------------------
+/// This is the distinguishing detail, and the reason the pre-existing
+/// tenant-isolation tests never caught it. Every attacker below is a real,
+/// active, authenticated member of the SAME tenant as the victim project — just
+/// a member of a DIFFERENT project in it. A cross-tenant test passes against the
+/// unfixed code (the tenant filter already stopped that) and proves nothing.
+///
+/// WHAT IS COVERED, AND WHAT IS NOT
+/// --------------------------------
+///   • The in-action write gate (RequireProjectMemberAsync → 403) is driven by
+///     constructing each controller directly against real SQLite with real
+///     ProjectMember rows — the MaterialSyncAuthorizationTests precedent.
+///   • <see cref="ProjectAccessAttribute"/> (the read gate → 404) IS exercised,
+///     by driving the filter directly with a hand-built ActionExecutingContext —
+///     the ProjectAccessCacheOutageTests precedent. That existing file only
+///     covers the CROSS-TENANT case; the within-tenant non-member case added
+///     here is the one that was broken.
+///   • <see cref="ControllersCarryTheReadGate"/> pins the attribute onto each
+///     controller by reflection, so removing it fails a test rather than
+///     silently re-opening the hole.
+///
+/// It does NOT boot a host: a WebApplicationFactory cannot run against SQLite
+/// (Program.cs issues a Postgres-only information_schema query with no
+/// try/catch) and a second factory is unreliable in this assembly (ROADMAP
+/// DEP-7, process-wide Hangfire teardown). Stated so a green run is not read as
+/// proof of end-to-end MVC wiring.
+///
+/// FIXTURE TRAP
+/// ------------
+/// PlanscapeDbContext's global filter is TenantId == CurrentTenantId and falls
+/// back to Guid.Empty without an ITenantContext, matching NO rows — under which
+/// a "denied" assertion passes for the wrong reason. Every context here is built
+/// WITH a tenant, and every denial test is paired with a member happy-path test
+/// asserting a non-empty effect.
+/// </summary>
+public class FederationAuthorizationTests
+{
+    // ── fixture ──────────────────────────────────────────────────────────────
+
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    /// <summary>
+    /// One tenant, two projects. <c>Insider</c> is an active member of
+    /// <c>Victim</c>. <c>Neighbour</c> is an active member of <c>Other</c> only —
+    /// same tenant, no membership on Victim. Neighbour is the attacker.
+    /// </summary>
+    private sealed record World(
+        SqliteConnection Conn,
+        Guid Tenant,
+        Guid VictimProject, Guid OtherProject,
+        Guid Insider, Guid Neighbour,
+        Guid VictimModel, Guid VictimNode);
+
+    private static World NewWorld()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var victim = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        var insider = Guid.NewGuid();
+        var neighbour = Guid.NewGuid();
+        var model = Guid.NewGuid();
+        var node = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "acme@example.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+
+            ctx.Projects.Add(new Project
+            {
+                Id = victim, TenantId = tenant, Name = "Victim Tower",
+                Code = $"VT-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = other, TenantId = tenant, Name = "Other Tower",
+                Code = $"OT-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            foreach (var (id, name) in new[] { (insider, "Insider"), (neighbour, "Neighbour") })
+                ctx.Users.Add(new AppUser
+                {
+                    Id = id, TenantId = tenant, Email = $"{name}-{Guid.NewGuid():N}@example.com",
+                    DisplayName = name, PasswordHash = "x", IsActive = true,
+                });
+
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = victim, UserId = insider,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+            // The whole point: Neighbour IS a member — of the other project.
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = other, UserId = neighbour,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+
+            ctx.ProjectModels.Add(new ProjectModel
+            {
+                Id = model, TenantId = tenant, ProjectId = victim,
+                Name = "Victim ARCH", FileName = "victim.glb", StoragePath = "t_x/victim.glb",
+            });
+
+            ctx.SceneNodes.Add(new SceneNode
+            {
+                Id = node, TenantId = tenant, ProjectId = victim, SourceModelId = model,
+                Discipline = "A", StoragePath = "t_x/chunk.glb", ContentHash = "deadbeef",
+            });
+
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, victim, other, insider, neighbour, model, node);
+    }
+
+    /// <summary>
+    /// A non-admin principal — Admin/Owner bypasses membership by design.
+    ///
+    /// <c>tenant_id</c> is required, not decorative: SceneNodesController's
+    /// chunk-file check runs through <see cref="ProjectVisibility"/>, which
+    /// reads the tenant off the claims and treats a missing one as
+    /// <see cref="Guid.Empty"/> — i.e. sees nothing. Omitting it would make the
+    /// non-member test pass while the member test failed, which is exactly the
+    /// "denied for the wrong reason" trap.
+    /// </summary>
+    private static ControllerContext ContextFor(Guid userId, Guid tenantId) => new()
+    {
+        HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim("user_id", userId.ToString()),
+                new Claim("sub", userId.ToString()),
+                new Claim("tenant_id", tenantId.ToString()),
+                new Claim("role", "Contributor"),
+            }, "test")),
+        },
+    };
+
+    private static ModelTransformController NewTransformController(World w, Guid actor)
+    {
+        var c = new ModelTransformController(
+            NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant),
+            delta: null!, logger: NullLogger<ModelTransformController>.Instance)
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+        return c;
+    }
+
+    private static CoordinateSystemController NewCrsController(World w, Guid actor)
+        => new(NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant))
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+
+    private static AlignmentController NewAlignmentController(World w, Guid actor)
+        => new(NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant))
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+
+    private static SceneNodesController NewSceneController(World w, Guid actor, IFileStorageService storage)
+        => new(NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant), storage)
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+
+    private static TransformUpsertDto SomeTransform(double tx = 12_345.0) =>
+        new(tx, 0, 0, RotationDeg: 0, ScaleFactor: 1.0, IsConfirmed: true, Notes: "hostile");
+
+    private static void AssertForbidden(ActionResult? result)
+    {
+        var denied = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, denied.StatusCode);
+    }
+
+    // ── ModelTransformController — the highest-value write ───────────────────
+
+    [Fact]
+    public async Task Neighbour_cannot_overwrite_another_projects_model_transform()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewTransformController(w, w.Neighbour)
+                .Upsert(w.VictimProject, w.VictimModel, SomeTransform(), default);
+
+            AssertForbidden(result);
+
+            // The denial must be a denial, not a 403 issued after the write.
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.False(await check.Set<ProjectModelTransform>().AnyAsync());
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_delete_another_projects_model_transform()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.Set<ProjectModelTransform>().Add(new ProjectModelTransform
+                {
+                    TenantId = w.Tenant, ProjectId = w.VictimProject,
+                    ProjectModelId = w.VictimModel, TranslationX = 999, IsConfirmed = true,
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var result = await NewTransformController(w, w.Neighbour)
+                .Delete(w.VictimProject, w.VictimModel, default);
+
+            var denied = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(403, denied.StatusCode);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.True(await check.Set<ProjectModelTransform>().AnyAsync(),
+                "the coordinator's transform was deleted by a non-member");
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_upsert_the_transform()
+    {
+        // The mirror case. A gate that denied everyone would pass every test
+        // above while breaking the feature.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewTransformController(w, w.Insider)
+                .Upsert(w.VictimProject, w.VictimModel, SomeTransform(777.0), default);
+
+            Assert.IsType<OkObjectResult>(result);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var saved = await check.Set<ProjectModelTransform>().SingleAsync();
+            Assert.Equal(777.0, saved.TranslationX);
+        }
+    }
+
+    // ── CoordinateSystemController — the frame everything aligns to ──────────
+
+    [Fact]
+    public async Task Neighbour_cannot_create_another_projects_coordinate_system()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewCrsController(w, w.Neighbour)
+                .Create(w.VictimProject, new CoordinateSystemDto { CrsEpsgCode = "EPSG:9999" }, default);
+
+            AssertForbidden(result.Result);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.False(await check.ProjectCoordinateSystems.AnyAsync());
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_update_or_delete_another_projects_coordinate_system()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.ProjectCoordinateSystems.Add(new ProjectCoordinateSystem
+                {
+                    TenantId = w.Tenant, ProjectId = w.VictimProject,
+                    CrsEpsgCode = "EPSG:27700", OriginEasting = 100, OriginNorthing = 200,
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var update = await NewCrsController(w, w.Neighbour)
+                .Update(w.VictimProject, new CoordinateSystemDto { CrsEpsgCode = "EPSG:9999" }, default);
+            AssertForbidden(update.Result);
+
+            var delete = await NewCrsController(w, w.Neighbour).Delete(w.VictimProject, default);
+            var denied = Assert.IsType<ObjectResult>(delete);
+            Assert.Equal(403, denied.StatusCode);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var crs = await check.ProjectCoordinateSystems.SingleAsync();
+            Assert.Equal("EPSG:27700", crs.CrsEpsgCode);
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_create_the_coordinate_system()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewCrsController(w, w.Insider)
+                .Create(w.VictimProject, new CoordinateSystemDto { CrsEpsgCode = "EPSG:27700" }, default);
+
+            Assert.IsType<CreatedAtActionResult>(result.Result);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.Equal("EPSG:27700", (await check.ProjectCoordinateSystems.SingleAsync()).CrsEpsgCode);
+        }
+    }
+
+    // ── AlignmentController — denial must happen BEFORE the work ─────────────
+
+    private sealed class SpyCoherenceJob : IFederatedCoherenceJob
+    {
+        public bool Ran { get; private set; }
+        public Task<FederatedCoherenceReport> RunAsync(Guid projectId, Guid tenantId, CancellationToken ct)
+        {
+            Ran = true;
+            return Task.FromResult(new FederatedCoherenceReport(
+                projectId, 0, 0, 0, 0, Array.Empty<CoherenceIssue>(), DateTime.UtcNow));
+        }
+    }
+
+    private sealed class SpyAutoAlign : IAutoAlignService
+    {
+        public bool Ran { get; private set; }
+        public Task<AutoAlignResult> ComputeAsync(
+            Guid projectId, Guid tenantId, Guid targetModelId,
+            Microsoft.AspNetCore.SignalR.IHubContext<Planscape.Infrastructure.SignalR.FederatedModelHub>? modelHub = null,
+            CancellationToken ct = default,
+            Microsoft.AspNetCore.SignalR.IHubContext<Planscape.Infrastructure.SignalR.NotificationHub>? notificationHub = null)
+        {
+            Ran = true;
+            return Task.FromResult(new AutoAlignResult(true, 1, 2, 3, 4, 5, null, null));
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_run_another_projects_coherence_scan()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var job = new SpyCoherenceJob();
+
+            var result = await NewAlignmentController(w, w.Neighbour)
+                .RunCoherence(w.VictimProject, job, default);
+
+            AssertForbidden(result);
+            Assert.False(job.Ran, "the scan ran before the caller was authorized");
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_auto_align_another_projects_model()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var svc = new SpyAutoAlign();
+
+            var result = await NewAlignmentController(w, w.Neighbour)
+                .AutoAlign(w.VictimProject, w.VictimModel, svc,
+                           modelHub: null!, notificationHub: null!, default);
+
+            AssertForbidden(result);
+            Assert.False(svc.Ran, "auto-align wrote a transform before the caller was authorized");
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_run_the_coherence_scan()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var job = new SpyCoherenceJob();
+
+            var result = await NewAlignmentController(w, w.Insider)
+                .RunCoherence(w.VictimProject, job, default);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.True(job.Ran);
+        }
+    }
+
+    // ── SceneNodesController — geometry download by node id ──────────────────
+
+    /// <summary>Serves one fixed blob; every other member is out of scope here.</summary>
+    private sealed class StubStorage : IFileStorageService
+    {
+        public bool Served { get; private set; }
+
+        public Task<Stream?> GetAsync(string path, CancellationToken ct = default, bool bypassTenantCheck = false)
+        {
+            Served = true;
+            return Task.FromResult<Stream?>(new MemoryStream(new byte[] { 0x67, 0x6C, 0x54, 0x46 }));
+        }
+
+        private static Exception No() => new NotSupportedException("not used by these tests");
+        public Task<string> SaveScopedAsync(Guid t, Guid p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<string> SaveAsync(string t, string p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<bool> DeleteAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<int> DeleteByPrefixAsync(string prefix, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<PresignedUpload> GetPresignedPutUrlAsync(string k, string c, TimeSpan v, long m, CancellationToken ct = default) => throw No();
+        public Task<string> GetPresignedGetUrlAsync(string k, TimeSpan v, CancellationToken ct = default, bool b = false) => throw No();
+        public Task MoveAsync(string s, string d, CancellationToken ct = default, bool b = false) => throw No();
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_download_another_projects_geometry_chunk()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var storage = new StubStorage();
+
+            var result = await NewSceneController(w, w.Neighbour, storage)
+                .GetChunkFile(w.VictimNode, default);
+
+            // 404, not 403 — matching [ProjectAccess], so the response does not
+            // confirm the chunk exists.
+            Assert.IsType<NotFoundResult>(result);
+            Assert.False(storage.Served, "the geometry was read from storage before the caller was authorized");
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_download_the_geometry_chunk()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var storage = new StubStorage();
+
+            var result = await NewSceneController(w, w.Insider, storage)
+                .GetChunkFile(w.VictimNode, default);
+
+            Assert.IsType<FileStreamResult>(result);
+            Assert.True(storage.Served);
+        }
+    }
+
+    // ── [ProjectAccess] — the read gate, driven directly ─────────────────────
+
+    /// <summary>
+    /// The within-tenant case the existing ProjectAccessCacheOutageTests does
+    /// not cover: same tenant, active user, member of a different project.
+    /// </summary>
+    [Fact]
+    public async Task ReadGate_404s_a_same_tenant_non_member()
+    {
+        var (ctx, next) = BuildFilterContext(member: false);
+
+        await new ProjectAccessAttribute().OnActionExecutionAsync(ctx, next.Delegate);
+
+        Assert.IsType<NotFoundResult>(ctx.Result);
+        Assert.False(next.WasCalled);
+    }
+
+    [Fact]
+    public async Task ReadGate_allows_a_project_member()
+    {
+        var (ctx, next) = BuildFilterContext(member: true);
+
+        await new ProjectAccessAttribute().OnActionExecutionAsync(ctx, next.Delegate);
+
+        Assert.Null(ctx.Result);
+        Assert.True(next.WasCalled);
+    }
+
+    /// <summary>
+    /// The gate is an attribute, so it can be deleted in a refactor without
+    /// breaking a single behavioural test. Pin it.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(ModelTransformController))]
+    [InlineData(typeof(CoordinateSystemController))]
+    [InlineData(typeof(AlignmentController))]
+    [InlineData(typeof(SceneNodesController))]
+    [InlineData(typeof(ModelDiffController))]
+    public void ControllersCarryTheReadGate(Type controller)
+    {
+        Assert.True(
+            controller.GetCustomAttributes(typeof(ProjectAccessAttribute), inherit: true).Length > 0,
+            $"{controller.Name} lost [ProjectAccess] — any authenticated user in the tenant can reach "
+            + "another project's federation data again.");
+    }
+
+    private static (ActionExecutingContext, NextSpy) BuildFilterContext(bool member)
+    {
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var caller = Guid.NewGuid();
+        var author = Guid.NewGuid();   // NOT the caller — the author bypass must not fire
+
+        var db = new PlanscapeDbContext(
+            new DbContextOptionsBuilder<PlanscapeDbContext>()
+                .UseInMemoryDatabase($"FedAuthz_{Guid.NewGuid():N}").Options,
+            new HttpContextAccessor(),
+            new FixedTenant(tenant));
+
+        db.Projects.Add(new Project
+        {
+            Id = project, TenantId = tenant, CreatedById = author,
+            Code = "FA-001", Name = "Victim",
+        });
+        if (member)
+        {
+            db.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = project, UserId = caller,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
+            });
+        }
+        db.SaveChanges();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(db);
+        services.AddSingleton<IDistributedCache>(new NoopDistributedCache());
+
+        var http = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, caller.ToString()),
+                new Claim("tenant_id", tenant.ToString()),
+                new Claim("role", "Contributor"),
+            }, "test")),
+        };
+
+        var routeData = new RouteData();
+        routeData.Values["projectId"] = project.ToString();
+
+        var ctx = new ActionExecutingContext(
+            new ActionContext(http, routeData, new ControllerActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            controller: null!);
+
+        return (ctx, new NextSpy(ctx));
+    }
+
+    /// <summary>Always-miss cache, so every call reaches the authoritative query.</summary>
+    private sealed class NoopDistributedCache : IDistributedCache
+    {
+        public byte[]? Get(string key) => null;
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => Task.FromResult<byte[]?>(null);
+        public void Refresh(string key) { }
+        public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+        public void Remove(string key) { }
+        public Task RemoveAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options) { }
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
+                             CancellationToken token = default) => Task.CompletedTask;
+    }
+
+    private sealed class NextSpy
+    {
+        private readonly ActionExecutingContext _ctx;
+        public NextSpy(ActionExecutingContext ctx) => _ctx = ctx;
+        public bool WasCalled { get; private set; }
+
+        public ActionExecutionDelegate Delegate => () =>
+        {
+            WasCalled = true;
+            return Task.FromResult(new ActionExecutedContext(
+                _ctx, new List<IFilterMetadata>(), controller: null!));
+        };
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Planscape.API.Authorization;
 using Planscape.API.Controllers;
+using Planscape.Core.DTOs;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -489,6 +490,220 @@ public class FederationAuthorizationTests
         }
     }
 
+    // ── IfcController — cross-host IFC identity ingest ───────────────────────
+    //
+    // Same class of hole as the five above, on a DIFFERENT pair of controllers:
+    // IfcController and GlobalIdRegistryController write the cross-host element
+    // IDENTITY (the IFC-GlobalId ↔ host-element-id table that clash, issues and
+    // BCF all resolve through). They carried [Authorize] and filtered by tenant
+    // only, so a member of any one project could rewrite another project's
+    // identity mappings in the same tenant. The gate here is the same
+    // RequireProjectMemberAsync (write, 403) + [ProjectAccess] (read, 404).
+
+    /// <summary>Records whether the ingest ran, so a denial is proven to fire
+    /// BEFORE the write — not a 403 issued after the identity table was touched.</summary>
+    private sealed class SpyIfcIngest : IIfcIngestService
+    {
+        public bool Ran { get; private set; }
+
+        public Task<IfcIngestResponse> IngestAsync(
+            Guid tenantId, Guid projectId, IfcIngestRequest request, CancellationToken ct = default)
+        {
+            Ran = true;
+            return Task.FromResult(new IfcIngestResponse { NewElements = 1 });
+        }
+
+        public Task<int> UpsertMappingsAsync(
+            Guid tenantId, Guid projectId, string host, string? hostDocumentGuid,
+            IEnumerable<ElementMappingDto> mappings, CancellationToken ct = default)
+            => throw new NotSupportedException("not used by these tests");
+    }
+
+    /// <summary>Records the IoT bind, so the second write endpoint's denial is
+    /// likewise proven to fire before the resolver is called.</summary>
+    private sealed class SpyIdentityResolver : IIdentityResolverService
+    {
+        public bool BindCalled { get; private set; }
+
+        public Task<string?> ResolveCanonicalGuidAsync(Guid p, string h, string e, CancellationToken ct = default)
+            => throw new NotSupportedException("not used by these tests");
+        public Task<IReadOnlyList<HostElementRef>> ResolveHostElementsAsync(Guid p, string g, string? h = null, CancellationToken ct = default)
+            => throw new NotSupportedException("not used by these tests");
+        public Task<IReadOnlyList<HostElementRef>> GetCrossHostFanoutAsync(Guid p, string g, CancellationToken ct = default)
+            => throw new NotSupportedException("not used by these tests");
+
+        public Task<IdentityBindResult> BindIotDeviceAsync(
+            Guid p, string g, string d, string? label = null, string? hostDoc = null, CancellationToken ct = default)
+        {
+            BindCalled = true;
+            return Task.FromResult(new IdentityBindResult(true, Guid.NewGuid()));
+        }
+    }
+
+    private static IfcController NewIfcController(
+        World w, Guid actor, IIfcIngestService ingest, IIdentityResolverService identity)
+        => new(NewContext(w.Conn, w.Tenant), identity, ingest)
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+
+    private static IfcIngestRequest SomeIfcPayload() => new()
+    {
+        Host = "revit",
+        Elements = new List<IfcElementDto>
+        {
+            new()
+            {
+                IfcGlobalId = "3xY_aBcDeFgHiJkLmNoPqR", HostElementId = "12345",
+                Discipline = "M", FullTag = "M-BLD1-Z01-L01-HVAC-SUP-AHU-0001",
+            },
+        },
+    };
+
+    [Fact]
+    public async Task Neighbour_cannot_ingest_into_another_projects_ifc_identity()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var ingest = new SpyIfcIngest();
+
+            var result = await NewIfcController(w, w.Neighbour, ingest, new SpyIdentityResolver())
+                .IngestData(w.VictimProject, SomeIfcPayload());
+
+            AssertForbidden(result.Result);
+            Assert.False(ingest.Ran, "the ingest ran before the caller was authorized");
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_bind_an_iot_device_in_another_project()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var identity = new SpyIdentityResolver();
+
+            var result = await NewIfcController(w, w.Neighbour, new SpyIfcIngest(), identity)
+                .BindIotDevice(w.VictimProject,
+                    new IfcController.IotBindingRequest { IfcGlobalId = "3xY_aBcDeFgHiJkLmNoPqR", DeviceId = "sensor-1" },
+                    default);
+
+            AssertForbidden(result.Result);
+            Assert.False(identity.BindCalled, "the IoT binding was written before the caller was authorized");
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_ingest_ifc_identity()
+    {
+        // The mirror case: the gate must not deny a real member.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var ingest = new SpyIfcIngest();
+
+            var result = await NewIfcController(w, w.Insider, ingest, new SpyIdentityResolver())
+                .IngestData(w.VictimProject, SomeIfcPayload());
+
+            Assert.IsType<OkObjectResult>(result.Result);
+            Assert.True(ingest.Ran);
+        }
+    }
+
+    // ── GlobalIdRegistryController — cross-tool identity mappings ─────────────
+
+    private static GlobalIdRegistryController NewRegistryController(World w, Guid actor)
+        => new(NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant))
+        { ControllerContext = ContextFor(actor, w.Tenant) };
+
+    private static GlobalIdRegistryController.RegistryCreateDto SomeRegistryRow() =>
+        new(IfcGlobalId: "3xY_aBcDeFgHiJkLmNoPqR", ArchiCadGuid: "AC-1", RevitUniqueId: "RV-1",
+            TeklaGuid: null, Discipline: "A", IfcType: "IfcWall", ElementName: "Wall 1",
+            NormalizedLevelName: "L01", Notes: null);
+
+    [Fact]
+    public async Task Neighbour_cannot_create_a_registry_row_in_another_project()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewRegistryController(w, w.Neighbour)
+                .Create(w.VictimProject, SomeRegistryRow(), default);
+
+            AssertForbidden(result.Result);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.False(await check.GlobalIdRegistry.AnyAsync());
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_update_or_delete_another_projects_registry_row()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var rowId = Guid.NewGuid();
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.GlobalIdRegistry.Add(new ElementGlobalIdRegistry
+                {
+                    Id = rowId, TenantId = w.Tenant, ProjectId = w.VictimProject,
+                    IfcGlobalId = "3xY_aBcDeFgHiJkLmNoPqR", RevitUniqueId = "RV-ORIG",
+                    MappingStatus = "ManuallyMapped",
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var update = await NewRegistryController(w, w.Neighbour)
+                .Update(w.VictimProject, rowId,
+                    new GlobalIdRegistryController.RegistryUpdateDto(
+                        ArchiCadGuid: "HIJACK", RevitUniqueId: null, TeklaGuid: null,
+                        MappingStatus: null, NormalizedLevelName: null, Notes: null),
+                    default);
+            AssertForbidden(update.Result);
+
+            var delete = await NewRegistryController(w, w.Neighbour)
+                .Delete(w.VictimProject, rowId, default);
+            var denied = Assert.IsType<ObjectResult>(delete);
+            Assert.Equal(403, denied.StatusCode);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var kept = await check.GlobalIdRegistry.SingleAsync();
+            Assert.Equal("RV-ORIG", kept.RevitUniqueId);
+            Assert.Null(kept.ArchiCadGuid);
+        }
+    }
+
+    [Fact]
+    public async Task Neighbour_cannot_auto_match_another_projects_registry()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewRegistryController(w, w.Neighbour)
+                .AutoMatch(w.VictimProject, default);
+
+            AssertForbidden(result);
+        }
+    }
+
+    [Fact]
+    public async Task Insider_can_still_create_a_registry_row()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var result = await NewRegistryController(w, w.Insider)
+                .Create(w.VictimProject, SomeRegistryRow(), default);
+
+            var created = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(201, created.StatusCode);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.Equal("RV-1", (await check.GlobalIdRegistry.SingleAsync()).RevitUniqueId);
+        }
+    }
+
     // ── [ProjectAccess] — the read gate, driven directly ─────────────────────
 
     /// <summary>
@@ -527,6 +742,8 @@ public class FederationAuthorizationTests
     [InlineData(typeof(AlignmentController))]
     [InlineData(typeof(SceneNodesController))]
     [InlineData(typeof(ModelDiffController))]
+    [InlineData(typeof(IfcController))]
+    [InlineData(typeof(GlobalIdRegistryController))]
     public void ControllersCarryTheReadGate(Type controller)
     {
         Assert.True(

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -724,3 +724,113 @@ after the geometry GLB push, calls `PushIfcDataAsync(CurrentProjectId, …, host
 So Revit is now a first-class `/ifc/data` producer. Plugin builds against the
 Revit 2025 API (0 errors). Code and docs now AGREE: H-1 = implemented + wired;
 residual = real-Revit runtime validation (checklist).
+
+---
+
+# PART IV — FEDERATION HARDENING (Security → Placement → Reliability)
+
+A follow-up review of multi-tool federation (Revit + ArchiCAD + Tekla-via-IFC →
+Planscape web viewer) split the remaining work into three independent tracks:
+
+| Track | Theme | Status |
+|---|---|---|
+| **A** | Security — cross-project (within-tenant) access control | **CLOSED** (below) |
+| **B** | Placement — automatic, correct model alignment | open — see [`PERFECT_PLACEMENT_PROMPT.md`](PERFECT_PLACEMENT_PROMPT.md) |
+| **C** | Reliability — silent geometry loss, deletes, versioning | open |
+
+Deliberately NOT re-opened: the identity round-trip (PRs #654–660 — IFC GlobalId
+canonical, deduped, UNIQUE-enforced), the coordinator's manually-confirmed
+transform always winning, the per-file StingBridge IFC-drop `doc_guid`, and the
+global `ITenantScoped` filter.
+
+## 18. Track A — cross-project access control (CLOSED)
+
+### The defect
+
+Cross-TENANT isolation was already sound: `PlanscapeDbContext` applies a global
+`ITenantScoped` query filter that falls back to `Guid.Empty` (matching no rows),
+so it fails closed. **Tenant is not the unit of authorization for federation
+data, though.** Five controllers carried only `[Authorize]` and filtered by
+tenant, so a user invited to ANY ONE project in a tenant could read and modify
+EVERY OTHER project in that tenant:
+
+| Surface | Exposure before |
+|---|---|
+| `ModelTransformController` | `PUT/DELETE .../transform` — overwrite or delete another project's coordinate transform |
+| `CoordinateSystemController` | `POST/PUT/DELETE .../coordinate-system` — redefine the CRS every model aligns against |
+| `AlignmentController` | `POST .../auto-align` (writes a transform), `POST .../coherence` |
+| `SceneNodesController` | `GET /projects/{id}/scene` + `GET /scene-nodes/{nodeId}/file` — download another project's geometry |
+| `ModelDiffController` | `GET .../diff` — another project's element-level change history |
+
+`ModelsController` and `IfcIngestController` already applied the documented gate
+(`ProjectAccessExtensions` / `[ProjectAccess]`); these five were simply missed.
+
+### The fix
+
+Mirrors `IfcIngestController` exactly — two layers, because they answer different
+questions and return different codes:
+
+- **`[ProjectAccess]`** (read gate → **404**) at the controller level. Admits
+  tenant Admin/Owner/SecurityOfficer, the project author, or an active member.
+  404 rather than 403 so a denial does not confirm the project exists.
+- **`RequireProjectMemberAsync`** (write gate → **403**) as the first statement of
+  every mutating action.
+
+Two endpoints needed bespoke handling:
+
+- `SceneNodesController.GetChunkFile` is routed by `{nodeId}`, not `{projectId}`,
+  so the attribute cannot resolve a project from route data. The owning project
+  is resolved off the node and checked explicitly against
+  `ProjectVisibility.CanSeeProjectAsync`, returning 404 to match.
+- `SceneNodesController.Ingest` is `[AllowAnonymous]` (converter shared bearer)
+  and likewise has no `{projectId}`; the attribute falls through by design and
+  the bearer check stands.
+
+**`FederatedModelHub.JoinProject` (A2)** had no check at all — the SignalR group
+name was the only key, so any authenticated user could subscribe to any project's
+`ModelUpdated` stream, across tenants. It now validates membership through the
+same `ProjectMembershipGuard`.
+
+> **Why the hub reads its tenant from the JWT rather than the ambient filter.**
+> `ITenantContext.TenantId` resolves off `IHttpContextAccessor`, which is not
+> reliably populated inside a SignalR hub method (the documented accessor is
+> `Context.GetHttpContext()`). An unresolved tenant makes `CurrentTenantId`
+> `Guid.Empty`, which the global filter treats as "matches no rows" — fail-closed,
+> but it would have denied every legitimate member too. The hub therefore reads
+> the tenant off the connection's principal, bypasses the ambient filter for that
+> one query, and re-applies tenant scope by hand. `NotificationHub.JoinProject`
+> carries the same latent fragility; it was left alone as out of scope.
+
+**`AutoAlignService.ComputeAsync` (A3)** persisted with a bare "overwrite if
+exists", ignoring `IsConfirmed`. The IFC-ingest path has always respected the flag
+("Only auto-update if not manually confirmed by a coordinator"); auto-align did
+not, so any run silently destroyed a coordinator's hand-set alignment. It now
+refuses — and, because this path is an explicit user action rather than an upload
+side effect, returns the transform it WOULD have applied so the coordinator can
+compare and decide deliberately.
+
+### Verification
+
+`tests/Planscape.Tests/` — 26 new tests across `FederationAuthorizationTests`,
+`FederatedModelHubAuthorizationTests`, `AutoAlignConfirmedTransformTests`.
+
+Every attacker in them is a real, active, authenticated member of the **same
+tenant** as the victim project, just a member of a different project. This is the
+distinguishing detail: a cross-tenant test passes against the unfixed code and
+proves nothing, which is exactly why the pre-existing tenant-isolation suite
+never caught this.
+
+The suite was run against the **unfixed** code with the source changes stashed:
+**13 failed, 8 passed** — every denial and gate test failed, while the happy-path
+tests passed, confirming the tests detect the defect rather than restate the fix
+and that the fixture is not simply denying everything. With the fix: 26/26 pass,
+and the full suite is **659 passed / 0 failed / 11 skipped**.
+
+Covered: the in-action 403 gate (controllers constructed directly against real
+SQLite with real `ProjectMember` rows), the `[ProjectAccess]` 404 gate (filter
+driven directly with a hand-built `ActionExecutingContext`), and a reflection
+test pinning the attribute onto all five controllers so removing it fails a test.
+NOT covered: end-to-end MVC wiring — no host is booted, because a
+`WebApplicationFactory` cannot run against SQLite (Program.cs issues a
+Postgres-only `information_schema` query with no try/catch) and a second factory
+is unreliable in this assembly (ROADMAP DEP-7).


### PR DESCRIPTION
## The bug (live)

Cross-**tenant** isolation is sound — the global `ITenantScoped` filter fails closed. But tenant is not the unit of authorization for federation data. Five controllers carried only `[Authorize]` and filtered by tenant, so **a user invited to any one project in a tenant could read and modify every other project in that tenant**:

| Surface | Exposure |
|---|---|
| `ModelTransformController` | `PUT/DELETE .../transform` — overwrite or delete another project's coordinate transform |
| `CoordinateSystemController` | `POST/PUT/DELETE .../coordinate-system` — redefine the CRS every model aligns against |
| `AlignmentController` | `POST .../auto-align` (writes a transform), `POST .../coherence` |
| `SceneNodesController` | `GET /projects/{id}/scene`, `GET /scene-nodes/{nodeId}/file` — download another project's geometry |
| `ModelDiffController` | `GET .../diff` — another project's element-level change history |

`ModelsController` and `IfcIngestController` already applied the documented gate; these five were missed.

## The fix

Mirrors `IfcIngestController` exactly — two layers, different questions, different codes:

- **`[ProjectAccess]`** (read gate → **404**) at controller level. 404 not 403, so a denial doesn't confirm the project exists.
- **`RequireProjectMemberAsync`** (write gate → **403**) as the first statement of every mutating action.

Two endpoints needed bespoke handling:
- `GetChunkFile` is routed by `{nodeId}`, so the attribute can't resolve a project from route data — the owning project is resolved off the node and checked explicitly, returning 404 to match.
- `Ingest` is `[AllowAnonymous]` (converter bearer) with no `{projectId}` — the attribute falls through by design.

**A2 — `FederatedModelHub.JoinProject`** had no check at all; the SignalR group name was the only key, so any authenticated user could subscribe to any project's `ModelUpdated` stream, across tenants. Now goes through `ProjectMembershipGuard`.

> It reads its tenant from the connection's JWT rather than the ambient filter. `ITenantContext` resolves off `IHttpContextAccessor`, which is **not reliably populated inside a hub method**; an unresolved tenant makes `CurrentTenantId` empty, which the filter treats as "matches no rows" — fail-closed, but it would have denied every legitimate member too. `NotificationHub` carries the same latent fragility; left alone as out of scope.

**A3 — `AutoAlignService.ComputeAsync`** persisted with a bare "overwrite if exists", ignoring `IsConfirmed`, silently destroying a coordinator's hand-set alignment. (The IFC-ingest path has always respected the flag.) It now refuses — and returns the transform it *would* have applied, since this path is an explicit user action, not an upload side effect.

## Verification

**26 new tests.** Every attacker is an active, authenticated member of the **same tenant** as the victim project, just a member of a *different* project. That's the distinguishing detail: a cross-tenant test passes against the unfixed code, which is exactly why the existing tenant-isolation suite never caught this.

Ran against the **unfixed** source (changes stashed): **13 failed, 8 passed** — every denial and gate test failed, while the happy-path tests passed. So the tests detect the defect rather than restate the fix, and the fixture isn't simply denying everything.

- With the fix: **26/26 pass**
- Full suite: **659 passed / 0 failed / 11 skipped**
- Build: **0 errors**, same 7 pre-existing warnings as baseline

Covered: the 403 in-action gate (controllers constructed directly against real SQLite with real `ProjectMember` rows), the 404 `[ProjectAccess]` gate (filter driven directly), and a reflection test pinning the attribute onto all five controllers so removing it fails a test.

**Not covered:** end-to-end MVC wiring — no host is booted (a `WebApplicationFactory` can't run against SQLite, and a second factory is unreliable here per ROADMAP DEP-7). Stated so a green run isn't read as proof of the pipeline.

Track A of a three-track federation-hardening effort; B (placement) and C (reliability) follow separately. Docs: `docs/COORDINATION_AUDIT_FINDINGS.md` PART IV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up — two identity controllers the first pass missed

A re-audit found the **same within-tenant hole on two more federation controllers** that also carried `[Authorize]` + tenant-only filtering. Both write the cross-host element **identity** table (the IFC-GlobalId ↔ host-element-id mapping that clash, issues and BCF resolve through), so a member of any one project could rewrite another project's identity in the same tenant.

| Surface | Exposure (before) |
|---|---|
| `IfcController` | `POST .../ifc/data`, `POST .../ifc/iot-binding` — ingest/overwrite another project's cross-host mappings + IoT bindings |
| `GlobalIdRegistryController` | `POST/PATCH/DELETE .../global-id-registry`, `POST .../auto-match` — create/edit/delete another project's canonical identity mappings |

Same fix, same two layers: `[ProjectAccess]` (read → 404) at controller level + `RequireProjectMemberAsync` (write → 403) as the first statement of every mutating action. `GetMappings` / `Resolve` / `List` / `Get` are reads covered by the class attribute.

**+9 tests** in `FederationAuthorizationTests`: a same-tenant non-member is 403'd on IFC ingest, IoT-binding, and registry create/update/delete/auto-match (spies prove the denial fires **before** the write); a real member still succeeds; and both controllers are added to the reflection theory that pins `[ProjectAccess]`. **27/27 in the class pass**, API builds **0 errors**.
