### PR TITLE
Reliability C1+C2: stop losing geometry deltas, and sync every model category

### DIFF
--- a/StingTools.Clash.Tests/GeometrySyncPlanTests.cs
+++ b/StingTools.Clash.Tests/GeometrySyncPlanTests.cs
@@ -1,0 +1,130 @@
+using System.Linq;
+using StingTools.Core.Clash;
+using Xunit;
+
+namespace StingTools.Clash.Tests;
+
+/// <summary>
+/// TRACK C1/C2 — the queue encoding and the retry rule for Planscape geometry
+/// sync.
+///
+/// WHY THESE TWO THINGS AND NOT THE HANDLER
+/// ----------------------------------------
+/// GeometrySyncHandler is an IExternalEventHandler that needs a UIApplication
+/// and a live Document, so nothing in it is reachable from a pure-logic test
+/// project (this one deliberately does not reference the Revit API). The two
+/// decisions that actually govern whether a change reaches the server are plain
+/// arithmetic over ints, so they were extracted into GeometrySyncPlan and are
+/// pinned here.
+///
+/// NOT COVERED: the handler's ordering (check the project link BEFORE draining),
+/// the re-queue call itself, and the new GeometrySyncUpdater's trigger scope.
+/// Those need Revit. Stated so a green run is not read as proof that a delta
+/// survives a failed upload in a real session.
+///
+/// THE DEFECT THIS GUARDS
+/// ----------------------
+/// The queue packs a deletion as a NEGATED element id. The sign is therefore the
+/// semantics: read it backwards and every deletion becomes an attempt to
+/// tessellate an element that no longer exists, while every edit becomes a
+/// tombstone that erases live geometry from the server.
+/// </summary>
+public class GeometrySyncPlanTests
+{
+    // ── the sign convention ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Positive_ids_are_changes_and_negative_ids_are_deletions()
+    {
+        var (changed, deleted) = GeometrySyncPlan.Partition(new[] { 10, -20, 30, -40 });
+
+        Assert.Equal(new[] { 10, 30 }, changed);
+        // Deletions come back POSITIVE — the sign was encoding, not data.
+        Assert.Equal(new[] { 20, 40 }, deleted);
+    }
+
+    [Fact]
+    public void A_zero_id_is_dropped_rather_than_guessed()
+    {
+        // 0 is not a valid Revit element id. Treating it as "changed" would try
+        // to tessellate nothing; treating it as "deleted" would tombstone
+        // element 0. Neither is right, so it goes nowhere.
+        var (changed, deleted) = GeometrySyncPlan.Partition(new[] { 0, 7 });
+
+        Assert.Equal(new[] { 7 }, changed);
+        Assert.Empty(deleted);
+    }
+
+    [Fact]
+    public void An_empty_or_null_drain_is_empty()
+    {
+        var (c1, d1) = GeometrySyncPlan.Partition(new int[0]);
+        Assert.Empty(c1);
+        Assert.Empty(d1);
+
+        var (c2, d2) = GeometrySyncPlan.Partition(null);
+        Assert.Empty(c2);
+        Assert.Empty(d2);
+    }
+
+    // ── the retry rule ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_retry_set_round_trips_through_the_queue_encoding()
+    {
+        // What goes back on the queue must partition again into what went in —
+        // otherwise a retry silently changes a deletion into an edit.
+        var retry = GeometrySyncPlan.BuildRetrySet(new[] { 10, 30 }, new[] { 20, 40 });
+        var (changed, deleted) = GeometrySyncPlan.Partition(retry);
+
+        Assert.Equal(new[] { 10, 30 }, changed);
+        Assert.Equal(new[] { 20, 40 }, deleted);
+    }
+
+    [Fact]
+    public void Only_extracted_changes_are_retried()
+    {
+        // THE rule. An element whose geometry could not be extracted (deleted
+        // since the edit, no solid, view-specific) is deliberately not retried:
+        // it would fail extraction again on every save, converting one lost
+        // delta into an infinite retry that also drags the genuinely retryable
+        // ids around with it forever.
+        //
+        // Caller drained {10, 20, 30} as changes but only extracted {10, 30}.
+        var retry = GeometrySyncPlan.BuildRetrySet(new[] { 10, 30 }, new int[0]);
+
+        Assert.Equal(new[] { 10, 30 }, retry);
+        Assert.DoesNotContain(20, retry);
+    }
+
+    [Fact]
+    public void Every_deletion_is_retried()
+    {
+        // A tombstone needs no geometry, so nothing can fail to extract — a
+        // deletion that did not reach the server is always worth sending again.
+        // Losing one is the worst case of the three: the element stays visible
+        // in the federated model forever, and a coordinator sees geometry that
+        // no longer exists in the source.
+        var retry = GeometrySyncPlan.BuildRetrySet(new int[0], new[] { 20, 40 });
+
+        Assert.Equal(new[] { -20, -40 }, retry);
+    }
+
+    [Fact]
+    public void Nothing_sendable_means_nothing_to_retry()
+    {
+        Assert.Empty(GeometrySyncPlan.BuildRetrySet(new int[0], new int[0]));
+        Assert.Empty(GeometrySyncPlan.BuildRetrySet(null, null));
+    }
+
+    [Fact]
+    public void Non_positive_inputs_never_reach_the_retry_set()
+    {
+        // Defensive: a negative "changed" id would be re-queued as a deletion,
+        // which would erase the element on the next successful sync.
+        var retry = GeometrySyncPlan.BuildRetrySet(new[] { -5, 0, 7 }, new[] { -3, 0, 9 });
+
+        Assert.Equal(new[] { 7, -9 }, retry);
+        Assert.All(retry, id => Assert.NotEqual(0, id));
+    }
+}

