### PR TITLE
Placement P1: apply high-confidence transforms automatically, keep the manual override

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Planscape.API.Authorization;
 using Planscape.API.Services;
+using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -191,10 +192,7 @@ public class IfcIngestController : ControllerBase
                 if (ar.HasMapConversion && (ar.SurveyEasting.HasValue || ar.SurveyNorthing.HasValue))
                 {
                     await UpsertProjectModelTransformAsync(
-                        projectId, effectiveModelId, tenantId,
-                        ar.SurveyEasting ?? 0, ar.SurveyNorthing ?? 0, ar.SurveyElevation ?? 0,
-                        ar.MapConversionRotationDeg ?? 0, result.UnitScaleToMm,
-                        ct);
+                        projectId, effectiveModelId, tenantId, ar, result.UnitScaleToMm, ct);
                 }
             }
             catch (Exception aex)
@@ -614,13 +612,23 @@ public class IfcIngestController : ControllerBase
     /// The translation is the negative of the survey origin so applying it brings
     /// georeferenced model coordinates back to the project origin.
     /// Called automatically during ingest when IfcMapConversion is present.
+    ///
+    /// <para>B1 — takes the whole <see cref="IfcAlignmentReport"/> rather than the
+    /// six numbers it needs, because grading the transform's confidence uses the
+    /// evidence AROUND the numbers (projected CRS, verdict) as much as the
+    /// numbers themselves, and splitting them across a long parameter list is how
+    /// the two auto-writers drift apart.</para>
     /// </summary>
     private async Task UpsertProjectModelTransformAsync(
         Guid projectId, Guid projectModelId, Guid tenantId,
-        double eastingM, double northingM, double elevationM,
-        double rotationDeg, double unitScaleToMm,
+        IfcAlignmentReport report, double unitScaleToMm,
         CancellationToken ct)
     {
+        double eastingM   = report.SurveyEasting ?? 0;
+        double northingM  = report.SurveyNorthing ?? 0;
+        double elevationM = report.SurveyElevation ?? 0;
+        double rotationDeg = report.MapConversionRotationDeg ?? 0;
+
         try
         {
             var existing = await _db.ProjectModelTransforms
@@ -639,37 +647,62 @@ public class IfcIngestController : ControllerBase
                 ? 1.0   // metres — no scale correction needed
                 : 1.0;  // mm — coordinates are already in mm, no scale correction
 
+            // B1 — grade the georeferencing so a trustworthy transform renders
+            // without a coordinator confirming it first. The project's own CRS is
+            // the second acceptable anchor when the file declares no
+            // IfcProjectedCRS of its own.
+            var projectCrs = await _db.ProjectCoordinateSystems.AsNoTracking()
+                .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == tenantId, ct);
+
+            var confidence = TransformConfidencePolicy.Evaluate(
+                hasMapConversion : report.HasMapConversion,
+                hasProjectedCrs  : report.HasProjectedCrs,
+                crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(
+                                       report.CrsName, projectCrs?.CrsEpsgCode ?? projectCrs?.CrsName),
+                surveyEasting    : report.SurveyEasting,
+                surveyNorthing   : report.SurveyNorthing,
+                verdict          : report.Verdict);
+
+            bool autoApply = TransformConfidencePolicy.ShouldAutoApply(confidence);
+            string confidenceText = TransformConfidencePolicy.ToStorageString(confidence);
+
             if (existing != null)
             {
                 // Only auto-update if not manually confirmed by a coordinator.
                 if (!existing.IsConfirmed)
                 {
-                    existing.TranslationX   = txMm;
-                    existing.TranslationY   = tyMm;
-                    existing.TranslationZ   = tzMm;
-                    existing.RotationDeg    = rotationDeg;
-                    existing.ScaleFactor    = scaleFactor;
-                    existing.IsAutoComputed = true;
-                    existing.UpdatedAt      = DateTime.UtcNow;
-                    existing.Notes          = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u}";
+                    existing.TranslationX         = txMm;
+                    existing.TranslationY         = tyMm;
+                    existing.TranslationZ         = tzMm;
+                    existing.RotationDeg          = rotationDeg;
+                    existing.ScaleFactor          = scaleFactor;
+                    existing.IsAutoComputed       = true;
+                    existing.AppliedAutomatically = autoApply;
+                    existing.Confidence           = confidenceText;
+                    existing.Source               = "ifc-map-conversion";
+                    existing.UpdatedAt            = DateTime.UtcNow;
+                    existing.Notes                = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u} (confidence {confidenceText})";
                 }
             }
             else
             {
                 _db.ProjectModelTransforms.Add(new Planscape.Core.Entities.ProjectModelTransform
                 {
-                    TenantId       = tenantId,
-                    ProjectId      = projectId,
-                    ProjectModelId = projectModelId,
-                    TranslationX   = txMm,
-                    TranslationY   = tyMm,
-                    TranslationZ   = tzMm,
-                    RotationDeg    = rotationDeg,
-                    ScaleFactor    = scaleFactor,
-                    IsAutoComputed = true,
-                    IsConfirmed    = false,
-                    AppliedAt      = DateTime.UtcNow,
-                    Notes          = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u}",
+                    TenantId             = tenantId,
+                    ProjectId            = projectId,
+                    ProjectModelId       = projectModelId,
+                    TranslationX         = txMm,
+                    TranslationY         = tyMm,
+                    TranslationZ         = tzMm,
+                    RotationDeg          = rotationDeg,
+                    ScaleFactor          = scaleFactor,
+                    IsAutoComputed       = true,
+                    IsConfirmed          = false,
+                    AppliedAutomatically = autoApply,
+                    Confidence           = confidenceText,
+                    Source               = "ifc-map-conversion",
+                    AppliedAt            = DateTime.UtcNow,
+                    Notes                = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u} (confidence {confidenceText})",
                 });
             }
             await _db.SaveChangesAsync(ct);
@@ -684,6 +717,10 @@ public class IfcIngestController : ControllerBase
                         rotationDeg, scaleFactor,
                         source = "IfcMapConversion",
                         autoComputed = true,
+                        // B1 — a model that MOVES on its own must say so in the
+                        // audit trail, and say what it was trusting when it did.
+                        confidence = confidenceText,
+                        appliedAutomatically = autoApply,
                     }));
             }
             catch { /* audit failure is non-fatal */ }

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
@@ -72,6 +72,9 @@ public class ModelTransformController : ControllerBase
                 scaleFactor      = 1.0,
                 isAutoComputed   = false,
                 isConfirmed      = false,
