### PR TITLE
Placement P4: read a full georeference from IFC and send it on upload

### DIFF
--- a/StingBridge/planscape/client.py
+++ b/StingBridge/planscape/client.py
@@ -395,12 +395,28 @@ class PlanscapeClient:
             log.debug("get_element_timestamps failed (non-fatal): %s", e)
             return {}
 
-    def upload_model(self, project_id: str, glb_path) -> dict:
-        """Upload a GLB file to Planscape /api/projects/{id}/models."""
+    def upload_model(self, project_id: str, glb_path, georef=None) -> dict:
+        """Upload a GLB file to Planscape /api/projects/{id}/models.
+
+        ``georef`` is an optional
+        :class:`stingtools_core.hosts.adapter.GeorefDescriptor`. When supplied
+        with a survey origin, the server turns it into a coordinate transform
+        and — if the coordinates are anchored to a named CRS — applies it
+        automatically, so the model lands in the federation without anyone
+        typing a transform.
+
+        It is passed as METADATA rather than baked into the geometry, matching
+        the Revit path: a site at easting 432,000 m would put every vertex
+        ~432 km from the origin, where 32-bit float mesh coordinates lose
+        millimetre precision.
+        """
         import mimetypes
         from pathlib import Path
         path = Path(glb_path)
         mime = mimetypes.guess_type(str(path))[0] or "model/gltf-binary"
+
+        fields = self._georef_fields(georef)
+
         # The file handle is opened per attempt: a retry after re-auth must
         # re-read from the start, and a consumed handle would upload 0 bytes.
         def _post():