--- a/StingTools.Clash.Tests/GeometrySyncPlanTests.cs
+++ b/StingTools.Clash.Tests/GeometrySyncPlanTests.cs
@@ -14,8 +14,8 @@ namespace StingTools.Clash.Tests;
 /// and a live Document, so nothing in it is reachable from a pure-logic test
 /// project (this one deliberately does not reference the Revit API). The two
 /// decisions that actually govern whether a change reaches the server are plain
-/// arithmetic over ints, so they were extracted into GeometrySyncPlan and are
-/// pinned here.
+/// arithmetic over 64-bit element ids, so they were extracted into
+/// GeometrySyncPlan and are pinned here.
 ///
 /// NOT COVERED: the handler's ordering (check the project link BEFORE draining),
 /// the re-queue call itself, and the new GeometrySyncUpdater's trigger scope.
@@ -36,11 +36,32 @@ public class GeometrySyncPlanTests
     [Fact]
     public void Positive_ids_are_changes_and_negative_ids_are_deletions()
     {
-        var (changed, deleted) = GeometrySyncPlan.Partition(new[] { 10, -20, 30, -40 });
+        var (changed, deleted) = GeometrySyncPlan.Partition(new long[] { 10, -20, 30, -40 });
 
-        Assert.Equal(new[] { 10, 30 }, changed);
+        Assert.Equal(new long[] { 10, 30 }, changed);
         // Deletions come back POSITIVE — the sign was encoding, not data.
-        Assert.Equal(new[] { 20, 40 }, deleted);
+        Assert.Equal(new long[] { 20, 40 }, deleted);
+    }
+
+    [Fact]
+    public void A_large_modified_id_stays_a_change_not_a_tombstone()
+    {
+        // THE 64-bit regression. Revit 2024+ ElementId.Value can exceed
+        // int.MaxValue. The old (int) cast wrapped such an id NEGATIVE, and a
+        // negative id is the deletion sentinel — so a large modified/added
+        // element was mis-split as a tombstone and the server soft-deleted live
+        // geometry the user had just edited. With 64-bit ids it stays positive
+        // (a change), and a genuine deletion of the same id still round-trips as
+        // a tombstone.
+        long big = (long)int.MaxValue + 5;   // wraps to a negative int
+
+        var (changed, deleted) = GeometrySyncPlan.Partition(new[] { big });
+        Assert.Equal(new[] { big }, changed);
+        Assert.Empty(deleted);
+
+        var (c2, d2) = GeometrySyncPlan.Partition(new[] { -big });
+        Assert.Empty(c2);
+        Assert.Equal(new[] { big }, d2);
     }
 
     [Fact]
@@ -49,16 +70,16 @@ public class GeometrySyncPlanTests
         // 0 is not a valid Revit element id. Treating it as "changed" would try
         // to tessellate nothing; treating it as "deleted" would tombstone
         // element 0. Neither is right, so it goes nowhere.
-        var (changed, deleted) = GeometrySyncPlan.Partition(new[] { 0, 7 });
+        var (changed, deleted) = GeometrySyncPlan.Partition(new long[] { 0, 7 });
 
-        Assert.Equal(new[] { 7 }, changed);
+        Assert.Equal(new long[] { 7 }, changed);
         Assert.Empty(deleted);
     }
 
     [Fact]
     public void An_empty_or_null_drain_is_empty()
     {
-        var (c1, d1) = GeometrySyncPlan.Partition(new int[0]);
+        var (c1, d1) = GeometrySyncPlan.Partition(new long[0]);
         Assert.Empty(c1);
         Assert.Empty(d1);
 
@@ -74,11 +95,11 @@ public class GeometrySyncPlanTests
     {
         // What goes back on the queue must partition again into what went in —
         // otherwise a retry silently changes a deletion into an edit.
-        var retry = GeometrySyncPlan.BuildRetrySet(new[] { 10, 30 }, new[] { 20, 40 });
+        var retry = GeometrySyncPlan.BuildRetrySet(new long[] { 10, 30 }, new long[] { 20, 40 });
         var (changed, deleted) = GeometrySyncPlan.Partition(retry);
 
-        Assert.Equal(new[] { 10, 30 }, changed);
-        Assert.Equal(new[] { 20, 40 }, deleted);
+        Assert.Equal(new long[] { 10, 30 }, changed);
+        Assert.Equal(new long[] { 20, 40 }, deleted);
     }
 
     [Fact]
@@ -91,10 +112,10 @@ public class GeometrySyncPlanTests
         // ids around with it forever.
         //
         // Caller drained {10, 20, 30} as changes but only extracted {10, 30}.
-        var retry = GeometrySyncPlan.BuildRetrySet(new[] { 10, 30 }, new int[0]);
+        var retry = GeometrySyncPlan.BuildRetrySet(new long[] { 10, 30 }, new long[0]);
 
-        Assert.Equal(new[] { 10, 30 }, retry);
-        Assert.DoesNotContain(20, retry);
+        Assert.Equal(new long[] { 10, 30 }, retry);
+        Assert.DoesNotContain(20L, retry);
     }
 
     [Fact]
@@ -105,15 +126,15 @@ public class GeometrySyncPlanTests
         // Losing one is the worst case of the three: the element stays visible
         // in the federated model forever, and a coordinator sees geometry that
         // no longer exists in the source.
-        var retry = GeometrySyncPlan.BuildRetrySet(new int[0], new[] { 20, 40 });
+        var retry = GeometrySyncPlan.BuildRetrySet(new long[0], new long[] { 20, 40 });
 
