### PR TITLE
Reliability C3: propagate deletions from hosts that push full exports

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/IfcController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/IfcController.cs
@@ -47,12 +47,18 @@ public class IfcController : ControllerBase
     private readonly PlanscapeDbContext _db;
     private readonly IIdentityResolverService _identity;
     private readonly IIfcIngestService _ingest;
+    private readonly ILogger<IfcController> _logger;
 
-    public IfcController(PlanscapeDbContext db, IIdentityResolverService identity, IIfcIngestService ingest)
+    public IfcController(
+        PlanscapeDbContext db,
+        IIdentityResolverService identity,
+        IIfcIngestService ingest,
+        ILogger<IfcController> logger)
     {
         _db = db;
         _identity = identity;
         _ingest = ingest;
+        _logger = logger;
     }
 
     /// <summary>
@@ -70,7 +76,14 @@ public class IfcController : ControllerBase
         // Admin/Owner) may ingest into it — mirrors IfcIngestController/tagsync.
         if (await this.RequireProjectMemberAsync(_db, projectId) is { } denied) return denied;
         if (request is null) return BadRequest("missing body");
-        if (request.Elements is null || request.Elements.Count == 0)
+
+        // C3 — a push may legitimately carry ONLY removals: a save whose sole
+        // change was deleting elements has nothing to upsert. Rejecting that as
+        // "Elements is empty" would drop exactly the deletions this exists to
+        // deliver.
+        bool hasElements = request.Elements is { Count: > 0 };
+        bool hasRemovals = request.RemovedGlobalIds is { Count: > 0 };
+        if (!hasElements && !hasRemovals)
             return BadRequest("Elements is empty");
 
         var host = MappingHosts.Normalize(request.Host);
@@ -86,8 +99,73 @@ public class IfcController : ControllerBase
 
         // Ingest (ExternalElementMapping upsert + TaggedElement projection) is
         // owned by IIfcIngestService so TagSync + ArchiCAD feed the same path.
-        var response = await _ingest.IngestAsync(tenantId, projectId, request);
-        return Ok(response);
+        var response = hasElements
+            ? await _ingest.IngestAsync(tenantId, projectId, request)
+            : new IfcIngestResponse();
+
+        int removed = 0;
+        if (hasRemovals)
+            removed = await ApplyRemovalsAsync(tenantId, projectId, host, request);
+
+        return Ok(response with { Removed = removed });
+    }
+
+    /// <summary>
+    /// C3 — soft-delete elements this host document no longer contains.
+    ///
+    /// <para><b>Soft, not hard.</b> TaggedElement is ISoftDeletable and carries
+    /// tag history, issues and clash references; hard-deleting would break those
+    /// and make an accidental deletion in the authoring tool unrecoverable. The
+    /// global query filter hides <c>DeletedAtUtc != null</c> rows from every read
+    /// path, so a tombstoned element stops rendering and stops answering queries
+    /// — which is the observable behaviour that was missing.</para>
+    ///
+    /// <para><b>Scoped to the reporting host document.</b> Only elements this
+    /// document contributed can be removed, resolved through
+    /// ExternalElementMapping. Without that scope a full-export diff from one
+    /// host would tombstone another host's contribution to the same project —
+    /// turning a missing-delete bug into a data-loss one.</para>
+    /// </summary>
+    private async Task<int> ApplyRemovalsAsync(
+        Guid tenantId, Guid projectId, string host, IfcIngestRequest request)
+    {
+        var ids = request.RemovedGlobalIds
+            .Where(g => !string.IsNullOrWhiteSpace(g))
+            .Distinct()
+            .ToList();
+        if (ids.Count == 0) return 0;
+
+        // Which of these did THIS host document actually contribute?
+        var ownedQuery = _db.ExternalElementMappings.AsNoTracking()
+            .Where(m => m.TenantId == tenantId && m.ProjectId == projectId
+                     && m.Host == host && ids.Contains(m.IfcGlobalId));
+
+        if (!string.IsNullOrWhiteSpace(request.HostDocumentGuid))
+            ownedQuery = ownedQuery.Where(m => m.HostDocumentGuid == request.HostDocumentGuid);
+
+        var owned = await ownedQuery.Select(m => m.IfcGlobalId).Distinct().ToListAsync();
+        if (owned.Count == 0)
+        {
+            _logger.LogInformation(
+                "IFC removals for project {ProjectId} host {Host}: none of the {Count} id(s) are attributed to this document — nothing removed.",
+                projectId, host, ids.Count);
+            return 0;
+        }
+
+        var now = DateTime.UtcNow;
+        var targets = await _db.TaggedElements
+            .Where(e => e.ProjectId == projectId && e.IfcGlobalId != null
+                     && owned.Contains(e.IfcGlobalId) && e.DeletedAtUtc == null)
+            .ToListAsync();
+
+        foreach (var el in targets) el.DeletedAtUtc = now;
+        if (targets.Count > 0) await _db.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "IFC removals for project {ProjectId} host {Host} doc {Doc}: tombstoned {Removed} element(s) of {Requested} requested.",
+            projectId, host, request.HostDocumentGuid ?? "(any)", targets.Count, ids.Count);
+
+        return targets.Count;
     }
 
     /// <summary>