+                appliedAutomatically = false,
+                confidence       = (string?)null,
+                source           = (string?)null,
                 appliedBy        = (string?)null,
                 appliedAt        = (DateTime?)null,
                 notes            = (string?)null,
@@ -89,6 +92,9 @@ public class ModelTransformController : ControllerBase
             scaleFactor      = xf.ScaleFactor,
             isAutoComputed   = xf.IsAutoComputed,
             isConfirmed      = xf.IsConfirmed,
+            appliedAutomatically = xf.AppliedAutomatically,
+            confidence       = xf.Confidence,
+            source           = xf.Source,
             appliedBy        = xf.AppliedBy,
             appliedAt        = xf.AppliedAt,
             notes            = xf.Notes,
@@ -153,6 +159,16 @@ public class ModelTransformController : ControllerBase
         xf.AppliedBy      = User.Identity?.Name;
         xf.AppliedAt      = DateTime.UtcNow;
 
+        // B1 — a hand-entered transform is never an "auto-applied" one, whatever
+        // the row held before. Clearing the flag here is what makes the
+        // precedence rule total: after a manual PUT the row is purely the
+        // coordinator's, and the automatic writers will not touch it again while
+        // IsConfirmed stands. A manual transform saved with IsConfirmed=false
+        // stays a draft and does not render — unchanged from previous behaviour.
+        xf.AppliedAutomatically = false;
+        xf.Confidence           = null;
+        xf.Source               = "manual";
+
         await _db.SaveChangesAsync(ct);
 
         // Re-compute SceneNode AABBs for this model
@@ -203,6 +219,9 @@ public class ModelTransformController : ControllerBase
             scaleFactor      = xf.ScaleFactor,
             isAutoComputed   = xf.IsAutoComputed,
             isConfirmed      = xf.IsConfirmed,
+            appliedAutomatically = xf.AppliedAutomatically,
+            confidence       = xf.Confidence,
+            source           = xf.Source,
             appliedBy        = xf.AppliedBy,
             appliedAt        = xf.AppliedAt,
             notes            = xf.Notes,

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -2091,6 +2091,16 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // index (lookups keep working) until an operator runs
         // POST /api/admin/identity/reconcile/apply and restarts. Atomic (single DO
         // block) so a failed convert can never leave the table with no index.
+        // B1 — auto-applied transforms. ProjectModelTransform gains three
+        // columns so a survey-derived alignment can render WITHOUT a coordinator
+        // confirming it, while a confirmed one still outranks it. Same
+        // idempotent-patch rationale as the columns above (ADR 0001): fresh DBs
+        // get them from the EF model via CreateTables, pre-existing DBs get them
+        // here. NOT NULL DEFAULT false on the flag so existing rows keep today's
+        // behaviour exactly — nothing starts rendering because of a deploy.
+        "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"AppliedAutomatically\" boolean NOT NULL DEFAULT false",
+        "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Confidence\" text NULL",
+        "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Source\" text NULL",
         "DO $$ BEGIN " +
         "IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' " +
             "AND indexname='IX_TaggedElements_ProjectId_IfcGlobalId' AND indexdef ILIKE '%UNIQUE%') " +

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1088,16 +1088,33 @@ THREE.ColorManagement.enabled = false;
   // BLK-2 — apply a stored ProjectModelTransform to a loaded model root.
   // Translation is stored in mm (server contract); GLB geometry is metres,
   // so convert ÷1000. Rotation is degrees about the project vertical (world Z).
-  // Composed as T·R·S. Guarded so absent / unconfirmed / identity transforms
+  // Composed as T·R·S. Guarded so absent / unapplied / identity transforms
   // leave the model untouched.
