### PR TITLE
Placement P5: correct the mirrored translation, and keep chunk bounds fresh

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcIngestController.cs
@@ -644,7 +644,7 @@ public class IfcIngestController : ControllerBase
                 // scale never reached the transform.
                 MapConversionScale: report.MapConversionScale);
 
-            var confidence = await _georefWriter.WriteAsync(
+            var write = await _georefWriter.WriteAsync(
                 projectId, projectModelId, tenantId, georef, report.Verdict, ct);
 
             // Gap 14: Write an audit log entry for the coordinate correction.
@@ -660,8 +660,12 @@ public class IfcIngestController : ControllerBase
                         autoComputed = true,
                         // B1 — a model that MOVES on its own must say so in the
                         // audit trail, and say what it was trusting when it did.
-                        confidence = TransformConfidencePolicy.ToStorageString(confidence),
-                        appliedAutomatically = TransformConfidencePolicy.ShouldAutoApply(confidence),
+                        confidence = TransformConfidencePolicy.ToStorageString(write.Confidence),
+                        appliedAutomatically = write.Written
+                                               && TransformConfidencePolicy.ShouldAutoApply(write.Confidence),
+                        translationXMm = write.TranslationXMm,
+                        translationYMm = write.TranslationYMm,
+                        frameSource = write.FrameSource,
                     }));
             }
             catch { /* audit failure is non-fatal */ }

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelTransformController.cs
@@ -33,17 +33,20 @@ public class ModelTransformController : ControllerBase
     private readonly PlanscapeDbContext _db;
     private readonly ITenantContext _tenant;
     private readonly IIfcDeltaService _delta;
+    private readonly ISceneNodeAabbRefresher _aabb;
     private readonly ILogger<ModelTransformController> _logger;
 
     public ModelTransformController(
         PlanscapeDbContext db,
         ITenantContext tenant,
         IIfcDeltaService delta,
+        ISceneNodeAabbRefresher aabb,
         ILogger<ModelTransformController> logger)
     {
         _db     = db;
         _tenant = tenant;
         _delta  = delta;
+        _aabb   = aabb;
         _logger = logger;
     }
 
@@ -195,40 +198,24 @@ public class ModelTransformController : ControllerBase
 
         await _db.SaveChangesAsync(ct);
 
-        // Re-compute SceneNode AABBs for this model
+        // P5 — recompute the chunks' world-space AABBs through the shared,
+        // idempotent refresher. The inline version that used to live here read
+        // the STORED (already-transformed) box and transformed it again, so two
+        // PUTs compounded; and it ran ONLY here, so both automatic writers left
+        // the manifest describing where chunks used to be.
         try
         {
-            var nodes = await _db.SceneNodes
-                .Where(n => n.SourceModelId == modelId && n.DeletedAt == null)
-                .ToListAsync(ct);
-
-            foreach (var node in nodes)
-            {
-                var (mnX, mnY, mnZ, mxX, mxY, mxZ) = ApplyTransform(
-                    xf,
-                    node.MinX, node.MinY, node.MinZ,
-                    node.MaxX, node.MaxY, node.MaxZ);
-
-                node.MinX = mnX;
-                node.MinY = mnY;
-                node.MinZ = mnZ;
-                node.MaxX = mxX;
-                node.MaxY = mxY;
-                node.MaxZ = mxZ;
-            }
-
-            if (nodes.Count > 0)
-                await _db.SaveChangesAsync(ct);
-
+            var updated = await _aabb.RefreshAsync(projectId, modelId, _tenant.TenantId, ct);
             _logger.LogInformation(
-                "ModelTransform upserted for model {ModelId}: updated {Count} SceneNode AABBs.",
-                modelId, nodes.Count);
+                "ModelTransform upserted for model {ModelId}: refreshed {Count} SceneNode AABBs.",
+                modelId, updated);
         }
         catch (Exception ex)
         {
-            // Non-fatal — transform is persisted; AABB update can be retried
+            // Non-fatal — the transform is persisted and correct; stale bounds
+            // are a culling artefact, not data loss, and the next write retries.
             _logger.LogWarning(ex,
-                "Failed to update SceneNode AABBs after transform upsert for model {ModelId}.",
+                "Failed to refresh SceneNode AABBs after transform upsert for model {ModelId}.",
                 modelId);
         }
 
@@ -273,6 +260,22 @@ public class ModelTransformController : ControllerBase
         _db.Set<ProjectModelTransform>().Remove(xf);
         await _db.SaveChangesAsync(ct);
 
+        // P5 — resetting to identity moves the model too, so the world-space
+        // chunk bounds are just as stale as after a write. With the transform
+        // row gone the refresher falls back to the identity and the world box
+        // returns to the local one — which only works because the local box is
+        // preserved separately; the old in-place version had destroyed it.
+        try
+        {
+            await _aabb.RefreshAsync(projectId, modelId, _tenant.TenantId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to refresh SceneNode AABBs after transform delete for model {ModelId}.",
+                modelId);
+        }
+
         _logger.LogInformation(
             "ModelTransform deleted for model {ModelId} in project {ProjectId}.",
             modelId, projectId);
@@ -280,40 +283,6 @@ public class ModelTransformController : ControllerBase
         return NoContent();
     }
 
-    // ── helpers ──────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Transform all 8 corners of the AABB using scale → Z-rotation → translation
-    /// and return the new axis-aligned bounding box.
-    /// </summary>
-    private static (double minX, double minY, double minZ, double maxX, double maxY, double maxZ) ApplyTransform(
-        ProjectModelTransform t,
-        double minX, double minY, double minZ,
-        double maxX, double maxY, double maxZ)
-    {
-        // All 8 corners of the input AABB, transformed via the ONE canonical
-        // ModelTransformMath (Z-up, mm, T·R·S) so the controller, the viewer,
-        // and the overlay test all share identical transform semantics.
-        double[] xs = [minX, maxX, minX, maxX, minX, maxX, minX, maxX];
-        double[] ys = [minY, minY, maxY, maxY, minY, minY, maxY, maxY];
-        double[] zs = [minZ, minZ, minZ, minZ, maxZ, maxZ, maxZ, maxZ];
-
-        var newXs = new double[8];
-        var newYs = new double[8];
-        var newZs = new double[8];
-
-        for (int i = 0; i < 8; i++)
-        {
-            var w = ModelTransformMath.ApplyMm(
-                t.TranslationX, t.TranslationY, t.TranslationZ,
-                t.RotationDeg, t.ScaleFactor,
-                xs[i], ys[i], zs[i]);
-            newXs[i] = w.X; newYs[i] = w.Y; newZs[i] = w.Z;
-        }
-
-        return (newXs.Min(), newYs.Min(), newZs.Min(),
-                newXs.Max(), newYs.Max(), newZs.Max());
-    }
 }
 
 /// <summary>Body DTO for PUT /transform.</summary>

--- a/Planscape.Server/src/Planscape.API/Controllers/SceneNodesController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/SceneNodesController.cs
@@ -168,8 +168,14 @@ public class SceneNodesController : ControllerBase
             FileSizeBytes = file.Length,
             VertexCount = req.VertexCount,
             Compression = req.Compression,
+            // P5 — the converter reports the chunk's LOCAL box. Store it in
+            // both places: Min/Max is the world box (identical until a transform
+            // exists) and Base* preserves the local one so the world box can be
+            // recomputed idempotently every time the model moves.
             MinX = box.minX, MinY = box.minY, MinZ = box.minZ,
             MaxX = box.maxX, MaxY = box.maxY, MaxZ = box.maxZ,
+            BaseMinX = box.minX, BaseMinY = box.minY, BaseMinZ = box.minZ,
+            BaseMaxX = box.maxX, BaseMaxY = box.maxY, BaseMaxZ = box.maxZ,
         };
         _db.SceneNodes.Add(node);
         await _db.SaveChangesAsync(ct);

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -770,6 +770,10 @@ builder.Services.AddScoped<Planscape.Infrastructure.Services.IAutoAlignService,
 // and Revit paths cannot drift apart on translation convention or confidence.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.IModelGeorefWriter,
     Planscape.Infrastructure.Services.ModelGeorefWriter>();
+// P5 — scene-chunk AABBs are world-space, so every transform write invalidates
+// them. One idempotent refresher, called from every write path.
+builder.Services.AddScoped<Planscape.Infrastructure.Services.ISceneNodeAabbRefresher,
+    Planscape.Infrastructure.Services.SceneNodeAabbRefresher>();
 // Gap G — Full project-wide federated coordinate coherence scan.
 builder.Services.AddScoped<Planscape.Infrastructure.Services.IFederatedCoherenceJob,
     Planscape.Infrastructure.Services.FederatedCoherenceJob>();
@@ -2114,6 +2118,18 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         "UPDATE \"ProjectModels\" SET \"Units\" = 'm' " +
             "WHERE \"UploadedBy\" = 'IFC→GLB converter' AND \"Format\" = 0 AND \"Units\" IS DISTINCT FROM 'm'",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"AppliedAutomatically\" boolean NOT NULL DEFAULT false",
+        // P5 — the chunk's LOCAL (pre-transform) AABB. Nullable: rows written
+        // before this have none, and the refresher captures the current values
+        // as the local box the first time it sees such a row. Keeping the local
+        // box is what makes the world-box recompute idempotent — the previous
+        // in-place version transformed an already-transformed box, so repeated
+        // writes compounded.
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMinX\" double precision NULL",
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMinY\" double precision NULL",
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMinZ\" double precision NULL",
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMaxX\" double precision NULL",
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMaxY\" double precision NULL",
+        "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMaxZ\" double precision NULL",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Confidence\" text NULL",
         "ALTER TABLE \"ProjectModelTransforms\" ADD COLUMN IF NOT EXISTS \"Source\" text NULL",
         "DO $$ BEGIN " +

--- a/Planscape.Server/src/Planscape.Core/Entities/SceneNode.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/SceneNode.cs
@@ -39,13 +39,42 @@ public class SceneNode : ITenantScoped
     /// <summary>Approximate vertex count — drives the auto-LOD heuristic.</summary>
     public int VertexCount { get; set; }
 