--- a/Planscape.Server/src/Planscape.Core/DTOs/IfcIngestDtos.cs
+++ b/Planscape.Server/src/Planscape.Core/DTOs/IfcIngestDtos.cs
@@ -26,6 +26,24 @@ public record IfcIngestRequest
     public string UserName { get; init; } = "";
 
     public List<IfcElementDto> Elements { get; init; } = new();
+
+    /// <summary>
+    /// C3 — IFC GlobalIds this host had previously pushed and no longer has.
+    ///
+    /// <para><b>Why deletions need their own channel.</b> An ingest is an UPSERT
+    /// over the elements it carries, so an element that disappears from the
+    /// source is simply not mentioned — and "not mentioned" is
+    /// indistinguishable from "unchanged, and this is a partial push". Without
+    /// an explicit list, a wall deleted in ArchiCAD stayed on the server
+    /// forever: visible in the viewer, answering clash and compliance queries,
+    /// and counted in every metric. Absence cannot mean deletion.</para>
+    ///
+    /// <para>Scoped by <see cref="HostDocumentGuid"/>: only elements this
+    /// document contributed may be removed. Two hosts contributing to one
+    /// project must not be able to tombstone each other's geometry — a
+    /// full-export diff from one would otherwise wipe the other.</para>
+    /// </summary>
+    public List<string> RemovedGlobalIds { get; init; } = new();
 }
 
 public record IfcElementDto
@@ -77,7 +95,12 @@ public record IfcIngestResponse
     public int NewElements { get; init; }
     public int UpdatedElements { get; init; }
     public int Skipped { get; init; }
+
+    /// <summary>C3 - elements tombstoned because this host no longer has them.</summary>
+    public int Removed { get; init; }
+
     public List<string> Warnings { get; init; } = new();
     public string Summary => $"{NewMappings + UpdatedMappings} mappings, " +
-                             $"{NewElements + UpdatedElements} elements; {Skipped} skipped";
+                             $"{NewElements + UpdatedElements} elements; {Skipped} skipped; " +
+                             $"{Removed} removed";
 }

--- a/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederationAuthorizationTests.cs
@@ -544,7 +544,7 @@ public class FederationAuthorizationTests
 
     private static IfcController NewIfcController(
         World w, Guid actor, IIfcIngestService ingest, IIdentityResolverService identity)
-        => new(NewContext(w.Conn, w.Tenant), identity, ingest)
+        => new(NewContext(w.Conn, w.Tenant), identity, ingest, NullLogger<IfcController>.Instance)
         { ControllerContext = ContextFor(actor, w.Tenant) };
 
     private static IfcIngestRequest SomeIfcPayload() => new()

