### PR TITLE
Placement P2: give the Revit GLB path a georef source, on one shared writer

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
@@ -8,6 +8,7 @@ using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
 using Planscape.Infrastructure.SignalR;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -66,6 +67,7 @@ public class IfcIngestController : ControllerBase
     private readonly Planscape.Core.Interfaces.IIfcAlignmentValidator _alignmentValidator;
     private readonly IHubContext<FederatedModelHub> _modelHub;
     private readonly IHubContext<NotificationHub> _notificationHub;
+    private readonly Planscape.Infrastructure.Services.IModelGeorefWriter _georefWriter;
     private readonly ILogger<IfcIngestController> _logger;
 
     public IfcIngestController(
@@ -76,6 +78,7 @@ public class IfcIngestController : ControllerBase
         Planscape.Core.Interfaces.IIfcAlignmentValidator alignmentValidator,
         IHubContext<FederatedModelHub> modelHub,
         IHubContext<NotificationHub> notificationHub,
+        Planscape.Infrastructure.Services.IModelGeorefWriter georefWriter,
         ILogger<IfcIngestController> logger)
     {
         _db = db;
@@ -85,6 +88,7 @@ public class IfcIngestController : ControllerBase
         _alignmentValidator = alignmentValidator;
         _modelHub = modelHub;
         _notificationHub = notificationHub;
+        _georefWriter = georefWriter;
         _logger = logger;
     }
 
@@ -609,103 +613,35 @@ public class IfcIngestController : ControllerBase
 
     /// <summary>
     /// Gap 4: Create or update a ProjectModelTransform row from IfcMapConversion data.
-    /// The translation is the negative of the survey origin so applying it brings
-    /// georeferenced model coordinates back to the project origin.
-    /// Called automatically during ingest when IfcMapConversion is present.
     ///
-    /// <para>B1 — takes the whole <see cref="IfcAlignmentReport"/> rather than the
-    /// six numbers it needs, because grading the transform's confidence uses the
-    /// evidence AROUND the numbers (projected CRS, verdict) as much as the
-    /// numbers themselves, and splitting them across a long parameter list is how
-    /// the two auto-writers drift apart.</para>
+    /// <para><b>B2 — this now delegates to <see cref="IModelGeorefWriter"/>.</b> The
+    /// translation convention, the metres→mm conversion, the confidence grading
+    /// and the "never overwrite a confirmed transform" rule used to live here as
+    /// one of two copies; the Revit GLB upload path needed the same logic, and a
+    /// third copy is how a building ends up in a different place depending on
+    /// which pipeline last touched it. The behaviour is unchanged — the shared
+    /// writer was built around this method's convention deliberately — but there
+    /// is now exactly one place to change it.</para>
     /// </summary>
     private async Task UpsertProjectModelTransformAsync(
         Guid projectId, Guid projectModelId, Guid tenantId,
         IfcAlignmentReport report, double unitScaleToMm,
         CancellationToken ct)
     {
-        double eastingM   = report.SurveyEasting ?? 0;
-        double northingM  = report.SurveyNorthing ?? 0;
-        double elevationM = report.SurveyElevation ?? 0;
-        double rotationDeg = report.MapConversionRotationDeg ?? 0;
-
         try
         {
-            var existing = await _db.ProjectModelTransforms
-                .FirstOrDefaultAsync(t =>
-                    t.ProjectId == projectId &&
-                    t.ProjectModelId == projectModelId &&
-                    t.TenantId == tenantId, ct);
+            var georef = new ModelGeoref(
+                EastingM      : report.SurveyEasting  ?? 0,
+                NorthingM     : report.SurveyNorthing ?? 0,
+                ElevationM    : report.SurveyElevation ?? 0,
+                TrueNorthDeg  : report.MapConversionRotationDeg ?? 0,
+                CrsCode       : report.CrsName,
+                HasDeclaredCrs: report.HasProjectedCrs,
+                LengthUnit    : report.LengthUnit,
+                SourceLabel   : "ifc-map-conversion");
 
-            // Convert survey origin from metres to mm (project length unit default).
-            double txMm = -eastingM  * 1000.0;   // negate: shift model to project origin
-            double tyMm = -northingM * 1000.0;
-            double tzMm = -elevationM * 1000.0;
-            // Scale correction: if model is in mm (unitScaleToMm=1) but CRS is in m,
-            // apply the inverse as a uniform scale on the transform.
-            double scaleFactor = (unitScaleToMm > 0 && Math.Abs(unitScaleToMm - 1000.0) < 1.0)
-                ? 1.0   // metres — no scale correction needed
-                : 1.0;  // mm — coordinates are already in mm, no scale correction
-
-            // B1 — grade the georeferencing so a trustworthy transform renders
-            // without a coordinator confirming it first. The project's own CRS is
-            // the second acceptable anchor when the file declares no
-            // IfcProjectedCRS of its own.
-            var projectCrs = await _db.ProjectCoordinateSystems.AsNoTracking()
-                .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == tenantId, ct);
-
-            var confidence = TransformConfidencePolicy.Evaluate(
-                hasMapConversion : report.HasMapConversion,
-                hasProjectedCrs  : report.HasProjectedCrs,
-                crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(
-                                       report.CrsName, projectCrs?.CrsEpsgCode ?? projectCrs?.CrsName),
-                surveyEasting    : report.SurveyEasting,
-                surveyNorthing   : report.SurveyNorthing,
-                verdict          : report.Verdict);
-
-            bool autoApply = TransformConfidencePolicy.ShouldAutoApply(confidence);
-            string confidenceText = TransformConfidencePolicy.ToStorageString(confidence);
-
-            if (existing != null)
-            {
-                // Only auto-update if not manually confirmed by a coordinator.
-                if (!existing.IsConfirmed)
-                {
-                    existing.TranslationX         = txMm;
-                    existing.TranslationY         = tyMm;
-                    existing.TranslationZ         = tzMm;
-                    existing.RotationDeg          = rotationDeg;
-                    existing.ScaleFactor          = scaleFactor;
-                    existing.IsAutoComputed       = true;
-                    existing.AppliedAutomatically = autoApply;
-                    existing.Confidence           = confidenceText;
-                    existing.Source               = "ifc-map-conversion";
-                    existing.UpdatedAt            = DateTime.UtcNow;
-                    existing.Notes                = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u} (confidence {confidenceText})";
-                }
-            }
-            else
-            {
-                _db.ProjectModelTransforms.Add(new Planscape.Core.Entities.ProjectModelTransform
-                {
-                    TenantId             = tenantId,
-                    ProjectId            = projectId,
-                    ProjectModelId       = projectModelId,
-                    TranslationX         = txMm,
-                    TranslationY         = tyMm,
-                    TranslationZ         = tzMm,
-                    RotationDeg          = rotationDeg,
-                    ScaleFactor          = scaleFactor,
-                    IsAutoComputed       = true,
-                    IsConfirmed          = false,
-                    AppliedAutomatically = autoApply,
-                    Confidence           = confidenceText,
-                    Source               = "ifc-map-conversion",
-                    AppliedAt            = DateTime.UtcNow,
-                    Notes                = $"Auto-computed from IfcMapConversion at {DateTime.UtcNow:u} (confidence {confidenceText})",
-                });
-            }
-            await _db.SaveChangesAsync(ct);
+            var confidence = await _georefWriter.WriteAsync(
+                projectId, projectModelId, tenantId, georef, report.Verdict, ct);
 
             // Gap 14: Write an audit log entry for the coordinate correction.
             try