-        Assert.Equal(new[] { -20, -40 }, retry);
+        Assert.Equal(new long[] { -20, -40 }, retry);
     }
 
     [Fact]
     public void Nothing_sendable_means_nothing_to_retry()
     {
-        Assert.Empty(GeometrySyncPlan.BuildRetrySet(new int[0], new int[0]));
+        Assert.Empty(GeometrySyncPlan.BuildRetrySet(new long[0], new long[0]));
         Assert.Empty(GeometrySyncPlan.BuildRetrySet(null, null));
     }
 
@@ -122,9 +143,9 @@ public class GeometrySyncPlanTests
     {
         // Defensive: a negative "changed" id would be re-queued as a deletion,
         // which would erase the element on the next successful sync.
-        var retry = GeometrySyncPlan.BuildRetrySet(new[] { -5, 0, 7 }, new[] { -3, 0, 9 });
+        var retry = GeometrySyncPlan.BuildRetrySet(new long[] { -5, 0, 7 }, new long[] { -3, 0, 9 });
 
-        Assert.Equal(new[] { 7, -9 }, retry);
-        Assert.All(retry, id => Assert.NotEqual(0, id));
+        Assert.Equal(new long[] { 7, -9 }, retry);
+        Assert.All(retry, id => Assert.NotEqual(0L, id));
     }
 }

--- a/StingTools.Clash.Tests/StingTools.Clash.Tests.csproj
+++ b/StingTools.Clash.Tests/StingTools.Clash.Tests.csproj
@@ -32,6 +32,7 @@
          LiveClash*, ClashSession, ClashScheduler, ClashKernel, ClashRun/BcfExport
          commands) since they are Revit-bound. -->
     <Compile Include="..\StingTools\Clash\ClashMeshBuffer.cs"      Link="Clash\ClashMeshBuffer.cs" />
+    <Compile Include="..\StingTools\Clash\GeometrySyncPlan.cs"    Link="Clash\GeometrySyncPlan.cs" />
     <Compile Include="..\StingTools\Clash\MollerSat.cs"            Link="Clash\MollerSat.cs" />
     <Compile Include="..\StingTools\Clash\ObbTree.cs"              Link="Clash\ObbTree.cs" />
     <Compile Include="..\StingTools\Clash\AabbSweep.cs"            Link="Clash\AabbSweep.cs" />

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -1504,7 +1504,7 @@ public sealed partial class PlanscapeServerClient : IDisposable
     /// deletedElementIds are tombstoned on the server.
     /// Uses <see cref="CurrentProjectId"/> — silently no-ops if not set.
     /// </summary>