+  //
+  // B1 — a transform is LIVE when a coordinator confirmed it (isConfirmed) OR
+  // when the platform graded its georeferencing HIGH and applied it on its own
+  // (appliedAutomatically). Previously the only gate was `isConfirmed !== false`,
+  // and BOTH automatic writers store isConfirmed=false — so a correct,
+  // survey-derived alignment was computed, stored, and then never rendered until
+  // somebody confirmed it by hand. That single line is why same-site models from
+  // different tools did not line up on their own.
+  //
+  // Precedence needs no tie-break here: the automatic writers refuse to overwrite
+  // a row with isConfirmed=true, so a confirmed row already holds the
+  // coordinator's numbers. Manual wins by construction, at write time.
+  //
+  // The `!== false` default is kept for isConfirmed so an older/partial payload
+  // that omits the field still renders as it did before.
   function applyModelTransform(root, t) {
     if (!root || !t) return;
     const tx = (+t.translationX || 0), ty = (+t.translationY || 0), tz = (+t.translationZ || 0);
     const rot = (+t.rotationDeg || 0);
     const scale = (t.scaleFactor != null ? +t.scaleFactor : 1) || 1;
     const confirmed = (t.isConfirmed !== false);   // default-confirmed if unspecified
+    const autoApplied = (t.appliedAutomatically === true);
+    const live = confirmed || autoApplied;
     const isIdentity = tx === 0 && ty === 0 && tz === 0 && rot === 0 && scale === 1;
-    if (!confirmed || isIdentity) return;
+    if (!live || isIdentity) return;
     try {
       root.scale.set(scale, scale, scale);
       root.rotation.z = rot * Math.PI / 180;

--- a/Planscape.Server/src/Planscape.Core/Coordinates/TransformConfidence.cs
+++ b/Planscape.Server/src/Planscape.Core/Coordinates/TransformConfidence.cs
@@ -1,0 +1,152 @@
+namespace Planscape.Core.Coordinates;
+
+/// <summary>
+/// How much the platform trusts an automatically-derived model transform.
+///
+/// This is the switch that decides whether a model MOVES on its own. It exists
+/// because "we computed a transform" and "we believe it enough to place a
+/// building with it" are different claims, and conflating them gives you one of
+/// two bad products: either nothing ever aligns without manual data entry, or
+/// every model without real survey data gets scattered across the site by a
+/// guess.
+/// </summary>
+public enum TransformConfidence
+{
+    /// <summary>
+    /// No usable georeference. The model stays where its author put it —
+    /// at the project origin. Explicitly NOT "apply a best guess": a model
+    /// parked at the origin is obviously un-placed and a coordinator fixes it
+    /// in seconds, whereas a model moved 500 km by a bad guess looks placed and
+    /// costs an investigation.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// A transform was derived, but from incomplete or unconfirmed evidence
+    /// (survey origin with no projected CRS to anchor it, or an alignment
+    /// report that FAILed). Stored and offered as a suggestion; NOT applied
+    /// automatically. A coordinator confirms it to make it live.
+    /// </summary>
+    Low = 1,
+
+    /// <summary>
+    /// Real, self-consistent georeferencing: a survey origin from
+    /// IfcMapConversion plus a CRS that either declares itself
+    /// (IfcProjectedCRS) or matches the project's own coordinate system, and an
+    /// alignment report that did not FAIL. Safe to apply without asking.
+    /// </summary>
+    High = 2,
+}
+
+/// <summary>
+/// The ONE place that decides whether an auto-derived transform is trustworthy
+/// enough to apply on its own.
+///
+/// <para><b>Why it is shared and Revit-free.</b> Two independent writers produce
+/// automatic transforms — the IFC ingest path and <c>AutoAlignService</c> — and
+/// a third (the Revit GLB upload path) is planned. If each carried its own
+/// notion of "good enough", the same model would render in different places
+/// depending on which pipeline touched it last. Keeping the rule here also makes
+/// it a pure function that can be unit-tested exhaustively without a database,
+/// an IFC file, or a Revit session.</para>
+/// </summary>
+public static class TransformConfidencePolicy
+{
+    /// <summary>
+    /// Grade the georeferencing evidence behind a transform.
+    /// </summary>
+    /// <param name="hasMapConversion">
+    /// The source declared an IfcMapConversion (or an equivalent host georef
+    /// block). Without it there is no survey origin and nothing to trust.
+    /// </param>
+    /// <param name="hasProjectedCrs">
+    /// The source declared an IfcProjectedCRS, so the easting/northing are
+    /// anchored to a named coordinate reference system.
+    /// </param>
+    /// <param name="crsMatchesProject">
+    /// The source's CRS matches the project's declared
+    /// <c>ProjectCoordinateSystem</c>. An alternative anchor to
+    /// <paramref name="hasProjectedCrs"/>: a file that names no CRS but whose
+    /// coordinates sit in the project's declared frame is equally placeable.
+    /// </param>
+    /// <param name="surveyEasting">Survey origin easting, if any.</param>
+    /// <param name="surveyNorthing">Survey origin northing, if any.</param>
+    /// <param name="verdict">
+    /// The IfcAlignmentReport verdict — "PASS" / "WARN" / "FAIL". WARN is
+    /// deliberately accepted: it is raised for things like a true-north delta
+    /// against a sibling model, which is a coordination note, not a reason to
+    /// leave the model unplaced. FAIL is not.
+    /// </param>
+    public static TransformConfidence Evaluate(
+        bool hasMapConversion,
+        bool hasProjectedCrs,
+        bool crsMatchesProject,
+        double? surveyEasting,
+        double? surveyNorthing,
+        string? verdict)
+    {
+        // No survey origin → nothing was derived from georeferencing at all.
+        if (!hasMapConversion || surveyEasting is null || surveyNorthing is null)
+            return TransformConfidence.None;
+
+        // A FAILed report means the validator found a contradiction it could not
+        // reconcile. Compute the transform, store it, but do not act on it.
+        if (string.Equals(verdict, "FAIL", StringComparison.OrdinalIgnoreCase))
+            return TransformConfidence.Low;
+
+        // Anchored either by its own declared CRS or by agreeing with the
+        // project's. Unanchored coordinates are plausible but unverifiable, so
+        // they stay a suggestion.
+        return (hasProjectedCrs || crsMatchesProject)
+            ? TransformConfidence.High
+            : TransformConfidence.Low;
+    }
+
+    /// <summary>
+    /// Whether a transform of this confidence may be applied to the model
+    /// without a coordinator confirming it first.
+    /// </summary>
+    public static bool ShouldAutoApply(TransformConfidence confidence)
+        => confidence == TransformConfidence.High;
+
+    /// <summary>
+    /// Persisted / wire form. Stored as a string rather than an int so a column
+    /// value is readable in a database session and survives enum reordering.
+    /// </summary>
+    public static string ToStorageString(TransformConfidence confidence) => confidence switch
+    {
+        TransformConfidence.High => "HIGH",
+        TransformConfidence.Low  => "LOW",
+        _                        => "NONE",
+    };
+
+    /// <summary>Inverse of <see cref="ToStorageString"/>; unknown input reads as None.</summary>
+    public static TransformConfidence FromStorageString(string? value) => value?.ToUpperInvariant() switch
+    {
+        "HIGH" => TransformConfidence.High,
+        "LOW"  => TransformConfidence.Low,
+        _      => TransformConfidence.None,
+    };
+
+    /// <summary>
+    /// True when two CRS identifiers refer to the same system. Tolerates the
+    /// common spellings ("EPSG:27700", "epsg:27700", "27700") because the string
+    /// arrives from IFC files written by half a dozen authoring tools.
+    /// Null/blank on either side is NOT a match — unknown is not equal.
+    /// </summary>
+    public static bool CrsEquivalent(string? a, string? b)
+    {
+        var na = NormaliseCrs(a);
+        var nb = NormaliseCrs(b);
+        return na.Length > 0 && na == nb;
+    }
+
+    private static string NormaliseCrs(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "";
+        var s = value.Trim().ToUpperInvariant();
+        if (s.StartsWith("EPSG:", StringComparison.Ordinal)) s = s[5..].Trim();
+        else if (s.StartsWith("EPSG", StringComparison.Ordinal)) s = s[4..].Trim(':', ' ');
+        return s;
+    }
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectModelTransform.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectModelTransform.cs
@@ -39,6 +39,45 @@ public class ProjectModelTransform : ITenantScoped
     /// <summary>True when a coordinator has explicitly confirmed or manually set the transform.</summary>
     public bool IsConfirmed { get; set; } = false;
 
+    /// <summary>
+    /// True when the platform applied this transform on its own, without a
+    /// coordinator confirming it, because the georeferencing behind it graded
+    /// <see cref="Planscape.Core.Coordinates.TransformConfidence.High"/>.
+    ///
+    /// <para><b>Why this is not just <see cref="IsAutoComputed"/>.</b>
+    /// <c>IsAutoComputed</c> records HOW the numbers were obtained; this records
+    /// whether they are LIVE. The two came apart badly: both automatic writers
+    /// stored <c>IsAutoComputed=true, IsConfirmed=false</c>, and the viewer
+    /// applied a transform only when <c>IsConfirmed</c> was not false — so a
+    /// perfectly good survey-derived alignment was computed, stored, and then
+    /// never rendered until somebody confirmed it by hand. That is the whole
+    /// "models don't line up automatically" symptom.</para>
+    ///
+    /// <para><b>Precedence.</b> <see cref="IsConfirmed"/> outranks this, and the
+    /// precedence is enforced when WRITING, not when rendering: an automatic
+    /// writer refuses to touch a row with <c>IsConfirmed=true</c>, so a
+    /// confirmed row always holds the coordinator's numbers and there is nothing
+    /// to reconcile at read time.</para>
+    /// </summary>
+    public bool AppliedAutomatically { get; set; } = false;
+
+    /// <summary>
+    /// How far the georeferencing evidence was trusted — "HIGH" | "LOW" | "NONE"
+    /// (see <see cref="Planscape.Core.Coordinates.TransformConfidencePolicy"/>).
+    /// Stored as text so the value is legible in a database session and survives
+    /// enum reordering. Null on rows written before this field existed and on
+    /// purely manual transforms.
+    /// </summary>
+    public string? Confidence { get; set; }
+
+    /// <summary>
+    /// Which pipeline produced the numbers: "manual" | "ifc-map-conversion" |
+    /// "auto-align" | "revit-georef". <see cref="AppliedBy"/> records WHO,
+    /// this records WHAT — needed because the UI has to explain to a
+    /// coordinator why a model moved on its own.
+    /// </summary>
+    public string? Source { get; set; }
+
     /// <summary>Display name of the user who last applied or confirmed this transform.</summary>
     public string? AppliedBy { get; set; }
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -1494,6 +1494,12 @@ public class PlanscapeDbContext : DbContext
             e.HasIndex(x => x.TenantId);
             e.Property(x => x.AppliedBy).HasMaxLength(200);
             e.Property(x => x.Notes).HasMaxLength(2000);
+            // B1 — auto-apply. Left unconstrained in length deliberately: the
+            // startup patcher adds these to pre-existing DBs as plain `text`,
+            // and a HasMaxLength here would make SchemaDriftChecker report a
+            // type mismatch between the EF model and the patched column.
+            e.Property(x => x.Confidence);
+            e.Property(x => x.Source);
             e.HasOne(x => x.Model).WithMany().HasForeignKey(x => x.ProjectModelId).OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
@@ -3,6 +3,7 @@ namespace Planscape.Infrastructure.Services;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Infrastructure.Data;
 using Planscape.Infrastructure.SignalR;
@@ -234,21 +235,39 @@ public sealed class AutoAlignService : IAutoAlignService
             existing.UpdatedAt = DateTime.UtcNow;
         }
 
-        existing.TranslationX   = tx;
-        existing.TranslationY   = ty;
-        existing.TranslationZ   = tz;
-        existing.RotationDeg    = rotDeg;
-        existing.ScaleFactor    = scaleFactor;
-        existing.IsAutoComputed = true;
-        existing.IsConfirmed    = false;
-        existing.AppliedBy      = "auto-align-service";
-        existing.AppliedAt      = DateTime.UtcNow;
+        // ── 6b. Grade the evidence, and apply it if it is strong enough ───────
+        // B1 — computing a transform and trusting it are different claims. The
+        // shared policy makes this path agree with the IFC ingest path, so the
+        // same model does not render in two different places depending on which
+        // pipeline touched it last.
+        var confidence = TransformConfidencePolicy.Evaluate(
+            hasMapConversion : targetReport.HasMapConversion,
+            hasProjectedCrs  : targetReport.HasProjectedCrs,
+            crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(
+                                   targetReport.CrsName, pcs?.CrsEpsgCode ?? pcs?.CrsName),
+            surveyEasting    : targetReport.SurveyEasting,
+            surveyNorthing   : targetReport.SurveyNorthing,
+            verdict          : targetReport.Verdict);
+
+        existing.TranslationX         = tx;
+        existing.TranslationY         = ty;
+        existing.TranslationZ         = tz;
+        existing.RotationDeg          = rotDeg;
+        existing.ScaleFactor          = scaleFactor;
+        existing.IsAutoComputed       = true;
+        existing.IsConfirmed          = false;
+        existing.AppliedAutomatically = TransformConfidencePolicy.ShouldAutoApply(confidence);
+        existing.Confidence           = TransformConfidencePolicy.ToStorageString(confidence);
+        existing.Source               = "auto-align";
+        existing.AppliedBy            = "auto-align-service";
+        existing.AppliedAt            = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(ct);
 
         _logger.LogInformation(
-            "AutoAlign computed for model {ModelId}: TX={TX:F3} TY={TY:F3} TZ={TZ:F3} Rot={Rot:F4}° Scale={Scale:F6} ref={Ref}",
-            targetModelId, tx, ty, tz, rotDeg, scaleFactor, referenceModelId ?? "PCS");
+            "AutoAlign computed for model {ModelId}: TX={TX:F3} TY={TY:F3} TZ={TZ:F3} Rot={Rot:F4}° Scale={Scale:F6} ref={Ref} confidence={Confidence} autoApplied={AutoApplied}",
+            targetModelId, tx, ty, tz, rotDeg, scaleFactor, referenceModelId ?? "PCS",
+            confidence, existing.AppliedAutomatically);
 
         // Gap K — broadcast the new transform so viewer clients refresh their
         // coordinate frame without polling.

--- a/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -48,12 +49,26 @@ public class AutoAlignConfirmedTransformTests
     private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Target, Guid Reference);
 
     /// <summary>
