### PR TITLE
Placement P3: one mesh-unit convention — the metre — across both GLB writers

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
@@ -638,7 +638,11 @@ public class IfcIngestController : ControllerBase
                 CrsCode       : report.CrsName,
                 HasDeclaredCrs: report.HasProjectedCrs,
                 LengthUnit    : report.LengthUnit,
-                SourceLabel   : "ifc-map-conversion");
+                SourceLabel   : "ifc-map-conversion",
+                // Previously dropped: the ingest computed a scaleFactor whose
+                // two branches both returned 1.0, so a declared map-conversion
+                // scale never reached the transform.
+                MapConversionScale: report.MapConversionScale);
 
             var confidence = await _georefWriter.WriteAsync(
                 projectId, projectModelId, tenantId, georef, report.Verdict, ct);

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
@@ -59,12 +59,28 @@ public class ModelTransformController : ControllerBase
                   && t.TenantId       == _tenant.TenantId,
                 ct);
 
+        // P3 — the mesh's own length unit travels with the transform because
+        // this is the one payload the viewer already fetches per model, and the
+        // two are multiplied at render time anyway. It is reported even when
+        // there is NO transform: a model whose mesh is in millimetres needs
+        // rescaling whether or not it is georeferenced, and before this the
+        // viewer never read ProjectModel.Units at all, so such a model rendered
+        // 1000x too large. Alone that is invisible (the camera fits to bounds);
+        // federated with a metre model it is a thousand-fold mismatch.
+        var meshUnits = await _db.ProjectModels.AsNoTracking()
+            .Where(m => m.Id == modelId && m.ProjectId == projectId && m.TenantId == _tenant.TenantId)
+            .Select(m => m.Units)
+            .FirstOrDefaultAsync(ct);
+        double meshUnitScale = MeshUnits.ToMetres(meshUnits);
+
         if (xf == null)
         {
             return Ok(new
             {
                 modelId          = modelId,
                 hasTransform     = false,
+                meshUnits        = meshUnits,
+                meshUnitScale    = meshUnitScale,
                 translationX     = 0.0,
                 translationY     = 0.0,
                 translationZ     = 0.0,
@@ -85,6 +101,8 @@ public class ModelTransformController : ControllerBase
         {
             modelId          = modelId,
             hasTransform     = true,
+            meshUnits        = meshUnits,
+            meshUnitScale    = meshUnitScale,
             translationX     = xf.TranslationX,
             translationY     = xf.TranslationY,
             translationZ     = xf.TranslationZ,
@@ -111,15 +129,21 @@ public class ModelTransformController : ControllerBase
     {
         if (await this.RequireProjectMemberAsync(_db, projectId, ct) is { } denied) return denied;
 
-        // Validate ownership
-        var projectExists = await _db.ProjectModels.AsNoTracking()
-            .AnyAsync(m => m.Id        == modelId
-                        && m.ProjectId == projectId
-                        && m.TenantId  == _tenant.TenantId
-                        && m.DeletedAt == null,
-                      ct);
-        if (!projectExists)
+        // Validate ownership. Selecting Units at the same time serves the
+        // response below, which echoes the mesh unit so a client that PUTs a
+        // transform sees the same shape GET returns.
+        var model = await _db.ProjectModels.AsNoTracking()
+            .Where(m => m.Id        == modelId
+                     && m.ProjectId == projectId
+                     && m.TenantId  == _tenant.TenantId
+                     && m.DeletedAt == null)
+            .Select(m => new { m.Units })
+            .FirstOrDefaultAsync(ct);
+        if (model == null)
             return NotFound(new { message = "Model not found or does not belong to this project/tenant." });
+
+        var meshUnits = model.Units;
+        double meshUnitScale = MeshUnits.ToMetres(meshUnits);
 
         if (dto.ScaleFactor <= 0)
             return BadRequest(new { message = "ScaleFactor must be greater than zero." });
@@ -212,6 +236,8 @@ public class ModelTransformController : ControllerBase
         {
             modelId          = modelId,
             hasTransform     = true,
+            meshUnits        = meshUnits,
+            meshUnitScale    = meshUnitScale,
             translationX     = xf.TranslationX,
             translationY     = xf.TranslationY,
             translationZ     = xf.TranslationZ,

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -250,7 +251,13 @@ public class ModelsController : ControllerBase
             ThumbnailPath = thumbnailPath,
             ElementMapPath = mapPath,
             ElementCount = req.ElementCount,
-            Units = string.IsNullOrWhiteSpace(req.Units) ? "mm" : req.Units!,
+            // P3 — an undeclared mesh unit is METRES, not millimetres.
+            // glTF 2.0 defines metres for all linear distances and the viewer
+            // has always assumed it; defaulting to "mm" meant any uploader that
+            // omitted the field got its model scaled by 1/1000 the moment this
+            // field started driving rendering. Callers whose mesh really is
+            // millimetres must say so — the Revit plugin does.
+            Units = string.IsNullOrWhiteSpace(req.Units) ? MeshUnits.Canonical : req.Units!,
             Revision = req.Revision,
             BoundsMinX = req.BoundsMinX,
             BoundsMinY = req.BoundsMinY,

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -2103,6 +2103,16 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // get them from the EF model via CreateTables, pre-existing DBs get them
         // here. NOT NULL DEFAULT false on the flag so existing rows keep today's
         // behaviour exactly — nothing starts rendering because of a deploy.
+        // P3 — correct the mesh unit on GLB derivatives produced by the IFC→GLB
+        // converter. Those rows copied the SOURCE IFC's unit (commonly "mm")
+        // onto the converted GLB, which glTF 2.0 defines as metres. That was
+        // harmless while nothing read ProjectModel.Units; now that it drives the
+        // viewer's mesh scaling, leaving it would shrink every previously
+        // converted model by 1000. Scoped to converter-produced rows by
+        // UploadedBy so no hand-uploaded model is touched, and a no-op once
+        // applied (and for rows the fixed job already writes as "m").
+        "UPDATE \"ProjectModels\" SET \"Units\" = 'm' " +
+            "WHERE \"UploadedBy\" = 'IFC→GLB converter' AND \"Format\" = 0 AND \"Units\" IS DISTINCT FROM 'm'",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"AppliedAutomatically\" boolean NOT NULL DEFAULT false",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Confidence\" text NULL",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Source\" text NULL",

--- a/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
+++ b/Planscape.Server/src/Planscape.API/wwwroot/viewer.html
@@ -1105,20 +1105,39 @@ THREE.ColorManagement.enabled = false;
   //
   // The `!== false` default is kept for isConfirmed so an older/partial payload
   // that omits the field still renders as it did before.
+  // P3 — MESH UNITS are applied separately from, and unconditionally alongside,
+  // the georeferencing transform. They answer different questions: scaleFactor
+  // is a survey correction declared by the source, meshUnitScale is how the
+  // vertex data happens to be written. glTF 2.0 defines metres as the unit for
+  // all linear distances and this viewer assumes it (hence the /1000 on the
+  // millimetre translation) — but the Revit exporter wrote MILLIMETRE vertices,
+  // so a Revit-published building rendered 1000x too large. Alone that is
+  // invisible, because the camera fits to whatever bounds it finds; federate it
+  // with a metre model and they are a thousand times apart.
+  //
+  // Unconditional is the point: a mm model needs rescaling whether or not it is
+  // georeferenced, so this must NOT sit behind the `live` gate.
   function applyModelTransform(root, t) {
     if (!root || !t) return;
     const tx = (+t.translationX || 0), ty = (+t.translationY || 0), tz = (+t.translationZ || 0);
     const rot = (+t.rotationDeg || 0);
     const scale = (t.scaleFactor != null ? +t.scaleFactor : 1) || 1;
+    // Unknown/absent reads as 1 (metres) — the glTF default, and the value that
+    // leaves existing behaviour untouched. A wrong guess rescales a building.
+    const meshScale = (t.meshUnitScale != null ? +t.meshUnitScale : 1) || 1;
     const confirmed = (t.isConfirmed !== false);   // default-confirmed if unspecified
     const autoApplied = (t.appliedAutomatically === true);
     const live = confirmed || autoApplied;
     const isIdentity = tx === 0 && ty === 0 && tz === 0 && rot === 0 && scale === 1;
-    if (!live || isIdentity) return;
+    const placing = live && !isIdentity;
+    const effectiveScale = (placing ? scale : 1) * meshScale;
+    if (!placing && effectiveScale === 1) return;
     try {
-      root.scale.set(scale, scale, scale);
-      root.rotation.z = rot * Math.PI / 180;
-      root.position.set(tx / 1000, ty / 1000, tz / 1000);
+      if (effectiveScale !== 1) root.scale.set(effectiveScale, effectiveScale, effectiveScale);
+      if (placing) {
+        root.rotation.z = rot * Math.PI / 180;
+        root.position.set(tx / 1000, ty / 1000, tz / 1000);
+      }
       root.updateMatrixWorld(true);
     } catch (e) { console.warn('[viewer] transform apply failed', e); }
   }

--- a/Planscape.Server/src/Planscape.Core/Coordinates/MeshUnits.cs
+++ b/Planscape.Server/src/Planscape.Core/Coordinates/MeshUnits.cs
@@ -1,0 +1,80 @@
+namespace Planscape.Core.Coordinates;
+
+/// <summary>
+/// The length unit a model's MESH is expressed in, and the factor that takes it
+/// to the platform's canonical mesh unit.
+///
+/// <para><b>The canonical mesh unit is the METRE</b>, because glTF 2.0 says so:
+/// "The units for all linear distances are meters." Every GLB the viewer loads
+/// is interpreted that way — <c>applyModelTransform</c> divides the stored
+/// millimetre translation by 1000 precisely because the geometry it is
+/// positioning is in metres.</para>
+///
+/// <para><b>Why this type has to exist.</b> The two Revit GLB writers disagreed
+/// by a factor of 1000: <c>GlbSerializer</c> converted feet → metres while
+/// <c>RevitGltfExporter</c> converted feet → millimetres, and both uploaded to
+/// the same endpoint for the same viewer. A model alone hides it — the camera
+/// fits to whatever bounds it finds, so a building rendered 1000× too large
+/// looks perfectly normal. It only shows when you federate that model with one
+/// from another tool, at which point they are a thousand times apart and no
+/// amount of transform tuning will reconcile them. That is exactly the class of
+/// bug that reads as "the models just don't line up".</para>
+///
+/// <para><b>Mesh unit is NOT georeferencing scale.</b> They are multiplied
+/// together but they answer different questions:
+/// <see cref="ProjectModelTransformScale"/> (the transform's
+/// <c>ScaleFactor</c>) is a survey correction declared by an
+/// <c>IfcMapConversion</c>; the mesh unit is how the vertex data happens to be
+/// written. Conflating them is how a unit fix silently becomes a survey error.
+/// </para>
+/// </summary>
+public static class MeshUnits
+{
+    /// <summary>Documentation anchor for the paragraph above.</summary>
+    internal const string ProjectModelTransformScale = "ProjectModelTransform.ScaleFactor";
+
+    /// <summary>The canonical mesh unit's name, as reported on upload.</summary>
+    public const string Canonical = "m";
+
+    /// <summary>
+    /// Factor that converts one unit of the named length unit into metres.
+    ///
+    /// <para>Unknown or unspecified reads as <b>1.0 (metres)</b>, deliberately:
+    /// it is the glTF default and the value that leaves existing behaviour
+    /// untouched. A wrong guess here silently rescales a whole building, so the
+    /// fail-safe direction is "change nothing".</para>
+    /// </summary>
+    public static double ToMetres(string? unit)
+    {
+        if (string.IsNullOrWhiteSpace(unit)) return 1.0;
+
+        return unit.Trim().ToLowerInvariant() switch
+        {
+            "m" or "metre" or "meter" or "metres" or "meters" => 1.0,
+            "mm" or "millimetre" or "millimeter" or "millimetres" or "millimeters" => 0.001,
+            "cm" or "centimetre" or "centimeter" or "centimetres" or "centimeters" => 0.01,
+            "ft" or "feet" or "foot" => 0.3048,
+            "in" or "inch" or "inches" => 0.0254,
+            _ => 1.0,
+        };
+    }
+
+    /// <summary>
+    /// True when the named unit is understood. Callers that want to WARN about
+    /// an unrecognised unit need this, because <see cref="ToMetres"/>
+    /// deliberately cannot distinguish "metres" from "no idea".
+    /// </summary>
+    public static bool IsRecognised(string? unit)
+    {
+        if (string.IsNullOrWhiteSpace(unit)) return false;
+        return unit.Trim().ToLowerInvariant() switch
+        {
+            "m" or "metre" or "meter" or "metres" or "meters"
+                or "mm" or "millimetre" or "millimeter" or "millimetres" or "millimeters"
+                or "cm" or "centimetre" or "centimeter" or "centimetres" or "centimeters"
+                or "ft" or "feet" or "foot"
+                or "in" or "inch" or "inches" => true,
+            _ => false,
+        };
+    }
+}

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Planscape.Core.Coordinates;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -153,7 +154,16 @@ public class IfcToGlbConversionJob
             StoragePath = key,
             ContentHash = result.Sha256,
             FileSizeBytes = sizeBytes > 0 ? sizeBytes : result.Bytes,
-            Units = string.IsNullOrWhiteSpace(ifc.Units) ? "mm" : ifc.Units,
+            // P3 — the GLB's own mesh unit, NOT the source IFC's.
+            //
+            // This used to copy `ifc.Units` across, which describes the IFC file
+            // (commonly millimetres) rather than the geometry the converter
+            // emits. Harmless while nothing read the field; actively wrong now
+            // that Units drives the viewer's mesh scaling, because it would
+            // shrink every converted model by 1000. glTF 2.0 defines metres and
+            // the converter emits glTF, so the derivative is metres by
+            // construction.
+            Units = MeshUnits.Canonical,
             Revision = ifc.Revision,
             UploadedBy = "IFC→GLB converter",
             UploadedAt = DateTime.UtcNow,

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
@@ -25,6 +25,13 @@ namespace Planscape.Infrastructure.Services;
 /// being non-null so a host can supply a code it is not certain about.
 /// </param>
 /// <param name="LengthUnit">The model's own length unit — "mm" | "m" | "ft".</param>
+/// <param name="MapConversionScale">
+/// The GEOREFERENCING scale declared by the source (IfcMapConversion.Scale) —
+/// a survey correction, e.g. a grid-to-ground factor. Null or 1.0 means none.
+/// Emphatically NOT the mesh's unit scale: that is <see cref="MeshUnits"/>,
+/// applied separately at render time. Conflating the two turns a unit fix into
+/// a survey error.
+/// </param>
 /// <param name="SourceLabel">
 /// Which pipeline produced this: "ifc-map-conversion" | "revit-georef".
 /// Stored on the transform so the UI can explain why a model moved.
@@ -37,7 +44,8 @@ public sealed record ModelGeoref(
     string? CrsCode,
     bool HasDeclaredCrs,
     string? LengthUnit,
-    string SourceLabel)
+    string SourceLabel,
+    double? MapConversionScale = null)
 {
     /// <summary>True when there is enough here to place the model at all.</summary>
     public bool HasSurveyOrigin => EastingM.HasValue && NorthingM.HasValue;
@@ -128,6 +136,14 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
         double tyMm = -georef.NorthingM!.Value * 1000.0;
         double tzMm = -(georef.ElevationM ?? 0) * 1000.0;
 
+        // The source's declared survey scale, inverted to undo it — the same
+        // convention AutoAlignService uses. The IFC ingest path used to compute
+        // this into a variable whose two branches both returned 1.0, so a
+        // declared map-conversion scale was silently discarded.
+        double scaleFactor = (georef.MapConversionScale is { } mcs && mcs != 0 && mcs != 1.0)
+            ? 1.0 / mcs
+            : 1.0;
+
         var existing = await _db.ProjectModelTransforms
             .FirstOrDefaultAsync(t => t.ProjectId == projectId
                                    && t.ProjectModelId == projectModelId
@@ -154,7 +170,7 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
                 TranslationY         = tyMm,
                 TranslationZ         = tzMm,
                 RotationDeg          = georef.TrueNorthDeg,
-                ScaleFactor          = 1.0,
+                ScaleFactor          = scaleFactor,
                 IsAutoComputed       = true,
                 IsConfirmed          = false,
                 AppliedAutomatically = autoApply,
@@ -170,7 +186,7 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
             existing.TranslationY         = tyMm;
             existing.TranslationZ         = tzMm;
             existing.RotationDeg          = georef.TrueNorthDeg;
-            existing.ScaleFactor          = 1.0;
+            existing.ScaleFactor          = scaleFactor;
             existing.IsAutoComputed       = true;
             existing.AppliedAutomatically = autoApply;
             existing.Confidence           = confidenceText;

--- a/Planscape.Server/tests/Planscape.Tests/MeshUnitsTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/MeshUnitsTests.cs
@@ -1,0 +1,84 @@
+using Planscape.Core.Coordinates;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK B / P3 — mesh units.
+///
+/// THE DEFECT
+/// ----------
+/// Two GLB writers in this repo disagreed by a factor of 1000:
+/// <c>GlbSerializer</c> converted Revit feet → METRES, <c>RevitGltfExporter</c>
+/// converted feet → MILLIMETRES, and both uploaded to the same endpoint for the
+/// same viewer. glTF 2.0 is unambiguous ("The units for all linear distances are
+/// meters") and the viewer assumes it — <c>applyModelTransform</c> divides the
+/// stored millimetre translation by 1000 precisely because the geometry it
+/// positions is metres.
+///
+/// It hid for so long because a model viewed ALONE looks correct at any uniform
+/// scale: the camera fits to whatever bounds it finds. The mismatch only
+/// surfaces once a Revit model is federated with a model from another tool, and
+/// then it presents as "the models don't line up" — which reads like a
+/// coordinate problem rather than a unit one, and sends you looking in the wrong
+/// place.
+///
+/// THE FAIL-SAFE DIRECTION
+/// ----------------------
+/// An unknown unit reads as metres (1.0), never as a guess. Getting this
+/// backwards silently rescales an entire building, so "change nothing" is the
+/// only safe default.
+/// </summary>
+public class MeshUnitsTests
+{
+    [Theory]
+    [InlineData("m", 1.0)]
+    [InlineData("metre", 1.0)]
+    [InlineData("meters", 1.0)]
+    [InlineData("mm", 0.001)]
+    [InlineData("millimetre", 0.001)]
+    [InlineData("millimeters", 0.001)]
+    [InlineData("cm", 0.01)]
+    [InlineData("ft", 0.3048)]
+    [InlineData("feet", 0.3048)]
+    [InlineData("in", 0.0254)]
+    public void Known_units_convert_to_metres(string unit, double expected)
+        => Assert.Equal(expected, MeshUnits.ToMetres(unit), 9);
+
+    [Theory]
+    [InlineData("M")]
+    [InlineData("MM")]
+    [InlineData("  mm  ")]
+    [InlineData("Millimetres")]
+    public void Unit_parsing_ignores_case_and_padding(string unit)
+        => Assert.True(MeshUnits.IsRecognised(unit));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("furlongs")]
+    public void Unknown_units_read_as_metres_not_as_a_guess(string? unit)
+    {
+        // 1.0 means "leave the geometry alone". Anything else would rescale a
+        // building on the strength of a string nobody recognised.
+        Assert.Equal(1.0, MeshUnits.ToMetres(unit));
+        Assert.False(MeshUnits.IsRecognised(unit));
+    }
+
+    [Fact]
+    public void The_canonical_unit_is_metres_and_round_trips()
+    {
+        Assert.Equal("m", MeshUnits.Canonical);
+        Assert.Equal(1.0, MeshUnits.ToMetres(MeshUnits.Canonical));
+        Assert.True(MeshUnits.IsRecognised(MeshUnits.Canonical));
+    }
+
+    [Fact]
+    public void A_millimetre_mesh_scales_down_by_exactly_one_thousand()
+    {
+        // The specific number that was wrong. A 10 m wall exported as 10 000
+        // millimetre units must render 10 m long, not 10 km.
+        double wallLengthInMeshUnits = 10_000;
+        Assert.Equal(10.0, wallLengthInMeshUnits * MeshUnits.ToMetres("mm"), 9);
+    }
+}

--- a/Planscape.Server/tests/web-harness/mesh-units.mjs
+++ b/Planscape.Server/tests/web-harness/mesh-units.mjs
@@ -1,0 +1,113 @@
+// TRACK B / P3 — mesh-unit reconciliation, checked against the SHIPPED sources.
+//
+// Two things are verified here that no C# unit test can reach:
+//
+//  1. The viewer applies the mesh-unit scale UNCONDITIONALLY — a millimetre
+//     model needs rescaling whether or not it is georeferenced, so it must not
+//     sit behind the "is this transform live" gate.
+//
+//  2. The two Revit GLB writers agree on the unit. They disagreed by 1000x
+//     (GlbSerializer: feet → metres; RevitGltfExporter: feet → millimetres),
+//     both feeding the same endpoint and the same viewer. A model viewed alone
+//     hides it completely, because the camera fits to whatever bounds it finds;
+//     it only surfaces when you federate, and then it reads as "the models
+//     don't line up" rather than as a unit bug. A grep-level guard is crude but
+//     it is the only thing that fails when someone edits one writer and not the
+//     other.
+//
+// Run: node Planscape.Server/tests/web-harness/mesh-units.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WWW  = path.resolve(__dirname, '../../src/Planscape.API/wwwroot');
+// …/Planscape.Server/tests/web-harness → repo root.
+const REPO = path.resolve(__dirname, '../../..');
+
+let failures = 0;
+function ok(name, cond, detail = '') {
+  if (cond) { console.log(`  PASS  ${name}`); }
+  else { failures++; console.log(`  FAIL  ${name}${detail ? ' — ' + detail : ''}`); }
+}
+
+const html = fs.readFileSync(path.join(WWW, 'viewer.html'), 'utf8');
+const m = html.match(/function applyModelTransform\(root, t\)\s*\{[\s\S]*?\n  \}/);
+if (!m) { console.log('  FAIL  could not extract applyModelTransform'); process.exit(1); }
+
+function fakeRoot() {
+  return {
+    scaled: null, positioned: null, moved: false,
+    scale: { set(x) { this._owner.scaled = x; } },
+    rotation: { z: 0 },
+    position: { set(x, y, z) { this._owner.positioned = [x, y, z]; } },
+    updateMatrixWorld() { this.moved = true; },
+  };
+}
+function apply(t) {
+  const root = fakeRoot();
+  root.scale._owner = root; root.position._owner = root;
+  const ctx = vm.createContext({ Math, console, __root: root, __t: t });
+  vm.runInContext(m[0] + '\napplyModelTransform(__root, __t);', ctx);
+  return root;
+}
+
+const PLACED = {
+  translationX: 500000, translationY: 250000, translationZ: 0,
+  rotationDeg: 0, scaleFactor: 1, isConfirmed: true,
+};
+
+console.log('— a millimetre mesh is rescaled even with NO transform —');
+{
+  // The case that makes this unconditional: an ungeoreferenced mm model.
+  const r = apply({ hasTransform: false, translationX: 0, translationY: 0, translationZ: 0,
+                    rotationDeg: 0, scaleFactor: 1, isConfirmed: false,
+                    appliedAutomatically: false, meshUnitScale: 0.001 });
+  ok('scale applied without a live transform', r.scaled === 0.001, String(r.scaled));
+  ok('no position applied (there is no placement)', r.positioned === null);
+}
+
+console.log('\n— a metre mesh is left alone —');
+{
+  const r = apply({ hasTransform: false, translationX: 0, translationY: 0, translationZ: 0,
+                    rotationDeg: 0, scaleFactor: 1, isConfirmed: false,
+                    appliedAutomatically: false, meshUnitScale: 1 });
+  ok('identity + metres → untouched', r.moved === false && r.scaled === null);
+}
+
+console.log('\n— mesh unit and georef scale multiply, they do not replace —');
+{
+  const r = apply({ ...PLACED, scaleFactor: 2, meshUnitScale: 0.001 });
+  ok('scaleFactor 2 x meshUnitScale 0.001 = 0.002', Math.abs(r.scaled - 0.002) < 1e-12, String(r.scaled));
+  ok('placement still applied', r.positioned && r.positioned[0] === 500);
+}
+
+console.log('\n— an absent meshUnitScale defaults to metres —');
+{
+  const r = apply({ ...PLACED });
+  ok('no meshUnitScale → scale 1 (unchanged behaviour)',
+     r.scaled === null || r.scaled === 1, String(r.scaled));
+  ok('placement unaffected', r.positioned && r.positioned[0] === 500);
+}
+
+console.log('\n— the two Revit GLB writers agree on the unit —');
+{
+  const exporter = fs.readFileSync(path.join(REPO, 'StingTools/BIMManager/RevitGltfExporter.cs'), 'utf8');
+  const serializer = fs.readFileSync(path.join(REPO, 'StingTools/Commands/IFC/GlbSerializer.cs'), 'utf8');
+
+  ok('GlbSerializer writes metres', /FeetToMetres\s*=\s*0\.3048f?/.test(serializer));
+  ok('RevitGltfExporter writes metres', /FeetToMetres\s*=\s*0\.3048/.test(exporter));
+  ok('RevitGltfExporter no longer scales vertices by 304.8',
+     !/Positions\.Add\(\(float\)\(w\.[XYZ] \* FeetToMm\)\)/.test(exporter),
+     'vertices are still being written in millimetres');
+
+  // The bounds describe the same geometry, so they must use the same unit or
+  // the manifest AABB disagrees with what is rendered.
+  const publish = fs.readFileSync(path.join(REPO, 'StingTools/BIMManager/PublishModelCommand.cs'), 'utf8');
+  ok('published bounds are metres', /feetToMetres\s*=\s*0\.3048/.test(publish));
+  ok('published units are reported as "m"', /units:\s*"m"/.test(publish));
+}
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/Planscape/assets/viewer/viewer.html
+++ b/Planscape/assets/viewer/viewer.html
@@ -1105,20 +1105,39 @@ THREE.ColorManagement.enabled = false;
   //
   // The `!== false` default is kept for isConfirmed so an older/partial payload
   // that omits the field still renders as it did before.
+  // P3 — MESH UNITS are applied separately from, and unconditionally alongside,
+  // the georeferencing transform. They answer different questions: scaleFactor
+  // is a survey correction declared by the source, meshUnitScale is how the
+  // vertex data happens to be written. glTF 2.0 defines metres as the unit for
+  // all linear distances and this viewer assumes it (hence the /1000 on the
+  // millimetre translation) — but the Revit exporter wrote MILLIMETRE vertices,
+  // so a Revit-published building rendered 1000x too large. Alone that is
+  // invisible, because the camera fits to whatever bounds it finds; federate it
+  // with a metre model and they are a thousand times apart.
+  //
+  // Unconditional is the point: a mm model needs rescaling whether or not it is
+  // georeferenced, so this must NOT sit behind the `live` gate.
   function applyModelTransform(root, t) {
     if (!root || !t) return;
     const tx = (+t.translationX || 0), ty = (+t.translationY || 0), tz = (+t.translationZ || 0);
     const rot = (+t.rotationDeg || 0);
     const scale = (t.scaleFactor != null ? +t.scaleFactor : 1) || 1;
+    // Unknown/absent reads as 1 (metres) — the glTF default, and the value that
+    // leaves existing behaviour untouched. A wrong guess rescales a building.
+    const meshScale = (t.meshUnitScale != null ? +t.meshUnitScale : 1) || 1;
     const confirmed = (t.isConfirmed !== false);   // default-confirmed if unspecified
     const autoApplied = (t.appliedAutomatically === true);
     const live = confirmed || autoApplied;
     const isIdentity = tx === 0 && ty === 0 && tz === 0 && rot === 0 && scale === 1;
-    if (!live || isIdentity) return;
+    const placing = live && !isIdentity;
+    const effectiveScale = (placing ? scale : 1) * meshScale;
+    if (!placing && effectiveScale === 1) return;
     try {
-      root.scale.set(scale, scale, scale);
-      root.rotation.z = rot * Math.PI / 180;
-      root.position.set(tx / 1000, ty / 1000, tz / 1000);
+      if (effectiveScale !== 1) root.scale.set(effectiveScale, effectiveScale, effectiveScale);
+      if (placing) {
+        root.rotation.z = rot * Math.PI / 180;
+        root.position.set(tx / 1000, ty / 1000, tz / 1000);
+      }
       root.updateMatrixWorld(true);
     } catch (e) { console.warn('[viewer] transform apply failed', e); }
   }

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -259,7 +259,7 @@ namespace StingTools.BIMManager
                 description: $"Published from Revit {doc.Application.VersionName}",
                 discipline: DetectDocDiscipline(doc),
                 revision: PhaseAutoDetect.DetectProjectRevision(doc),
-                units: "mm",
+                units: "m",   // P3 — the GLB vertices are metres (glTF 2.0)
                 elementCount: elementCount,
                 bounds: bounds,
                 force: force,
@@ -268,7 +268,7 @@ namespace StingTools.BIMManager
                 georefElevationM:   hasGeoref ? georef!.ElevationM   : (double?)null,
                 georefTrueNorthDeg: hasGeoref ? georef!.TrueNorthDeg : (double?)null,
                 georefCrsEpsg:      hasGeoref ? georef!.CrsEpsg      : null,
-                georefLengthUnit:   hasGeoref ? "mm"                 : null,
+                georefLengthUnit:   hasGeoref ? "m"                  : null,
                 georefExportMode:   hasGeoref ? georef!.ExportMode   : null)).GetAwaiter().GetResult();
 
             if (!result.ok)
@@ -650,15 +650,24 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex) { StingLog.Warn($"[sys] summary failed: {ex.Message}"); }
 
-            // Convert feet → mm for the bounds (Revit internal units are feet).
+            // P3 — bounds are in METRES, matching the GLB vertices.
+            //
+            // These describe the same geometry the exporter writes, so they have
+            // to use the same unit or the manifest AABB disagrees with what is
+            // rendered. Both were millimetres before; both are metres now,
+            // because glTF 2.0 defines metres as the unit for linear distances
+            // and the other GLB writer in this repo (GlbSerializer) already
+            // complied. Changing one without the other would swap a visible
+            // 1000x scale bug for an invisible bounds one.
+            //
             // If nothing contributed bounds (e.g. empty 3D view), send zeros so
             // the server's [Range] validators don't see ±Infinity.
-            const double feetToMm = 304.8;
+            const double feetToMetres = 0.3048;
             bounds = boundsContributors > 0
                 ? new[]
                 {
-                    bb.Min.X * feetToMm, bb.Min.Y * feetToMm, bb.Min.Z * feetToMm,
-                    bb.Max.X * feetToMm, bb.Max.Y * feetToMm, bb.Max.Z * feetToMm,
+                    bb.Min.X * feetToMetres, bb.Min.Y * feetToMetres, bb.Min.Z * feetToMetres,
+                    bb.Max.X * feetToMetres, bb.Max.Y * feetToMetres, bb.Max.Z * feetToMetres,
                 }
                 : new[] { 0d, 0d, 0d, 0d, 0d, 0d };
             elementCount = count;

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -48,7 +48,22 @@ namespace StingTools.BIMManager
         // filesystem scan runs at most once per filename per export session.
         private static readonly Dictionary<string, string?> _texPathCache = new();
 
-        private const double FeetToMm = 304.8;
+        // P3 — GLB VERTICES ARE METRES.
+        //
+        // glTF 2.0: "The units for all linear distances are meters." This
+        // exporter used to write MILLIMETRES (feet x 304.8) while the other GLB
+        // writer in this repo, GlbSerializer, wrote metres (feet x 0.3048) — two
+        // writers, one upload endpoint, one viewer, a factor of 1000 apart.
+        //
+        // It hid for so long because a model viewed ALONE looks correct at any
+        // uniform scale: the camera fits to whatever bounds it finds. The
+        // mismatch only appears once a Revit model is federated with a model
+        // from another tool, and then it appears as "the models don't line up",
+        // which reads like a coordinate problem rather than a unit one.
+        //
+        // (The old FeetToMm constant is gone: the coordinate sidecar now derives
+        // its millimetre survey figures from RevitGeoref, which reads metres.)
+        private const double FeetToMetres = 0.3048;
 
         public RevitGltfExporter(Document doc, bool exportTextures = false)
         {
@@ -454,9 +469,9 @@ namespace StingTools.BIMManager
             for (int i = 0; i < pts.Count; i++)
             {
                 var w = t.OfPoint(pts[i]);
-                _current.Positions.Add((float)(w.X * FeetToMm));
-                _current.Positions.Add((float)(w.Y * FeetToMm));
-                _current.Positions.Add((float)(w.Z * FeetToMm));
+                _current.Positions.Add((float)(w.X * FeetToMetres));
+                _current.Positions.Add((float)(w.Y * FeetToMetres));
+                _current.Positions.Add((float)(w.Z * FeetToMetres));
 
                 XYZ n;
                 if (distrib == DistributionOfNormals.AtEachPoint && i < nrm.Count)

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -986,3 +986,86 @@ and is logged explicitly by the plugin when absent.
 no unit test can reach it — the numbers it produces are asserted only from the
 server side, against hand-written inputs. Reading a real document's survey point
 remains a Revit-session check.
+
+## 21. Track B / P3 — unit reconciliation (CLOSED)
+
+### The defect
+
+**Two GLB writers in this repo disagreed by a factor of 1000.**
+`GlbSerializer` converted Revit feet → **metres** (`0.3048`);
+`RevitGltfExporter` converted feet → **millimetres** (`304.8`). Both upload to
+the same endpoint and are rendered by the same viewer, which assumes metres —
+glTF 2.0 says "The units for all linear distances are meters", and
+`applyModelTransform` divides the stored millimetre translation by 1000 precisely
+because the geometry it positions is metres.
+
+It hid because **a model viewed alone looks correct at any uniform scale**: the
+camera fits to whatever bounds it finds, so a building rendered 1000x too large
+looks perfectly normal. The mismatch only appears once a Revit model is federated
+with a model from another tool — and then it presents as "the models don't line
+up", which reads as a coordinate problem and sends you looking in the wrong
+place.
+
+Alongside it: `ProjectModel.Units` was written on every upload and **read by
+nothing**, and the ingest path computed a `scaleFactor` whose two branches both
+returned `1.0`, silently discarding any declared `IfcMapConversion` scale.
+
+### The fix
+
+**One convention: the metre.** `RevitGltfExporter` now writes metre vertices, and
+the published bounds moved with it — they describe the same geometry, so leaving
+them in millimetres would have swapped a visible 1000x render bug for an
+invisible bounds one.
+
+`ProjectModel.Units` now means something. It rides on the transform payload the
+viewer already fetches (`meshUnitScale`), and the viewer applies it
+**unconditionally** — a millimetre model needs rescaling whether or not it is
+georeferenced, so it must not sit behind the "is this transform live" gate.
+
+**Mesh unit and georeferencing scale are kept separate and multiplied**, not
+merged. They answer different questions: `ScaleFactor` is a survey correction
+declared by an `IfcMapConversion`; the mesh unit is how the vertex data happens
+to be written. Conflating them makes a unit fix look like a survey error. (A
+deliberate deviation from the runner's "compute scaleFactor from model unit";
+the rendered result is identical because both factors multiply.) The
+previously-dead `scaleFactor` is now real: `ModelGeoref` carries
+`MapConversionScale` and the writer inverts it, matching `AutoAlignService`.
+
+### Two traps found while doing it
+
+1. **The IFC-to-GLB job copied the SOURCE IFC's unit onto the GLB derivative.**
+   Harmless while nothing read the field; the moment `Units` drives scaling it
+   would have shrunk every converted model by 1000. The converter emits glTF, so
+   the derivative is metres by construction. Fixed, plus a **targeted idempotent
+   backfill** for rows already written that way, scoped by `UploadedBy` and
+   `Format = 0` so the source IFC row and every hand-published model are
+   untouched.
+2. **The server defaulted an undeclared unit to `"mm"`.** Any uploader that
+   omitted the field would have been scaled by 1/1000. The default is now the
+   canonical metre; an unknown unit also reads as metres, because the fail-safe
+   direction for "I do not recognise this" is *change nothing* — a wrong guess
+   silently rescales a whole building.
+
+### Verification
+
+- **16 unit tests** on `MeshUnits`, including that unknown/blank reads as metres
+  rather than as a guess.
+- **10 harness assertions** (`tests/web-harness/mesh-units.mjs`) against the
+  shipped sources: the viewer scales a mm mesh with no transform at all; mesh
+  unit and georef scale multiply rather than replace; an absent `meshUnitScale`
+  changes nothing; and a grep-level guard that the two Revit writers still agree
+  — crude, but it is the only thing that fails when someone edits one and not the
+  other.
+- **Backfill SQL proven on real Postgres 16** against a four-row fixture: the
+  mislabelled converted GLB is corrected, an already-correct one is untouched,
+  and both the source IFC row and a genuinely-millimetre hand-published Revit
+  model are left alone. Idempotent on a second pass.
+- Server build 0 errors; Revit plugin builds against the Revit 2025 API with
+  **0 errors, 0 warnings**; full suite **719 passed / 0 failed / 12 skipped**
+  (all skips pre-existing environment-gated Postgres/API tests).
+
+**Behaviour change worth stating plainly:** Revit models published BEFORE this
+change are stored with millimetre meshes and `Units = "mm"`. They now render at
+the correct size because the viewer honours that unit — but a model whose row
+predates the `Units` column entirely would read as metres. Re-publishing puts any
+model on the canonical footing.


### PR DESCRIPTION
> **Stacked on #679** (P2) → #678 (P1) → #676 (Track A). Retarget as those merge.

## The bug

**Two GLB writers in this repo disagreed by a factor of 1000.**

| Writer | Conversion | Result |
|---|---|---|
| `GlbSerializer` | feet × `0.3048` | metres |
| `RevitGltfExporter` | feet × `304.8` | **millimetres** |

Both upload to the same endpoint and are rendered by the same viewer — which assumes metres. glTF 2.0: *"The units for all linear distances are meters."* `applyModelTransform` divides the stored millimetre translation by 1000 precisely because the geometry it positions is metres.

It hid because **a model viewed alone looks correct at any uniform scale** — the camera fits to whatever bounds it finds, so a building rendered 1000× too large looks perfectly normal. The mismatch only surfaces once a Revit model is federated with one from another tool, and then it reads as *"the models don't line up"* — a coordinate problem, sending you looking in entirely the wrong place.

Alongside it: `ProjectModel.Units` was written on every upload and **read by nothing**, and the ingest path computed a `scaleFactor` whose two branches both returned `1.0`, silently discarding any declared `IfcMapConversion` scale.

## The fix

**One convention: the metre.** `RevitGltfExporter` writes metre vertices, and the published bounds moved with it — same geometry, so leaving bounds in mm would swap a *visible* render bug for an *invisible* bounds one.

`ProjectModel.Units` now means something: it rides on the transform payload the viewer already fetches (`meshUnitScale`), applied **unconditionally** — a mm model needs rescaling whether or not it's georeferenced, so it must not sit behind the "is this transform live" gate.

**Mesh unit and georef scale stay separate and multiply.** `ScaleFactor` is a *survey correction* declared by an `IfcMapConversion`; the mesh unit is how the vertex data happens to be written. Conflating them makes a unit fix look like a survey error. *(Deliberate deviation from the runner's "compute scaleFactor from model unit" — the rendered result is identical because both multiply.)* The dead `scaleFactor` is now real: `ModelGeoref` carries `MapConversionScale`, the writer inverts it, matching `AutoAlignService`.

## Two traps found on the way

1. **The IFC→GLB job copied the SOURCE IFC's unit onto the GLB derivative.** Harmless while nothing read the field — the moment `Units` drives scaling it would have shrunk every converted model by 1000. The converter emits glTF, so the derivative is metres by construction. Fixed, plus a **targeted idempotent backfill** scoped by `UploadedBy` + `Format = 0`, so the source IFC row and every hand-published model are untouched.
2. **The server defaulted an undeclared unit to `"mm"`.** Any uploader omitting the field would be scaled by 1/1000. Now the canonical metre — and an unknown unit also reads as metres, because the fail-safe direction for "I don't recognise this" is **change nothing**; a wrong guess silently rescales a whole building.

## Verification

- **16 unit tests** on `MeshUnits`, including that unknown/blank reads as metres rather than as a guess.
- **10 harness assertions** against the **shipped sources** — the viewer scales a mm mesh with *no* transform; mesh unit and georef scale multiply rather than replace; an absent `meshUnitScale` changes nothing; plus a grep-level guard that the two Revit writers still agree. Crude, but it's the only thing that fails when someone edits one and not the other.
- **Backfill SQL proven on real Postgres 16** against a 4-row fixture: mislabelled converted GLB corrected; already-correct one untouched; **source IFC row and a genuinely-mm hand-published Revit model both left alone**. Idempotent on a second pass.
- Server 0 errors; **Revit plugin builds against the Revit 2025 API: 0 errors, 0 warnings**; full suite **719 passed / 0 failed / 12 skipped** (all skips pre-existing environment-gated).

## Behaviour change, stated plainly

Revit models published *before* this change are stored with mm meshes and `Units = "mm"`. They now render at the **correct** size because the viewer honours that unit. A row predating the `Units` column entirely would read as metres. Re-publishing puts any model on the canonical footing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up (review):** same as one level down — this PR's mesh-unit edit was only in `wwwroot/viewer.html`. Ported it into the canonical `Planscape/assets/viewer/viewer.html` so the build target does not revert it and the source↔wwwroot byte-equal drift gate passes.