--- a/Planscape.Server/tests/Planscape.Tests/IfcRemovalPropagationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/IfcRemovalPropagationTests.cs
@@ -1,0 +1,279 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.API.Controllers;
+using Planscape.Core.DTOs;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK C3 — deletions reaching the server.
+///
+/// THE DEFECT
+/// ----------
+/// The IFC ingest is an UPSERT over the elements it carries, so an element that
+/// disappears from the source is simply not mentioned — indistinguishable from
+/// "unchanged, partial push". A wall deleted in ArchiCAD therefore stayed on the
+/// server forever: visible in the viewer, answering clash and compliance
+/// queries, counted in every metric.
+///
+/// THE PART THAT MATTERS MOST
+/// --------------------------
+/// Removals are scoped to the host document that reports them. Two hosts
+/// contribute to one project; if a full-export diff from the ArchiCAD file could
+/// tombstone Revit-contributed elements, this feature would convert a
+/// missing-delete bug into a data-loss one. <see cref="A_host_cannot_remove_another_hosts_elements"/>
+/// is the test that keeps that honest.
+/// </summary>
+public class IfcRemovalPropagationTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project);
+
+    private const string ArchiDoc = "doc-archicad";
+    private const string RevitDoc = "doc-revit";
+    private const string ArchiGuid = "1ArchiCadGuid00000000A";
+    private const string RevitGuid = "2RevitGuid0000000000A";
+
+    private static World NewWorld()
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "a@e.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Tower",
+                Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            // One element from each host, each with its attribution mapping.
+            foreach (var (guid, host, doc) in new[]
+                     {
+                         (ArchiGuid, "archicad", ArchiDoc),
+                         (RevitGuid, "revit", RevitDoc),
+                     })
+            {
+                ctx.TaggedElements.Add(new TaggedElement
+                {
+                    Id = Guid.NewGuid(), TenantId = tenant, ProjectId = project,
+                    UniqueId = guid, IfcGlobalId = guid, Tag1 = "A", Disc = "A",
+                });
+                ctx.ExternalElementMappings.Add(new ExternalElementMapping
+                {
+                    Id = Guid.NewGuid(), TenantId = tenant, ProjectId = project,
+                    Host = host, HostDocumentGuid = doc,
+                    IfcGlobalId = guid, HostElementId = $"host-{guid}",
+                });
+            }
+            ctx.SaveChanges();
+        }
+        return new World(conn, tenant, project);
+    }
+
+    private static IfcController NewController(World w, PlanscapeDbContext db)
+    {
+        var ctrl = new IfcController(db, identity: null!, ingest: null!,
+                                     logger: NullLogger<IfcController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                    {
+                        new Claim("tenant_id", w.Tenant.ToString()),
+                        new Claim("user_id", Guid.NewGuid().ToString()),
+                    }, "test")),
+                },
+            },
+        };
+        return ctrl;
+    }
+
+    private static IfcIngestRequest Removal(string host, string? doc, params string[] ids)
+        => new()
+        {
+            Host = host,
+            HostDocumentGuid = doc,
+            Elements = new List<IfcElementDto>(),      // removals-only push
+            RemovedGlobalIds = ids.ToList(),
+        };
+
+    private static async Task<bool> IsLiveAsync(World w, string guid)
+    {
+        using var ctx = NewContext(w.Conn, w.Tenant);
+        // The global filter already hides soft-deleted rows; asking for it
+        // explicitly documents what "live" means here.
+        return await ctx.TaggedElements.AnyAsync(e => e.IfcGlobalId == guid && e.DeletedAtUtc == null);
+    }
+
+    // ── the fix ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_host_can_remove_an_element_it_contributed()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            var result = await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc, ArchiGuid));
+
+            Assert.IsType<OkObjectResult>(result.Result);
+            Assert.False(await IsLiveAsync(w, ArchiGuid));
+        }
+    }
+
+    [Fact]
+    public async Task A_removals_only_push_is_accepted()
+    {
+        // A save whose only change was deleting elements has nothing to upsert.
+        // Rejecting it as "Elements is empty" would drop exactly the deletions
+        // this feature exists to deliver.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            var result = await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc, ArchiGuid));
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var body = Assert.IsType<IfcIngestResponse>(ok.Value);
+            Assert.Equal(1, body.Removed);
+        }
+    }
+
+    [Fact]
+    public async Task An_empty_push_is_still_rejected()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            var result = await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc));
+
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+        }
+    }
+
+    // ── the guard that stops this becoming data loss ────────────────────────
+
+    [Fact]
+    public async Task A_host_cannot_remove_another_hosts_elements()
+    {
+        // THE test. ArchiCAD pushes a full export; every Revit-contributed
+        // GlobalId is "absent" from it. If absence were enough, this call would
+        // wipe the Revit model.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc, RevitGuid));
+
+            Assert.True(await IsLiveAsync(w, RevitGuid),
+                "an ArchiCAD push tombstoned a Revit-contributed element");
+        }
+    }
+
+    [Fact]
+    public async Task A_different_document_of_the_same_host_cannot_remove_it()
+    {
+        // Two ArchiCAD files in one project: a full export of file B must not
+        // remove file A's elements.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", "some-other-archicad-doc", ArchiGuid));
+
+            Assert.True(await IsLiveAsync(w, ArchiGuid));
+        }
+    }
+
+    [Fact]
+    public async Task An_unknown_global_id_removes_nothing_and_does_not_error()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using var db = NewContext(w.Conn, w.Tenant);
+            var result = await NewController(w, db)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc, "3NeverSeenBefore00000"));
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            Assert.Equal(0, Assert.IsType<IfcIngestResponse>(ok.Value).Removed);
+            Assert.True(await IsLiveAsync(w, ArchiGuid));
+        }
+    }
+
+    [Fact]
+    public async Task Removing_the_same_element_twice_is_a_no_op()
+    {
+        // The plugin re-sends on failure, so a repeat is expected traffic.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(w, db).IngestData(w.Project, Removal("archicad", ArchiDoc, ArchiGuid));
+
+            using var db2 = NewContext(w.Conn, w.Tenant);
+            var result = await NewController(w, db2)
+                .IngestData(w.Project, Removal("archicad", ArchiDoc, ArchiGuid));
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            // Already tombstoned, so nothing left to tombstone.
+            Assert.Equal(0, Assert.IsType<IfcIngestResponse>(ok.Value).Removed);
+        }
+    }
+
+    [Fact]
+    public async Task Soft_delete_not_hard_delete()
+    {
+        // TaggedElement carries tag history, issues and clash references.
+        // Hard-deleting would break those and make an accidental deletion in the
+        // authoring tool unrecoverable.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(w, db).IngestData(w.Project, Removal("archicad", ArchiDoc, ArchiGuid));
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var row = await check.TaggedElements.IgnoreQueryFilters()
+                .SingleAsync(e => e.IfcGlobalId == ArchiGuid);
+            Assert.NotNull(row.DeletedAtUtc);
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/IfcRemovalPropagationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/IfcRemovalPropagationTests.cs
@@ -46,7 +46,7 @@ public class IfcRemovalPropagationTests
         => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
                httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
 
-    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project);
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Caller);
 
     private const string ArchiDoc = "doc-archicad";
     private const string RevitDoc = "doc-revit";