-    public async Task<bool> PostGeometryDeltaAsync(byte[] glbBytes, IList<int> deletedElementIds)
+    public async Task<bool> PostGeometryDeltaAsync(byte[] glbBytes, IList<long> deletedElementIds)
     {
         if (CurrentProjectId == Guid.Empty) return false;
         if (!await EnsureAuthenticatedAsync()) return false;

--- a/StingTools/Clash/GeometrySyncPlan.cs
+++ b/StingTools/Clash/GeometrySyncPlan.cs
@@ -4,7 +4,8 @@
 // IExternalEventHandler that needs a UIApplication and a Document, so nothing in
 // it is reachable from the pure-logic test projects; but the two decisions that
 // actually govern whether a change reaches the server — how the queue encoding
-// is read, and which ids are worth retrying — are plain arithmetic over ints.
+// is read, and which ids are worth retrying — are plain arithmetic over 64-bit
+// element ids.
 using System.Collections.Generic;
 
 namespace StingTools.Core.Clash
@@ -13,8 +14,11 @@ namespace StingTools.Core.Clash
     /// The queue encoding and the retry rule for Planscape geometry sync.
     ///
     /// <para><b>The encoding.</b> <c>LiveClashUpdater.GeometrySyncQueue</c>
-    /// carries a single int per change: positive means "this element was added
-    /// or modified", negative means "this element was deleted". Packing a
+    /// carries a single 64-bit id per change: positive means "this element was
+    /// added or modified", negative means "this element was deleted". A 64-bit id
+    /// is deliberate — Revit 2024+ element ids can exceed <c>int.MaxValue</c>, and
+    /// truncating one to <c>int</c> could wrap it negative and flip an edit into a
+    /// deletion. Packing a
     /// deletion as a negated id keeps one queue and one drain, but it means the
     /// sign IS the semantics — read it backwards and every deletion becomes an
     /// attempt to tessellate an element that no longer exists, while every edit
@@ -27,13 +31,13 @@ namespace StingTools.Core.Clash
         /// ids to tombstone. Both come back POSITIVE — the sign is queue
         /// encoding, not data.
         /// </summary>
-        public static (List<int> Changed, List<int> Deleted) Partition(IEnumerable<int> drained)
+        public static (List<long> Changed, List<long> Deleted) Partition(IEnumerable<long> drained)
         {
-            var changed = new List<int>();
-            var deleted = new List<int>();
+            var changed = new List<long>();
+            var deleted = new List<long>();
             if (drained == null) return (changed, deleted);
 
-            foreach (int id in drained)
+            foreach (long id in drained)
             {
                 if (id < 0) deleted.Add(-id);
                 else if (id > 0) changed.Add(id);
@@ -57,14 +61,14 @@ namespace StingTools.Core.Clash
         /// <para>Deletions are always retryable: a tombstone needs no geometry,
         /// so there is nothing that can fail to extract.</para>
         /// </summary>
-        public static List<int> BuildRetrySet(
-            IEnumerable<int> extractedChangedIds, IEnumerable<int> deletedIds)
+        public static List<long> BuildRetrySet(
+            IEnumerable<long> extractedChangedIds, IEnumerable<long> deletedIds)
         {
-            var retry = new List<int>();
+            var retry = new List<long>();
             if (extractedChangedIds != null)
-                foreach (int id in extractedChangedIds) if (id > 0) retry.Add(id);
+                foreach (long id in extractedChangedIds) if (id > 0) retry.Add(id);
             if (deletedIds != null)
-                foreach (int id in deletedIds) if (id > 0) retry.Add(-id);
+                foreach (long id in deletedIds) if (id > 0) retry.Add(-id);
             return retry;
         }
     }

--- a/StingTools/Clash/GeometrySyncPlan.cs
+++ b/StingTools/Clash/GeometrySyncPlan.cs
@@ -1,0 +1,71 @@
+// GeometrySyncPlan.cs — the Revit-free decisions inside geometry sync.
+//
+// Extracted so they can be tested. GeometrySyncHandler itself is an
+// IExternalEventHandler that needs a UIApplication and a Document, so nothing in
+// it is reachable from the pure-logic test projects; but the two decisions that
+// actually govern whether a change reaches the server — how the queue encoding
+// is read, and which ids are worth retrying — are plain arithmetic over ints.
+using System.Collections.Generic;
+
+namespace StingTools.Core.Clash
+{
+    /// <summary>
+    /// The queue encoding and the retry rule for Planscape geometry sync.
+    ///
+    /// <para><b>The encoding.</b> <c>LiveClashUpdater.GeometrySyncQueue</c>
+    /// carries a single int per change: positive means "this element was added
+    /// or modified", negative means "this element was deleted". Packing a
+    /// deletion as a negated id keeps one queue and one drain, but it means the
+    /// sign IS the semantics — read it backwards and every deletion becomes an
+    /// attempt to tessellate an element that no longer exists, while every edit
+    /// becomes a tombstone that erases live geometry from the server.</para>
+    /// </summary>
+    public static class GeometrySyncPlan
+    {
+        /// <summary>
+        /// Split drained queue entries into element ids to re-export and element
+        /// ids to tombstone. Both come back POSITIVE — the sign is queue
+        /// encoding, not data.
+        /// </summary>
+        public static (List<int> Changed, List<int> Deleted) Partition(IEnumerable<int> drained)
+        {
+            var changed = new List<int>();
+            var deleted = new List<int>();
+            if (drained == null) return (changed, deleted);
+
+            foreach (int id in drained)
+            {
+                if (id < 0) deleted.Add(-id);
+                else if (id > 0) changed.Add(id);
+                // 0 is not a valid Revit element id; drop it rather than
+                // tessellating nothing or tombstoning everything.
+            }
+            return (changed, deleted);
+        }
+
+        /// <summary>
+        /// The ids to put back on the queue when an upload fails, in queue
+        /// encoding (negative = deletion).
+        ///
+        /// <para><b>Only what was actually sendable.</b> A changed element whose
+        /// geometry could not be extracted — deleted since the edit, no solid,
+        /// view-specific — is deliberately NOT retried. It would fail extraction
+        /// again on every subsequent save, so re-queueing it converts a lost
+        /// delta into an infinite one that also drags the genuinely retryable
+        /// ids around with it forever.</para>
+        ///
+        /// <para>Deletions are always retryable: a tombstone needs no geometry,
+        /// so there is nothing that can fail to extract.</para>
+        /// </summary>
+        public static List<int> BuildRetrySet(
+            IEnumerable<int> extractedChangedIds, IEnumerable<int> deletedIds)
+        {
+            var retry = new List<int>();
+            if (extractedChangedIds != null)
+                foreach (int id in extractedChangedIds) if (id > 0) retry.Add(id);
+            if (deletedIds != null)
+                foreach (int id in deletedIds) if (id > 0) retry.Add(-id);
+            return retry;
+        }
+    }
+}

--- a/StingTools/Clash/GeometrySyncUpdater.cs
+++ b/StingTools/Clash/GeometrySyncUpdater.cs
@@ -1,0 +1,112 @@
+// GeometrySyncUpdater.cs — the IUpdater that feeds Planscape geometry sync.
+//
+// CRITICAL: never throws. Never starts a transaction. All real work is deferred
+// to GeometrySyncHandler via an ExternalEvent on document save.
+using System;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+
+namespace StingTools.Core.Clash
+{
+    /// <summary>
+    /// C2 — geometry sync gets its own updater, over every model category,
+    /// independent of clash detection.
+    ///
+    /// <para><b>What was wrong.</b> <see cref="LiveClashUpdater"/> was the sole
+    /// producer for <see cref="LiveClashUpdater.GeometrySyncQueue"/>, and its
+    /// trigger covers the nine categories CLASH cares about: ducts, pipes, cable
+    /// tray, conduit, walls, floors, ceilings, structural framing and columns.
+    /// Doors, windows, mechanical equipment, plumbing and lighting fixtures,
+    /// furniture, specialty equipment, generic models, stairs, railings, roofs
+    /// and curtain panels therefore never reached the server automatically — a
+    /// coordinator could move every door in the building and the federated model
+    /// would not change. Worse, the clash trigger is opt-out
+    /// (<c>LIVE_CLASH_TRIGGERS_ENABLED=false</c>), so a project that turned off
+    /// clash triggers silently turned off ALL geometry sync while tag sync kept
+    /// flowing — the model looked connected and was not.</para>
+    ///
+    /// <para><b>Why a separate updater rather than a wider clash filter.</b>
+    /// Widening the clash trigger would drag every door and chair into clash
+    /// re-checks, which is a different feature with different performance
+    /// characteristics and a different opt-out. The two consumers want different
+    /// scopes, so they get their own triggers.</para>
+    ///
+    /// <para><b>Scope.</b> All non-type, non-view-specific elements —
+    /// "everything in the model that has a physical presence". Enqueueing is
+    /// O(1) per changed element and the expensive part (tessellation and
+    /// upload) happens once per document save, so the broad trigger costs a
+    /// queue push per edit rather than per-edit geometry work.</para>
+    /// </summary>
+    public sealed class GeometrySyncUpdater : IUpdater
+    {
+        // Distinct from LiveClashUpdater's id — two updaters, two triggers, two
+        // lifecycles. Reusing the id would make one registration silently
+        // replace the other.
+        public static readonly UpdaterId UpdaterGuid = new UpdaterId(
+            new AddInId(new Guid("3C9A4E2D-5F7B-4A12-9B8F-C1D2E3F4A5B6")),
+            new Guid("7E1B5C34-9A26-4D8F-B0E7-2F5A6C8D9E01"));
+
+        public UpdaterId GetUpdaterId() => UpdaterGuid;
+        public string GetUpdaterName() => "STING Geometry Sync Updater";
+        public string GetAdditionalInformation() => "Queues changed model elements for Planscape geometry sync.";
+        public ChangePriority GetChangePriority() => ChangePriority.MEPAccessoriesFittingsSegmentsWires;
+
+        public void Execute(UpdaterData data)
+        {
+            try
+            {
+                var doc = data.GetDocument();
+                string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
+
+                foreach (var id in data.GetModifiedElementIds())
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
+                foreach (var id in data.GetAddedElementIds())
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
+                // Negative id is the tombstone sentinel the handler splits on.
+                foreach (var id in data.GetDeletedElementIds())
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, -(int)id.Value));
+            }
+            catch (Exception ex)
+            {
+                // An updater that throws is disabled by Revit for the session,
+                // which would silently stop all geometry sync.
+                StingLog.Error("GeometrySyncUpdater.Execute swallowed", ex);
+            }
+        }
+
+        /// <summary>
+        /// Register the updater and attach triggers. Deliberately NOT gated on
+        /// <c>LIVE_CLASH_TRIGGERS_ENABLED</c>: that flag turns off clash
+        /// detection, and turning off clash detection must not silently stop the
+        /// federated model from updating.
+        /// </summary>
+        public static void Register(UIControlledApplication uiApp)
+        {
+            try
+            {
+                UpdaterRegistry.RegisterUpdater(new GeometrySyncUpdater());
+
+                // Every model element instance: not an ElementType, and not
+                // owned by a view (which excludes annotation, tags, dimensions
+                // and other view-specific graphics that carry no model
+                // geometry). Expressed as filters rather than a category list so
+                // it cannot drift out of date as categories are added — a list
+                // is exactly how the clash trigger ended up missing doors.
+                var modelInstances = new LogicalAndFilter(
+                    new ElementIsElementTypeFilter(true),                 // inverted: instances only
+                    new ElementOwnerViewFilter(ElementId.InvalidElementId));
+
+                UpdaterRegistry.AddTrigger(UpdaterGuid, modelInstances, Element.GetChangeTypeGeometry());
+                UpdaterRegistry.AddTrigger(UpdaterGuid, modelInstances, Element.GetChangeTypeElementAddition());
+                UpdaterRegistry.AddTrigger(UpdaterGuid, modelInstances, Element.GetChangeTypeElementDeletion());
+
+                StingLog.Info("GeometrySyncUpdater registered over all model categories.");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("GeometrySyncUpdater.Register failed", ex);
+            }
+        }
+    }
+}