-    /// <summary>AABB in millimetres — six doubles. Lets the viewer cull off-camera chunks.</summary>
+    /// <summary>
+    /// AABB in millimetres — six doubles, in WORLD space (i.e. with the model's
+    /// <c>ProjectModelTransform</c> already applied). Lets the viewer cull
+    /// off-camera chunks.
+    /// </summary>
     public double MinX { get; set; }
     public double MinY { get; set; }
     public double MinZ { get; set; }
     public double MaxX { get; set; }
     public double MaxY { get; set; }
     public double MaxZ { get; set; }
+
+    /// <summary>
+    /// P5 — the chunk's AABB in its own LOCAL frame, before any transform.
+    ///
+    /// <para>Without this the world AABB could not be recomputed idempotently.
+    /// The refresh used to read the stored (already-transformed) box and
+    /// transform it AGAIN, so two transform writes compounded and the chunk's
+    /// bounds drifted further from the geometry each time — which meant the
+    /// obvious fix of "recompute after every transform write" would have made
+    /// the bug worse, not better. Keeping the local box means the world box is
+    /// always a pure function of (local, transform) and can be recomputed any
+    /// number of times.</para>
+    ///
+    /// <para>Nullable because rows written before this existed have none. The
+    /// refresher captures the current values as the local box the first time it
+    /// sees such a row — correct for a chunk that was never transformed, and
+    /// the best available otherwise; re-publishing the model restores truth,
+    /// since ingest writes both boxes.</para>
+    /// </summary>
+    public double? BaseMinX { get; set; }
+    public double? BaseMinY { get; set; }
+    public double? BaseMinZ { get; set; }
+    public double? BaseMaxX { get; set; }
+    public double? BaseMaxY { get; set; }
+    public double? BaseMaxZ { get; set; }
 
     /// <summary>Compression: "none" | "draco" | "meshopt".</summary>
     public string Compression { get; set; } = "none";

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
@@ -47,12 +47,17 @@ public sealed record AutoAlignResult(
 public sealed class AutoAlignService : IAutoAlignService
 {
     private readonly PlanscapeDbContext          _db;
+    private readonly IModelGeorefWriter           _georefWriter;
     private readonly ILogger<AutoAlignService>   _logger;
 
-    public AutoAlignService(PlanscapeDbContext db, ILogger<AutoAlignService> logger)
+    public AutoAlignService(
+        PlanscapeDbContext db,
+        IModelGeorefWriter georefWriter,
+        ILogger<AutoAlignService> logger)
     {
-        _db     = db;
-        _logger = logger;
+        _db           = db;
+        _georefWriter = georefWriter;
+        _logger       = logger;
     }
 
     public async Task<AutoAlignResult> ComputeAsync(
@@ -136,6 +141,17 @@ public sealed class AutoAlignService : IAutoAlignService
 
             if (refReport?.SurveyEasting != null)
             {
+                // P5 — this is now REPORTING only, not the frame.
+                //
+                // "The most recently validated sibling" was a non-deterministic
+                // frame: it moved every time another model was uploaded, so a
+                // transform computed on Monday was expressed against a different
+                // origin from one computed on Tuesday, and the two silently
+                // disagreed. The writer resolves a STABLE frame instead
+                // (declared benchmark → nominated reference → CRS origin), and
+                // since the same frame is subtracted from every model, relative
+                // placement is identical either way — only the absolute offset
+                // differs, and the viewer recentres that away.
                 refEasting       = refReport.SurveyEasting.Value;
                 refNorthing      = refReport.SurveyNorthing ?? 0;
                 refElevation     = refReport.SurveyElevation;
@@ -157,49 +173,64 @@ public sealed class AutoAlignService : IAutoAlignService
             }
         }
 
-        // ── 5. Compute relative transform ─────────────────────────────────────
-        //   To bring the target INTO the reference frame we subtract the target
-        //   survey origin and add the reference survey origin.
-        //   Values are in metres; multiply by 1000 to get mm (project default).
-        double targetEasting   = targetReport.SurveyEasting!.Value;
-        double targetNorthing  = targetReport.SurveyNorthing ?? 0;
-        double targetElevation = targetReport.SurveyElevation ?? 0;
-        double targetRotDeg    = targetReport.MapConversionRotationDeg ?? 0;
+        // ── 5. Delegate to the ONE writer ─────────────────────────────────────
+        //
+        // P5 — this method used to compute and persist the transform itself,
+        // with its own translation convention (reference-relative) alongside the
+        // IFC ingest path's (each-model-to-origin). Two conventions for the same
+        // job is how a model ends up in a different place depending on which
+        // pipeline last touched it, so both now go through ModelGeorefWriter:
+        // it resolves the project frame, applies the sign, grades the
+        // confidence, and refuses to overwrite a confirmed transform.
+        //
+        // The reference model this method resolved above (steps 3-4) is exactly
+        // the frame the writer resolves for itself, so the behaviour is
+        // preserved — minus the mirrored sign that was in both copies.
+        var georef = new ModelGeoref(
+            EastingM      : targetReport.SurveyEasting,
+            NorthingM     : targetReport.SurveyNorthing,
+            ElevationM    : targetReport.SurveyElevation,
+            TrueNorthDeg  : targetReport.MapConversionRotationDeg ?? 0,
+            CrsCode       : targetReport.CrsName,
+            HasDeclaredCrs: targetReport.HasProjectedCrs,
+            LengthUnit    : targetReport.LengthUnit,
+            SourceLabel   : "auto-align",
+            MapConversionScale: targetReport.MapConversionScale);
 
-        double tx = (refEasting  - targetEasting)  * 1000.0;
-        double ty = (refNorthing - targetNorthing) * 1000.0;
-        double tz = ((refElevation ?? 0) - targetElevation)  * 1000.0;
-
-        double rotDeg = (refRotDeg ?? 0) - targetRotDeg;
-
-        double scaleFactor = (targetReport.MapConversionScale.HasValue
-                              && targetReport.MapConversionScale.Value != 0
-                              && targetReport.MapConversionScale.Value != 1.0)
-                           ? 1.0 / targetReport.MapConversionScale.Value
-                           : 1.0;
-
-        // ── 6. Persist (overwrite if exists) ──────────────────────────────────
-        var existing = await _db.Set<ProjectModelTransform>()
+        // Read the pre-existing row BEFORE the write so a confirmed transform
+        // can be reported back to the caller rather than silently skipped.
+        var existing = await _db.Set<ProjectModelTransform>().AsNoTracking()
             .FirstOrDefaultAsync(
                 t => t.ProjectModelId == targetModelId
                   && t.ProjectId      == projectId
                   && t.TenantId       == tenantId,
                 ct);
 
-        // ── 6a. Never overwrite a manually-confirmed transform ────────────────
+        // The writer owns the arithmetic and hands back what it computed —
+        // including when it REFUSES to write, so a refusal can still tell the
+        // coordinator what the survey data says. Recomputing it here is exactly
+        // how the two implementations drifted apart before P5.
+        var write = await _georefWriter.WriteAsync(
+            projectId, targetModelId, tenantId, georef, targetReport.Verdict, ct);
+
+        double tx = write.TranslationXMm;
+        double ty = write.TranslationYMm;
+        double tz = write.TranslationZMm;
+        double rotDeg = write.RotationDeg;
+        double scaleFactor = write.ScaleFactor;
+
+        // ── 6. Never overwrite a manually-confirmed transform ─────────────────
         // A coordinator who has confirmed an alignment has made a judgement the
         // survey data does not capture (a mis-stated IfcMapConversion, a model
         // deliberately parked off-site, a base point agreed on site). The IFC
-        // ingest path has always respected that (IfcIngestController: "Only
-        // auto-update if not manually confirmed by a coordinator") — this path
-        // did not, so any auto-align run silently destroyed the confirmed
-        // alignment and the coordinator's only signal was the model jumping.
+        // ingest path has always respected that; this path did not, so any
+        // auto-align run silently destroyed the confirmed alignment and the
+        // coordinator's only signal was the model jumping.
         //
         // Unlike the ingest path, which skips quietly because it is a side
         // effect of an upload, this one is an explicit user action: report the
-        // refusal AND the transform that would have been applied, so the
-        // coordinator can compare it against the one they confirmed and decide
-        // deliberately (delete the transform, or PUT a new one).
+        // refusal, so the coordinator can decide deliberately (delete the
+        // transform, or PUT a new one).
         if (existing is { IsConfirmed: true })
         {
             _logger.LogInformation(
@@ -208,6 +239,10 @@ public sealed class AutoAlignService : IAutoAlignService
 
             return new AutoAlignResult(
                 Success         : false,
+                // What auto-align WOULD have applied, so the coordinator can
+                // compare it against the alignment they confirmed and decide
+                // deliberately. A bare refusal would be useless at exactly the
+                // moment the answer matters.
                 TranslationX    : tx,
                 TranslationY    : ty,
                 TranslationZ    : tz,
@@ -219,55 +254,11 @@ public sealed class AutoAlignService : IAutoAlignService
                                 + "comparison; delete the existing transform or PUT a new one to change it.");
         }
 
-        if (existing == null)
-        {
-            existing = new ProjectModelTransform
-            {
-                TenantId       = tenantId,
-                ProjectId      = projectId,
-                ProjectModelId = targetModelId,
-                CreatedAt      = DateTime.UtcNow,
-            };
-            _db.Set<ProjectModelTransform>().Add(existing);
-        }
-        else
-        {
-            existing.UpdatedAt = DateTime.UtcNow;
-        }
-
-        // ── 6b. Grade the evidence, and apply it if it is strong enough ───────
-        // B1 — computing a transform and trusting it are different claims. The
-        // shared policy makes this path agree with the IFC ingest path, so the
-        // same model does not render in two different places depending on which
-        // pipeline touched it last.
-        var confidence = TransformConfidencePolicy.Evaluate(
-            hasMapConversion : targetReport.HasMapConversion,
-            hasProjectedCrs  : targetReport.HasProjectedCrs,
-            crsMatchesProject: TransformConfidencePolicy.CrsEquivalent(
-                                   targetReport.CrsName, pcs?.CrsEpsgCode ?? pcs?.CrsName),
-            surveyEasting    : targetReport.SurveyEasting,
-            surveyNorthing   : targetReport.SurveyNorthing,
-            verdict          : targetReport.Verdict);
-
-        existing.TranslationX         = tx;
-        existing.TranslationY         = ty;
-        existing.TranslationZ         = tz;
-        existing.RotationDeg          = rotDeg;
-        existing.ScaleFactor          = scaleFactor;
-        existing.IsAutoComputed       = true;
-        existing.IsConfirmed          = false;
-        existing.AppliedAutomatically = TransformConfidencePolicy.ShouldAutoApply(confidence);
-        existing.Confidence           = TransformConfidencePolicy.ToStorageString(confidence);
-        existing.Source               = "auto-align";
-        existing.AppliedBy            = "auto-align-service";
-        existing.AppliedAt            = DateTime.UtcNow;
-
-        await _db.SaveChangesAsync(ct);
-
         _logger.LogInformation(
             "AutoAlign computed for model {ModelId}: TX={TX:F3} TY={TY:F3} TZ={TZ:F3} Rot={Rot:F4}° Scale={Scale:F6} ref={Ref} confidence={Confidence} autoApplied={AutoApplied}",
             targetModelId, tx, ty, tz, rotDeg, scaleFactor, referenceModelId ?? "PCS",
-            confidence, existing.AppliedAutomatically);
+            TransformConfidencePolicy.ToStorageString(write.Confidence),
+            TransformConfidencePolicy.ShouldAutoApply(write.Confidence));
 
         // Gap K — broadcast the new transform so viewer clients refresh their
         // coordinate frame without polling.

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
@@ -185,8 +185,23 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
         // → mm. NOT negated: see the class remarks. t = +origin - frameOrigin is
         // what makes a point shared by two models land on the same world
         // coordinate; the old negation mirrored models about the origin.
-        double txMm = (georef.EastingM!.Value  - frame.EastingM)  * 1000.0;
-        double tyMm = (georef.NorthingM!.Value - frame.NorthingM) * 1000.0;
+        //
+        // P5b — the displacement is measured on CRS grid axes, but the rendered
+        // world is the project FRAME: the rotation below is frame-relative
+        // (θ_model − θ_frame), so a frame declared off grid north spins the
+        // geometry by −θ_frame. The translation has to live in those same axes,
+        // or geometry and translation disagree and two models with different
+        // survey origins stop overlaying — the error is (R(−θ_frame) − I)·
+        // (originB − originA), which grows with frame rotation and separation and
+        // is zero only at θ_frame = 0. So rotate the grid displacement by
+        // −θ_frame too. Identity for a grid-aligned frame, which is why those
+        // projects were unaffected. Z is orthogonal to the planar frame spin.
+        double dxE = georef.EastingM!.Value  - frame.EastingM;    // metres, CRS grid axes
+        double dyN = georef.NorthingM!.Value - frame.NorthingM;
+        double frameRad = -frame.TrueNorthDeg * Math.PI / 180.0;  // −θ_frame, same CCW convention as ApplyMm
+        double frameCos = Math.Cos(frameRad), frameSin = Math.Sin(frameRad);
+        double txMm = (frameCos * dxE - frameSin * dyN) * 1000.0; // grid displacement, rotated into frame axes
+        double tyMm = (frameSin * dxE + frameCos * dyN) * 1000.0;
         double tzMm = ((georef.ElevationM ?? 0) - frame.ElevationM) * 1000.0;
 
         // Rotation is likewise relative to the frame: a project whose declared

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
@@ -51,6 +51,31 @@ public sealed record ModelGeoref(
     public bool HasSurveyOrigin => EastingM.HasValue && NorthingM.HasValue;
 }
 
+/// <summary>
+/// What the writer computed, and whether it stored it.
+///
+/// <para>The computed numbers are returned even when <see cref="Written"/> is
+/// false. That is deliberate: when the write is refused because a coordinator
+/// confirmed the transform by hand, the useful answer is "here is what the
+/// survey data says, compare it with yours" — not a bare refusal. Returning
+/// them from here keeps the arithmetic in ONE place; the alternative was for
+/// the caller to recompute it, which is how the two implementations drifted
+/// apart in the first place.</para>
+/// </summary>
+public sealed record GeorefWriteResult(
+    TransformConfidence Confidence,
+    bool Written,
+    double TranslationXMm,
+    double TranslationYMm,
+    double TranslationZMm,
+    double RotationDeg,
+    double ScaleFactor,
+    string FrameSource)
+{
+    public static GeorefWriteResult Nothing(TransformConfidence confidence = TransformConfidence.None)
+        => new(confidence, false, 0, 0, 0, 0, 1.0, "none");
+}
+
 public interface IModelGeorefWriter
 {
     /// <summary>
@@ -58,11 +83,10 @@ public interface IModelGeorefWriter
     /// host's georeferencing, grading its confidence so a trustworthy one
     /// renders without a coordinator confirming it.
     ///
-    /// Never overwrites a transform a coordinator has confirmed. Returns the
-    /// confidence it graded, or <see cref="TransformConfidence.None"/> when
-    /// there was nothing usable to write.
+    /// Never overwrites a transform a coordinator has confirmed — in that case
+    /// the computed values are still returned, with <c>Written = false</c>.
     /// </summary>
-    Task<TransformConfidence> WriteAsync(
+    Task<GeorefWriteResult> WriteAsync(
         Guid projectId, Guid projectModelId, Guid tenantId,
         ModelGeoref georef, string? verdict, CancellationToken ct = default);
 }
@@ -80,26 +104,51 @@ public interface IModelGeorefWriter
 /// three, and the agreement is enforced by construction rather than by
 /// vigilance.</para>
 ///
-/// <para><b>The translation convention.</b> Each model is moved from its own
-/// survey origin back to the project origin: <c>t = -origin</c>, metres → mm.
-/// This is the convention the IFC ingest path has always used, preserved here
-/// deliberately so introducing this writer changes no existing behaviour.
-/// (<c>AutoAlignService</c> computes a RELATIVE transform instead — the two are
-/// reconciled separately; see the P5 note in
-/// <c>docs/COORDINATION_AUDIT_FINDINGS.md</c>.)</para>
+/// <para><b>The translation convention (P5).</b> A model's geometry is authored
+/// about its own internal origin, and its georeferencing states where that
+/// origin sits in the survey CRS. So the transform that carries the model into
+/// the shared world is
+/// <c>t = (modelSurveyOrigin - projectFrameOrigin)</c>, metres → mm.</para>
+///
+/// <para>This corrects a sign, and the sign was the bug. Both writers previously
+/// computed the NEGATION — the ingest path used <c>t = -modelOrigin</c> and
+/// <c>AutoAlignService</c> used <c>t = referenceOrigin - modelOrigin</c>. Take
+/// one physical point shared by two models: in model A's local frame it sits at
+/// <c>S - A</c>, in model B's at <c>S - B</c>. Applying <c>t = +A</c> puts it at
+/// <c>A + (S - A) = S</c> for A and at <c>S</c> for B — the same world point,
+/// which is exactly what "the models overlay" means. Applying <c>t = -A</c> puts
+/// it at <c>S - 2A</c>, and two models end up mirrored about the origin: an
+/// east-west pair swaps sides. The existing overlay proof
+/// (<c>ModelTransformMathTests</c>) could not catch this because it inverts and
+/// re-applies the SAME transform, proving the math self-consistent rather than
+/// proving the transform was derived correctly from survey data.</para>
+///
+/// <para><b>The frame origin</b> is resolved once, here, so every writer agrees:
+/// the project's declared <c>ProjectCoordinateSystem</c> benchmark if there is
+/// one, else the coordinator's nominated reference model's survey origin, else
+/// zero (raw CRS coordinates). Subtracting it keeps world coordinates small —
+/// a site at easting 432,000 m rendered about a zero frame origin puts geometry
+/// 432 km out, where float precision dies — while preserving every model's true
+/// offset from every other, because the same frame is subtracted from all of
+/// them.</para>
 /// </summary>
 public sealed class ModelGeorefWriter : IModelGeorefWriter
 {
     private readonly PlanscapeDbContext _db;
+    private readonly ISceneNodeAabbRefresher _aabb;
     private readonly ILogger<ModelGeorefWriter> _logger;
 
-    public ModelGeorefWriter(PlanscapeDbContext db, ILogger<ModelGeorefWriter> logger)
+    public ModelGeorefWriter(
+        PlanscapeDbContext db,
+        ISceneNodeAabbRefresher aabb,
+        ILogger<ModelGeorefWriter> logger)
     {
         _db = db;
+        _aabb = aabb;
         _logger = logger;
     }
 
-    public async Task<TransformConfidence> WriteAsync(
+    public async Task<GeorefWriteResult> WriteAsync(
         Guid projectId, Guid projectModelId, Guid tenantId,
         ModelGeoref georef, string? verdict, CancellationToken ct = default)
     {
@@ -112,11 +161,13 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
             _logger.LogInformation(
                 "Georef for model {ModelId}: no survey origin ({Source}) — left at project origin, no transform written.",
                 projectModelId, georef.SourceLabel);
-            return TransformConfidence.None;
+            return GeorefWriteResult.Nothing();
         }
 
         var projectCrs = await _db.ProjectCoordinateSystems.AsNoTracking()
             .FirstOrDefaultAsync(x => x.ProjectId == projectId && x.TenantId == tenantId, ct);
+
+        var frame = await ResolveFrameOriginAsync(projectId, tenantId, projectModelId, projectCrs, ct);
 
         var confidence = TransformConfidencePolicy.Evaluate(
             hasMapConversion : true,
@@ -130,11 +181,18 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
         bool autoApply = TransformConfidencePolicy.ShouldAutoApply(confidence);
         string confidenceText = TransformConfidencePolicy.ToStorageString(confidence);
 
-        // Survey origin (metres) → translation (mm). Negated: applying it brings
-        // georeferenced model coordinates back to the project origin.
-        double txMm = -georef.EastingM!.Value  * 1000.0;
-        double tyMm = -georef.NorthingM!.Value * 1000.0;
-        double tzMm = -(georef.ElevationM ?? 0) * 1000.0;
+        // P5 — the model's survey origin expressed in the project frame, metres
+        // → mm. NOT negated: see the class remarks. t = +origin - frameOrigin is
+        // what makes a point shared by two models land on the same world
+        // coordinate; the old negation mirrored models about the origin.
+        double txMm = (georef.EastingM!.Value  - frame.EastingM)  * 1000.0;
+        double tyMm = (georef.NorthingM!.Value - frame.NorthingM) * 1000.0;
+        double tzMm = ((georef.ElevationM ?? 0) - frame.ElevationM) * 1000.0;
+
+        // Rotation is likewise relative to the frame: a project whose declared
+        // coordinate system is itself rotated off grid north must not have that
+        // rotation applied twice.
+        double rotationDeg = georef.TrueNorthDeg - frame.TrueNorthDeg;
 
         // The source's declared survey scale, inverted to undo it — the same
         // convention AutoAlignService uses. The IFC ingest path used to compute
@@ -156,7 +214,8 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
             _logger.LogInformation(
                 "Georef for model {ModelId}: skipped — an existing transform is manually confirmed.",
                 projectModelId);
-            return confidence;
+            return new GeorefWriteResult(confidence, Written: false,
+                txMm, tyMm, tzMm, rotationDeg, scaleFactor, frame.Source);
         }
 
         if (existing == null)
@@ -169,7 +228,7 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
                 TranslationX         = txMm,
                 TranslationY         = tyMm,
                 TranslationZ         = tzMm,
-                RotationDeg          = georef.TrueNorthDeg,
+                RotationDeg          = rotationDeg,
                 ScaleFactor          = scaleFactor,
                 IsAutoComputed       = true,
                 IsConfirmed          = false,
@@ -185,7 +244,7 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
             existing.TranslationX         = txMm;
             existing.TranslationY         = tyMm;
             existing.TranslationZ         = tzMm;
-            existing.RotationDeg          = georef.TrueNorthDeg;
+            existing.RotationDeg          = rotationDeg;
             existing.ScaleFactor          = scaleFactor;
             existing.IsAutoComputed       = true;
             existing.AppliedAutomatically = autoApply;
@@ -197,11 +256,85 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
 
         await _db.SaveChangesAsync(ct);
 
+        // P5 — the manifest AABBs describe where the chunks are in WORLD space,
+        // so moving a model invalidates them. Both automatic writers used to
+        // skip this (only the manual PUT did it), leaving the viewer culling
+        // against bounds for a position the model no longer occupied: geometry
+        // that vanishes when you look straight at it. Best-effort — the
+        // transform is already committed and correct, and stale bounds are a
+        // culling artefact, not data loss.
+        try
+        {
+            await _aabb.RefreshAsync(projectId, projectModelId, tenantId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "SceneNode AABB refresh failed for model {ModelId} (non-fatal — transform is stored).",
+                projectModelId);
+        }
+
         _logger.LogInformation(
-            "Georef for model {ModelId}: TX={TX:F1} TY={TY:F1} TZ={TZ:F1} mm Rot={Rot:F4}° source={Source} confidence={Confidence} autoApplied={AutoApplied}",
-            projectModelId, txMm, tyMm, tzMm, georef.TrueNorthDeg,
+            "Georef for model {ModelId}: TX={TX:F1} TY={TY:F1} TZ={TZ:F1} mm Rot={Rot:F4}° frame={Frame} source={Source} confidence={Confidence} autoApplied={AutoApplied}",
+            projectModelId, txMm, tyMm, tzMm, rotationDeg, frame.Source,
             georef.SourceLabel, confidenceText, autoApply);
 
-        return confidence;
+        return new GeorefWriteResult(confidence, Written: true,
+            txMm, tyMm, tzMm, rotationDeg, scaleFactor, frame.Source);
     }
+
+    /// <summary>
+    /// The origin every model in this project is positioned relative to.
+    ///
+    /// <para>Resolved in one place so both automatic writers agree by
+    /// construction. Order of preference, strongest evidence first:</para>
+    /// <list type="number">
+    /// <item>the project's declared <c>ProjectCoordinateSystem</c> benchmark —
+    /// an explicit coordinator decision;</item>
+    /// <item>the survey origin of the coordinator's nominated reference model —
+    /// an implicit one ("everything lines up with this");</item>
+    /// <item>zero, i.e. raw CRS coordinates.</item>
+    /// </list>
+    ///
+    /// <para>Whichever is chosen, the SAME frame is subtracted from every model,
+    /// so relative offsets are preserved exactly. Choosing a frame near the site
+    /// only buys precision: world coordinates stay small instead of sitting
+    /// hundreds of kilometres from the origin where 32-bit float stops
+    /// resolving millimetres.</para>
+    /// </summary>
+    private async Task<FrameOrigin> ResolveFrameOriginAsync(
+        Guid projectId, Guid tenantId, Guid excludeModelId,
+        ProjectCoordinateSystem? projectCrs, CancellationToken ct)
+    {
+        if (projectCrs?.OriginEasting is { } oe && projectCrs.OriginNorthing is { } on)
+        {
+            return new FrameOrigin(oe, on, projectCrs.OriginElevation ?? 0,
+                                   projectCrs.TrueNorthDeg, "project-coordinate-system");
+        }
+
+        if (projectCrs?.ReferenceModelId is { } refId && refId != excludeModelId)
+        {
+            var refReport = await _db.IfcAlignmentReports.AsNoTracking()
+                .Where(r => r.ProjectModelId == refId
+                         && r.ProjectId == projectId
+                         && r.TenantId == tenantId
+                         && r.SurveyEasting != null)
+                .OrderByDescending(r => r.ValidatedAt)
+                .FirstOrDefaultAsync(ct);
+
+            if (refReport?.SurveyEasting is { } re)
+            {
+                return new FrameOrigin(re, refReport.SurveyNorthing ?? 0,
+                                       refReport.SurveyElevation ?? 0,
+                                       refReport.MapConversionRotationDeg ?? 0,
+                                       "reference-model");
+            }
+        }
+
+        // No declared frame: raw CRS coordinates. Correct, just large.
+        return new FrameOrigin(0, 0, 0, 0, "crs-origin");
+    }
+
+    private readonly record struct FrameOrigin(
+        double EastingM, double NorthingM, double ElevationM, double TrueNorthDeg, string Source);
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/SceneNodeAabbRefresher.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/SceneNodeAabbRefresher.cs
@@ -1,0 +1,133 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Coordinates;
+using Planscape.Core.Entities;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Infrastructure.Services;
+
+public interface ISceneNodeAabbRefresher
+{
+    /// <summary>
+    /// Recompute the world-space AABB of every scene chunk belonging to a model
+    /// from its local AABB and the model's current transform. Returns the number
+    /// of chunks updated. Idempotent — safe to call after every transform write.
+    /// </summary>
+    Task<int> RefreshAsync(Guid projectId, Guid projectModelId, Guid tenantId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Keeps the federation manifest's chunk bounds honest.
+///
+/// <para><b>Why it is a service.</b> This logic lived inline in
+/// <c>ModelTransformController.Upsert</c> and ran ONLY there. Both automatic
+/// transform writers — IFC ingest and auto-align — moved models without it, so
+/// the manifest AABBs the viewer culls against described where the chunks used
+/// to be. Symptom: geometry that vanishes when the camera looks straight at it,
+/// or loads when it is nowhere near the frustum. Extracting it makes "recompute
+/// after every transform write" a single call rather than three copies.</para>
+///
+/// <para><b>Why idempotence had to come first.</b> The inline version read the
+/// STORED (already-transformed) box and transformed it again, so a second write
+/// compounded the transform and the bounds drifted further from the geometry
+/// each time. Calling that from more places would have multiplied the bug. The
+/// world box is now derived from <see cref="SceneNode.BaseMinX"/>… — the chunk's
+/// own local box — so it is a pure function of (local, transform) and can be
+/// recomputed any number of times with the same result.</para>
+/// </summary>
+public sealed class SceneNodeAabbRefresher : ISceneNodeAabbRefresher
+{
+    private readonly PlanscapeDbContext _db;
+    private readonly ILogger<SceneNodeAabbRefresher> _logger;
+
+    public SceneNodeAabbRefresher(PlanscapeDbContext db, ILogger<SceneNodeAabbRefresher> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<int> RefreshAsync(
+        Guid projectId, Guid projectModelId, Guid tenantId, CancellationToken ct = default)
+    {
+        var nodes = await _db.SceneNodes
+            .Where(n => n.SourceModelId == projectModelId && n.DeletedAt == null)
+            .ToListAsync(ct);
+        if (nodes.Count == 0) return 0;
+
+        var xf = await _db.ProjectModelTransforms.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.ProjectModelId == projectModelId
+                                   && t.ProjectId == projectId
+                                   && t.TenantId == tenantId, ct);
+
+        foreach (var node in nodes)
+        {
+            // Capture the local box the first time we see a pre-P5 row. For a
+            // chunk that was never transformed this is exactly right; for one
+            // that was, it is the best available until the model is re-published
+            // (ingest writes both boxes).
+            node.BaseMinX ??= node.MinX;
+            node.BaseMinY ??= node.MinY;
+            node.BaseMinZ ??= node.MinZ;
+            node.BaseMaxX ??= node.MaxX;
+            node.BaseMaxY ??= node.MaxY;
+            node.BaseMaxZ ??= node.MaxZ;
+
+            var (mnX, mnY, mnZ, mxX, mxY, mxZ) = TransformBox(
+                xf,
+                node.BaseMinX!.Value, node.BaseMinY!.Value, node.BaseMinZ!.Value,
+                node.BaseMaxX!.Value, node.BaseMaxY!.Value, node.BaseMaxZ!.Value);
+
+            node.MinX = mnX; node.MinY = mnY; node.MinZ = mnZ;
+            node.MaxX = mxX; node.MaxY = mxY; node.MaxZ = mxZ;
+        }
+
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Refreshed {Count} SceneNode AABBs for model {ModelId} (transform: {HasTransform}).",
+            nodes.Count, projectModelId, xf == null ? "none" : "present");
+
+        return nodes.Count;
+    }
+
+    /// <summary>
+    /// Transform all 8 corners of a local AABB and return the enclosing
+    /// axis-aligned box.
+    ///
+    /// <para>All eight corners, not just min and max: under a Z rotation the
+    /// transformed min corner is not generally the min of the transformed box,
+    /// so transforming only the two extreme corners produces a box that is both
+    /// wrong and often too small — which culls visible geometry.</para>
+    ///
+    /// <para>A null transform is the identity, so an untransformed model's world
+    /// box equals its local box.</para>
+    /// </summary>
+    internal static (double minX, double minY, double minZ, double maxX, double maxY, double maxZ) TransformBox(
+        ProjectModelTransform? t,
+        double minX, double minY, double minZ,
+        double maxX, double maxY, double maxZ)
+    {
+        if (t == null) return (minX, minY, minZ, maxX, maxY, maxZ);
+
+        double[] xs = [minX, maxX, minX, maxX, minX, maxX, minX, maxX];
+        double[] ys = [minY, minY, maxY, maxY, minY, minY, maxY, maxY];
+        double[] zs = [minZ, minZ, minZ, minZ, maxZ, maxZ, maxZ, maxZ];
+
+        var nx = new double[8];
+        var ny = new double[8];
+        var nz = new double[8];
+
+        for (int i = 0; i < 8; i++)
+        {
+            // The ONE canonical transform, so the manifest, the viewer and the
+            // overlay proof cannot disagree about what a transform means.
+            var w = ModelTransformMath.ApplyMm(
+                t.TranslationX, t.TranslationY, t.TranslationZ,
+                t.RotationDeg, t.ScaleFactor,
+                xs[i], ys[i], zs[i]);
+            nx[i] = w.X; ny[i] = w.Y; nz[i] = w.Z;
+        }
+
+        return (nx.Min(), ny.Min(), nz.Min(), nx.Max(), ny.Max(), nz.Max());
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/AutoAlignConfirmedTransformTests.cs
@@ -146,7 +146,17 @@ public class AutoAlignConfirmedTransformTests
     }
 
     private static AutoAlignService NewService(World w)
-        => new(NewContext(w.Conn, w.Tenant), NullLogger<AutoAlignService>.Instance);
+    {
+        // P5 — auto-align no longer does its own transform arithmetic; it
+        // delegates to the shared writer so it cannot drift from the ingest
+        // path. One context across all three so they share a change tracker.
+        var db = NewContext(w.Conn, w.Tenant);
+        var writer = new ModelGeorefWriter(
+            db,
+            new SceneNodeAabbRefresher(db, NullLogger<SceneNodeAabbRefresher>.Instance),
+            NullLogger<ModelGeorefWriter>.Instance);
+        return new AutoAlignService(db, writer, NullLogger<AutoAlignService>.Instance);
+    }
 
     [Fact]
     public async Task A_confirmed_transform_is_not_overwritten()
@@ -183,9 +193,19 @@ public class AutoAlignConfirmedTransformTests
         {
             var result = await NewService(w).ComputeAsync(w.Project, w.Tenant, w.Target);
 
-            // reference(1000, 2000) - target(1500, 2500), in metres → mm.
-            Assert.Equal(-500_000.0, result.TranslationX, 3);
-            Assert.Equal(-500_000.0, result.TranslationY, 3);
+            // P5 — the target's own survey origin, in the project frame.
+            //
+            // This used to assert reference(1000) - target(1500) = -500 m. Two
+            // things changed. The sign was wrong (see FederationFrameTests), and
+            // the frame is no longer "whichever sibling was validated most
+            // recently" — that origin moved every time another model was
+            // uploaded, so transforms computed on different days disagreed.
+            // With no ProjectCoordinateSystem in this fixture the frame is zero,
+            // so the target sits at its raw CRS position of 1500 m. Relative
+            // placement is unaffected: the same frame is subtracted from every
+            // model.
+            Assert.Equal(1_500_000.0, result.TranslationX, 3);
+            Assert.Equal(2_500_000.0, result.TranslationY, 3);
         }
     }
 
@@ -203,8 +223,8 @@ public class AutoAlignConfirmedTransformTests
 
             using var check = NewContext(w.Conn, w.Tenant);
             var xf = await check.Set<ProjectModelTransform>().SingleAsync();
-            Assert.Equal(-500_000.0, xf.TranslationX, 3);
-            Assert.Equal(-500_000.0, xf.TranslationY, 3);
+            Assert.Equal(1_500_000.0, xf.TranslationX, 3);
+            Assert.Equal(2_500_000.0, xf.TranslationY, 3);
             Assert.True(xf.IsAutoComputed);
             Assert.False(xf.IsConfirmed);
             Assert.Equal("auto-align-service", xf.AppliedBy);
@@ -254,7 +274,7 @@ public class AutoAlignConfirmedTransformTests
             var xf = await check.Set<ProjectModelTransform>().SingleAsync();
 
             // Computed and stored — a coordinator can still confirm it.
-            Assert.Equal(-500_000.0, xf.TranslationX, 3);
+            Assert.Equal(1_500_000.0, xf.TranslationX, 3);
             // But not live.
             Assert.False(xf.AppliedAutomatically);
             Assert.Equal("LOW", xf.Confidence);

--- a/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
@@ -198,9 +198,11 @@ public class FederationAuthorizationTests
 
     private static ModelTransformController NewTransformController(World w, Guid actor)
     {
+        var db = NewContext(w.Conn, w.Tenant);
         var c = new ModelTransformController(
-            NewContext(w.Conn, w.Tenant), new FixedTenant(w.Tenant),
-            delta: null!, logger: NullLogger<ModelTransformController>.Instance)
+            db, new FixedTenant(w.Tenant), delta: null!,
+            aabb: new SceneNodeAabbRefresher(db, NullLogger<SceneNodeAabbRefresher>.Instance),
+            logger: NullLogger<ModelTransformController>.Instance)
         { ControllerContext = ContextFor(actor, w.Tenant) };
         return c;
     }

--- a/Planscape.Server/tests/Planscape.Tests/FederationFrameTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationFrameTests.cs
@@ -283,4 +283,44 @@ public class FederationFrameTests
             Assert.Equal(15.0, a.RotationDeg, 6);   // 25 model − 10 frame
         }
     }
+
+    [Fact]
+    public async Task A_shared_point_coincides_even_when_the_frame_is_rotated()
+    {
+        // The rotated-frame counterpart of
+        // A_point_shared_by_two_models_maps_to_one_world_coordinate. The stored
+        // rotation is frame-relative (θ_model − θ_frame), so the geometry is spun
+        // by −θ_frame into the project's declared axes. The translation is a CRS-
+        // grid displacement and must live in those SAME axes, or geometry and
+        // translation disagree: two models with DIFFERENT survey origins stop
+        // overlaying, the error being (R(−θ_frame) − I)·(originB − originA) —
+        // zero only when θ_frame = 0, which is why the un-rotated cases passed.
+        // Here the frame is rotated 30° and the two blocks are 500 m / 400 m
+        // apart, so the bug throws them ~100+ m out of registration.
+        var w = NewWorld(frameEasting: 431_000.0, frameNorthing: 314_000.0);
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                var pcs = await seed.ProjectCoordinateSystems.SingleAsync();
+                pcs.TrueNorthDeg = 30.0;
+                await seed.SaveChangesAsync();
+            }
+
+            var (a, b) = await PlaceBoth(w);
+
+            const double pillarE = 432_200.0, pillarN = 315_150.0;
+            var localA = ((pillarE - AEast) * 1000.0, (pillarN - ANorth) * 1000.0);
+            var localB = ((pillarE - BEast) * 1000.0, (pillarN - BNorth) * 1000.0);
+
+            var wa = ModelTransformMath.ApplyMm(a.TranslationX, a.TranslationY, a.TranslationZ,
+                                                a.RotationDeg, a.ScaleFactor, localA.Item1, localA.Item2, 0);
+            var wb = ModelTransformMath.ApplyMm(b.TranslationX, b.TranslationY, b.TranslationZ,
+                                                b.RotationDeg, b.ScaleFactor, localB.Item1, localB.Item2, 0);
+
+            Assert.Equal(wa.X, wb.X, 3);
+            Assert.Equal(wa.Y, wb.Y, 3);
+            Assert.Equal(wa.Z, wb.Z, 3);
+        }
+    }
 }