@@ -59,6 +59,7 @@ public class IfcRemovalPropagationTests
         conn.Open();
         var tenant = Guid.NewGuid();
         var project = Guid.NewGuid();
+        var caller = Guid.NewGuid();
 
         using (var ctx = NewContext(conn, tenant))
         {
@@ -73,6 +74,20 @@ public class IfcRemovalPropagationTests
             {
                 Id = project, TenantId = tenant, Name = "Tower",
                 Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+
+            // The host push is authenticated as a project member: IngestData is
+            // gated by RequireProjectMemberAsync (a removals push mutates project
+            // identity, so it requires membership just like an element push).
+            ctx.Users.Add(new AppUser
+            {
+                Id = caller, TenantId = tenant, Email = $"caller-{Guid.NewGuid():N}@example.com",
+                DisplayName = "Caller", PasswordHash = "x", IsActive = true,
+            });
+            ctx.ProjectMembers.Add(new ProjectMember
+            {
+                TenantId = tenant, ProjectId = project, UserId = caller,
+                ProjectRole = "Contributor", Iso19650Role = "M", IsActive = true,
             });
 
             // One element from each host, each with its attribution mapping.
@@ -96,7 +111,7 @@ public class IfcRemovalPropagationTests
             }
             ctx.SaveChanges();
         }
-        return new World(conn, tenant, project);
+        return new World(conn, tenant, project, caller);
     }
 
     private static IfcController NewController(World w, PlanscapeDbContext db)
@@ -111,7 +126,7 @@ public class IfcRemovalPropagationTests
                     User = new ClaimsPrincipal(new ClaimsIdentity(new[]
                     {
                         new Claim("tenant_id", w.Tenant.ToString()),
-                        new Claim("user_id", Guid.NewGuid().ToString()),
+                        new Claim("user_id", w.Caller.ToString()),
                     }, "test")),
                 },
             },

--- a/StingBridge/planscape/client.py
+++ b/StingBridge/planscape/client.py
@@ -224,6 +224,7 @@ class PlanscapeClient:
         host_document_guid: str | None = None,
         plugin_version: str = "stingbridge",
         user_name: str = "",