@@ -713,21 +649,18 @@ public class IfcIngestController : ControllerBase
                 await _audit.LogAsync("TRANSFORM_UPSERT", "ProjectModelTransform", projectModelId.ToString(),
                     System.Text.Json.JsonSerializer.Serialize(new {
                         projectId,
-                        translationXMm = txMm, translationYMm = tyMm, translationZMm = tzMm,
-                        rotationDeg, scaleFactor,
+                        surveyEastingM  = report.SurveyEasting,
+                        surveyNorthingM = report.SurveyNorthing,
+                        rotationDeg     = report.MapConversionRotationDeg ?? 0,
                         source = "IfcMapConversion",
                         autoComputed = true,
                         // B1 — a model that MOVES on its own must say so in the
                         // audit trail, and say what it was trusting when it did.
-                        confidence = confidenceText,
-                        appliedAutomatically = autoApply,
+                        confidence = TransformConfidencePolicy.ToStorageString(confidence),
+                        appliedAutomatically = TransformConfidencePolicy.ShouldAutoApply(confidence),
                     }));
             }
             catch { /* audit failure is non-fatal */ }
-
-            _logger.LogInformation(
-                "Gap 4: upserted ProjectModelTransform for model {ModelId}: T=({Tx:F1},{Ty:F1},{Tz:F1})mm rot={Rot:F2}°",
-                projectModelId, txMm, tyMm, tzMm, rotationDeg);
         }
         catch (Exception ex)
         {

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
 using Planscape.API.Authorization;
 
 namespace Planscape.API.Controllers;
@@ -33,6 +34,7 @@ public class ModelsController : ControllerBase
     private readonly PlanscapeDbContext _db;
     private readonly IFileStorageService _storage;
     private readonly IConverterClient _converter;
+    private readonly IModelGeorefWriter _georef;
     private readonly ILogger<ModelsController> _logger;
 
     // Upload cap — glTF can be large but anything over this is almost certainly
@@ -43,11 +45,13 @@ public class ModelsController : ControllerBase
         PlanscapeDbContext db,
         IFileStorageService storage,
         IConverterClient converter,
+        IModelGeorefWriter georef,
         ILogger<ModelsController> logger)
     {
         _db = db;
         _storage = storage;
         _converter = converter;
+        _georef = georef;
         _logger = logger;
     }
 
@@ -280,6 +284,18 @@ public class ModelsController : ControllerBase
         _logger.LogInformation("Model uploaded — {ModelId} {Format} {Size} bytes for project {ProjectId}",
             row.Id, row.Format, row.FileSizeBytes, projectId);
 
+        // ── B2 — georeferencing → coordinate transform ──────────────────────
+        // Revit exports geometry about the project internal origin, so without
+        // this every Revit model landed at 0,0,0 no matter where the building
+        // is. The survey position arrives as metadata (never baked into the
+        // mesh — a 40 km easting in the vertex data destroys float precision),
+        // and the shared writer turns it into the same kind of transform the IFC
+        // ingest path produces, graded by the same confidence policy.
+        //
+        // Best-effort: a georef failure must not fail an otherwise-good upload.
+        // The geometry is already committed and the model is usable un-placed.
+        await TryWriteGeorefAsync(projectId, row.Id, project.TenantId, req, ct);
+
         // IFC with a configured converter — kick off async IFC→GLB conversion.
         // The IFC is retained as the source row; the sidecar publishes the
         // renderable GLB back through this same endpoint as a separate model.
@@ -298,6 +314,56 @@ public class ModelsController : ControllerBase
         }
 
         return CreatedAtAction(nameof(Get), new { projectId, modelId = row.Id }, ToMetaDto(row));
+    }
+
+    // ── B2 — georef helper ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Turn the optional georef block on an upload into a stored transform.
+    /// No-ops when the caller sent no survey position.
+    /// </summary>
+    private async Task TryWriteGeorefAsync(
+        Guid projectId, Guid modelId, Guid tenantId, UploadModelRequest req, CancellationToken ct)
+    {
+        if (req.GeorefEastingM is null || req.GeorefNorthingM is null) return;
+
+        // A SharedCoordinates export already sits in the survey frame, so
+        // applying the survey origin again would double-count it and put the
+        // model twice as far from where it belongs. Record the position but
+        // write no transform.
+        if (string.Equals(req.GeorefExportMode, "SharedCoordinates", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation(
+                "Model {ModelId} was exported in shared coordinates — geometry is already in the survey frame, no transform written.",
+                modelId);
+            return;
+        }
+
+        try
+        {
+            var georef = new ModelGeoref(
+                EastingM      : req.GeorefEastingM,
+                NorthingM     : req.GeorefNorthingM,
+                ElevationM    : req.GeorefElevationM,
+                TrueNorthDeg  : req.GeorefTrueNorthDeg ?? 0,
+                CrsCode       : req.GeorefCrsEpsg,
+                HasDeclaredCrs: !string.IsNullOrWhiteSpace(req.GeorefCrsEpsg),
+                LengthUnit    : req.GeorefLengthUnit,
+                SourceLabel   : "revit-georef");
+
+            // No IfcAlignmentValidator has run on a GLB, so there is no verdict
+            // to fail on. "PASS" here means "nothing contradicted it", and the
+            // CRS anchor still decides whether it grades HIGH.
+            await _georef.WriteAsync(projectId, modelId, tenantId, georef, verdict: "PASS", ct);
+        }
+        catch (Exception ex)
+        {
+            // The geometry is committed and the model is usable un-placed;
+            // losing the upload over a transform write would be worse.
+            _logger.LogWarning(ex,
+                "Georef transform write failed for model {ModelId} (non-fatal — model is published, un-placed).",
+                modelId);
+        }
     }
 
     // ── Downloads ──────────────────────────────────────────────────────
@@ -747,6 +813,51 @@ public class UploadModelRequest
     /// revision (e.g. updated element map only).
     /// </summary>
     public bool Force { get; set; }
+
+    // ── B2 — georeferencing (optional) ──────────────────────────────────────
+    //
+    // Revit exports its geometry about the PROJECT INTERNAL origin
+    // (ClashExportContext uses Transform.Identity), so a published GLB carries
+    // no survey position and every Revit model landed at 0,0,0 regardless of
+    // where the building actually is. The fix is to send the survey position as
+    // METADATA rather than baking it into the mesh — the same shape the IFC path
+    // already uses, and the reason a 40 km easting does not destroy float
+    // precision in the vertex data.
+    //
+    // All of these are optional. A model without them stays at the origin, which
+    // is the correct outcome for an ungeoreferenced model.
+
+    /// <summary>Survey easting of the model's internal origin, in METRES.</summary>
+    public double? GeorefEastingM { get; set; }
+
+    /// <summary>Survey northing of the model's internal origin, in METRES.</summary>
+    public double? GeorefNorthingM { get; set; }
+
+    /// <summary>Survey elevation of the model's internal origin, in METRES.</summary>
+    public double? GeorefElevationM { get; set; }
+
+    /// <summary>
+    /// Rotation from CRS grid north to the model's internal north, in degrees
+    /// (clockwise positive) — Revit's <c>ProjectPosition.Angle</c>.
+    /// </summary>
+    public double? GeorefTrueNorthDeg { get; set; }
+
+    /// <summary>
+    /// The model's declared CRS, e.g. "EPSG:27700". Supplying it is what lets
+    /// the transform grade HIGH and be applied without a coordinator confirming
+    /// it; without a CRS anchor the transform is stored as a suggestion only.
+    /// </summary>
+    public string? GeorefCrsEpsg { get; set; }
+
+    /// <summary>The model's own length unit — "mm" | "m" | "ft".</summary>
+    public string? GeorefLengthUnit { get; set; }
+
+    /// <summary>
+    /// "ProjectInternal" | "SharedCoordinates" — how the geometry was exported.
+    /// A SharedCoordinates export already sits in the survey frame, so applying
+    /// the survey origin again would double-count it.
+    /// </summary>
+    public string? GeorefExportMode { get; set; }
 }
 
 /// <summary>

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -765,6 +765,11 @@ builder.Services.AddScoped<Planscape.Core.Interfaces.ICbmPlanner,
 // Gap F — Auto-compute coordinate transform from IfcMapConversion data.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.IAutoAlignService,
     Planscape.Infrastructure.Services.AutoAlignService>();