--- a/Planscape.Server/tests/Planscape.Tests/FederationFrameTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationFrameTests.cs
@@ -1,0 +1,286 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Coordinates;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK B / P5 — the translation convention, and the property that actually
+/// matters: two models of the same site must end up in the right place RELATIVE
+/// TO EACH OTHER.
+///
+/// THE DEFECT
+/// ----------
+/// Both automatic writers computed the NEGATION of the correct translation. The
+/// IFC ingest path used <c>t = -modelOrigin</c>; AutoAlignService used
+/// <c>t = referenceOrigin - modelOrigin</c>.
+///
+/// A model's geometry is authored about its own internal origin, and its
+/// georeferencing says where that origin sits in the survey CRS. So a physical
+/// point S sits at local coordinate <c>S - A</c> in model A. The transform maps
+/// local to world as <c>world = t + local</c>:
+///
+///   with t = +A :  world = A + (S - A) = S          ✓ both models agree on S
+///   with t = -A :  world = -A + (S - A) = S - 2A    ✗ and B lands at S - 2B
+///
+/// So two models came out MIRRORED about the origin — an east-west pair swaps
+/// sides. The existing overlay proof (ModelTransformMathTests) could not catch
+/// it: it inverts a transform and re-applies the SAME transform, which proves
+/// <c>Apply(Inverse(w)) == w</c> for any transform whatsoever. It proves the
+/// math is self-consistent, never that the transform was DERIVED correctly from
+/// survey data. These tests derive it.
+/// </summary>
+public class FederationFrameTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid ModelA, Guid ModelB);
+
+    private static World NewWorld(
+        double? frameEasting = null, double? frameNorthing = null, Guid? referenceModelId = null)
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "acme@example.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Campus",
+                Code = $"CM-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            foreach (var (id, name) in new[] { (a, "Block A"), (b, "Block B") })
+                ctx.ProjectModels.Add(new ProjectModel
+                {
+                    Id = id, TenantId = tenant, ProjectId = project,
+                    Name = name, FileName = $"{name}.glb", StoragePath = $"t_x/{id:N}.glb",
+                    Units = "m",
+                });
+
+            if (frameEasting.HasValue || referenceModelId.HasValue)
+            {
+                ctx.ProjectCoordinateSystems.Add(new ProjectCoordinateSystem
+                {
+                    TenantId = tenant, ProjectId = project, CrsEpsgCode = "EPSG:27700",
+                    OriginEasting = frameEasting, OriginNorthing = frameNorthing,
+                    ReferenceModelId = referenceModelId,
+                });
+            }
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, project, a, b);
+    }
+
+    private static ModelGeorefWriter NewWriter(World w)
+    {
+        var db = NewContext(w.Conn, w.Tenant);
+        return new ModelGeorefWriter(
+            db,
+            new SceneNodeAabbRefresher(db, NullLogger<SceneNodeAabbRefresher>.Instance),
+            NullLogger<ModelGeorefWriter>.Instance);
+    }
+
+    private static ModelGeoref At(double eastingM, double northingM, double elevationM = 0, double northDeg = 0)
+        => new(eastingM, northingM, elevationM, northDeg, "EPSG:27700", true, "m", "ifc-map-conversion");
+
+    // Two blocks 500 m apart: A east/north of the origin, B 500 m further on.
+    private const double AEast = 432_000.0, ANorth = 315_000.0;
+    private const double BEast = 432_500.0, BNorth = 315_400.0;
+
+    private static async Task<(ProjectModelTransform a, ProjectModelTransform b)> PlaceBoth(World w)
+    {
+        await NewWriter(w).WriteAsync(w.Project, w.ModelA, w.Tenant, At(AEast, ANorth), "PASS");
+        await NewWriter(w).WriteAsync(w.Project, w.ModelB, w.Tenant, At(BEast, BNorth), "PASS");
+
+        using var check = NewContext(w.Conn, w.Tenant);
+        var rows = await check.ProjectModelTransforms.AsNoTracking().ToListAsync();
+        return (rows.Single(r => r.ProjectModelId == w.ModelA),
+                rows.Single(r => r.ProjectModelId == w.ModelB));
+    }
+
+    // ── the property that matters ───────────────────────────────────────────
+
+    [Fact]
+    public async Task Two_models_keep_their_true_relative_offset()
+    {
+        // B is 500 m EAST and 400 m NORTH of A on the ground. Whatever frame is
+        // chosen, that must survive into world space — same sign, same magnitude.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (a, b) = await PlaceBoth(w);
+
+            Assert.Equal((BEast - AEast) * 1000.0, b.TranslationX - a.TranslationX, 3);
+            Assert.Equal((BNorth - ANorth) * 1000.0, b.TranslationY - a.TranslationY, 3);
+        }
+    }
+
+    [Fact]
+    public async Task The_offset_is_not_mirrored()
+    {
+        // The specific regression. Under the old t = -origin convention the
+        // difference came out NEGATED: B ended up west and south of A. This
+        // asserts the sign explicitly, because a magnitude-only check passes
+        // against the bug.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (a, b) = await PlaceBoth(w);
+
+            Assert.True(b.TranslationX > a.TranslationX,
+                "B is east of A on the ground but landed west of it — the translation is mirrored");
+            Assert.True(b.TranslationY > a.TranslationY,
+                "B is north of A on the ground but landed south of it — the translation is mirrored");
+        }
+    }
+
+    [Fact]
+    public async Task A_point_shared_by_two_models_maps_to_one_world_coordinate()
+    {
+        // The real definition of "the models overlay", derived from survey data
+        // rather than assumed. A pillar at survey (432,200, 315,150) sits at a
+        // different LOCAL coordinate in each model; both must render it in the
+        // same place.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (a, b) = await PlaceBoth(w);
+
+            const double pillarE = 432_200.0, pillarN = 315_150.0;
+            // Local coordinate of the pillar in each model, in mm.
+            var localA = ((pillarE - AEast) * 1000.0, (pillarN - ANorth) * 1000.0);
+            var localB = ((pillarE - BEast) * 1000.0, (pillarN - BNorth) * 1000.0);
+
+            var wa = ModelTransformMath.ApplyMm(a.TranslationX, a.TranslationY, a.TranslationZ,
+                                                a.RotationDeg, a.ScaleFactor, localA.Item1, localA.Item2, 0);
+            var wb = ModelTransformMath.ApplyMm(b.TranslationX, b.TranslationY, b.TranslationZ,
+                                                b.RotationDeg, b.ScaleFactor, localB.Item1, localB.Item2, 0);
+
+            Assert.Equal(wa.X, wb.X, 3);
+            Assert.Equal(wa.Y, wb.Y, 3);
+            Assert.Equal(wa.Z, wb.Z, 3);
+        }
+    }
+
+    // ── the frame ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task With_no_declared_frame_models_sit_at_their_raw_crs_position()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var (a, _) = await PlaceBoth(w);
+            Assert.Equal(AEast * 1000.0, a.TranslationX, 3);
+        }
+    }
+
+    [Fact]
+    public async Task A_declared_benchmark_becomes_the_frame_origin()
+    {
+        // Subtracting a site-local benchmark keeps world coordinates small.
+        // A site at easting 432 km rendered about a zero origin puts geometry
+        // where 32-bit float stops resolving millimetres.
+        var w = NewWorld(frameEasting: 432_000.0, frameNorthing: 315_000.0);
+        using (w.Conn)
+        {
+            var (a, b) = await PlaceBoth(w);
+
+            Assert.Equal(0.0, a.TranslationX, 3);          // A IS the benchmark
+            Assert.Equal(500_000.0, b.TranslationX, 3);    // B: 500 m east, in mm
+
+            // …and the relative offset is untouched by the choice of frame.
+            Assert.Equal((BEast - AEast) * 1000.0, b.TranslationX - a.TranslationX, 3);
+        }
+    }
+
+    [Fact]
+    public async Task A_nominated_reference_model_becomes_the_frame_origin()
+    {
+        var w = NewWorld(referenceModelId: null);
+        using (w.Conn)
+        {
+            // Nominate A as the reference, and give it an alignment report so
+            // the frame can be resolved from it.
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.IfcAlignmentReports.Add(new IfcAlignmentReport
+                {
+                    TenantId = w.Tenant, ProjectId = w.Project, ProjectModelId = w.ModelA,
+                    HasMapConversion = true, HasProjectedCrs = true, CrsName = "EPSG:27700",
+                    SurveyEasting = AEast, SurveyNorthing = ANorth, SurveyElevation = 0,
+                    MapConversionRotationDeg = 0, Verdict = "PASS", ValidatedAt = DateTime.UtcNow,
+                });
+                seed.ProjectCoordinateSystems.Add(new ProjectCoordinateSystem
+                {
+                    TenantId = w.Tenant, ProjectId = w.Project, CrsEpsgCode = "EPSG:27700",
+                    ReferenceModelId = w.ModelA,
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            await NewWriter(w).WriteAsync(w.Project, w.ModelB, w.Tenant, At(BEast, BNorth), "PASS");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var b = await check.ProjectModelTransforms.AsNoTracking()
+                .SingleAsync(t => t.ProjectModelId == w.ModelB);
+
+            // B expressed relative to A: 500 m east, 400 m north.
+            Assert.Equal(500_000.0, b.TranslationX, 3);
+            Assert.Equal(400_000.0, b.TranslationY, 3);
+        }
+    }
+
+    [Fact]
+    public async Task Rotation_is_expressed_relative_to_the_frame()
+    {
+        // A project whose declared coordinate system is itself rotated off grid
+        // north must not have that rotation applied twice.
+        var w = NewWorld(frameEasting: 432_000.0, frameNorthing: 315_000.0);
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                var pcs = await seed.ProjectCoordinateSystems.SingleAsync();
+                pcs.TrueNorthDeg = 10.0;
+                await seed.SaveChangesAsync();
+            }
+
+            await NewWriter(w).WriteAsync(w.Project, w.ModelA, w.Tenant,
+                At(AEast, ANorth, northDeg: 25.0), "PASS");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var a = await check.ProjectModelTransforms.AsNoTracking().SingleAsync();
+            Assert.Equal(15.0, a.RotationDeg, 6);   // 25 model − 10 frame
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
@@ -90,7 +90,16 @@ public class ModelGeorefWriterTests
     }
 
     private static ModelGeorefWriter NewWriter(World w)
-        => new(NewContext(w.Conn, w.Tenant), NullLogger<ModelGeorefWriter>.Instance);
+    {
+        // The refresher shares the writer's context so both see one change
+        // tracker — the writer saves the transform, the refresher then reads it
+        // back to recompute chunk bounds.
+        var db = NewContext(w.Conn, w.Tenant);
+        return new ModelGeorefWriter(
+            db,
+            new SceneNodeAabbRefresher(db, NullLogger<SceneNodeAabbRefresher>.Instance),
+            NullLogger<ModelGeorefWriter>.Instance);
+    }
 
     /// <summary>A Revit publish from a site at BNG easting 432,000 m.</summary>
     private static ModelGeoref RevitGeoref(string? crs = "EPSG:27700") => new(
@@ -106,24 +115,29 @@ public class ModelGeorefWriterTests
     // ── the placement itself ────────────────────────────────────────────────
 
     [Fact]
-    public async Task A_survey_origin_becomes_a_negated_millimetre_translation()
+    public async Task A_survey_origin_becomes_a_millimetre_translation_into_the_project_frame()
     {
         var w = NewWorld();
         using (w.Conn)
         {
-            var confidence = await NewWriter(w).WriteAsync(
+            var write = await NewWriter(w).WriteAsync(
                 w.Project, w.Model, w.Tenant, RevitGeoref(), verdict: "PASS");
 
-            Assert.Equal(TransformConfidence.High, confidence);
+            Assert.Equal(TransformConfidence.High, write.Confidence);
 
             using var check = NewContext(w.Conn, w.Tenant);
             var xf = await check.ProjectModelTransforms.SingleAsync();
 
-            // metres → mm, negated: applying it brings the georeferenced model
-            // back to the project origin.
-            Assert.Equal(-432_000_000.0, xf.TranslationX, 3);
-            Assert.Equal(-315_000_000.0, xf.TranslationY, 3);
-            Assert.Equal(-12_500.0, xf.TranslationZ, 3);
+            // P5 — metres → mm, NOT negated. The model's geometry is authored
+            // about its own internal origin and this transform says where that
+            // origin sits, so a physical point shared with another model lands
+            // on the same world coordinate. The earlier negation put models
+            // mirrored about the origin; see FederationFrameTests.
+            // No ProjectCoordinateSystem here, so the frame origin is zero and
+            // the model sits at its raw CRS position.
+            Assert.Equal(432_000_000.0, xf.TranslationX, 3);
+            Assert.Equal(315_000_000.0, xf.TranslationY, 3);
+            Assert.Equal(12_500.0, xf.TranslationZ, 3);
             Assert.Equal(3.25, xf.RotationDeg, 6);
             Assert.Equal(1.0, xf.ScaleFactor, 6);
             Assert.Equal("revit-georef", xf.Source);
@@ -157,9 +171,9 @@ public class ModelGeorefWriterTests
         using (w.Conn)
         {
             var georef = RevitGeoref(crs: "27700") with { HasDeclaredCrs = false };
-            var confidence = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
+            var write = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
 
-            Assert.Equal(TransformConfidence.High, confidence);
+            Assert.Equal(TransformConfidence.High, write.Confidence);
         }
     }
 
@@ -172,14 +186,14 @@ public class ModelGeorefWriterTests
         var w = NewWorld();
         using (w.Conn)
         {
-            var confidence = await NewWriter(w).WriteAsync(
+            var write = await NewWriter(w).WriteAsync(
                 w.Project, w.Model, w.Tenant, RevitGeoref(crs: null), "PASS");
 
-            Assert.Equal(TransformConfidence.Low, confidence);
+            Assert.Equal(TransformConfidence.Low, write.Confidence);
 
             using var check = NewContext(w.Conn, w.Tenant);
             var xf = await check.ProjectModelTransforms.SingleAsync();
-            Assert.Equal(-432_000_000.0, xf.TranslationX, 3);   // computed
+            Assert.Equal(432_000_000.0, xf.TranslationX, 3);    // computed
             Assert.False(xf.AppliedAutomatically);              // but not live
             Assert.Equal("LOW", xf.Confidence);
         }
@@ -197,9 +211,9 @@ public class ModelGeorefWriterTests
         using (w.Conn)
         {
             var georef = RevitGeoref() with { EastingM = null, NorthingM = null };
-            var confidence = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
+            var write = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
 
-            Assert.Equal(TransformConfidence.None, confidence);
+            Assert.Equal(TransformConfidence.None, write.Confidence);
 
             using var check = NewContext(w.Conn, w.Tenant);
             Assert.False(await check.ProjectModelTransforms.AnyAsync());
@@ -249,7 +263,7 @@ public class ModelGeorefWriterTests
 
             using var check = NewContext(w.Conn, w.Tenant);
             var xf = await check.ProjectModelTransforms.SingleAsync();   // exactly one
-            Assert.Equal(-500_000_000.0, xf.TranslationX, 3);
+            Assert.Equal(500_000_000.0, xf.TranslationX, 3);
             Assert.NotNull(xf.UpdatedAt);
         }
     }
@@ -260,10 +274,10 @@ public class ModelGeorefWriterTests
         var w = NewWorld();
         using (w.Conn)
         {
-            var confidence = await NewWriter(w).WriteAsync(
+            var write = await NewWriter(w).WriteAsync(
                 w.Project, w.Model, w.Tenant, RevitGeoref(), verdict: "FAIL");
 
-            Assert.Equal(TransformConfidence.Low, confidence);
+            Assert.Equal(TransformConfidence.Low, write.Confidence);
 
             using var check = NewContext(w.Conn, w.Tenant);
             Assert.False((await check.ProjectModelTransforms.SingleAsync()).AppliedAutomatically);

--- a/Planscape.Server/tests/Planscape.Tests/SceneNodeAabbRefresherTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/SceneNodeAabbRefresherTests.cs
@@ -1,0 +1,267 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK B / P5 — scene-chunk bounds after a model moves.
+///
+/// THE DEFECT
+/// ----------
+/// The world-space AABB recompute lived inline in
+/// <c>ModelTransformController.Upsert</c> and had two problems that compounded
+/// each other:
+///
+/// 1. It ran ONLY there. Both automatic transform writers (IFC ingest,
+///    auto-align) moved models without touching the bounds, so the federation
+///    manifest described where the chunks USED to be. The viewer culls against
+///    those bounds, so the symptom is geometry that disappears when the camera
+///    looks straight at it — or streams in when it is nowhere near the frustum.
+///
+/// 2. It read the STORED (already-transformed) box and transformed it AGAIN. So
+///    the obvious fix — "call it after every transform write" — would have made
+///    things worse, not better: each call would have compounded the transform
+///    and walked the bounds further from the geometry.
+///
+/// Fixing (2) had to come first, which is why <see cref="SceneNode.BaseMinX"/>…
+/// exists: the world box is now a pure function of (local box, transform) and
+/// can be recomputed any number of times with the same answer.
+/// </summary>
+public class SceneNodeAabbRefresherTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Model, Guid Node);
+
+    /// <param name="withBaseBox">
+    /// false reproduces a row written BEFORE the local box existed.
+    /// </param>
+    private static World NewWorld(bool withBaseBox = true)
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var model = Guid.NewGuid();
+        var node = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "acme@example.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Tower",
+                Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            ctx.ProjectModels.Add(new ProjectModel
+            {
+                Id = model, TenantId = tenant, ProjectId = project,
+                Name = "ARCH", FileName = "a.glb", StoragePath = "t_x/a.glb",
+            });
+
+            var n = new SceneNode
+            {
+                Id = node, TenantId = tenant, ProjectId = project, SourceModelId = model,
+                Discipline = "A", StoragePath = "t_x/c.glb", ContentHash = "abc",
+                MinX = 0, MinY = 0, MinZ = 0, MaxX = 1000, MaxY = 2000, MaxZ = 3000,
+            };
+            if (withBaseBox)
+            {
+                n.BaseMinX = 0; n.BaseMinY = 0; n.BaseMinZ = 0;
+                n.BaseMaxX = 1000; n.BaseMaxY = 2000; n.BaseMaxZ = 3000;
+            }
+            ctx.SceneNodes.Add(n);
+            ctx.SaveChanges();
+        }
+
+        return new World(conn, tenant, project, model, node);
+    }
+
+    private static SceneNodeAabbRefresher NewRefresher(PlanscapeDbContext db)
+        => new(db, NullLogger<SceneNodeAabbRefresher>.Instance);
+
+    private static async Task AddTransformAsync(World w, double tx, double rotDeg = 0, double scale = 1.0)
+    {
+        using var ctx = NewContext(w.Conn, w.Tenant);
+        ctx.ProjectModelTransforms.Add(new ProjectModelTransform
+        {
+            TenantId = w.Tenant, ProjectId = w.Project, ProjectModelId = w.Model,
+            TranslationX = tx, RotationDeg = rotDeg, ScaleFactor = scale,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task<SceneNode> ReadNodeAsync(World w)
+    {
+        using var ctx = NewContext(w.Conn, w.Tenant);
+        return await ctx.SceneNodes.AsNoTracking().SingleAsync();
+    }
+
+    // ── the idempotence that made this safe to call everywhere ──────────────
+
+    [Fact]
+    public async Task Refreshing_twice_gives_the_same_answer_as_once()
+    {
+        // THE regression. The old in-place version transformed an
+        // already-transformed box, so the second call moved the bounds another
+        // 5 m and every subsequent call moved them further.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 5000);
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+            var once = await ReadNodeAsync(w);
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+            var twice = await ReadNodeAsync(w);
+
+            Assert.Equal(once.MinX, twice.MinX, 6);
+            Assert.Equal(once.MaxX, twice.MaxX, 6);
+            Assert.Equal(5000.0, twice.MinX, 6);
+            Assert.Equal(6000.0, twice.MaxX, 6);
+        }
+    }
+
+    [Fact]
+    public async Task The_local_box_is_never_mutated()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 5000);
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+
+            var n = await ReadNodeAsync(w);
+            Assert.Equal(0.0, n.BaseMinX);
+            Assert.Equal(1000.0, n.BaseMaxX);
+        }
+    }
+
+    [Fact]
+    public async Task Removing_the_transform_returns_the_box_to_its_local_position()
+    {
+        // Only possible because the local box survives. The old in-place
+        // version had overwritten it, so a DELETE could never restore anything.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 5000);
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+            Assert.Equal(5000.0, (await ReadNodeAsync(w)).MinX, 6);
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+            {
+                db.ProjectModelTransforms.RemoveRange(db.ProjectModelTransforms);
+                await db.SaveChangesAsync();
+            }
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+
+            var n = await ReadNodeAsync(w);
+            Assert.Equal(0.0, n.MinX, 6);
+            Assert.Equal(1000.0, n.MaxX, 6);
+        }
+    }
+
+    // ── back-compat with rows written before the local box existed ──────────
+
+    [Fact]
+    public async Task A_pre_existing_row_has_its_local_box_captured_on_first_refresh()
+    {
+        var w = NewWorld(withBaseBox: false);
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 5000);
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+
+            var n = await ReadNodeAsync(w);
+            Assert.Equal(0.0, n.BaseMinX);      // captured from the pre-refresh box
+            Assert.Equal(5000.0, n.MinX, 6);    // and the world box moved once
+        }
+    }
+
+    // ── the rotation case that a two-corner shortcut gets wrong ─────────────
+
+    [Fact]
+    public async Task A_rotated_box_encloses_all_eight_transformed_corners()
+    {
+        // Rotating 90° about Z maps (x, y) → (-y, x), so a 1000 x 2000 footprint
+        // becomes 2000 x 1000. Transforming only the min and max corners would
+        // produce min=(-2000, 0) max=(0, 1000) read in the wrong order and give
+        // an inverted, too-small box — which culls geometry that is on screen.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 0, rotDeg: 90);
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+
+            var n = await ReadNodeAsync(w);
+            Assert.Equal(-2000.0, n.MinX, 6);
+            Assert.Equal(0.0, n.MaxX, 6);
+            Assert.Equal(0.0, n.MinY, 6);
+            Assert.Equal(1000.0, n.MaxY, 6);
+            Assert.True(n.MaxX >= n.MinX && n.MaxY >= n.MinY, "the box came out inverted");
+        }
+    }
+
+    [Fact]
+    public async Task Scale_is_applied_before_translation()
+    {
+        // T·R·S — the composition ModelTransformMath documents. If scale were
+        // applied after translation the offset would be scaled too.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            await AddTransformAsync(w, tx: 1000, scale: 2.0);
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewRefresher(db).RefreshAsync(w.Project, w.Model, w.Tenant);
+
+            var n = await ReadNodeAsync(w);
+            Assert.Equal(1000.0, n.MinX, 6);              // 0*2 + 1000
+            Assert.Equal(3000.0, n.MaxX, 6);              // 1000*2 + 1000
+        }
+    }
+
+    [Fact]
+    public async Task A_model_with_no_chunks_is_a_no_op()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            var updated = await NewRefresher(db).RefreshAsync(w.Project, Guid.NewGuid(), w.Tenant);
+            Assert.Equal(0, updated);
+        }
+    }
+}

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -1125,3 +1125,101 @@ northings / height / scale. Three fields were unset or wrong:
 **NOT verified:** extraction against a real `.ifc`. `ifcopenshell` is not a core
 dependency — that is the point of core — so the unit-scale branch and `by_type`
 against a real file remain an environment-gated check.