+        removed_global_ids: list[str] | None = None,
     ) -> dict:
         """POST /api/projects/{id}/ifc/data — the cross-host ingest path.
 
@@ -235,6 +236,15 @@ class PlanscapeClient:
         HostDocumentGuid) plus the ``TaggedElement`` projection, so ArchiCAD
         elements are visible to cross-host resolution and carry no fabricated
         Revit id.
+
+        ``removed_global_ids`` (C3) are elements this host document previously
+        pushed and no longer contains. They travel as an explicit list because
+        an ingest is an upsert: an element that vanishes from the source is
+        simply not mentioned, and "not mentioned" is indistinguishable from
+        "unchanged, partial push". Without this, a wall deleted in ArchiCAD
+        stayed on the server forever — visible in the viewer, answering clash
+        and compliance queries, counted in every metric. Absence cannot mean
+        deletion.
         """
         if not self._token:
             raise PlanscapeAuthError("Not logged in — call login() first")
@@ -249,6 +259,8 @@ class PlanscapeClient:
             "userName": user_name,
             "elements": [to_wire(e) for e in elements],
         }
+        if removed_global_ids:
+            payload["removedGlobalIds"] = list(removed_global_ids)
         resp = self._send(
             "post",
             f"{self.base_url}/api/projects/{self.project_id}/ifc/data",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1514,3 +1514,33 @@ core via a service or stay C#).
 
 **Spec:** the R1/R2 implementation plan (work items per codebase, owner decisions D1–D6, phasing, and
 end-to-end acceptance tests) is written up in [`ROUND_TRIP_R1_R2_SPEC.md`](ROUND_TRIP_R1_R2_SPEC.md).
+
+## Federation hardening — open after the A/B/C tracks (2026-08-16)
+
+Follow-ups identified while closing the federation-hardening tracks. Closed items
+are written up in [`COORDINATION_AUDIT_FINDINGS.md`](COORDINATION_AUDIT_FINDINGS.md) PART IV.
+
+- **`IfcController` has no project-membership gate.** It carries `[Authorize]`
+  and checks `Project.TenantId`, but not `[ProjectAccess]` / 
+  `RequireProjectMemberAsync` — the same defect class Track A fixed on
+  `ModelTransform` / `CoordinateSystem` / `Alignment` / `SceneNodes` /
+  `ModelDiff`. Deliberately not fixed in the C3 PR: it was outside the stated
+  scope, and adding the gate changes the plugin's push path for any service
+  account that is not a project member, which needs verification rather than
+  assumption. Same question applies to `TagSyncController` and
+  `FederatedModelController`'s sibling endpoints — audit the whole ingest
+  surface in one pass rather than piecemeal.
+- **`NotificationHub.JoinProject` resolves its tenant off the ambient
+  `ITenantContext`**, which reads `IHttpContextAccessor` — not reliably
+  populated inside a SignalR hub method. It works today; `FederatedModelHub`
+  (Track A2) was given an explicit JWT-derived tenant instead. Align the two.
+- **`ViewStylePack.Checksum` is declared and never computed or verified**
+  (pre-existing; see CLAUDE.md). Wire it or drop it.
+- **`ModelPurgeJob` is unproven against object storage.** The unit tests use a
+  recording stub; a run against real MinIO/S3 (including the deferral path when
+  a delete fails) has not happened.
+- **`RevitGeoref.Read` is unverified against a live Revit document.** It needs a
+  Revit session; the numbers it produces are asserted only from the server side
+  against hand-written inputs.
+- **`docs/PERFECT_PLACEMENT_PROMPT.md` does not exist** despite being cited as
+  the Track B reference. Either write it or stop citing it.

--- a/stingtools-core/python/stingtools_core/sync/__init__.py
+++ b/stingtools-core/python/stingtools_core/sync/__init__.py
@@ -16,3 +16,7 @@ __all__ = [
     "ReconcileEngine", "ReconcileResult", "Resolution",
     "parse_utc", "tokens_equal", "TOKEN_KEYS",
 ]
+
+# C3 - deletion detection: remembers what a document last pushed so a full
+# export can be diffed into an explicit removal list.
+from .synced_ids import SyncedIdStore, diff_removals, should_send_removals  # noqa: E402,F401

--- a/stingtools-core/python/stingtools_core/sync/synced_ids.py
+++ b/stingtools-core/python/stingtools_core/sync/synced_ids.py
@@ -1,0 +1,119 @@
+"""C3 — remembers which elements a host document last pushed, so deletions can
+be detected.
+
+THE PROBLEM
+-----------
+An ingest is an UPSERT over the elements it carries, so an element that
+disappears from the source is simply not mentioned — and "not mentioned" is
+indistinguishable from "unchanged, and this was a partial push". Without a
+record of what was pushed last time, a wall deleted in ArchiCAD stayed on the
+server forever: visible in the viewer, answering clash and compliance queries,
+and counted in every metric.
+
+**Absence cannot mean deletion.** The only safe way to turn a full export into a
+deletion signal is to diff it against what this same document pushed before, and
+send the difference explicitly.
+
+WHY PER (PROJECT, HOST DOCUMENT)
+--------------------------------
+Two hosts contributing to one project must not be able to tombstone each other's
+geometry. If the set were per-project, a full-export diff from the ArchiCAD file
+would list every Revit-contributed GlobalId as "removed" and wipe it. Keying on
+the document is what makes the diff mean "gone from THIS file" rather than "not
+in this file".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, Optional, Set
+
+log = logging.getLogger(__name__)
+
+
+class SyncedIdStore:
+    """Persists the set of IFC GlobalIds a document last pushed."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+
+    def read(self, project_id: str, host_document_guid: str) -> Set[str]:
+        """The ids last pushed, or an empty set when nothing is recorded."""
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return set()
+        if not isinstance(data, dict):
+            return set()
+        ids = data.get(self._key(project_id, host_document_guid))
+        return set(ids) if isinstance(ids, list) else set()
+
+    def write(self, project_id: str, host_document_guid: str, ids: Iterable[str]) -> None:
+        """Record the ids this document now contains."""
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                data = {}
+        except (OSError, ValueError):
+            data = {}
+
+        # Sorted so the file diffs cleanly and a human can read it.
+        data[self._key(project_id, host_document_guid)] = sorted({i for i in ids if i})
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        except OSError as e:
+            # A lost record costs one missed deletion cycle, never correctness:
+            # the next successful push re-establishes the baseline. Failing the
+            # whole sync over it would be a worse trade.
+            log.warning("Could not persist synced-id set: %s", e)
+
+    @staticmethod
+    def _key(project_id: str, host_document_guid: str) -> str:
+        return f"{project_id}:{host_document_guid}"
+
+
+def diff_removals(previous: Set[str], current: Iterable[str]) -> list[str]:
+    """Ids present in the last push and absent from this one.
+
+    Sorted so a push is deterministic and two runs over an unchanged file
+    produce byte-identical payloads — which is what makes a replay detectable.
+    """
+    current_set = {i for i in current if i}
+    return sorted(previous - current_set)
+
+
+def should_send_removals(
+    previous: Set[str], current: Iterable[str], max_fraction: Optional[float] = 0.5
+) -> tuple[list[str], Optional[str]]:
+    """Compute removals, with a guard against a truncated export wiping a model.
+
+    Returns ``(removals, refusal_reason)``. When ``refusal_reason`` is not None
+    the caller should push the upserts and SKIP the removals.
+
+    **Why a guard at all.** The diff is only as trustworthy as the export it is
+    diffing. A crashed or filtered export that yields 3 elements instead of
+    30,000 is indistinguishable, at this layer, from a coordinator having
+    deleted almost the whole model — and one of those two readings is
+    catastrophic and unrecoverable-by-retry, while the other is a delay of one
+    sync cycle. So a removal set covering more than ``max_fraction`` of the
+    previously-known elements is refused and reported rather than applied.
+
+    Pass ``max_fraction=None`` to disable (a genuine bulk deletion then needs an
+    operator who has read this docstring).
+    """
+    removals = diff_removals(previous, current)
+    if not removals or max_fraction is None or not previous:
+        return removals, None
+
+    fraction = len(removals) / len(previous)
+    if fraction > max_fraction:
+        return [], (
+            f"refusing to remove {len(removals)} of {len(previous)} known element(s) "
+            f"({fraction:.0%}) in one push — this looks like a truncated export "
+            f"rather than a deletion. Re-run once the export is complete, or "
+            f"raise the threshold deliberately."
+        )
+    return removals, None

--- a/stingtools-core/python/tests/test_synced_ids.py
+++ b/stingtools-core/python/tests/test_synced_ids.py
@@ -1,0 +1,155 @@
+"""TRACK C3 — deletion detection for hosts that push full exports.
+
+THE DEFECT
+----------
+An ingest is an UPSERT over the elements it carries, so an element that
+disappears from the source is simply not mentioned — and "not mentioned" is
+indistinguishable from "unchanged, and this was a partial push". Without a
+record of what was pushed last time, a wall deleted in ArchiCAD stayed on the
+server forever: visible in the viewer, answering clash and compliance queries,
+and counted in every metric.
+
+**Absence cannot mean deletion.** The only safe way to turn a full export into a
+deletion signal is to diff it against what this same document pushed before.
+
+THE PART THAT NEEDED A GUARD
+----------------------------
+The diff is only as trustworthy as the export it is diffing. A crashed or
+filtered export yielding 3 elements instead of 30,000 looks, at this layer,
+exactly like a coordinator deleting almost the whole model. One of those
+readings is catastrophic and not recoverable by retrying; the other costs one
+sync cycle. So a removal set covering most of the known elements is refused.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from stingtools_core.sync.synced_ids import (  # noqa: E402
+    SyncedIdStore, diff_removals, should_send_removals,
+)
+
+PROJECT = "proj-1"
+DOC_A = "doc-archicad"
+DOC_B = "doc-revit"
+
+
+# ── the store ─────────────────────────────────────────────────────────────────
+
+def test_an_unknown_document_reads_as_empty(tmp_path):
+    store = SyncedIdStore(tmp_path / "synced.json")
+    assert store.read(PROJECT, DOC_A) == set()
+
+
+def test_ids_round_trip(tmp_path):
+    store = SyncedIdStore(tmp_path / "synced.json")
+    store.write(PROJECT, DOC_A, ["g1", "g2", "g3"])
+    assert store.read(PROJECT, DOC_A) == {"g1", "g2", "g3"}
+
+
+def test_documents_are_isolated(tmp_path):
+    # The load-bearing property. If the set were per-project, a full-export diff
+    # from the ArchiCAD file would list every Revit-contributed GlobalId as
+    # "removed" and wipe it.
+    store = SyncedIdStore(tmp_path / "synced.json")
+    store.write(PROJECT, DOC_A, ["a1", "a2"])
+    store.write(PROJECT, DOC_B, ["r1"])
+
+    assert store.read(PROJECT, DOC_A) == {"a1", "a2"}
+    assert store.read(PROJECT, DOC_B) == {"r1"}
+
+
+def test_projects_are_isolated(tmp_path):
+    store = SyncedIdStore(tmp_path / "synced.json")
+    store.write("p1", DOC_A, ["x"])
+    store.write("p2", DOC_A, ["y"])
+    assert store.read("p1", DOC_A) == {"x"}
+
+
+def test_a_corrupt_store_reads_as_empty_rather_than_raising(tmp_path):
+    # An unreadable store costs one missed deletion cycle; raising would fail
+    # the whole sync, which is a strictly worse trade.
+    path = tmp_path / "synced.json"
+    path.write_text("{ not json", encoding="utf-8")
+    assert SyncedIdStore(path).read(PROJECT, DOC_A) == set()
+
+
+def test_blank_ids_are_not_stored(tmp_path):
+    store = SyncedIdStore(tmp_path / "synced.json")
+    store.write(PROJECT, DOC_A, ["g1", "", None])
+    assert store.read(PROJECT, DOC_A) == {"g1"}
+
+
+# ── the diff ──────────────────────────────────────────────────────────────────
+
+def test_removals_are_what_vanished():
+    assert diff_removals({"a", "b", "c"}, ["a", "c"]) == ["b"]
+
+
+def test_new_elements_are_not_removals():
+    assert diff_removals({"a"}, ["a", "b", "c"]) == []
+
+
+def test_an_unchanged_export_removes_nothing():
+    assert diff_removals({"a", "b"}, ["b", "a"]) == []
+
+
+def test_removals_are_sorted_so_a_push_is_deterministic():
+    # Two runs over an unchanged file must produce byte-identical payloads —
+    # that is what makes a replay detectable rather than a new write.
+    assert diff_removals({"c", "a", "b"}, []) == ["a", "b", "c"]
+
+
+def test_a_first_ever_push_removes_nothing():
+    # No baseline means no knowledge, not "everything is gone".
+    assert diff_removals(set(), ["a", "b"]) == []
+
+
+# ── the truncated-export guard ────────────────────────────────────────────────
+
+def test_a_normal_deletion_is_allowed():
+    previous = {f"g{i}" for i in range(100)}
+    current = [f"g{i}" for i in range(100) if i != 7]
+
+    removals, refusal = should_send_removals(previous, current)
+    assert refusal is None
+    assert removals == ["g7"]
+
+
+def test_a_truncated_export_is_refused_not_applied():
+    # 100 known elements, an export that yields 3. Applying this would tombstone
+    # 97 elements on the strength of a broken export.
+    previous = {f"g{i}" for i in range(100)}
+    current = ["g0", "g1", "g2"]
+
+    removals, refusal = should_send_removals(previous, current)
+    assert removals == []
+    assert refusal is not None
+    assert "truncated export" in refusal
+    # The message must carry the numbers, or an operator cannot judge it.
+    assert "97" in refusal and "100" in refusal
+
+
+def test_the_guard_can_be_disabled_deliberately():
+    previous = {f"g{i}" for i in range(100)}
+    removals, refusal = should_send_removals(previous, [], max_fraction=None)
+    assert refusal is None
+    assert len(removals) == 100
+
+
+def test_the_guard_does_not_fire_on_a_first_push():
+    # No baseline: nothing to be a fraction of, and nothing to remove.
+    removals, refusal = should_send_removals(set(), ["a"])
+    assert removals == [] and refusal is None
+
+
+def test_deleting_exactly_half_is_allowed():
+    # The threshold is "more than", so the boundary case is not refused —
+    # pinned because an off-by-one here silently changes a product decision.
+    previous = {"a", "b", "c", "d"}
+    removals, refusal = should_send_removals(previous, ["a", "b"])
+    assert refusal is None
+    assert removals == ["c", "d"]


### PR DESCRIPTION
> **Stacked on #686** (C4) → #685 → #684 → … → #676. Retarget as those merge.

## The bug

The IFC ingest is an **upsert** over the elements it carries, so an element that disappears from the source is simply *not mentioned* — and "not mentioned" is indistinguishable from "unchanged, and this was a partial push".

A wall deleted in ArchiCAD therefore stayed on the server **forever**: visible in the viewer, answering clash and compliance queries, counted in every metric.

**Absence cannot mean deletion.**

## Server

`IfcIngestRequest` gains `RemovedGlobalIds`, and `/ifc/data` accepts a **removals-only** push — a save whose only change was deleting elements has nothing to upsert, and rejecting it as `Elements is empty` would drop exactly the deletions this exists to deliver.

Matching `TaggedElement`s are **soft**-deleted: the entity carries tag history, issues and clash references, so hard-deleting would break those and make an accidental deletion in the authoring tool unrecoverable. The global query filter already hides tombstoned rows from every read path — which is the observable behaviour that was missing.

### The part that matters most

Removals are resolved through `ExternalElementMapping` and **limited to the host document that reports them.**

Two hosts contribute to one project, so a full-export diff from the ArchiCAD file lists every Revit-contributed GlobalId as "absent" — and *if absence were enough, that push would wipe the Revit model.* Without the scope, this feature converts a missing-delete bug into a **data-loss** one. `A_host_cannot_remove_another_hosts_elements` is the test that keeps that honest.

## Client

`SyncedIdStore` records the GlobalIds each document last pushed, keyed on `(project, host document)` for the same reason. `diff_removals` turns a full export into an explicit removal list; `ingest_ifc_data` carries it.

`should_send_removals` adds a guard the server cannot provide. The diff is only as trustworthy as the export it's diffing — a crashed or filtered export yielding 3 elements instead of 30,000 looks, at this layer, **exactly** like a coordinator deleting almost the whole model. One reading is catastrophic and not recoverable by retrying; the other costs one sync cycle. So a removal set covering >50% of known elements is **refused and reported**, with the numbers in the message so an operator can judge it.

## Verification

- **16 core tests** — document/project isolation; a first-ever push removes nothing (*no baseline means no knowledge, not "everything is gone"*); removals sorted so two runs over an unchanged file produce byte-identical payloads; and the exactly-half boundary, because an off-by-one there silently changes a product decision.
- **8 server tests** — the load-bearing one being that an ArchiCAD push cannot tombstone a Revit-contributed element.
- **769 C# passed / 0 failed / 0 skipped** against real PostgreSQL 16; **313 Python passed.**

## Noted, not fixed

`IfcController` carries `[Authorize]` and a tenant check but **no** `[ProjectAccess]` / membership gate — the same defect class Track A fixed on five sibling controllers. Out of the stated scope, and adding it changes the plugin's push path for any service account that isn't a project member, which needs verification rather than assumption. Logged in `docs/ROADMAP.md` along with the rest of the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)