+// B2 — the ONE writer that turns a host's georeferencing (IFC IfcMapConversion,
+// Revit ProjectPosition) into a stored ProjectModelTransform. Shared so the IFC
+// and Revit paths cannot drift apart on translation convention or confidence.
+builder.Services.AddScoped<Planscape.Infrastructure.Services.IModelGeorefWriter,
+    Planscape.Infrastructure.Services.ModelGeorefWriter>();
 // Gap G — Full project-wide federated coordinate coherence scan.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.IFederatedCoherenceJob,
     Planscape.Infrastructure.Services.FederatedCoherenceJob>();

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
@@ -1,0 +1,191 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Coordinates;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// A host's georeferencing, normalised. Whatever the source — an IFC
+/// <c>IfcMapConversion</c>, Revit's <c>ProjectPosition</c>, or an ArchiCAD
+/// survey point — it reduces to these numbers.
+/// </summary>
+/// <param name="EastingM">Survey easting of the model's internal origin, METRES.</param>
+/// <param name="NorthingM">Survey northing of the model's internal origin, METRES.</param>
+/// <param name="ElevationM">Survey elevation of the model's internal origin, METRES.</param>
+/// <param name="TrueNorthDeg">
+/// Rotation from the CRS grid north to the model's internal north, degrees
+/// clockwise-positive.
+/// </param>
+/// <param name="CrsCode">The source's declared CRS ("EPSG:27700"), or null.</param>
+/// <param name="HasDeclaredCrs">
+/// The source declared a projected CRS of its own (IfcProjectedCRS, or a Revit
+/// export that carries an EPSG code). Distinct from <paramref name="CrsCode"/>
+/// being non-null so a host can supply a code it is not certain about.
+/// </param>
+/// <param name="LengthUnit">The model's own length unit — "mm" | "m" | "ft".</param>
+/// <param name="SourceLabel">
+/// Which pipeline produced this: "ifc-map-conversion" | "revit-georef".
+/// Stored on the transform so the UI can explain why a model moved.
+/// </param>
+public sealed record ModelGeoref(
+    double? EastingM,
+    double? NorthingM,
+    double? ElevationM,
+    double TrueNorthDeg,
+    string? CrsCode,
+    bool HasDeclaredCrs,
+    string? LengthUnit,
+    string SourceLabel)
+{
+    /// <summary>True when there is enough here to place the model at all.</summary>
+    public bool HasSurveyOrigin => EastingM.HasValue && NorthingM.HasValue;
+}
+
+public interface IModelGeorefWriter
+{
+    /// <summary>
+    /// Persist (upsert) the <see cref="ProjectModelTransform"/> implied by a
+    /// host's georeferencing, grading its confidence so a trustworthy one
+    /// renders without a coordinator confirming it.
+    ///
+    /// Never overwrites a transform a coordinator has confirmed. Returns the
+    /// confidence it graded, or <see cref="TransformConfidence.None"/> when
+    /// there was nothing usable to write.
+    /// </summary>
+    Task<TransformConfidence> WriteAsync(
+        Guid projectId, Guid projectModelId, Guid tenantId,
+        ModelGeoref georef, string? verdict, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The ONE place that turns a host's georeferencing into a stored transform.
+///
+/// <para><b>Why this exists.</b> Three pipelines produce automatic transforms —
+/// IFC ingest, the Revit GLB upload, and <c>AutoAlignService</c>. Each used to
+/// carry (or, for Revit, lack) its own copy of the translation convention, the
+/// unit handling and the overwrite rules. Copies drift, and when they drift the
+/// symptom is a building in the wrong place depending on which pipeline last
+/// touched it — the most expensive class of bug in this system and the hardest
+/// to attribute. Centralising it means a convention change is one edit, not
+/// three, and the agreement is enforced by construction rather than by
+/// vigilance.</para>
+///
+/// <para><b>The translation convention.</b> Each model is moved from its own
+/// survey origin back to the project origin: <c>t = -origin</c>, metres → mm.
+/// This is the convention the IFC ingest path has always used, preserved here
+/// deliberately so introducing this writer changes no existing behaviour.
+/// (<c>AutoAlignService</c> computes a RELATIVE transform instead — the two are
+/// reconciled separately; see the P5 note in
+/// <c>docs/COORDINATION_AUDIT_FINDINGS.md</c>.)</para>
+/// </summary>
+public sealed class ModelGeorefWriter : IModelGeorefWriter
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<ModelGeorefWriter> _logger;
+
+    public ModelGeorefWriter(PlanscapeDbContext db, ILogger<ModelGeorefWriter> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<TransformConfidence> WriteAsync(
+        Guid projectId, Guid projectModelId, Guid tenantId,
+        ModelGeoref georef, string? verdict, CancellationToken ct = default)
+    {
+        if (!georef.HasSurveyOrigin)
+        {
+            // Nothing to place the model with. Deliberately writes NO transform:
+            // a model at the project origin is visibly un-placed and a
+            // coordinator fixes it in seconds, whereas a guessed transform looks
+            // placed and costs an investigation.
+            _logger.LogInformation(
+                "Georef for model {ModelId}: no survey origin ({Source}) — left at project origin, no transform written.",
+                projectModelId, georef.SourceLabel);
+            return TransformConfidence.None;
+        }
+
+        var projectCrs = await _db.ProjectCoordinateSystems.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == tenantId, ct);
+
+        var confidence = TransformConfidencePolicy.Evaluate(
+            hasMapConversion : true,
+            hasProjectedCrs  : georef.HasDeclaredCrs,
+            crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(
+                                   georef.CrsCode, projectCrs?.CrsEpsgCode ?? projectCrs?.CrsName),
+            surveyEasting    : georef.EastingM,
+            surveyNorthing   : georef.NorthingM,
+            verdict          : verdict);
+
+        bool autoApply = TransformConfidencePolicy.ShouldAutoApply(confidence);
+        string confidenceText = TransformConfidencePolicy.ToStorageString(confidence);
+
+        // Survey origin (metres) → translation (mm). Negated: applying it brings
+        // georeferenced model coordinates back to the project origin.
+        double txMm = -georef.EastingM!.Value  * 1000.0;
+        double tyMm = -georef.NorthingM!.Value * 1000.0;
+        double tzMm = -(georef.ElevationM ?? 0) * 1000.0;
+
+        var existing = await _db.ProjectModelTransforms
+            .FirstOrDefaultAsync(t => t.ProjectId == projectId
+                                   && t.ProjectModelId == projectModelId
+                                   && t.TenantId == tenantId, ct);
+
+        if (existing is { IsConfirmed: true })
+        {
+            // A coordinator has asserted this alignment against evidence the
+            // survey data does not carry. An automatic writer never overrules it.
+            _logger.LogInformation(
+                "Georef for model {ModelId}: skipped — an existing transform is manually confirmed.",
+                projectModelId);
+            return confidence;
+        }
+
+        if (existing == null)
+        {
+            _db.ProjectModelTransforms.Add(new ProjectModelTransform
+            {
+                TenantId             = tenantId,
+                ProjectId            = projectId,
+                ProjectModelId       = projectModelId,
+                TranslationX         = txMm,
+                TranslationY         = tyMm,
+                TranslationZ         = tzMm,
+                RotationDeg          = georef.TrueNorthDeg,
+                ScaleFactor          = 1.0,
+                IsAutoComputed       = true,
+                IsConfirmed          = false,
+                AppliedAutomatically = autoApply,
+                Confidence           = confidenceText,
+                Source               = georef.SourceLabel,
+                AppliedAt            = DateTime.UtcNow,
+                Notes                = $"Auto-computed from {georef.SourceLabel} at {DateTime.UtcNow:u} (confidence {confidenceText})",
+            });
+        }
+        else
+        {
+            existing.TranslationX         = txMm;
+            existing.TranslationY         = tyMm;
+            existing.TranslationZ         = tzMm;
+            existing.RotationDeg          = georef.TrueNorthDeg;
+            existing.ScaleFactor          = 1.0;
+            existing.IsAutoComputed       = true;
+            existing.AppliedAutomatically = autoApply;
+            existing.Confidence           = confidenceText;
+            existing.Source               = georef.SourceLabel;
+            existing.UpdatedAt            = DateTime.UtcNow;
+            existing.Notes                = $"Auto-computed from {georef.SourceLabel} at {DateTime.UtcNow:u} (confidence {confidenceText})";
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Georef for model {ModelId}: TX={TX:F1} TY={TY:F1} TZ={TZ:F1} mm Rot={Rot:F4}° source={Source} confidence={Confidence} autoApplied={AutoApplied}",
+            projectModelId, txMm, tyMm, tzMm, georef.TrueNorthDeg,
+            georef.SourceLabel, confidenceText, autoApply);
+
+        return confidence;
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
@@ -1,0 +1,306 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Coordinates;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK B / P2 — the shared georef → transform writer.
+///
+/// WHY THIS CLASS EXISTS AT ALL
+/// ----------------------------
+/// Three pipelines produce automatic transforms: IFC ingest, the Revit GLB
+/// upload, and AutoAlignService. Before P2 the Revit path had NO georef source
+/// (its GLB is exported about the project internal origin, so every Revit model
+/// landed at 0,0,0 wherever the building actually was), and the IFC path carried
+/// its own private copy of the translation convention. Adding a second copy for
+/// Revit is how a building ends up in a different place depending on which
+/// pipeline last touched it — the most expensive class of bug here and the
+/// hardest to attribute. So there is one writer, and these tests pin its
+/// contract.
+///
+/// THE CONVENTION UNDER TEST
+/// -------------------------
+/// Each model is moved from its own survey origin back to the project origin:
+/// t = -origin, metres → mm. This is what the IFC ingest path has always done;
+/// preserving it exactly is what makes introducing the shared writer a no-op for
+/// existing IFC uploads.
+/// </summary>
+public class ModelGeorefWriterTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Model);
+
+    private static World NewWorld(string? projectCrs = null)
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var model = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "acme@example.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Tower",
+                Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            ctx.ProjectModels.Add(new ProjectModel
+            {
+                Id = model, TenantId = tenant, ProjectId = project,
+                Name = "ARCH", FileName = "arch.glb", StoragePath = "t_x/arch.glb",
+            });
+            if (projectCrs != null)
+            {
+                ctx.ProjectCoordinateSystems.Add(new ProjectCoordinateSystem
+                {
+                    TenantId = tenant, ProjectId = project, CrsEpsgCode = projectCrs,
+                });
+            }
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, project, model);
+    }
+
+    private static ModelGeorefWriter NewWriter(World w)
+        => new(NewContext(w.Conn, w.Tenant), NullLogger<ModelGeorefWriter>.Instance);
+
+    /// <summary>A Revit publish from a site at BNG easting 432,000 m.</summary>
+    private static ModelGeoref RevitGeoref(string? crs = "EPSG:27700") => new(
+        EastingM      : 432_000.0,
+        NorthingM     : 315_000.0,
+        ElevationM    : 12.5,
+        TrueNorthDeg  : 3.25,
+        CrsCode       : crs,
+        HasDeclaredCrs: crs != null,
+        LengthUnit    : "mm",
+        SourceLabel   : "revit-georef");
+
+    // ── the placement itself ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_survey_origin_becomes_a_negated_millimetre_translation()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var confidence = await NewWriter(w).WriteAsync(
+                w.Project, w.Model, w.Tenant, RevitGeoref(), verdict: "PASS");
+
+            Assert.Equal(TransformConfidence.High, confidence);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.ProjectModelTransforms.SingleAsync();
+
+            // metres → mm, negated: applying it brings the georeferenced model
+            // back to the project origin.
+            Assert.Equal(-432_000_000.0, xf.TranslationX, 3);
+            Assert.Equal(-315_000_000.0, xf.TranslationY, 3);
+            Assert.Equal(-12_500.0, xf.TranslationZ, 3);
+            Assert.Equal(3.25, xf.RotationDeg, 6);
+            Assert.Equal(1.0, xf.ScaleFactor, 6);
+            Assert.Equal("revit-georef", xf.Source);
+            Assert.True(xf.IsAutoComputed);
+        }
+    }
+
+    [Fact]
+    public async Task A_declared_crs_makes_the_transform_auto_applied()
+    {
+        // This is what turns "the numbers are stored" into "the model moves".
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, RevitGeoref(), "PASS");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.ProjectModelTransforms.SingleAsync();
+            Assert.True(xf.AppliedAutomatically);
+            Assert.Equal("HIGH", xf.Confidence);
+        }
+    }
+
+    [Fact]
+    public async Task The_projects_own_crs_is_an_acceptable_anchor()
+    {
+        // Revit has no native CRS concept, so a model may arrive without one.
+        // If the PROJECT declares the CRS and the model agrees, that is still a
+        // real anchor — but only when the model actually names it.
+        var w = NewWorld(projectCrs: "EPSG:27700");
+        using (w.Conn)
+        {
+            var georef = RevitGeoref(crs: "27700") with { HasDeclaredCrs = false };
+            var confidence = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
+
+            Assert.Equal(TransformConfidence.High, confidence);
+        }
+    }
+
+    [Fact]
+    public async Task Without_any_crs_anchor_the_transform_is_stored_but_not_applied()
+    {
+        // The honest outcome for a Revit model published from a project where
+        // nobody has declared the coordinate system: we have coordinates but
+        // nothing says which system they are in.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var confidence = await NewWriter(w).WriteAsync(
+                w.Project, w.Model, w.Tenant, RevitGeoref(crs: null), "PASS");
+
+            Assert.Equal(TransformConfidence.Low, confidence);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.ProjectModelTransforms.SingleAsync();
+            Assert.Equal(-432_000_000.0, xf.TranslationX, 3);   // computed
+            Assert.False(xf.AppliedAutomatically);              // but not live
+            Assert.Equal("LOW", xf.Confidence);
+        }
+    }
+
+    // ── the "do nothing" cases, which matter as much as the placement ───────
+
+    [Fact]
+    public async Task No_survey_origin_writes_no_transform_at_all()
+    {
+        // Deliberately not "write an identity transform" and emphatically not
+        // "guess". An un-placed model sitting at the origin is visibly
+        // un-placed; a guessed one looks placed and costs an investigation.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var georef = RevitGeoref() with { EastingM = null, NorthingM = null };
+            var confidence = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
+
+            Assert.Equal(TransformConfidence.None, confidence);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.False(await check.ProjectModelTransforms.AnyAsync());
+        }
+    }
+
+    [Fact]
+    public async Task A_confirmed_transform_is_never_overwritten()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.ProjectModelTransforms.Add(new ProjectModelTransform
+                {
+                    TenantId = w.Tenant, ProjectId = w.Project, ProjectModelId = w.Model,
+                    TranslationX = 11, TranslationY = 22, TranslationZ = 33,
+                    IsConfirmed = true, AppliedBy = "coordinator@example.com",
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, RevitGeoref(), "PASS");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.ProjectModelTransforms.SingleAsync();
+            Assert.Equal(11, xf.TranslationX);
+            Assert.Equal(22, xf.TranslationY);
+            Assert.True(xf.IsConfirmed);
+            Assert.Equal("coordinator@example.com", xf.AppliedBy);
+        }
+    }
+
+    [Fact]
+    public async Task Re_publishing_updates_the_existing_transform_rather_than_duplicating_it()
+    {
+        // ProjectModelTransform has a UNIQUE index on ProjectModelId — a second
+        // INSERT would throw, so an upsert is required, not merely tidy.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, RevitGeoref(), "PASS");
+
+            var moved = RevitGeoref() with { EastingM = 500_000.0 };
+            await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, moved, "PASS");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var xf = await check.ProjectModelTransforms.SingleAsync();   // exactly one
+            Assert.Equal(-500_000_000.0, xf.TranslationX, 3);
+            Assert.NotNull(xf.UpdatedAt);
+        }
+    }
+
+    [Fact]
+    public async Task A_failed_alignment_verdict_is_stored_but_not_applied()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var confidence = await NewWriter(w).WriteAsync(
+                w.Project, w.Model, w.Tenant, RevitGeoref(), verdict: "FAIL");
+
+            Assert.Equal(TransformConfidence.Low, confidence);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.False((await check.ProjectModelTransforms.SingleAsync()).AppliedAutomatically);
+        }
+    }
+
+    // ── the IFC path must not have changed ──────────────────────────────────
+
+    [Fact]
+    public async Task The_ifc_source_label_produces_the_same_numbers_as_the_revit_one()
+    {
+        // The whole point of the shared writer: two hosts reporting the same
+        // survey origin must land in the same place. If this ever diverges,
+        // models from different tools stop lining up — silently.
+        var w1 = NewWorld();
+        var w2 = NewWorld();
+        using (w1.Conn)
+        using (w2.Conn)
+        {
+            var ifc = RevitGeoref() with { SourceLabel = "ifc-map-conversion" };
+
+            await NewWriter(w1).WriteAsync(w1.Project, w1.Model, w1.Tenant, RevitGeoref(), "PASS");
+            await NewWriter(w2).WriteAsync(w2.Project, w2.Model, w2.Tenant, ifc, "PASS");
+
+            using var c1 = NewContext(w1.Conn, w1.Tenant);
+            using var c2 = NewContext(w2.Conn, w2.Tenant);
+            var a = await c1.ProjectModelTransforms.SingleAsync();
+            var b = await c2.ProjectModelTransforms.SingleAsync();
+
+            Assert.Equal(a.TranslationX, b.TranslationX, 6);
+            Assert.Equal(a.TranslationY, b.TranslationY, 6);
+            Assert.Equal(a.TranslationZ, b.TranslationZ, 6);
+            Assert.Equal(a.RotationDeg, b.RotationDeg, 6);
+            Assert.Equal(a.AppliedAutomatically, b.AppliedAutomatically);
+            // Only the provenance label differs.
+            Assert.Equal("revit-georef", a.Source);
+            Assert.Equal("ifc-map-conversion", b.Source);
+        }
+    }
+}

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -2140,7 +2140,20 @@ public sealed partial class PlanscapeServerClient : IDisposable
         string units = "mm",
         int? elementCount = null,
         double[]? bounds = null,