+    /// Georeferencing quality of the TARGET model's report, which is what
+    /// <see cref="TransformConfidencePolicy"/> grades.
+    /// </summary>
+    public enum Georef   // public: xunit [InlineData] carries it into a public test signature
+    {
+        /// <summary>IfcProjectedCRS present + PASS → HIGH → auto-applied.</summary>
+        Strong,
+        /// <summary>Survey origin but no CRS anchor → LOW → suggestion only.</summary>
+        Unanchored,
+        /// <summary>Anchored, but the validator FAILed → LOW → suggestion only.</summary>
+        Failed,
+    }
+
+    /// <summary>
     /// A project with two georeferenced models: a reference at survey origin
     /// (1000, 2000) and a target at (1500, 2500). Auto-align therefore has real
     /// work to do — a fixture where it fails for lack of data would make the
     /// "did not overwrite" assertion pass for the wrong reason.
     /// </summary>
-    private static World NewWorld(bool targetTransformConfirmed)
+    private static World NewWorld(bool targetTransformConfirmed, Georef georef = Georef.Strong)
     {
         var conn = new SqliteConnection("DataSource=:memory:");
         conn.Open();
@@ -101,9 +116,14 @@ public class AutoAlignConfirmedTransformTests
             {
                 TenantId = tenant, ProjectId = project, ProjectModelId = target,
                 HasMapConversion = true,
+                // Only the STRONG case declares a projected CRS; the other two
+                // are what a real-world file without one looks like.
+                HasProjectedCrs = georef == Georef.Strong,
+                CrsName = georef == Georef.Strong ? "EPSG:27700" : null,
                 SurveyEasting = 1500, SurveyNorthing = 2500, SurveyElevation = 0,
                 MapConversionRotationDeg = 0,
-                Verdict = "PASS", ValidatedAt = DateTime.UtcNow,
+                Verdict = georef == Georef.Failed ? "FAIL" : "PASS",
+                ValidatedAt = DateTime.UtcNow,
             });
 
             ctx.Set<ProjectModelTransform>().Add(new ProjectModelTransform
@@ -188,6 +208,56 @@ public class AutoAlignConfirmedTransformTests
             Assert.True(xf.IsAutoComputed);
             Assert.False(xf.IsConfirmed);
             Assert.Equal("auto-align-service", xf.AppliedBy);
+        }
+    }
+
+    // ── B1 — does the computed transform actually go LIVE? ───────────────────
+
+    [Fact]
+    public async Task A_high_confidence_result_is_marked_auto_applied()
+    {
+        // The P1 fix. Before it, this row was written with IsConfirmed=false and
+        // nothing else, and the viewer's `isConfirmed !== false` gate discarded
+        // it — so a correct survey-derived alignment never rendered.
+        var w = NewWorld(targetTransformConfirmed: false, georef: Georef.Strong);
+        using (w.Conn)
+        {
+            var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
+            Assert.True(result.Success, result.Message);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.Set<ProjectModelTransform>().SingleAsync();
+
+            Assert.True(xf.AppliedAutomatically);
+            Assert.Equal("HIGH", xf.Confidence);
+            Assert.Equal("auto-align", xf.Source);
+            // Still not "confirmed" — that word is reserved for a human.
+            Assert.False(xf.IsConfirmed);
+        }
+    }
+
+    [Theory]
+    [InlineData(Georef.Unanchored)]   // survey origin, but no CRS to anchor it
+    [InlineData(Georef.Failed)]       // anchored, but the validator FAILed
+    public async Task A_low_confidence_result_is_stored_but_not_auto_applied(Georef georef)
+    {
+        // The other half of the contract, and the reason this is not just
+        // "apply everything": a model whose georeference cannot be trusted stays
+        // where it is instead of being flung across the site by a guess.
+        var w = NewWorld(targetTransformConfirmed: false, georef: georef);
+        using (w.Conn)
+        {
+            var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
+            Assert.True(result.Success, result.Message);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.Set<ProjectModelTransform>().SingleAsync();
+
+            // Computed and stored — a coordinator can still confirm it.
+            Assert.Equal(-500_000.0, xf.TranslationX, 3);
+            // But not live.
+            Assert.False(xf.AppliedAutomatically);
+            Assert.Equal("LOW", xf.Confidence);
         }
     }
 }