--- a/StingTools/Clash/GeometrySyncUpdater.cs
+++ b/StingTools/Clash/GeometrySyncUpdater.cs
@@ -59,13 +59,18 @@ namespace StingTools.Core.Clash
                 var doc = data.GetDocument();
                 string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
 
+                // id.Value is a 64-bit ElementId (Revit 2024+). Enqueue the full
+                // long: the old (int) cast wrapped a large id negative, and the
+                // handler reads a negative id as a delete tombstone — so a large
+                // modified/added element was mis-split as a deletion and the
+                // server soft-deleted live geometry the user had just edited.
                 foreach (var id in data.GetModifiedElementIds())
-                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, id.Value));
                 foreach (var id in data.GetAddedElementIds())
-                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, id.Value));
                 // Negative id is the tombstone sentinel the handler splits on.
                 foreach (var id in data.GetDeletedElementIds())
-                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, -(int)id.Value));
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, -id.Value));
             }
             catch (Exception ex)
             {

--- a/StingTools/Clash/LiveClashUpdater.cs
+++ b/StingTools/Clash/LiveClashUpdater.cs
@@ -21,6 +21,13 @@ namespace StingTools.Core.Clash
         // Parallel queue consumed by GeometrySyncHandler (delta geometry push to Planscape).
         // Kept separate from DirtyQueue so clash detection and geometry sync can drain
         // independently at their own rates without racing on the same queue.
+        //
+        // C2 - PRODUCED BY GeometrySyncUpdater, not by this class. It lives here
+        // because DrainGeometrySyncIds and the handler already reference it and
+        // moving it would churn call sites for no behavioural gain; but this
+        // updater no longer writes to it. Clash covers nine categories, geometry
+        // sync covers all of them, and conflating the two is what made doors and
+        // equipment invisible to the server.
         public static readonly ConcurrentQueue<(string DocGuid, int ElementId)> GeometrySyncQueue =
             new ConcurrentQueue<(string, int)>();
 
@@ -58,22 +65,18 @@ namespace StingTools.Core.Clash
                 var doc = data.GetDocument();
                 string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
                 // ElementId.IntegerValue is obsolete in Revit 2024+; use Value (Int64).
+                // C2 - this updater feeds CLASH only. It no longer pushes to
+                // GeometrySyncQueue: GeometrySyncUpdater owns that queue and
+                // covers every model category, whereas this trigger covers the
+                // nine categories clash cares about. Enqueuing from both would
+                // simply duplicate work for those nine.
                 foreach (var id in data.GetModifiedElementIds())
-                {
                     DirtyQueue.Enqueue((docGuid, (int)id.Value));
-                    GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
-                }
                 foreach (var id in data.GetAddedElementIds())
-                {
                     DirtyQueue.Enqueue((docGuid, (int)id.Value));
-                    GeometrySyncQueue.Enqueue((docGuid, (int)id.Value));
-                }
                 // Deleted elements: pushed with -1 sentinel to trigger removal from BVH.
                 foreach (var id in data.GetDeletedElementIds())
-                {
                     DirtyQueue.Enqueue((docGuid, -(int)id.Value));
-                    GeometrySyncQueue.Enqueue((docGuid, -(int)id.Value));
-                }
             }
             catch (Exception ex)
             {

--- a/StingTools/Clash/LiveClashUpdater.cs
+++ b/StingTools/Clash/LiveClashUpdater.cs
@@ -28,20 +28,20 @@ namespace StingTools.Core.Clash
         // updater no longer writes to it. Clash covers nine categories, geometry
         // sync covers all of them, and conflating the two is what made doors and
         // equipment invisible to the server.
-        public static readonly ConcurrentQueue<(string DocGuid, int ElementId)> GeometrySyncQueue =
-            new ConcurrentQueue<(string, int)>();
+        public static readonly ConcurrentQueue<(string DocGuid, long ElementId)> GeometrySyncQueue =
+            new ConcurrentQueue<(string, long)>();
 
         /// <summary>
         /// Drain all geometry-sync entries that belong to <paramref name="doc"/>.
         /// Items for other documents are re-enqueued so they aren't lost.
         /// Returns element IDs (positive = changed, negative = deleted sentinel).
         /// </summary>
-        public static List<int> DrainGeometrySyncIds(Document doc)
+        public static List<long> DrainGeometrySyncIds(Document doc)
         {
-            if (doc == null) return new System.Collections.Generic.List<int>();
+            if (doc == null) return new System.Collections.Generic.List<long>();
             string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
-            var result   = new System.Collections.Generic.List<int>();
-            var requeue  = new System.Collections.Generic.List<(string, int)>();
+            var result   = new System.Collections.Generic.List<long>();
+            var requeue  = new System.Collections.Generic.List<(string, long)>();
             while (GeometrySyncQueue.TryDequeue(out var item))
             {
                 if (string.Equals(item.DocGuid, docGuid, StringComparison.Ordinal))

--- a/StingTools/Commands/IFC/GeometrySyncHandler.cs
+++ b/StingTools/Commands/IFC/GeometrySyncHandler.cs
@@ -64,57 +64,137 @@ namespace StingTools.Commands.IFC
                 var doc = app?.ActiveUIDocument?.Document;
                 if (doc == null || doc.IsFamilyDocument) return;
 
+                // C1 - CHECK BEFORE DRAINING.
+                //
+                // Draining is destructive: the ids leave the queue and the only
+                // other copy is the local list below. PostGeometryDeltaAsync
+                // returns false immediately when CurrentProjectId is unset, so
+                // draining first meant every edit made before the document was
+                // linked to a project was silently and permanently discarded -
+                // no error, no retry, and the model on the server just quietly
+                // stopped matching the model in Revit.
+                var client = StingTools.BIMManager.PlanscapeServerClient.Instance;
+                if (client == null || !client.IsConnected)
+                {
+                    StingLog.Info("GeometrySyncHandler: not connected - leaving changes queued for the next save.");
+                    return;
+                }
+                if (client.CurrentProjectId == Guid.Empty)
+                {
+                    StingLog.Info(
+                        "GeometrySyncHandler: this document is not linked to a Planscape project - " +
+                        "leaving changes queued. Publish the model or link the project to start syncing.");
+                    return;
+                }
+
                 var dirtyIds = LiveClashUpdater.DrainGeometrySyncIds(doc);
                 if (dirtyIds.Count == 0) return;
 
-                // Separate additions/modifications from deletions
-                var changedIds = new List<int>();
-                var deletedIds = new List<int>();
-                foreach (int id in dirtyIds)
-                {
-                    if (id < 0) deletedIds.Add(-id);
-                    else        changedIds.Add(id);
-                }
+                // Separate additions/modifications from deletions. The sign IS
+                // the semantics (see GeometrySyncPlan), so it lives in one
+                // tested place rather than being re-derived here.
+                var (changedIds, deletedIds) = GeometrySyncPlan.Partition(dirtyIds);
 
                 // Extract mesh geometry on the Revit API thread (required)
                 var buffers = new List<ClashMeshBuffer>(changedIds.Count);
+                var extractedIds = new List<int>(changedIds.Count);
                 string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
                 foreach (int eid in changedIds)
                 {
                     var buf = TryExtractElement(doc, eid, docGuid);
-                    if (buf != null) buffers.Add(buf);
+                    if (buf != null) { buffers.Add(buf); extractedIds.Add(eid); }
                 }
+                // Only what was actually sendable is worth retrying — an element
+                // that cannot be tessellated would fail again on every save.
+                var attemptedIds = GeometrySyncPlan.BuildRetrySet(extractedIds, deletedIds);
 
                 StingLog.Info($"GeometrySyncHandler: {buffers.Count} changed, {deletedIds.Count} deleted");
 
                 if (buffers.Count == 0 && deletedIds.Count == 0) return;
 
-                // Fire-and-forget: serialise + HTTP off the Revit API thread
+                // Serialise + HTTP off the Revit API thread. Still detached from
+                // the API thread (it must be), but no longer fire-and-FORGET:
+                // the result decides whether the drained ids are dropped or put
+                // back.
                 var capturedBuffers  = buffers;
                 var capturedDeleted  = deletedIds;
+                var capturedAttempts = attemptedIds;
+                var capturedDocGuid  = docGuid;
                 _ = Task.Run(async () =>
                 {
+                    bool delivered = false;
+                    string reason = "unknown";
                     try
                     {
                         byte[] glb = capturedBuffers.Count > 0
                             ? GlbSerializer.Serialize(capturedBuffers)
                             : Array.Empty<byte>();
 
-                        var client = StingTools.BIMManager.PlanscapeServerClient.Instance;
-                        if (client == null || !client.IsConnected) return;
-
-                        await client.PostGeometryDeltaAsync(glb, capturedDeleted);
-                        StingLog.Info($"GeometrySyncHandler: delta uploaded ({glb.Length / 1024} kB, {capturedDeleted.Count} tombstones)");
+                        var c = StingTools.BIMManager.PlanscapeServerClient.Instance;
+                        if (c == null || !c.IsConnected)
+                        {
+                            reason = "connection dropped before the upload started";
+                        }
+                        else
+                        {
+                            // C1 - the return value was previously discarded, so
+                            // a non-2xx, an expired token or an unset project id
+                            // all looked identical to success.
+                            delivered = await c.PostGeometryDeltaAsync(glb, capturedDeleted);
+                            if (delivered)
+                                StingLog.Info($"GeometrySyncHandler: delta uploaded ({glb.Length / 1024} kB, {capturedDeleted.Count} tombstones)");
+                            else
+                                reason = c.LastError ?? "server rejected the delta";
+                        }
                     }
                     catch (Exception ex)
                     {
-                        StingLog.Warn($"GeometrySyncHandler background upload: {ex.Message}");
+                        reason = ex.Message;
                     }
+
+                    if (!delivered) RequeueForRetry(capturedDocGuid, capturedAttempts, reason);
                 });
             }
             catch (Exception ex)
             {
                 StingLog.Error("GeometrySyncHandler.Execute", ex);
+            }
+        }
+
+        /// <summary>
+        /// C1 - put drained ids back so the next save retries them.
+        ///
+        /// <para>Without this a failed upload was terminal: the ids had already
+        /// left the queue, the task's result was discarded, and the elements
+        /// were never considered again. The Revit model and the server model
+        /// diverged permanently, and nothing anywhere said so - the next edit to
+        /// a DIFFERENT element would sync fine, which makes the gap look like it
+        /// never happened.</para>
+        ///
+        /// <para>Re-queued rather than retried in a loop on purpose: the trigger
+        /// is a document save, so the natural retry is the next one. A tight
+        /// retry loop here would hammer an unreachable server from a background
+        /// thread with no backoff and no way for the user to stop it.</para>
+        /// </summary>
+        private static void RequeueForRetry(string docGuid, List<int> elementIds, string reason)
+        {
+            try
+            {
+                if (elementIds == null || elementIds.Count == 0) return;
+                foreach (int id in elementIds)
+                    LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, id));
+
+                StingLog.Warn(
+                    $"GeometrySyncHandler: delta upload failed ({reason}) - " +
+                    $"{elementIds.Count} element(s) re-queued and will retry on the next save.");
+            }
+            catch (Exception ex)
+            {
+                // If even the re-queue fails the changes really are lost, so say
+                // so loudly rather than letting it read as a delivered delta.
+                StingLog.Error(
+                    $"GeometrySyncHandler: delta upload failed AND {elementIds?.Count ?? 0} element(s) " +
+                    "could not be re-queued - these changes will not reach the server.", ex);
             }
         }
 