+
+## 23. Track B / P5 — one translation convention, and fresh chunk bounds (CLOSED)
+
+### The defect: the translation was mirrored
+
+Both automatic writers computed the **negation** of the correct translation. The
+IFC ingest path used `t = -modelOrigin`; `AutoAlignService` used
+`t = referenceOrigin - modelOrigin`.
+
+A model's geometry is authored about its own internal origin, and its
+georeferencing states where that origin sits in the survey CRS. So a physical
+point `S` sits at local coordinate `S - A` in model A. The transform maps local
+to world as `world = t + local`:
+
+```
+t = +A  →  world = A + (S - A) = S        ✓ both models agree on S
+t = -A  →  world = -A + (S - A) = S - 2A  ✗ and B lands at S - 2B
+```
+
+Two models therefore came out **mirrored about the origin** — an east-west pair
+swaps sides. The correct transform is `t = modelSurveyOrigin - projectFrameOrigin`.
+
+**Why the existing "overlay proof" did not catch it.** `ModelTransformMathTests`
+inverts a transform and re-applies *the same* transform, which proves
+`Apply(Inverse(w)) == w` for any transform whatsoever. It proves the math is
+self-consistent — never that the transform was *derived* correctly from survey
+data. `FederationFrameTests` derives it, and asserts the sign explicitly, because
+a magnitude-only check passes against the bug.
+
+### One frame, resolved once
+
+`ModelGeorefWriter` now resolves the project frame in one place, strongest
+evidence first: the declared `ProjectCoordinateSystem` benchmark → the
+coordinator's nominated reference model → zero (raw CRS). The **same** frame is
+subtracted from every model, so relative placement is identical whichever is
+chosen; a site-local frame only buys precision (a site at easting 432 km rendered
+about a zero origin puts geometry where 32-bit float stops resolving
+millimetres).
+
+`AutoAlignService` no longer does its own transform arithmetic — it delegates to
+the same writer, so the two cannot drift. Its old frame ("the most recently
+validated sibling model") is dropped and is now **reporting only**: that origin
+moved every time another model was uploaded, so a transform computed on Monday
+was expressed against a different origin from one computed on Tuesday and the two
+silently disagreed.
+
+The writer returns what it computed **even when it refuses to write** (a
+coordinator-confirmed transform). A refusal that cannot say what the survey data
+implies is useless at exactly the moment the answer matters — and having the
+caller recompute it is how the two implementations drifted apart to begin with.
+
+### The defect: chunk bounds went stale, and could not simply be refreshed
+
+The world-space AABB recompute lived inline in `ModelTransformController.Upsert`
+and had two problems that compounded:
+
+1. **It ran only there.** Both automatic writers moved models without touching
+   the bounds, so the federation manifest described where chunks *used to be*.
+   The viewer culls against those bounds — the symptom is geometry that vanishes
+   when the camera looks straight at it, or streams in nowhere near the frustum.
+2. **It transformed an already-transformed box.** So the obvious fix — call it
+   after every transform write — would have made things *worse*, compounding the
+   transform on each call.
+
+Fixing (2) had to come first. `SceneNode` gains a nullable **local** AABB
+(`BaseMinX`…), so the world box is a pure function of (local, transform) and can
+be recomputed any number of times with the same answer. `SceneNodeAabbRefresher`
+is now called from the manual PUT, the manual DELETE (resetting to identity moves
+the model too) and the shared writer — which covers both automatic paths at once.
+
+Rows written before this have no local box; the refresher captures the current
+values the first time it sees one — correct for a chunk that was never
+transformed, and the best available otherwise. Re-publishing restores truth,
+since ingest now writes both boxes.
+
+### Verification
+
+- **7 frame tests** — true relative offset preserved; the offset is not mirrored
+  (asserted by sign, not magnitude); a point shared by two models maps to one
+  world coordinate; a declared benchmark and a nominated reference model each
+  become the frame; rotation is frame-relative.
+- **7 refresher tests** — refreshing twice equals refreshing once (the
+  regression); the local box is never mutated; removing the transform returns the
+  box to its local position; a pre-existing row has its local box captured; a
+  rotated box encloses all eight transformed corners (a two-corner shortcut
+  produces an inverted, too-small box that culls visible geometry); scale applies
+  before translation.
+- Existing sign expectations in `ModelGeorefWriterTests` and
+  `AutoAlignConfirmedTransformTests` were updated **with the reason recorded in
+  each test**, since they pinned the mirrored behaviour.
+- Schema patch verified on real Postgres 16: idempotent, and a pre-existing row
+  keeps its box with the local box left NULL for first-refresh capture.
+- Full suite **734 passed / 0 failed / 11 skipped**; both web harnesses green;
+  server build 0 errors.
+
+**Behaviour change, stated plainly:** every automatically-placed model moves.
+That is the point — they were mirrored. Coordinator-confirmed transforms are
+untouched, and a re-publish or an auto-align run re-derives the rest.


### PR DESCRIPTION
> **Stacked on #681** (P4) → #680 (P3) → #679 (P2) → #678 (P1) → #676 (Track A). Retarget as those merge.

## The bug: the translation was mirrored

Both automatic writers computed the **negation** of the correct translation. IFC ingest used `t = -modelOrigin`; `AutoAlignService` used `t = referenceOrigin - modelOrigin`.

A model's geometry is authored about its own internal origin, and its georeferencing states where that origin sits in the survey CRS. So a physical point `S` sits at local coordinate `S - A` in model A, and `world = t + local`:

```
t = +A  →  world = A + (S - A) = S         ✓ both models agree on S
t = -A  →  world = -A + (S - A) = S - 2A   ✗ and B lands at S - 2B
```

Two models came out **mirrored about the origin** — an east-west pair swaps sides. Correct: `t = modelSurveyOrigin - projectFrameOrigin`.

### Why the existing "overlay proof" missed it

`ModelTransformMathTests` inverts a transform and re-applies **the same** transform, proving `Apply(Inverse(w)) == w` — true for *any* transform. It proves the math is self-consistent, never that the transform was **derived** correctly from survey data. The new tests derive it, and assert the **sign** explicitly, because a magnitude-only check passes against the bug.

## One frame, resolved once

`ModelGeorefWriter` resolves the project frame in one place — declared `ProjectCoordinateSystem` benchmark → nominated reference model → zero. The **same** frame is subtracted from every model, so relative placement is identical whichever is chosen; a site-local frame only buys precision.

`AutoAlignService` no longer does its own arithmetic — it delegates to the writer, so the two cannot drift. Its old frame ("the most recently validated sibling") is **dropped** and now reporting-only: that origin moved every time another model was uploaded, so transforms computed on different days silently disagreed.

The writer returns what it computed **even when it refuses to write**. A refusal that can't say what the survey data implies is useless at exactly the moment the answer matters — and having the caller recompute it is how the two implementations drifted apart in the first place.

## The bug: chunk bounds went stale — and couldn't simply be refreshed

The AABB recompute lived inline in the manual PUT, with two problems that compounded:

1. **It ran only there.** Both automatic writers left the manifest describing where chunks *used to be*. The viewer culls against those bounds → geometry vanishes when the camera looks straight at it.
2. **It transformed an already-transformed box.** So the obvious fix — "call it after every write" — would have made it **worse**, compounding on each call.

Fixing (2) had to come first. `SceneNode` gains a nullable **local** AABB, so the world box is a pure function of (local, transform) and is recomputable any number of times. The refresher is now called from the manual PUT, the manual DELETE (resetting to identity moves the model too) and the shared writer — covering both automatic paths at once.

## Verification

- **7 frame tests** — relative offset preserved; **not mirrored** (asserted by sign); a point shared by two models maps to one world coordinate; benchmark and nominated reference each become the frame; rotation is frame-relative.
- **7 refresher tests** — refreshing twice equals once (*the* regression); local box never mutated; removing the transform restores the local position; a rotated box encloses **all eight** corners (a two-corner shortcut yields an inverted, too-small box that culls visible geometry); scale applies before translation.
- Existing sign expectations in two files were updated **with the reason recorded in each test** — they pinned the mirrored behaviour.
- Schema patch verified idempotent on **real Postgres 16**.
- Full suite **734 passed / 0 failed / 11 skipped**; both web harnesses green; build 0 errors.

## Behaviour change, stated plainly

**Every automatically-placed model moves.** That is the point — they were mirrored. Coordinator-confirmed transforms are untouched; a re-publish or an auto-align run re-derives the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up (review):** this PR made the stored rotation frame-relative but left the translation on raw CRS-grid axes, so under a rotated project frame two models with different survey origins stop overlaying by `(R(−θ_frame) − I)·(originB − originA)` (~133 m at 30°). Added the missing `R(−θ_frame)` to the translation + a rotated-frame shared-point test (verified RED before, GREEN after; grid-aligned frames unchanged). Full suite 735/0/11.