--- a/Planscape.Server/tests/Planscape.Tests/TransformConfidencePolicyTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/TransformConfidencePolicyTests.cs
@@ -1,0 +1,175 @@
+using Planscape.Core.Coordinates;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK B / P1 — the rule that decides whether a model MOVES on its own.
+///
+/// This is a pure function with no database, IFC file, or Revit session behind
+/// it, which is the point: two independent pipelines (IFC ingest and
+/// AutoAlignService, with the Revit GLB path to follow) produce automatic
+/// transforms, and if each carried its own notion of "good enough" the same
+/// model would render in different places depending on which one touched it
+/// last. Exhaustive coverage is cheap here and expensive anywhere else.
+///
+/// The product decision under test: a model with no usable georeference is left
+/// at the origin rather than moved by a guess. An un-placed model at the origin
+/// is obviously un-placed and a coordinator fixes it in seconds; a model moved
+/// 500 km by a bad guess looks placed and costs an investigation.
+/// </summary>
+public class TransformConfidencePolicyTests
+{
+    // ── HIGH — safe to apply without asking ─────────────────────────────────
+
+    [Theory]
+    [InlineData("PASS")]
+    [InlineData("WARN")]   // WARN is a coordination note, not a placement error
+    public void MapConversion_plus_own_projected_crs_is_High(string verdict)
+    {
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: true, crsMatchesProject: false,
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: verdict);
+
+        Assert.Equal(TransformConfidence.High, c);
+        Assert.True(TransformConfidencePolicy.ShouldAutoApply(c));
+    }
+
+    [Fact]
+    public void MapConversion_with_no_own_crs_but_matching_project_crs_is_High()
+    {
+        // A file that names no CRS of its own but whose coordinates sit in the
+        // project's declared frame is just as placeable as one that does.
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: false, crsMatchesProject: true,
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: "PASS");
+
+        Assert.Equal(TransformConfidence.High, c);
+    }
+
+    // ── LOW — stored as a suggestion, never applied on its own ──────────────
+
+    [Fact]
+    public void MapConversion_with_no_crs_anchor_is_Low()
+    {
+        // Plausible coordinates, but nothing says which coordinate system they
+        // are in — unverifiable, so it stays a suggestion.
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: false, crsMatchesProject: false,
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: "PASS");
+
+        Assert.Equal(TransformConfidence.Low, c);
+        Assert.False(TransformConfidencePolicy.ShouldAutoApply(c));
+    }
+
+    [Fact]
+    public void A_FAILed_alignment_report_caps_confidence_at_Low()
+    {
+        // Even with a perfect-looking georef: FAIL means the validator found a
+        // contradiction it could not reconcile. Compute it, store it, don't act.
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: true, crsMatchesProject: true,
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: "FAIL");
+
+        Assert.Equal(TransformConfidence.Low, c);
+        Assert.False(TransformConfidencePolicy.ShouldAutoApply(c));
+    }
+
+    [Fact]
+    public void Verdict_matching_is_case_insensitive()
+    {
+        Assert.Equal(TransformConfidence.Low, TransformConfidencePolicy.Evaluate(
+            true, true, true, 1000, 2000, "fail"));
+    }
+
+    // ── NONE — nothing was derived from georeferencing at all ───────────────
+
+    [Fact]
+    public void No_map_conversion_is_None()
+    {
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: false, hasProjectedCrs: true, crsMatchesProject: true,
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: "PASS");
+
+        Assert.Equal(TransformConfidence.None, c);
+        Assert.False(TransformConfidencePolicy.ShouldAutoApply(c));
+    }
+
+    [Theory]
+    [InlineData(null, 2000.0)]
+    [InlineData(1000.0, null)]
+    [InlineData(null, null)]
+    public void A_missing_survey_ordinate_is_None(double? easting, double? northing)
+    {
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: true, crsMatchesProject: true,
+            surveyEasting: easting, surveyNorthing: northing, verdict: "PASS");
+
+        Assert.Equal(TransformConfidence.None, c);
+    }
+
+    // ── CRS equivalence — the string arrives from many authoring tools ───────
+
+    [Theory]
+    [InlineData("EPSG:27700", "EPSG:27700")]
+    [InlineData("epsg:27700", "EPSG:27700")]
+    [InlineData("EPSG:27700", "27700")]
+    [InlineData("  EPSG:27700  ", "epsg:27700")]
+    [InlineData("EPSG27700", "27700")]
+    public void Equivalent_crs_spellings_match(string a, string b)
+        => Assert.True(TransformConfidencePolicy.CrsEquivalent(a, b));
+
+    [Theory]
+    [InlineData("EPSG:27700", "EPSG:4326")]
+    [InlineData("EPSG:27700", null)]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("   ", "EPSG:27700")]
+    public void Different_or_unknown_crs_do_not_match(string? a, string? b)
+        => Assert.False(TransformConfidencePolicy.CrsEquivalent(a, b));
+
+    [Fact]
+    public void Unknown_is_not_equal_to_unknown()
+    {
+        // Load-bearing: if null == null matched, EVERY model without a declared
+        // CRS in a project without a declared CRS would grade HIGH and be moved
+        // automatically on no evidence whatsoever.
+        Assert.False(TransformConfidencePolicy.CrsEquivalent(null, null));
+
+        var c = TransformConfidencePolicy.Evaluate(
+            hasMapConversion: true, hasProjectedCrs: false,
+            crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(null, null),
+            surveyEasting: 1000, surveyNorthing: 2000, verdict: "PASS");
+        Assert.Equal(TransformConfidence.Low, c);
+    }
+
+    // ── storage round-trip ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(TransformConfidence.High, "HIGH")]
+    [InlineData(TransformConfidence.Low, "LOW")]
+    [InlineData(TransformConfidence.None, "NONE")]
+    public void Storage_strings_round_trip(TransformConfidence c, string text)
+    {
+        Assert.Equal(text, TransformConfidencePolicy.ToStorageString(c));
+        Assert.Equal(c, TransformConfidencePolicy.FromStorageString(text));
+    }
+
+    [Theory]
+    [InlineData("high")]
+    [InlineData("HIGH")]
+    public void Storage_parsing_is_case_insensitive(string text)
+        => Assert.Equal(TransformConfidence.High, TransformConfidencePolicy.FromStorageString(text));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("banana")]
+    public void Unrecognised_storage_values_read_as_None(string? text)
+    {
+        // Rows written before this column existed read as null. They must NOT
+        // read as "trusted" — the fail-safe direction is "do not move it".
+        Assert.Equal(TransformConfidence.None, TransformConfidencePolicy.FromStorageString(text));
+        Assert.False(TransformConfidencePolicy.ShouldAutoApply(
+            TransformConfidencePolicy.FromStorageString(text)));
+    }
+}