-        bool force = false)
+        bool force = false,
+        // B2 — optional georeferencing. Sent as METADATA beside the geometry,
+        // never baked into the mesh: a site at easting 432,000 m would put every
+        // vertex ~432 km from the origin, where 32-bit float loses millimetre
+        // precision and surfaces z-fight. The server turns this into a
+        // ProjectModelTransform, the same way it does for IFC IfcMapConversion.
+        // Omit it and the model publishes as before, un-placed at the origin.
+        double? georefEastingM = null,
+        double? georefNorthingM = null,
+        double? georefElevationM = null,
+        double? georefTrueNorthDeg = null,
+        string? georefCrsEpsg = null,
+        string? georefLengthUnit = null,
+        string? georefExportMode = null)
     {
         if (!await EnsureAuthenticatedAsync()) return (false, Guid.Empty, LastError, false);
         if (!File.Exists(modelFilePath))       return (false, Guid.Empty, $"Model file not found: {modelFilePath}", false);
@@ -2178,6 +2191,18 @@ public sealed partial class PlanscapeServerClient : IDisposable
             AddField("Units", units);
             if (force) AddField("Force", "true");
             if (elementCount.HasValue) AddField("ElementCount", elementCount.Value.ToString());
+            // B2 — georef block. Field names match UploadModelRequest exactly.
+            string Inv(double v) => v.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (georefEastingM.HasValue && georefNorthingM.HasValue)
+            {
+                AddField("GeorefEastingM",  Inv(georefEastingM.Value));
+                AddField("GeorefNorthingM", Inv(georefNorthingM.Value));
+                if (georefElevationM.HasValue)   AddField("GeorefElevationM",   Inv(georefElevationM.Value));
+                if (georefTrueNorthDeg.HasValue) AddField("GeorefTrueNorthDeg", Inv(georefTrueNorthDeg.Value));
+                AddField("GeorefCrsEpsg",     georefCrsEpsg);
+                AddField("GeorefLengthUnit",  georefLengthUnit);
+                AddField("GeorefExportMode",  georefExportMode);
+            }
             if (bounds != null && bounds.Length == 6)
             {
                 AddField("BoundsMinX", bounds[0].ToString(System.Globalization.CultureInfo.InvariantCulture));

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -221,6 +221,36 @@ namespace StingTools.BIMManager
             int elementCount, double[] bounds,
             bool force, string successHeadline)
         {
+            // B2 — send the survey position alongside the geometry so the server
+            // can place this model in the federation without a coordinator
+            // typing a transform. Null when the document has no project location
+            // or its survey point was never moved off the origin, in which case
+            // the model publishes exactly as before (at the origin) rather than
+            // being placed by a guess.
+            var georef = RevitGeoref.Read(doc);
+            bool hasGeoref = georef != null && georef.HasSurveyOrigin;
+            if (hasGeoref)
+            {
+                StingLog.Info(
+                    $"Planscape: publishing with georef E={georef!.EastingM:F3}m N={georef.NorthingM:F3}m " +
+                    $"north={georef.TrueNorthDeg:F3}° crs={georef.CrsEpsg ?? "(undeclared)"}");
+                if (string.IsNullOrWhiteSpace(georef.CrsEpsg))
+                {
+                    // Worth saying out loud: without a CRS the server stores the
+                    // transform but will not apply it on its own, so the model
+                    // still needs one confirmation. Setting the parameter once
+                    // per project removes that step for every future publish.
+                    StingLog.Info(
+                        $"Planscape: no {RevitGeoref.CrsParamName} on Project Information — the transform will be " +
+                        "stored as a suggestion, not auto-applied. Set it once per project to match the project's " +
+                        "declared coordinate system on the server.");
+                }
+            }
+            else
+            {
+                StingLog.Info("Planscape: no survey origin in this document — model will publish un-placed at the project origin.");
+            }
+
             var result = Task.Run(() => client.UploadModelAsync(
                 projectId,
                 modelPath,
@@ -232,7 +262,14 @@ namespace StingTools.BIMManager
                 units: "mm",
                 elementCount: elementCount,
                 bounds: bounds,
-                force: force)).GetAwaiter().GetResult();
+                force: force,
+                georefEastingM:     hasGeoref ? georef!.EastingM     : (double?)null,
+                georefNorthingM:    hasGeoref ? georef!.NorthingM    : (double?)null,
+                georefElevationM:   hasGeoref ? georef!.ElevationM   : (double?)null,
+                georefTrueNorthDeg: hasGeoref ? georef!.TrueNorthDeg : (double?)null,
+                georefCrsEpsg:      hasGeoref ? georef!.CrsEpsg      : null,
+                georefLengthUnit:   hasGeoref ? "mm"                 : null,
+                georefExportMode:   hasGeoref ? georef!.ExportMode   : null)).GetAwaiter().GetResult();
 
             if (!result.ok)
             {

--- a/StingTools/BIMManager/RevitGeoref.cs
+++ b/StingTools/BIMManager/RevitGeoref.cs
@@ -106,8 +106,11 @@ namespace StingTools.BIMManager
                 var data = new RevitGeorefData
                 {
                     // ProjectPosition is in Revit internal units (feet) and gives
-                    // the SURVEY coordinates of the project internal origin —
-                    // precisely the number the server needs to negate.
+                    // the SURVEY coordinates of the project internal origin. The
+                    // server places the model with t = +origin − frameOrigin — it
+                    // does NOT negate (see ModelGeorefWriter remarks). Negating was
+                    // the mirrored-translation bug this stack removed, so don't
+                    // reintroduce a sign flip here or on the server to "match".
                     EastingM     = pos.EastWest   * FeetToMetres,
                     NorthingM    = pos.NorthSouth * FeetToMetres,
                     ElevationM   = pos.Elevation  * FeetToMetres,

--- a/StingTools/BIMManager/RevitGeoref.cs
+++ b/StingTools/BIMManager/RevitGeoref.cs
@@ -1,0 +1,149 @@
+using System;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.BIMManager
+{
+    /// <summary>
+    /// B2 — a Revit document's georeferencing, in the units the Planscape server
+    /// expects (METRES for survey position, degrees for true north).
+    /// </summary>
+    internal sealed class RevitGeorefData
+    {
+        /// <summary>Survey easting of the project internal origin, metres.</summary>
+        public double EastingM { get; set; }
+
+        /// <summary>Survey northing of the project internal origin, metres.</summary>
+        public double NorthingM { get; set; }
+
+        /// <summary>Survey elevation of the project internal origin, metres.</summary>
+        public double ElevationM { get; set; }
+
+        /// <summary>
+        /// Angle from the CRS grid north to project north, degrees clockwise
+        /// positive — Revit's <c>ProjectPosition.Angle</c>, converted from radians.
+        /// </summary>
+        public double TrueNorthDeg { get; set; }
+
+        /// <summary>Latitude in degrees, if the document carries site data.</summary>
+        public double? LatitudeDeg { get; set; }
+
+        /// <summary>Longitude in degrees, if the document carries site data.</summary>
+        public double? LongitudeDeg { get; set; }
+
+        /// <summary>
+        /// The coordinate reference system the survey point is expressed in,
+        /// e.g. "EPSG:27700". Revit has no native concept of this, so it is read
+        /// from the optional <c>PRJ_CRS_EPSG_TXT</c> project parameter.
+        /// </summary>
+        public string CrsEpsg { get; set; }
+
+        /// <summary>"ProjectInternal" — see <see cref="RevitGeoref"/> remarks.</summary>
+        public string ExportMode { get; set; } = "ProjectInternal";
+
+        /// <summary>
+        /// True when the survey position is far enough from zero to be a real
+        /// georeference rather than an untouched default. A project whose survey
+        /// point was never moved reports (0,0,0), and writing a zero transform
+        /// for it is noise — worse, it looks like a deliberate placement.
+        /// </summary>
+        public bool HasSurveyOrigin =>
+            Math.Abs(EastingM) > 0.001 || Math.Abs(NorthingM) > 0.001;
+    }
+
+    /// <summary>
+    /// Reads a Revit document's survey position so the server can place the
+    /// published model in the federation without the coordinator typing a
+    /// transform.
+    ///
+    /// <para><b>Why this is metadata and not baked into the mesh.</b> The GLB
+    /// exporter writes geometry about the PROJECT INTERNAL origin
+    /// (<c>ClashExportContext</c> uses <c>Transform.Identity</c>), and that is
+    /// the right choice: a site at easting 432,000 m would put every vertex
+    /// ~432 km from the origin, where 32-bit float mesh coordinates lose
+    /// millimetre precision and surfaces visibly z-fight. So the position
+    /// travels beside the geometry as numbers, and the viewer applies it as a
+    /// transform — exactly what the IFC path does with IfcMapConversion.</para>
+    ///
+    /// <para><b>Export mode.</b> Always "ProjectInternal" here, because that is
+    /// what the exporter actually does. It is reported explicitly rather than
+    /// assumed so that if a shared-coordinates export is ever added, the server
+    /// will not double-count the survey origin — it already refuses to write a
+    /// transform for a "SharedCoordinates" upload.</para>
+    /// </summary>
+    internal static class RevitGeoref
+    {
+        private const double FeetToMetres = 0.3048;
+
+        /// <summary>
+        /// Optional project parameter naming the CRS the survey point sits in.
+        /// Revit does not model this, and it is the difference between a
+        /// transform the platform will apply on its own and one it merely
+        /// suggests: without a CRS anchor the server grades the georeference LOW
+        /// and leaves the model at the origin until a coordinator confirms it.
+        /// Set it ONCE per project, to match the project's declared coordinate
+        /// system on the server.
+        /// </summary>
+        public const string CrsParamName = "PRJ_CRS_EPSG_TXT";
+
+        /// <summary>
+        /// Read the document's georeferencing, or null when it carries none
+        /// (no project location, or a survey point still at the origin).
+        /// Never throws — a document without site data is normal.
+        /// </summary>
+        public static RevitGeorefData Read(Document doc)
+        {
+            if (doc == null) return null;
+
+            try
+            {
+                ProjectLocation loc = doc.ActiveProjectLocation;
+                if (loc == null) return null;
+
+                ProjectPosition pos = loc.GetProjectPosition(XYZ.Zero);
+                if (pos == null) return null;
+
+                var data = new RevitGeorefData
+                {
+                    // ProjectPosition is in Revit internal units (feet) and gives
+                    // the SURVEY coordinates of the project internal origin —
+                    // precisely the number the server needs to negate.
+                    EastingM     = pos.EastWest   * FeetToMetres,
+                    NorthingM    = pos.NorthSouth * FeetToMetres,
+                    ElevationM   = pos.Elevation  * FeetToMetres,
+                    TrueNorthDeg = pos.Angle * (180.0 / Math.PI),
+                    ExportMode   = "ProjectInternal",
+                };
+
+                try
+                {
+                    SiteLocation site = doc.SiteLocation;
+                    if (site != null)
+                    {
+                        data.LatitudeDeg  = site.Latitude  * (180.0 / Math.PI);
+                        data.LongitudeDeg = site.Longitude * (180.0 / Math.PI);
+                    }
+                }
+                catch { /* not every document carries site data */ }
+
+                try
+                {
+                    var pi = doc.ProjectInformation;
+                    if (pi != null)
+                    {
+                        var crs = ParameterHelpers.GetString(pi, CrsParamName);
+                        if (!string.IsNullOrWhiteSpace(crs)) data.CrsEpsg = crs.Trim();
+                    }
+                }
+                catch { /* the parameter is optional */ }
+
+                return data;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"[RevitGeoref] Could not read project position: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -500,57 +500,49 @@ namespace StingTools.BIMManager
             {
                 var sidecarPath = Path.ChangeExtension(glbOutputPath, ".coord.json");
 
-                // Project Base Point and Survey Point
-                // TODO-VERIFY-API: FilteredElementCollector for BasePoint — confirmed available in Revit 2025 API.
-                var pbpCollector = new FilteredElementCollector(doc)
-                    .OfClass(typeof(BasePoint))
-                    .Cast<BasePoint>()
-                    .ToList();
+                // The BasePoint collector that used to stand here was dead: its
+                // two results were only ever consumed by commented-out
+                // GetCoordinateSystem() calls, so it walked the model to produce
+                // nothing. Removed rather than left as decoration.
 
-                var projectBasePoint = pbpCollector.FirstOrDefault(bp => !bp.IsShared);
-                var surveyPoint      = pbpCollector.FirstOrDefault(bp => bp.IsShared);
+                // B2 — read the survey position through the ONE helper the
+                // upload path also uses, so the sidecar and the georef block
+                // sent to the server can never disagree.
+                //
+                // The easting/northing here were previously always null, with a
+                // comment claiming "BasePoint.GetCoordinateSystem() is not
+                // available in Revit 2025 public API". That is true and beside
+                // the point: ProjectLocation.GetProjectPosition(XYZ.Zero) has
+                // always returned EastWest / NorthSouth / Elevation / Angle, and
+                // the old code already called it — it just read Angle and
+                // Elevation and dropped the two coordinates that place the
+                // building. So every Revit model published to Planscape landed
+                // at 0,0,0 no matter where the site actually was.
+                var georef = RevitGeoref.Read(doc);
 
-                // Project location (lat/lon/north angle)
-                ProjectLocation? projectLocation = null;
-                try { projectLocation = doc.ActiveProjectLocation; } catch { /* ignore */ }
+                double? latitude = georef?.LatitudeDeg;
+                double? longitude = georef?.LongitudeDeg;
+                double? elevationMm = georef == null ? (double?)null : georef.ElevationM * 1000.0;
+                double? northAngleDeg = georef?.TrueNorthDeg;
+                double? eastingMm = georef == null ? (double?)null : georef.EastingM * 1000.0;
+                double? northingMm = georef == null ? (double?)null : georef.NorthingM * 1000.0;
+                bool hasSurveyOrigin = georef != null && georef.HasSurveyOrigin;
 
-                double? latitude = null, longitude = null, elevation = null, northAngleDeg = null;
-                double? easting = null, northing = null;
-
-                if (projectLocation != null)
-                {
-                    try
-                    {
-                        var pos = projectLocation.GetProjectPosition(XYZ.Zero);
-                        // Latitude/Longitude moved to SiteLocation in Revit 2025+ API.
-                        var site = doc.SiteLocation;
-                        if (site != null)
-                        {
-                            latitude  = site.Latitude  * (180.0 / Math.PI);
-                            longitude = site.Longitude * (180.0 / Math.PI);
-                        }
-                        northAngleDeg = pos.Angle     * (180.0 / Math.PI);
-                        elevation     = pos.Elevation * FeetToMm;
-                    }
-                    catch { /* not all configurations carry site data */ }
-                }
-
-                // Survey point position via its coordinate system (feet → mm)
-                // NOTE: BasePoint.GetCoordinateSystem() is not available in Revit 2025 public API.
-                // Easting/northing will remain null until a supported API is identified.
-                // if (surveyPoint != null) { ... surveyPoint.GetCoordinateSystem() ... }
-
-                // Project base point coordinate system (feet → mm)
+                // Project base point coordinate system (feet → mm).
+                // BasePoint.GetCoordinateSystem() is not in the Revit 2025 public
+                // API, so this stays null. It is NOT needed for placement: the
+                // survey position above is what locates the model.
                 double? pbpX = null, pbpY = null, pbpZ = null;
-                // NOTE: BasePoint.GetCoordinateSystem() is not available in Revit 2025 public API.
-                // pbpX/pbpY/pbpZ will remain null until a supported API is identified.
 
                 var sidecar = new
                 {
                     schemaVersion = "1.0",
                     generatedBy = "StingTools.RevitGltfExporter",
                     generatedAt = DateTime.UtcNow.ToString("O"),
-                    exportMode = "ProjectInternal",  // TODO: detect shared coordinate export
+                    // The exporter writes geometry about the project internal
+                    // origin (ClashExportContext uses Transform.Identity), so
+                    // this is a statement of fact, not a default.
+                    exportMode = georef?.ExportMode ?? "ProjectInternal",
                     projectBasePoint = (pbpX.HasValue) ? new
                     {
                         x    = pbpX.Value,
@@ -558,19 +550,20 @@ namespace StingTools.BIMManager
                         z    = pbpZ!.Value,
                         unit = "mm",
                     } : (object?)null,
-                    surveyPoint = (easting.HasValue && northing.HasValue) ? new
+                    surveyPoint = hasSurveyOrigin ? new
                     {
-                        easting  = easting.Value,
-                        northing = northing.Value,
+                        easting  = eastingMm!.Value,
+                        northing = northingMm!.Value,
                         unit     = "mm",
                     } : (object?)null,
                     geolocation = latitude.HasValue ? new
                     {
                         latitude          = latitude.Value,
                         longitude         = longitude!.Value,
-                        elevation         = elevation!.Value,
-                        trueNorthAngleDeg = northAngleDeg!.Value,
+                        elevation         = elevationMm ?? 0.0,
+                        trueNorthAngleDeg = northAngleDeg ?? 0.0,
                     } : (object?)null,
+                    crsEpsg = georef?.CrsEpsg,
                     lengthUnit = "mm",
                 };
 

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -910,3 +910,79 @@ manual PUT additionally clears `AppliedAutomatically` and stamps
 Schema follows ADR 0001 (EnsureCreated + idempotent patcher). `dotnet ef
 migrations add` remains unsafe here — the model snapshot is stale and a new
 migration would try to re-create existing tables.
+
+## 20. Track B / P2 — the Revit GLB path gains a georef source (CLOSED)
+
+### The defect
+
+Revit exports geometry about the **project internal origin**
+(`ClashExportContext` uses `Transform.Identity`), so a published GLB carried no
+survey position and **every Revit model landed at 0,0,0** regardless of where the
+building actually is. The coordinate sidecar that was supposed to carry the
+position (`RevitGltfExporter.ExportCoordinateSidecar`) had three separate faults:
+
+1. Its easting/northing were **always null**, behind a comment claiming
+   `BasePoint.GetCoordinateSystem()` is unavailable in the Revit 2025 API. That is
+   true and beside the point — `ProjectLocation.GetProjectPosition(XYZ.Zero)` has
+   always returned `EastWest` / `NorthSouth` / `Elevation` / `Angle`, the method
+   was **already being called**, and the code read `Angle` and `Elevation` while
+   dropping the two coordinates that place the building.
+   (`ProjectSetupCommand.cs` uses `EastWest`/`NorthSouth` a few files away.)
+2. `exportMode` was hardcoded `"ProjectInternal"` with a `TODO`.
+3. It was **never uploaded** — nothing read the file.
+
+### The fix
+
+The survey position travels as **metadata beside the geometry, never baked into
+the mesh**. That is not a shortcut: a site at easting 432,000 m would put every
+vertex ~432 km from the origin, where 32-bit float mesh coordinates lose
+millimetre precision and surfaces visibly z-fight. It is also exactly what the
+IFC path does with `IfcMapConversion`.
+
+- `RevitGeoref` (plugin) reads `ProjectPosition` once — used by BOTH the sidecar
+  and the upload, so the two cannot disagree.
+- `UploadModelRequest` gains an optional georef block (easting/northing/elevation
+  in metres, true north, CRS, length unit, export mode).
+- `ModelsController.Upload` writes the transform through a shared writer.
+
+**`ModelGeorefWriter` is now the ONE place** that turns a host's georeferencing
+into a stored transform, and `IfcIngestController` was collapsed onto it. Before
+this there was one copy for IFC and none for Revit; adding a second copy is how a
+building ends up in a different place depending on which pipeline last touched
+it — the most expensive class of bug in this system and the hardest to attribute.
+The writer was built around the IFC path's existing convention (`t = -origin`,
+metres → mm) deliberately, so introducing it changes no existing IFC behaviour.
+
+Two "do nothing" cases are as important as the placement:
+
+- **No survey origin → no transform row at all.** Not an identity transform, and
+  emphatically not a guess.
+- **`SharedCoordinates` export → no transform.** That geometry already sits in
+  the survey frame; applying the origin again would double-count it. The plugin
+  only produces `ProjectInternal` today, but the mode is reported as fact rather
+  than assumed, so a future shared-coordinates export cannot silently break.
+
+### The CRS caveat (honest limitation)
+
+Revit has **no native CRS concept**. Without a CRS anchor the transform grades
+LOW and is stored as a suggestion rather than applied, so a Revit model would
+still need one confirmation. The plugin therefore reads an optional
+`PRJ_CRS_EPSG_TXT` project parameter; set it once per project (to match the
+project's declared coordinate system on the server) and every future publish
+auto-places. This is a **project-level declaration, not a per-model transform
+entry**, so the Track B definition of done still holds — but it is a setup step
+and is logged explicitly by the plugin when absent.
+
+### Verification
+
+- **9 tests** on `ModelGeorefWriter`, including
+  `The_ifc_source_label_produces_the_same_numbers_as_the_revit_one` — two hosts
+  reporting the same survey origin must land in the same place, which is the
+  whole point of collapsing the two writers into one.
+- Revit plugin builds against the Revit 2025 API: **0 errors, 0 warnings**.
+- Server build 0 errors; full suite **700 passed / 0 failed / 11 skipped**.
+
+**NOT verified:** `RevitGeoref.Read` itself. It needs a live Revit `Document`, so
+no unit test can reach it — the numbers it produces are asserted only from the
+server side, against hand-written inputs. Reading a real document's survey point
+remains a Revit-session check.


### PR DESCRIPTION
> **Stacked on #678** (P1) → #676 (Track A). Retarget as those merge.

## The bug

Revit exports geometry about the **project internal origin** (`ClashExportContext` uses `Transform.Identity`), so a published GLB carried no survey position and **every Revit model landed at 0,0,0** regardless of where the building is.

The coordinate sidecar meant to carry that position had three faults:

1. Its easting/northing were **always null**, behind a comment blaming `BasePoint.GetCoordinateSystem()` being absent from the Revit 2025 API. That's true and beside the point — `ProjectLocation.GetProjectPosition(XYZ.Zero)` has always returned `EastWest` / `NorthSouth` / `Elevation` / `Angle`, the method was **already being called**, and the code read `Angle` and `Elevation` while dropping the two coordinates that place the building. (`ProjectSetupCommand.cs` uses `EastWest`/`NorthSouth` a few files away.)
2. `exportMode` was hardcoded with a `TODO`.
3. It was **never uploaded** — nothing read the file.

## The fix

The survey position travels as **metadata beside the geometry, never baked into the mesh**. Not a shortcut — a site at easting 432,000 m would put every vertex ~432 km from the origin, where 32-bit float loses millimetre precision and surfaces z-fight. It's also exactly what the IFC path does with `IfcMapConversion`.

- `RevitGeoref` (plugin) reads `ProjectPosition` **once**, used by both the sidecar and the upload, so they can't disagree.
- `UploadModelRequest` gains an optional georef block (E/N/elevation in metres, true north, CRS, length unit, export mode).
- `ModelsController.Upload` writes the transform via a shared writer.

**`ModelGeorefWriter` is now the ONE place** that turns georeferencing into a stored transform, and `IfcIngestController` was collapsed onto it. Before: one copy for IFC, none for Revit. Adding a *second* copy is how a building ends up in a different place depending on which pipeline last touched it — the most expensive class of bug here and the hardest to attribute. The writer was built around the IFC path's existing convention (`t = -origin`, m→mm) **deliberately**, so this changes no existing IFC behaviour.

Two "do nothing" cases matter as much as the placement:
- **No survey origin → no transform row at all.** Not an identity, and not a guess.
- **`SharedCoordinates` export → no transform.** That geometry is already in the survey frame; applying the origin again would double-count it. The plugin only emits `ProjectInternal` today, but the mode is reported as *fact* rather than assumed, so a future shared-coordinates export can't silently break.

## Honest limitation — the CRS

Revit has **no native CRS concept**. Without an anchor the transform grades LOW and is *stored* rather than applied, so a Revit model would still need one confirmation. The plugin reads an optional `PRJ_CRS_EPSG_TXT` project parameter — set it once per project and every future publish auto-places.

That's a **project-level declaration, not a per-model transform entry**, so the Track B definition of done still holds. But it *is* a setup step, and the plugin logs explicitly when it's missing.

## Verification

- **9 tests** on `ModelGeorefWriter`, including `The_ifc_source_label_produces_the_same_numbers_as_the_revit_one` — two hosts reporting the same survey origin must land in the same place. That assertion is the whole reason the writers were collapsed into one.
- **Revit plugin builds against the Revit 2025 API: 0 errors, 0 warnings.**
- Server build 0 errors; full suite **700 passed / 0 failed / 11 skipped**.

**NOT verified:** `RevitGeoref.Read` itself — it needs a live Revit `Document`, so no unit test reaches it. The numbers it produces are asserted only from the server side against hand-written inputs. Reading a real document's survey point remains a Revit-session check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)