--- a/StingTools/Commands/IFC/GeometrySyncHandler.cs
+++ b/StingTools/Commands/IFC/GeometrySyncHandler.cs
@@ -97,9 +97,9 @@ namespace StingTools.Commands.IFC
 
                 // Extract mesh geometry on the Revit API thread (required)
                 var buffers = new List<ClashMeshBuffer>(changedIds.Count);
-                var extractedIds = new List<int>(changedIds.Count);
+                var extractedIds = new List<long>(changedIds.Count);
                 string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
-                foreach (int eid in changedIds)
+                foreach (long eid in changedIds)
                 {
                     var buf = TryExtractElement(doc, eid, docGuid);
                     if (buf != null) { buffers.Add(buf); extractedIds.Add(eid); }
@@ -176,12 +176,12 @@ namespace StingTools.Commands.IFC
         /// retry loop here would hammer an unreachable server from a background
         /// thread with no backoff and no way for the user to stop it.</para>
         /// </summary>
-        private static void RequeueForRetry(string docGuid, List<int> elementIds, string reason)
+        private static void RequeueForRetry(string docGuid, List<long> elementIds, string reason)
         {
             try
             {
                 if (elementIds == null || elementIds.Count == 0) return;
-                foreach (int id in elementIds)
+                foreach (long id in elementIds)
                     LiveClashUpdater.GeometrySyncQueue.Enqueue((docGuid, id));
 
                 StingLog.Warn(
@@ -200,11 +200,11 @@ namespace StingTools.Commands.IFC
 
         // ── Per-element tessellation ─────────────────────────────────────────
 
-        private static ClashMeshBuffer TryExtractElement(Document doc, int elementId, string docGuid)
+        private static ClashMeshBuffer TryExtractElement(Document doc, long elementId, string docGuid)
         {
             try
             {
-                var el = doc.GetElement(new ElementId((long)elementId));
+                var el = doc.GetElement(new ElementId(elementId));
                 if (el == null || el.Category == null) return null;
 
                 var opts = new Options

--- a/StingTools/Commands/IFC/IFC_PushModelCommand.cs
+++ b/StingTools/Commands/IFC/IFC_PushModelCommand.cs
@@ -110,7 +110,7 @@ namespace StingTools.Commands.IFC
                     byte[] glb = GlbSerializer.Serialize(buffers);
                     StingLog.Info($"IFC_PushModel: GLB serialised ({glb.Length / 1024:N0} kB), uploading…");
 
-                    bool ok = await client.PostGeometryDeltaAsync(glb, System.Array.Empty<int>());
+                    bool ok = await client.PostGeometryDeltaAsync(glb, System.Array.Empty<long>());
                     StingLog.Info(ok
                         ? $"IFC_PushModel: geometry upload succeeded ({glb.Length / 1024:N0} kB)"
                         : $"IFC_PushModel: geometry upload failed — {client.LastError}");

--- a/StingTools/Core/StingToolsApp.cs
+++ b/StingTools/Core/StingToolsApp.cs
@@ -202,6 +202,11 @@ namespace StingTools.Core
                 // use clash detection opt out via LIVE_CLASH_TRIGGERS_ENABLED=false
                 // in project_config.json.
                 LiveClashUpdater.Register(application);
+                // C2 - geometry sync has its own updater over ALL model
+                // categories. Registered separately (and unconditionally) so
+                // turning off clash triggers cannot silently stop the federated
+                // model from receiving changes.
+                GeometrySyncUpdater.Register(application);
 
                 // Register the SLD sync updater (IUpdater) — starts disabled. The
                 // SLD panel's "live sync" toggle writes sld_sync_enabled; without


### PR DESCRIPTION
> **Stacked on #683** (Track B) → … → #676. Retarget as those merge. First of Track C.

Two defects in the Revit geometry-delta pipeline. Both fail **silently** and present as *"the server's model just isn't the same as mine."*

## C1 — a failed delta was permanently lost

`GeometrySyncHandler` drained the change queue and then fired the upload as a **discard-result** `Task.Run`.

Draining is destructive: the ids leave the queue and the only other copy is a local list. `PostGeometryDeltaAsync` returns `false` immediately when `CurrentProjectId` is unset, and also on a non-2xx or an idle-expired token — and **the result was thrown away**, so all three looked exactly like success. The elements were never considered again; the Revit model and the server model diverged permanently, and nothing said so. The next edit to a *different* element would sync fine, which makes the gap look like it never happened.

Now: the project link is checked **before** draining; the upload's result is read; on failure the ids go back for the next save.

Re-queued rather than retried in a loop **on purpose** — the trigger is a document save, so the natural retry is the next one; a tight loop would hammer an unreachable server from a background thread with no backoff and no way to stop it.

**Only what was actually sendable is retried.** An element whose geometry can't be extracted (deleted since the edit, no solid, view-specific) would fail extraction again every save — converting one lost delta into an *infinite* retry that drags the genuinely retryable ids along forever. **Deletions are always retried:** a tombstone needs no geometry, and a lost one is the worst case — the element stays visible in the federated model forever.

## C2 — only nine categories ever synced

`LiveClashUpdater` was the sole producer for `GeometrySyncQueue`, and its trigger covers the nine categories **clash** cares about. Doors, windows, mechanical equipment, plumbing and lighting fixtures, furniture, specialty equipment, generic models, stairs, railings, roofs, curtain panels → **never reached the server automatically.** A coordinator could move every door in the building and the federated model would not change.

Worse: the clash trigger is **opt-out**, so a project with `LIVE_CLASH_TRIGGERS_ENABLED=false` silently turned off *all* geometry sync while tag sync kept flowing — the model looked connected and was not.

Geometry sync now has its **own** updater over every model element instance — expressed as **filters** (not an `ElementType`, not owned by a view) rather than a category list, *because a list is exactly how the clash trigger ended up missing doors*. It registers unconditionally, so turning off clash detection can't stop the federated model updating. `LiveClashUpdater` no longer double-produces.

## Testing — and its honest limit

`GeometrySyncHandler` is an `IExternalEventHandler` needing a `UIApplication` and a live `Document`, so it's unreachable from the pure-logic test projects. The two decisions that actually govern whether a change reaches the server — the queue's **sign encoding** and the **retry rule** — were extracted into `GeometrySyncPlan` and pinned by **8 tests**, including:

- the retry set **round-trips** through the encoding (otherwise a retry silently turns a deletion into an edit);
- a negative "changed" id can **never** reach the retry set (it would *erase* the element on the next successful sync).

**NOT covered:** the handler's ordering (check the link before draining), the re-queue call itself, and the new updater's trigger scope — all need Revit. A green run is **not** proof that a delta survives a failed upload in a real session.

## Build / test

- Plugin against the Revit 2025 API: **0 errors, 0 warnings**
- `StingTools.Clash.Tests`: **71 passed, 1 failed** — `DuplicateLiveClashUpdater_FileIsRemoved`, which is **pre-existing on `origin/main`** (CLAUDE.md tracks it as #596) and untouched here. Verified with `git cat-file -e origin/main:…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)