--- a/Planscape.Server/tests/web-harness/transform-gate.mjs
+++ b/Planscape.Server/tests/web-harness/transform-gate.mjs
@@ -1,0 +1,131 @@
+// TRACK B / P1 — headless verification of the viewer's transform gate.
+//
+// THE DEFECT
+// ----------
+// `applyModelTransform` in viewer.html decided whether to move a model with:
+//
+//     const confirmed = (t.isConfirmed !== false);
+//     if (!confirmed || isIdentity) return;
+//
+// Both automatic writers — the IFC ingest path and AutoAlignService — store
+// `IsConfirmed = false`. So a correct, survey-derived alignment was computed,
+// persisted, sent to the viewer, and then discarded by this one line, every
+// time, until a human confirmed it by hand. That is the whole "same-site models
+// from different tools don't line up on their own" symptom, and it lives in four
+// tokens of JavaScript.
+//
+// WHAT THIS HARNESS DOES
+// ----------------------
+// Same approach as align-audit.mjs: Playwright/jsdom are not available on this
+// host, so rather than drive a browser it extracts `applyModelTransform` from
+// the SHIPPED viewer.html (read off disk, not a copy) and runs it in a `vm`
+// sandbox against a fake three.js root that records what was mutated. A
+// regression in the gate fails here.
+//
+// Run: node Planscape.Server/tests/web-harness/transform-gate.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WWW = path.resolve(__dirname, '../../src/Planscape.API/wwwroot');
+
+let failures = 0;
+function ok(name, cond, detail = '') {
+  if (cond) { console.log(`  PASS  ${name}`); }
+  else { failures++; console.log(`  FAIL  ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+const html = fs.readFileSync(path.join(WWW, 'viewer.html'), 'utf8');
+
+// ── extract the shipped function ────────────────────────────────────────────
+const m = html.match(/function applyModelTransform\(root, t\)\s*\{[\s\S]*?\n  \}/);
+if (!m) {
+  console.log('  FAIL  could not extract applyModelTransform from viewer.html');
+  process.exit(1);
+}
+
+/** A minimal stand-in for a three.js Object3D that records mutations. */
+function fakeRoot() {
+  return {
+    moved: false,
+    scale: { set(x, y, z) { this._v = [x, y, z]; } },
+    rotation: { z: 0 },
+    position: { set(x, y, z) { this._v = [x, y, z]; } },
+    updateMatrixWorld() { this.moved = true; },
+  };
+}
+
+/** Run the shipped gate against one transform payload; returns the root. */
+function apply(transform) {
+  const root = fakeRoot();
+  const ctx = vm.createContext({ Math, console, __root: root, __t: transform });
+  vm.runInContext(m[0] + '\napplyModelTransform(__root, __t);', ctx);
+  return root;
+}
+
+const REAL = { translationX: 500000, translationY: 250000, translationZ: 0, rotationDeg: 12, scaleFactor: 1 };
+
+console.log('— B1: an auto-applied transform actually moves the model —');
+{
+  // The regression case. This is exactly what both automatic writers produce.
+  const r = apply({ ...REAL, isConfirmed: false, appliedAutomatically: true });
+  ok('appliedAutomatically=true + isConfirmed=false → APPLIED', r.moved === true,
+     'this is the original defect: a survey-derived transform that never rendered');
+  ok('translation converted mm → metres', r.position._v && r.position._v[0] === 500,
+     JSON.stringify(r.position._v));
+  ok('rotation applied about Z in radians',
+     Math.abs(r.rotation.z - (12 * Math.PI / 180)) < 1e-12);
+}
+
+console.log('\n— manual confirmation still applies (unchanged behaviour) —');
+{
+  const r = apply({ ...REAL, isConfirmed: true, appliedAutomatically: false });
+  ok('isConfirmed=true → APPLIED', r.moved === true);
+}
+{
+  // Older/partial payloads that omit the field must behave as before.
+  const r = apply({ ...REAL });
+  ok('isConfirmed absent → APPLIED (back-compat default)', r.moved === true);
+}
+
+console.log('\n— a low-confidence suggestion must NOT move the model —');
+{
+  // The other half of the contract. A model with no usable georeference stays at
+  // the origin, where it is obviously un-placed, rather than being scattered
+  // across the site by a guess.
+  const r = apply({ ...REAL, isConfirmed: false, appliedAutomatically: false });
+  ok('isConfirmed=false + appliedAutomatically=false → NOT applied', r.moved === false);
+}
+{
+  const r = apply({ ...REAL, isConfirmed: false, appliedAutomatically: 'yes' });
+  ok('appliedAutomatically must be strictly true (no truthy coercion)', r.moved === false);
+}
+
+console.log('\n— identity and absent transforms remain no-ops —');
+{
+  const r = apply({ translationX: 0, translationY: 0, translationZ: 0, rotationDeg: 0,
+                    scaleFactor: 1, isConfirmed: true, appliedAutomatically: true });
+  ok('identity transform → NOT applied', r.moved === false);
+}
+{
+  const r = fakeRoot();
+  const ctx = vm.createContext({ Math, console, __root: r, __t: null });
+  vm.runInContext(m[0] + '\napplyModelTransform(__root, __t);', ctx);
+  ok('null transform → NOT applied, no throw', r.moved === false);
+}
+
+console.log('\n— the gate reads the field the server actually sends —');
+{
+  // Guards against the two halves drifting: the server projects
+  // `appliedAutomatically` (camelCase) in ModelTransformController.
+  ok('viewer.html references appliedAutomatically', /appliedAutomatically/.test(html));
+  const ctrl = fs.readFileSync(
+    path.resolve(__dirname, '../../src/Planscape.API/Controllers/ModelTransformController.cs'), 'utf8');
+  ok('ModelTransformController projects appliedAutomatically',
+     /appliedAutomatically\s*=/.test(ctrl));
+}
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1088,16 +1088,33 @@ THREE.ColorManagement.enabled = false;
   // BLK-2 — apply a stored ProjectModelTransform to a loaded model root.
   // Translation is stored in mm (server contract); GLB geometry is metres,
   // so convert ÷1000. Rotation is degrees about the project vertical (world Z).
-  // Composed as T·R·S. Guarded so absent / unconfirmed / identity transforms
+  // Composed as T·R·S. Guarded so absent / unapplied / identity transforms
   // leave the model untouched.
+  //
+  // B1 — a transform is LIVE when a coordinator confirmed it (isConfirmed) OR
+  // when the platform graded its georeferencing HIGH and applied it on its own
+  // (appliedAutomatically). Previously the only gate was `isConfirmed !== false`,
+  // and BOTH automatic writers store isConfirmed=false — so a correct,
+  // survey-derived alignment was computed, stored, and then never rendered until
+  // somebody confirmed it by hand. That single line is why same-site models from
+  // different tools did not line up on their own.
+  //
+  // Precedence needs no tie-break here: the automatic writers refuse to overwrite
+  // a row with isConfirmed=true, so a confirmed row already holds the
+  // coordinator's numbers. Manual wins by construction, at write time.
+  //
+  // The `!== false` default is kept for isConfirmed so an older/partial payload
+  // that omits the field still renders as it did before.
   function applyModelTransform(root, t) {
     if (!root || !t) return;
     const tx = (+t.translationX || 0), ty = (+t.translationY || 0), tz = (+t.translationZ || 0);
     const rot = (+t.rotationDeg || 0);
     const scale = (t.scaleFactor != null ? +t.scaleFactor : 1) || 1;
     const confirmed = (t.isConfirmed !== false);   // default-confirmed if unspecified
+    const autoApplied = (t.appliedAutomatically === true);
+    const live = confirmed || autoApplied;
     const isIdentity = tx === 0 && ty === 0 && tz === 0 && rot === 0 && scale === 1;
-    if (!confirmed || isIdentity) return;
+    if (!live || isIdentity) return;
     try {
       root.scale.set(scale, scale, scale);
       root.rotation.z = rot * Math.PI / 180;

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -834,3 +834,79 @@ NOT covered: end-to-end MVC wiring — no host is booted, because a
 `WebApplicationFactory` cannot run against SQLite (Program.cs issues a
 Postgres-only `information_schema` query with no try/catch) and a second factory
 is unreliable in this assembly (ROADMAP DEP-7).
+
+## 19. Track B / P1 — auto-applied transforms (CLOSED)
+
+### The defect
+
+The alignment machinery was sound and **not wired to the screen**. Both automatic
+writers — the IFC ingest path and `AutoAlignService` — store
+`IsConfirmed = false`, and the viewer's gate was:
+
+```js
+const confirmed = (t.isConfirmed !== false);
+if (!confirmed || isIdentity) return;
+```
+
+So a correct, survey-derived alignment was computed, persisted, sent to the
+viewer, and then discarded by that one line — every time — until a human
+confirmed it by hand. That is the whole "same-site models from different tools
+don't line up on their own" symptom, and it lived in four tokens of JavaScript.
+
+### The fix
+
+`IsAutoComputed` records HOW the numbers were obtained; it could not also record
+whether they are LIVE. `ProjectModelTransform` gains three columns:
+
+| Column | Meaning |
+|---|---|
+| `AppliedAutomatically` | the platform applied this on its own, because the georeferencing graded HIGH |
+| `Confidence` | `HIGH` / `LOW` / `NONE` — what was trusted |
+| `Source` | `manual` / `ifc-map-conversion` / `auto-align` / `revit-georef` — which pipeline produced it |
+
+The viewer now applies when `isConfirmed === true` **OR**
+`appliedAutomatically === true`.
+
+**Only HIGH-confidence transforms move a model.** `TransformConfidencePolicy`
+(`Planscape.Core/Coordinates/`) is the single shared rule: a survey origin from
+IfcMapConversion, plus a CRS that either declares itself (IfcProjectedCRS) or
+matches the project's own, plus a non-FAIL alignment report. Anything less is
+stored as a suggestion and left for a coordinator. A model with **no** usable
+georeference stays at the origin — deliberately not "apply a best guess": an
+un-placed model at the origin is obviously un-placed and is fixed in seconds,
+whereas a model flung 500 km by a guess looks placed and costs an investigation.
+
+The policy is shared and Revit-free precisely because three pipelines produce
+automatic transforms (ingest, auto-align, and the Revit GLB path in P2); if each
+carried its own notion of "good enough", the same model would render in different
+places depending on which one touched it last.
+
+**Precedence is enforced at WRITE time, not render time.** The automatic writers
+refuse to touch a row with `IsConfirmed = true`, so a confirmed row always holds
+the coordinator's numbers and there is nothing to reconcile when drawing. A
+manual PUT additionally clears `AppliedAutomatically` and stamps
+`Source = "manual"`, which makes the rule total.
+
+### Verification
+
+- **19 policy unit tests** (`TransformConfidencePolicyTests`) — exhaustive over a
+  pure function. Includes the load-bearing case that `CrsEquivalent(null, null)`
+  is **false**: if unknown matched unknown, every model without a declared CRS in
+  a project without one would grade HIGH and be moved on no evidence at all.
+- **3 write-path tests** on `AutoAlignService` — HIGH is marked auto-applied;
+  unanchored and FAILed evidence are stored but NOT auto-applied.
+- **12 viewer-gate assertions** (`tests/web-harness/transform-gate.mjs`) — the
+  shipped `applyModelTransform` is extracted from `viewer.html` on disk and run in
+  a `vm` sandbox against a fake three.js root. Re-introducing the old gate
+  (`const live = confirmed;`) was tried: **3 of 12 fail**, including the headline
+  "auto-applied transform actually moves the model".
+- **Schema patch proven on real Postgres 16**: against a database recreated in its
+  pre-B1 shape, the three `ADD COLUMN IF NOT EXISTS` statements applied cleanly,
+  were idempotent on a second pass, and left a pre-existing row at
+  `AppliedAutomatically = false` — so no existing project starts rendering
+  differently because of a deploy.
+- Full suite **691 passed / 0 failed / 11 skipped**; build 0 errors.
+
+Schema follows ADR 0001 (EnsureCreated + idempotent patcher). `dotnet ef
+migrations add` remains unsafe here — the model snapshot is stale and a new
+migration would try to re-create existing tables.


### PR DESCRIPTION
> **Stacked on #676** (Track A). Base is `claude/federation-authz`; retarget to `main` once that merges.

## The bug

The alignment machinery was sound and **not wired to the screen**. Both automatic writers — the IFC ingest path and `AutoAlignService` — store `IsConfirmed = false`, and the viewer's gate was:

```js
const confirmed = (t.isConfirmed !== false);
if (!confirmed || isIdentity) return;
```

So a correct, survey-derived alignment was computed, persisted, sent to the viewer, and then **discarded by that one line**, every time, until a human confirmed it by hand. That's the whole "same-site models from different tools don't line up on their own" symptom, and it lived in four tokens of JavaScript.

## The fix

`IsAutoComputed` records *how* the numbers were obtained; it couldn't also record whether they're **live**. `ProjectModelTransform` gains:

| Column | Meaning |
|---|---|
| `AppliedAutomatically` | applied on its own, because the georeferencing graded HIGH |
| `Confidence` | `HIGH` / `LOW` / `NONE` |
| `Source` | `manual` / `ifc-map-conversion` / `auto-align` / `revit-georef` |

Viewer now applies when `isConfirmed === true` **OR** `appliedAutomatically === true`.

**Only HIGH-confidence transforms move a model.** `TransformConfidencePolicy` is the single shared rule: survey origin from IfcMapConversion + a CRS that either declares itself (IfcProjectedCRS) or matches the project's own + a non-FAIL report. Anything less is stored as a *suggestion*.

A model with **no** usable georeference stays at the origin — deliberately not "apply a best guess". An un-placed model at the origin is obviously un-placed and gets fixed in seconds; a model flung 500 km by a guess *looks placed* and costs an investigation.

The policy is shared and Revit-free because three pipelines produce automatic transforms (the Revit GLB path joins in P2). If each carried its own notion of "good enough", the same model would render in different places depending on which touched it last.

**Precedence is enforced at write time, not render time.** Automatic writers refuse to touch a confirmed row, so a confirmed row always holds the coordinator's numbers — nothing to reconcile when drawing. A manual PUT also clears `AppliedAutomatically` and stamps `Source="manual"`, making the rule total. (A manual transform saved with `IsConfirmed=false` stays a draft and doesn't render — unchanged.)

## Verification

- **19 policy unit tests** — exhaustive over a pure function. Includes the load-bearing case that `CrsEquivalent(null, null)` is **false**: if unknown matched unknown, every model without a declared CRS in a project without one would grade HIGH and be moved on *no evidence at all*.
- **3 write-path tests** on `AutoAlignService` — HIGH is marked auto-applied; unanchored and FAILed evidence are stored but not applied.
- **12 viewer-gate assertions** (`tests/web-harness/transform-gate.mjs`) — extracts the shipped `applyModelTransform` from `viewer.html` **on disk** and runs it in a `vm` sandbox against a fake three.js root (the `align-audit.mjs` precedent). Re-introducing the old gate was tried: **3 of 12 fail**, including the headline one.
- **Schema patch proven on real Postgres 16** — against a DB recreated in its *pre-change* shape, the three `ADD COLUMN IF NOT EXISTS` statements applied cleanly, were idempotent on a second pass, and left a pre-existing row at `AppliedAutomatically = false`. **No existing project starts rendering differently on deploy.**
- Full suite **691 passed / 0 failed / 11 skipped**; build **0 errors**.

Schema follows ADR 0001 (EnsureCreated + idempotent patcher). `dotnet ef migrations add` remains unsafe here — the model snapshot is stale and a new migration would try to re-create existing tables.

## Not in this PR

P2 (Revit GLB georef source), P3 (unit reconciliation — the dead `scaleFactor`), P4 (StingBridge georef), P5 (translation conventions + AABB freshness). This PR is the one that makes an *already-correct* transform actually render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up (review):** the `applyModelTransform` edit landed only in the generated `wwwroot/viewer.html`. The canonical source is `Planscape/assets/viewer/viewer.html` (the `SyncCoordinationViewer` MSBuild target copies source→wwwroot each build) and the `coordination-viewer-drift` CI gate fails on the divergence. Ported the identical change to the source so the two are byte-equal again (all 7 synced files verified).