@@ -408,6 +424,9 @@ class PlanscapeClient:
                 return self._session.post(
                     f"{self.base_url}/api/projects/{project_id}/models",
                     files={"file": (path.name, f, mime)},
+                    # Multipart form fields ride alongside the file. Names match
+                    # the server's UploadModelRequest properties exactly.
+                    data=fields or None,
                     # The session sets Content-Type: application/json globally,
                     # which would override the multipart boundary header that
                     # `files=` generates and corrupt the upload. None deletes
@@ -426,6 +445,51 @@ class PlanscapeClient:
             raise PlanscapeAuthError("Token expired or invalid (re-auth failed)")
         resp.raise_for_status()
         return resp.json()
+
+    @staticmethod
+    def _georef_fields(georef) -> dict:
+        """Flatten a GeorefDescriptor into the server's multipart field names.
+
+        Returns an empty dict when there is nothing usable, which is the
+        important case: a model with no survey origin must upload WITHOUT a
+        georef block so the server leaves it at the project origin rather than
+        placing it on a guess. An un-placed model at the origin is visibly
+        un-placed; a mis-placed one looks correct.
+        """
+        if georef is None:
+            return {}
+
+        easting = getattr(georef, "easting", None)
+        northing = getattr(georef, "northing", None)
+        if easting is None or northing is None:
+            return {}
+
+        fields = {
+            "GeorefEastingM": repr(float(easting)),
+            "GeorefNorthingM": repr(float(northing)),
+            # The server treats a Revit-style project-internal export as the
+            # default; IFC geometry is likewise authored about the file's own
+            # origin, with IfcMapConversion describing where that origin sits.
+            "GeorefExportMode": "ProjectInternal",
+        }
+
+        elevation = getattr(georef, "elevation", None)
+        if elevation is not None:
+            fields["GeorefElevationM"] = repr(float(elevation))
+
+        true_north = getattr(georef, "true_north_deg", None)
+        if true_north is not None:
+            fields["GeorefTrueNorthDeg"] = repr(float(true_north))
+
+        crs = getattr(georef, "crs_epsg", None)
+        if crs:
+            fields["GeorefCrsEpsg"] = str(crs)
+
+        unit = getattr(georef, "length_unit", None)
+        if unit:
+            fields["GeorefLengthUnit"] = str(unit)
+
+        return fields
 
     def get_compliance(self) -> dict:
         """GET latest compliance snapshot for the project."""

--- a/StingBridge/tests/test_upload_georef.py
+++ b/StingBridge/tests/test_upload_georef.py
@@ -1,0 +1,116 @@
+"""TRACK B / P4 — the model upload carries the host's georeferencing.
+
+``GeorefDescriptor`` existed with ZERO consumers: nothing built a full one and
+nothing sent one anywhere. So an ArchiCAD or Tekla IFC pushed through the bridge
+arrived at the server with no survey position, landed at the project origin, and
+had to be placed by hand — which is the manual step the whole placement track
+exists to remove.
+
+These tests pin the wire contract, because that is where it silently breaks: the
+field NAMES must match the server's ``UploadModelRequest`` properties exactly
+(``GeorefEastingM`` and friends). A typo there is not an error at either end —
+ASP.NET model binding simply leaves the property null, the server writes no
+transform, and the model quietly stays at the origin. Nothing fails; the building
+is just in the wrong place.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+_CORE = _REPO_ROOT / "stingtools-core" / "python"
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from StingBridge.planscape.client import PlanscapeClient  # noqa: E402
+from stingtools_core.hosts.adapter import GeorefDescriptor  # noqa: E402
+
+
+def _fields(georef):
+    return PlanscapeClient._georef_fields(georef)
+
+
+def _anchored(**kw):
+    base = dict(logeoref_tier=50, crs_epsg="EPSG:27700",
+                easting=432000.0, northing=315000.0, elevation=12.5,
+                true_north_deg=3.25, scale=1.0, length_unit="m")
+    base.update(kw)
+    return GeorefDescriptor(**base)
+
+
+# ── the wire contract ─────────────────────────────────────────────────────────
+
+def test_field_names_match_the_servers_upload_request():
+    # These strings are the contract. If the server renames a property, this
+    # test is what fails — instead of the model silently landing at 0,0,0.
+    f = _fields(_anchored())
+    assert set(f) == {
+        "GeorefEastingM", "GeorefNorthingM", "GeorefElevationM",
+        "GeorefTrueNorthDeg", "GeorefCrsEpsg", "GeorefLengthUnit",
+        "GeorefExportMode",
+    }
+
+
+def test_values_survive_as_full_precision_strings():
+    f = _fields(_anchored())
+    assert float(f["GeorefEastingM"]) == 432000.0
+    assert float(f["GeorefNorthingM"]) == 315000.0
+    assert float(f["GeorefElevationM"]) == 12.5
+    assert float(f["GeorefTrueNorthDeg"]) == 3.25
+    assert f["GeorefCrsEpsg"] == "EPSG:27700"
+    assert f["GeorefLengthUnit"] == "m"
+
+
+def test_a_survey_easting_is_not_rounded_away():
+    # repr() rather than str(): a UK easting carries 6 significant figures
+    # before the decimal point, and losing the fractional part is a
+    # centimetre-to-metre error at the far end of a site.
+    f = _fields(_anchored(easting=432123.456789))
+    assert float(f["GeorefEastingM"]) == 432123.456789
+
+
+# ── the "send nothing" cases, which matter more ───────────────────────────────
+
+def test_no_descriptor_sends_no_georef():
+    assert _fields(None) == {}
+
+
+def test_a_descriptor_without_a_survey_origin_sends_no_georef():
+    # The load-bearing case. A model with no IfcMapConversion must upload
+    # WITHOUT a georef block so the server leaves it at the project origin.
+    # An un-placed model at the origin is visibly un-placed; a model placed on
+    # a guess looks correct and costs an investigation.
+    assert _fields(GeorefDescriptor(logeoref_tier=0)) == {}
+    assert _fields(_anchored(easting=None)) == {}
+    assert _fields(_anchored(northing=None)) == {}
+
+
+def test_optional_fields_are_omitted_rather_than_sent_empty():
+    # An absent CRS must not arrive as "" — the server's confidence policy
+    # compares CRS strings, and "" is not the same claim as "unknown".
+    f = _fields(_anchored(crs_epsg=None, elevation=None, true_north_deg=None))
+    assert "GeorefCrsEpsg" not in f
+    assert "GeorefElevationM" not in f
+    assert "GeorefTrueNorthDeg" not in f
+    # The origin itself still goes.
+    assert float(f["GeorefEastingM"]) == 432000.0
+
+
+def test_export_mode_is_project_internal():
+    # IFC geometry is authored about the file's own origin, with
+    # IfcMapConversion describing where that origin sits — so the server must
+    # apply the origin, not assume the geometry is already in the survey frame.
+    # Sending "SharedCoordinates" here would make the server skip the transform
+    # and leave the model unplaced.
+    assert _fields(_anchored())["GeorefExportMode"] == "ProjectInternal"
+
+
+def test_a_zero_true_north_is_sent_not_dropped():
+    # 0.0 is a real, meaningful value ("aligned with grid north"). A falsy
+    # check instead of an is-None check would drop it and lose the distinction
+    # between "no rotation" and "rotation unknown".
+    f = _fields(_anchored(true_north_deg=0.0))
+    assert float(f["GeorefTrueNorthDeg"]) == 0.0

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -1069,3 +1069,59 @@ change are stored with millimetre meshes and `Units = "mm"`. They now render at
 the correct size because the viewer honours that unit — but a model whose row
 predates the `Units` column entirely would read as metres. Re-publishing puts any
 model on the canonical footing.
+
+## 22. Track B / P4 — StingBridge / core producer georef (CLOSED)
+
+### The defect
+
+`GeorefDescriptor` existed with **zero consumers**. Nothing built a complete one
+and nothing sent one anywhere, so an ArchiCAD or Tekla IFC pushed through the
+bridge arrived at the server with no survey position, landed at the project
+origin, and had to be placed by hand — the manual step this track exists to
+remove.
+
+`IfcFileHostAdapter.georef_descriptor` read only `IfcMapConversion`'s eastings /
+northings / height / scale. Three fields were unset or wrong:
+
+| Field | Before | Why it mattered |
+|---|---|---|
+| `crs_epsg` | never read | The server's confidence policy grades an unanchored survey origin LOW, stores the transform as a *suggestion*, and leaves the model at the origin until someone confirms it. Reading `IfcProjectedCRS.Name` is what makes a model auto-place. |
+| `true_north_deg` | never read | A model's rotation was silently dropped. A building at the right easting and northing but rotated 20° off is arguably worse than one at the origin, because it *looks* placed. |
+| `length_unit` | defaulted `"mm"` | Eastings/northings are metres by IFC definition, so any consumer that trusted the field was off by 1000. |
+
+### The fix
+
+- **True north** from `XAxisAbscissa` / `XAxisOrdinate` via
+  `atan2(XAxisOrdinate, XAxisAbscissa)` — **the same formula the server uses** in
+  `IfcAlignmentValidator.MapConversionRotationDeg`. It has to be: the same file
+  described by this adapter and ingested by the server must not disagree about
+  which way the building faces.
+- **CRS** from `IfcProjectedCRS.Name`, which also raises the LoGeoRef tier
+  (50 with a named CRS, 30 without — coordinates whose system is unstated are a
+  weaker claim).
+- **Length unit** read from the model via
+  `ifcopenshell.util.unit.calculate_unit_scale`, falling back to metres.
+- The descriptor's default `length_unit` changed `"mm"` → `"m"`, so an
+  un-populated descriptor now means *change nothing* rather than *rescale by
+  1000*. (One existing test pinned the old default and was updated with the
+  reason.)
+- `PlanscapeClient.upload_model` accepts a descriptor and flattens it onto the
+  multipart upload as the same `Georef*` fields the Revit path uses.
+
+### Verification
+
+- **14 tests** on the extraction (`stingtools-core/python/tests/test_georef_descriptor.py`),
+  driven through a stand-in model so no `ifcopenshell` install is needed — the
+  defects were all in extraction and arithmetic, which is what these pin.
+- **8 tests** on the wire contract (`StingBridge/tests/test_upload_georef.py`).
+  These matter because a field-name typo is **not an error at either end**:
+  ASP.NET model binding leaves the property null, the server writes no
+  transform, and the model quietly stays at the origin. Nothing fails; the
+  building is just in the wrong place. Also pinned: a model with no survey
+  origin sends **no** georef block at all, and a zero true north is sent rather
+  than dropped by a falsy check ("no rotation" ≠ "rotation unknown").
+- Full Python suites green: **118 core**, **179 StingBridge**.
+
+**NOT verified:** extraction against a real `.ifc`. `ifcopenshell` is not a core
+dependency — that is the point of core — so the unit-scale branch and `by_type`
+against a real file remain an environment-gated check.

--- a/stingtools-core/python/stingtools_core/hosts/adapter.py
+++ b/stingtools-core/python/stingtools_core/hosts/adapter.py
@@ -35,9 +35,18 @@ class GeorefDescriptor:
     easting: Optional[float] = None        # metres
     northing: Optional[float] = None       # metres
     elevation: Optional[float] = None      # metres
-    true_north_deg: Optional[float] = None # clockwise from CRS Y
-    scale: float = 1.0                     # IfcMapConversion.Scale
-    length_unit: str = "mm"                # canonical project unit on this model
+    true_north_deg: Optional[float] = None # degrees, atan2(XAxisOrdinate, XAxisAbscissa)
+    scale: float = 1.0                     # IfcMapConversion.Scale (survey correction)
+
+    #: This MODEL's own length unit — "m" | "mm" | "cm" | "ft" | "in".
+    #:
+    #: Defaults to metres, not millimetres. The previous "mm" default was
+    #: actively wrong: easting/northing above are metres by IFC definition, so
+    #: a descriptor built without an explicit unit described its own
+    #: coordinates as 1000x too large. Metres is also the glTF canonical and
+    #: the server's fail-safe for an unknown unit, so an un-populated
+    #: descriptor now means "change nothing" rather than "rescale by 1000".
+    length_unit: str = "m"
 
 
 @dataclass(frozen=True)

--- a/stingtools-core/python/stingtools_core/hosts/ifc_file.py
+++ b/stingtools-core/python/stingtools_core/hosts/ifc_file.py
@@ -121,24 +121,105 @@ class IfcFileHostAdapter(HostAdapter):
         return Tag.from_pset(pset)
 
     def georef_descriptor(self) -> GeorefDescriptor:
-        """Best-effort coordinate evidence. Full tiered extraction is Part 2/Phase C;
-        this returns what is cheaply available so headless callers have a value."""
+        """The coordinate evidence this file carries.
+
+        P4 — this used to return only ``IfcMapConversion``'s eastings /
+        northings / height / scale, leaving ``crs_epsg`` and
+        ``true_north_deg`` unset and ``length_unit`` at its ``"mm"`` default.
+        Those three omissions matter more than they look:
+
+        * **No CRS** means the server cannot anchor the coordinates. Its
+          confidence policy grades an unanchored survey origin LOW, so the
+          transform is stored as a suggestion and the model is left at the
+          project origin until a coordinator confirms it by hand — the exact
+          manual step this whole track exists to remove.
+        * **No true north** silently drops a model's rotation. A building
+          placed at the right easting and northing but rotated 20 degrees off
+          is arguably worse than one left at the origin, because it looks
+          placed.
+        * **``length_unit="mm"`` was simply wrong.** Eastings and northings
+          from ``IfcMapConversion`` are metres by IFC definition, and the
+          field defaulted to millimetres, so any consumer that trusted it was
+          off by 1000.
+
+        The rotation formula ``atan2(XAxisOrdinate, XAxisAbscissa)`` matches
+        ``IfcAlignmentValidator.MapConversionRotationDeg`` on the server
+        exactly. It has to: the same file ingested through the server and
+        described by this adapter must not disagree about which way the
+        building faces.
+        """
+        import math
+
         try:
-            import ifcopenshell.util.geolocation as geo  # type: ignore
             mc = self.model.by_type("IfcMapConversion")
-            if mc:
-                m = mc[0]
-                return GeorefDescriptor(
-                    logeoref_tier=50,
-                    easting=getattr(m, "Eastings", None),
-                    northing=getattr(m, "Northings", None),
-                    elevation=getattr(m, "OrthogonalHeight", None),
-                    scale=getattr(m, "Scale", None) or 1.0,
-                )
-            _ = geo  # available for the Phase C tiered resolver
         except Exception:
-            pass
-        return GeorefDescriptor(logeoref_tier=0)
+            return GeorefDescriptor(logeoref_tier=0)
+
+        if not mc:
+            return GeorefDescriptor(logeoref_tier=0, length_unit=self._length_unit())
+
+        m = mc[0]
+
+        # XAxisAbscissa / XAxisOrdinate are the direction cosines of the
+        # model's +X axis in the map CRS. Both default to (1, 0) — i.e. no
+        # rotation — when the file omits them.
+        true_north_deg = None
+        xa = getattr(m, "XAxisAbscissa", None)
+        xo = getattr(m, "XAxisOrdinate", None)
+        if xa is not None and xo is not None:
+            try:
+                true_north_deg = math.degrees(math.atan2(float(xo), float(xa)))
+            except (TypeError, ValueError):
+                true_north_deg = None
+
+        # IfcProjectedCRS.Name is the CRS identifier ("EPSG:27700"). It is what
+        # promotes this georeference from "some coordinates" to "coordinates in
+        # a named system", which is what lets the server apply it unattended.
+        crs_epsg = None
+        try:
+            crs = self.model.by_type("IfcProjectedCRS")
+            if crs:
+                crs_epsg = getattr(crs[0], "Name", None) or None
+        except Exception:
+            crs_epsg = None
+
+        scale = getattr(m, "Scale", None)
+
+        return GeorefDescriptor(
+            # 50 with a named CRS, 30 without: coordinates whose system is
+            # unstated are a weaker claim, and the tier is what a consumer
+            # reads to decide whether to trust them.
+            logeoref_tier=50 if crs_epsg else 30,
+            crs_epsg=crs_epsg,
+            easting=getattr(m, "Eastings", None),
+            northing=getattr(m, "Northings", None),
+            elevation=getattr(m, "OrthogonalHeight", None),
+            true_north_deg=true_north_deg,
+            scale=scale if scale else 1.0,
+            length_unit=self._length_unit(),
+        )
+
+    def _length_unit(self) -> str:
+        """This file's own length unit, as a short code ("m" / "mm" / "ft").
+
+        Read from the model rather than assumed. ``calculate_unit_scale``
+        returns metres per file unit, which is the only thing that
+        distinguishes a 10-unit wall that is 10 m long from one that is 10 mm
+        long. Falls back to metres when ifcopenshell is unavailable or the file
+        declares nothing — the same fail-safe the server uses, because
+        "leave it alone" is the only safe response to an unknown unit.
+        """
+        try:
+            import ifcopenshell.util.unit as unit_util  # type: ignore
+            metres_per_unit = float(unit_util.calculate_unit_scale(self.model))
+        except Exception:
+            return "m"
+
+        for code, factor in (("m", 1.0), ("mm", 0.001), ("cm", 0.01),
+                             ("ft", 0.3048), ("in", 0.0254)):
+            if abs(metres_per_unit - factor) < factor * 1e-6:
+                return code
+        return "m"
 
     # -- write -----------------------------------------------------------------
     def write_tag(self, element: Any, tag: Tag) -> bool:

--- a/stingtools-core/python/tests/test_georef_descriptor.py
+++ b/stingtools-core/python/tests/test_georef_descriptor.py
@@ -1,0 +1,173 @@
+"""TRACK B / P4 — georeferencing extraction from an IFC file.
+
+THE DEFECT
+----------
+``IfcFileHostAdapter.georef_descriptor`` read only ``IfcMapConversion``'s
+eastings / northings / height / scale. Three fields were left unset or wrong:
+
+* ``crs_epsg`` — never read, so the coordinates had no named system. The
+  server's confidence policy grades an unanchored survey origin LOW, stores
+  the transform as a suggestion, and leaves the model at the project origin
+  until a coordinator confirms it by hand — the exact manual step this track
+  exists to remove.
+* ``true_north_deg`` — never read, so a model's rotation was silently dropped.
+  A building at the right easting and northing but rotated 20 degrees off is
+  arguably worse than one left at the origin, because it *looks* placed.
+* ``length_unit`` — defaulted to ``"mm"`` while eastings/northings are metres
+  by IFC definition, so any consumer that trusted it was off by 1000.
+
+NO ifcopenshell REQUIRED
+------------------------
+``ifcopenshell`` is not a dependency of core (that is the point of core), so
+these tests drive the adapter with a tiny stand-in model exposing just the
+``by_type`` surface the method uses. That is enough to pin the extraction and
+the arithmetic, which is where the defects were. It does NOT prove the method
+works against a real ``.ifc`` — a real-file check needs ifcopenshell installed
+and is a separate, environment-gated concern.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stingtools_core import IfcFileHostAdapter
+
+
+class _Entity:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class _Model:
+    """Minimal stand-in exposing only ``by_type``."""
+
+    def __init__(self, **by_type):
+        self._by_type = by_type
+
+    def by_type(self, name):
+        return self._by_type.get(name, [])
+
+
+def _adapter(**by_type):
+    return IfcFileHostAdapter(model=_Model(**by_type), host_name="archicad")
+
+
+def _map_conversion(**kw):
+    base = dict(Eastings=432000.0, Northings=315000.0, OrthogonalHeight=12.5,
+                XAxisAbscissa=1.0, XAxisOrdinate=0.0, Scale=1.0)
+    base.update(kw)
+    return _Entity(**base)
+
+
+# ── the survey origin ─────────────────────────────────────────────────────────
+
+def test_map_conversion_origin_is_read():
+    g = _adapter(IfcMapConversion=[_map_conversion()]).georef_descriptor()
+    assert g.easting == 432000.0
+    assert g.northing == 315000.0
+    assert g.elevation == 12.5
+
+
+def test_no_map_conversion_is_tier_zero():
+    g = _adapter().georef_descriptor()
+    assert g.logeoref_tier == 0
+    assert g.easting is None and g.northing is None
+
+
+# ── true north — previously dropped entirely ──────────────────────────────────
+
+def test_true_north_is_derived_from_the_x_axis_direction():
+    # 30 degrees: XAxisAbscissa = cos(30), XAxisOrdinate = sin(30).
+    mc = _map_conversion(XAxisAbscissa=math.cos(math.radians(30)),
+                         XAxisOrdinate=math.sin(math.radians(30)))
+    g = _adapter(IfcMapConversion=[mc]).georef_descriptor()
+    assert g.true_north_deg is not None
+    assert abs(g.true_north_deg - 30.0) < 1e-9
+
+
+def test_true_north_matches_the_servers_formula():
+    # The server computes atan2(XAxisOrdinate, XAxisAbscissa) in
+    # IfcAlignmentValidator. The same file described here and ingested there
+    # must not disagree about which way the building faces.
+    xa, xo = 0.8660254037844387, -0.49999999999999994   # -30 degrees
+    g = _adapter(IfcMapConversion=[_map_conversion(XAxisAbscissa=xa, XAxisOrdinate=xo)]).georef_descriptor()
+    assert abs(g.true_north_deg - math.degrees(math.atan2(xo, xa))) < 1e-12
+
+
+def test_an_unrotated_model_reports_zero_not_none():
+    # (1, 0) is the IFC default and means "no rotation". Reporting None here
+    # would make a correctly-unrotated model indistinguishable from one whose
+    # rotation was never read.
+    g = _adapter(IfcMapConversion=[_map_conversion()]).georef_descriptor()
+    assert g.true_north_deg == 0.0
+
+
+def test_missing_axis_fields_leave_true_north_unset():
+    mc = _map_conversion()
+    del mc.XAxisAbscissa
+    del mc.XAxisOrdinate
+    g = _adapter(IfcMapConversion=[mc]).georef_descriptor()
+    assert g.true_north_deg is None
+
+
+# ── CRS — the field that decides whether the model auto-places ────────────────
+
+def test_projected_crs_name_is_read_and_raises_the_tier():
+    g = _adapter(IfcMapConversion=[_map_conversion()],
+                 IfcProjectedCRS=[_Entity(Name="EPSG:27700")]).georef_descriptor()
+    assert g.crs_epsg == "EPSG:27700"
+    assert g.logeoref_tier == 50
+
+
+def test_without_a_crs_the_tier_is_lower():
+    # Coordinates whose system is unstated are a weaker claim, and the tier is
+    # what a consumer reads to decide how far to trust them.
+    g = _adapter(IfcMapConversion=[_map_conversion()]).georef_descriptor()
+    assert g.crs_epsg is None
+    assert g.logeoref_tier == 30
+
+
+def test_a_blank_crs_name_is_treated_as_absent():
+    g = _adapter(IfcMapConversion=[_map_conversion()],
+                 IfcProjectedCRS=[_Entity(Name="")]).georef_descriptor()
+    assert g.crs_epsg is None
+
+
+# ── scale ─────────────────────────────────────────────────────────────────────
+
+def test_map_conversion_scale_is_carried():
+    g = _adapter(IfcMapConversion=[_map_conversion(Scale=0.9996)]).georef_descriptor()
+    assert abs(g.scale - 0.9996) < 1e-12
+
+
+def test_a_missing_or_zero_scale_reads_as_one():
+    # Zero would be a division-by-zero waiting to happen downstream, and a
+    # missing scale means "no correction", not "collapse the model".
+    assert _adapter(IfcMapConversion=[_map_conversion(Scale=None)]).georef_descriptor().scale == 1.0
+    assert _adapter(IfcMapConversion=[_map_conversion(Scale=0)]).georef_descriptor().scale == 1.0
+
+
+# ── length unit ───────────────────────────────────────────────────────────────
+
+def test_length_unit_falls_back_to_metres_without_ifcopenshell():
+    # ifcopenshell is not a core dependency, so calculate_unit_scale is
+    # unavailable here and the fallback is what runs. Metres is the fail-safe:
+    # "leave it alone" is the only safe response to an unknown unit.
+    g = _adapter(IfcMapConversion=[_map_conversion()]).georef_descriptor()
+    assert g.length_unit == "m"
+
+
+# ── robustness ────────────────────────────────────────────────────────────────
+
+def test_a_model_that_raises_on_by_type_degrades_quietly():
+    class _Hostile:
+        def by_type(self, name):
+            raise RuntimeError("corrupt file")
+
+    g = IfcFileHostAdapter(model=_Hostile(), host_name="tekla").georef_descriptor()
+    assert g.logeoref_tier == 0

--- a/stingtools-core/python/tests/test_hosts.py
+++ b/stingtools-core/python/tests/test_hosts.py
@@ -96,7 +96,16 @@ def test_ifc_file_adapter_implements_contract():
 
 def test_georef_descriptor_defaults():
     g = GeorefDescriptor()
-    assert g.logeoref_tier == 0 and g.scale == 1.0 and g.length_unit == "mm"
+    assert g.logeoref_tier == 0 and g.scale == 1.0
+    # P4 — the default length unit is METRES, not millimetres.
+    #
+    # This assertion used to read "mm" and was pinning a bug: easting/northing
+    # on this descriptor are metres by IFC definition, so a descriptor built
+    # without an explicit unit described its own coordinates as 1000x too
+    # large. Metres is also the glTF canonical and the server's fail-safe for
+    # an unknown unit, so an un-populated descriptor now means "change
+    # nothing" instead of "rescale by 1000".
+    assert g.length_unit == "m"
 
 
 def test_change_delta_carries_review_payload():


### PR DESCRIPTION
> **Stacked on #680** (P3) → #679 (P2) → #678 (P1) → #676 (Track A). Retarget as those merge.

## The bug

`GeorefDescriptor` existed with **zero consumers**. Nothing built a complete one and nothing sent one anywhere — so an ArchiCAD or Tekla IFC pushed through the bridge arrived with no survey position, landed at the project origin, and had to be placed by hand. That's the manual step this whole track exists to remove.

`IfcFileHostAdapter.georef_descriptor` read only `IfcMapConversion`'s eastings/northings/height/scale. Three fields were unset or wrong:

| Field | Before | Why it mattered |
|---|---|---|
| `crs_epsg` | never read | The server grades an *unanchored* survey origin LOW, stores the transform as a suggestion, and leaves the model at the origin until someone confirms it. Reading `IfcProjectedCRS.Name` is what makes a model auto-place. |
| `true_north_deg` | never read | A model's rotation was silently dropped. A building at the right E/N but rotated 20° off is arguably *worse* than one at the origin — because it looks placed. |
| `length_unit` | defaulted `"mm"` | Eastings/northings are **metres** by IFC definition, so any consumer trusting the field was off by 1000. |

## The fix

- **True north** from `atan2(XAxisOrdinate, XAxisAbscissa)` — the **same formula the server uses** in `IfcAlignmentValidator`. It has to be: the same file described here and ingested there must not disagree about which way the building faces.
- **CRS** from `IfcProjectedCRS.Name`, which also raises the LoGeoRef tier (50 with a named CRS, 30 without — coordinates whose system is unstated are a weaker claim).
- **Length unit** read from the model via `calculate_unit_scale`, falling back to metres.
- Descriptor default `length_unit` `"mm"` → `"m"`, so an un-populated descriptor means *change nothing* rather than *rescale by 1000*. One existing test pinned the old default and was updated **with the reason**.
- `PlanscapeClient.upload_model` accepts a descriptor and flattens it onto the multipart upload as the same `Georef*` fields the Revit path uses.

## Verification

- **14 tests** on the extraction, driven through a stand-in model so no `ifcopenshell` install is needed — the defects were all in extraction and arithmetic, which is exactly what these pin.
- **8 tests** on the wire contract. These matter because a field-name typo is **not an error at either end**: ASP.NET model binding leaves the property null, the server writes no transform, and the model quietly stays at the origin. *Nothing fails; the building is just in the wrong place.*
  Also pinned: a model with no survey origin sends **no** georef block at all, and a zero true north is *sent* rather than dropped by a falsy check — "no rotation" ≠ "rotation unknown".
- Full Python suites green: **118 core**, **179 StingBridge**.

**NOT verified:** extraction against a real `.ifc`. `ifcopenshell` isn't a core dependency (that's the point of core), so the unit-scale branch and `by_type` against a real file remain an environment-gated check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)