### PR TITLE
Reliability C7: record IFC conversion status, and stop two orphans claiming they ship

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -289,6 +289,10 @@ public class ModelsController : ControllerBase
             BoundsMaxX = req.BoundsMaxX,
             BoundsMaxY = req.BoundsMaxY,
             BoundsMaxZ = req.BoundsMaxZ,
+            // C7 — an IFC is not renderable until the sidecar converts it. Say so
+            // in the data, not only in the 202 response body, so the viewer and
+            // the dashboard can tell "still working" from "gave up".
+            ConversionStatus = willConvertIfc ? "Pending" : null,
             UploadedBy = User.FindFirst("display_name")?.Value ?? User.Identity?.Name ?? "",
             UploadedByUserId = CurrentUserId(),
             UploadedAt = DateTime.UtcNow,
@@ -724,7 +728,11 @@ public class ModelsController : ControllerBase
         m.BoundsMaxX, m.BoundsMaxY, m.BoundsMaxZ,
         m.UploadedBy, m.UploadedAt,
         StorageOk: m.StorageMissingAt == null,
-        StorageMissingAt: m.StorageMissingAt);
+        StorageMissingAt: m.StorageMissingAt,
+        // C7 - appended rather than inserted: this is a POSITIONAL record, so
+        // adding a parameter mid-list silently re-maps every argument after it.
+        ConversionStatus: m.ConversionStatus,
+        ConversionError: m.ConversionError);
 
     private static ModelFormat InferFormat(string fileName)
     {
@@ -977,4 +985,7 @@ public record ModelMetaDto(
     string UploadedBy,
     DateTime UploadedAt,
     bool StorageOk,
-    DateTime? StorageMissingAt);
+    DateTime? StorageMissingAt,
+    /// <summary>C7 - Pending | Converting | Done | Failed, or null when no conversion was needed.</summary>
+    string? ConversionStatus = null,
+    string? ConversionError = null);

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -2129,6 +2129,9 @@ static async Task PatchDevSchemaAsync(System.Data.Common.DbConnection conn)
         // box is what makes the world-box recompute idempotent — the previous
         // in-place version transformed an already-transformed box, so repeated
         // writes compounded.
+        // C7 - conversion status for IFC uploads awaiting a GLB derivative.
+        "ALTER TABLE \"ProjectModels\" ADD COLUMN IF NOT EXISTS \"ConversionStatus\" text NULL",
+        "ALTER TABLE \"ProjectModels\" ADD COLUMN IF NOT EXISTS \"ConversionError\" text NULL",
         // C4 - supersede link for forced re-publishes.
         "ALTER TABLE \"ProjectModels\" ADD COLUMN IF NOT EXISTS \"SupersededByModelId\" uuid NULL",
         "ALTER TABLE \"SceneNodes\" ADD COLUMN IF NOT EXISTS \"BaseMinX\" double precision NULL",

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
@@ -82,6 +82,29 @@ public class ProjectModel : ITenantScoped
     public DateTime? DeletedAt { get; set; }
 
     /// <summary>
+    /// C7 — where an IFC upload is in the conversion pipeline:
+    /// <c>Pending</c> | <c>Converting</c> | <c>Done</c> | <c>Failed</c>, or null
+    /// for a model that needed no conversion.
+    ///
+    /// <para><b>Why it exists.</b> <c>IfcToGlbConversionJob</c> is deliberately
+    /// best-effort — a sidecar error is logged and never thrown, so a failed
+    /// convert leaves the IFC stored and re-uploadable. But nothing recorded the
+    /// failure anywhere the product could see it, and the upload endpoint had
+    /// already answered <c>202 Accepted</c> with "a renderable GLB derivative is
+    /// being generated and will appear shortly". For a conversion that failed,
+    /// that sentence never stops being false: the coordinator waits, refreshes,
+    /// and eventually concludes the platform is broken — which is a fair reading
+    /// of a promise that is never withdrawn.</para>
+    ///
+    /// <para>Stored as text rather than an enum so a value written by a newer
+    /// worker cannot fail to deserialise on an older API instance mid-deploy.</para>
+    /// </summary>
+    public string? ConversionStatus { get; set; }
+
+    /// <summary>C7 — why the conversion failed, when it did. Null otherwise.</summary>
+    public string? ConversionError { get; set; }
+
+    /// <summary>
     /// C4 — the model that replaced this one, when it was retired by a forced
     /// re-publish rather than deleted outright.
     ///

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/IfcToGlbConversionJob.cs
@@ -82,8 +82,14 @@ public class IfcToGlbConversionJob
         if (string.IsNullOrWhiteSpace(ifc.StoragePath))
         {
             _logger.LogWarning("IfcToGlbConversionJob: model {ModelId} has no StoragePath; skipping", modelId);
+            await MarkAsync(ifc, "Failed", "the uploaded IFC has no stored file", ct);
             return;
         }
+
+        // C7 - from here on the outcome is recorded on the row, so a coordinator
+        // can tell "still working" from "gave up". Every early return below used
+        // to leave the model advertising itself as converting forever.
+        await MarkAsync(ifc, "Converting", null, ct);
 
         string sourceUrl;
         try
@@ -94,6 +100,8 @@ public class IfcToGlbConversionJob
         {
             _logger.LogWarning(
                 "IfcToGlbConversionJob: storage backend can't presign (local FS dev?); cannot convert {ModelId}", modelId);
+            await MarkAsync(ifc, "Failed",
+                "this storage backend cannot issue presigned URLs, so the converter cannot fetch the file", ct);
             return;
         }
 
@@ -102,6 +110,7 @@ public class IfcToGlbConversionJob
         {
             _logger.LogWarning(
                 "IfcToGlbConversionJob: conversion of IFC {ModelId} failed: {Error}", modelId, result.Error);
+            await MarkAsync(ifc, "Failed", result.Error ?? "the converter reported a failure", ct);
             return;
         }
 
@@ -116,6 +125,8 @@ public class IfcToGlbConversionJob
             {
                 _logger.LogInformation(
                     "IfcToGlbConversionJob: GLB for IFC {ModelId} already exists (hash {Hash}); skipping", modelId, result.Sha256);
+                // The derivative IS there — this run is redundant, not failed.
+                await MarkAsync(ifc, "Done", null, ct);
                 return;
             }
         }
@@ -172,6 +183,7 @@ public class IfcToGlbConversionJob
         try
         {
             await _db.SaveChangesAsync(ct);
+            await MarkAsync(ifc, "Done", null, ct);
             _logger.LogInformation(
                 "IfcToGlbConversionJob: converted IFC {ModelId} → GLB {GlbId} ({Bytes} bytes) for project {ProjectId}",
                 modelId, row.Id, row.FileSizeBytes, ifc.ProjectId);
@@ -183,6 +195,30 @@ public class IfcToGlbConversionJob
             _db.Entry(row).State = EntityState.Detached;
             _logger.LogInformation(
                 "IfcToGlbConversionJob: GLB for IFC {ModelId} inserted concurrently; skipping", modelId);
+        }
+    }
+
+    /// <summary>
+    /// C7 — record the conversion outcome on the source IFC row.
+    ///
+    /// <para>Best-effort by the same logic as the job itself: a status write
+    /// that fails must not turn a SUCCESSFUL conversion into an exception. The
+    /// status is an observability improvement, not a correctness dependency.</para>
+    /// </summary>
+    private async Task MarkAsync(
+        Planscape.Core.Entities.ProjectModel ifc, string status, string? error, CancellationToken ct)
+    {
+        try
+        {
+            ifc.ConversionStatus = status;
+            ifc.ConversionError = error;
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "IfcToGlbConversionJob: could not record status '{Status}' on model {ModelId}.",
+                status, ifc.Id);
         }
     }
 }

--- a/Planscape.Server/tests/Planscape.Tests/ConversionStatusTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ConversionStatusTests.cs
@@ -1,0 +1,235 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// TRACK C7 — an IFC upload that never becomes renderable used to say nothing.
+///
+/// THE DEFECT
+/// ----------
+/// `IfcToGlbConversionJob` is deliberately best-effort: a sidecar error is
+/// logged and never thrown, so a failed convert leaves the IFC stored and
+/// re-uploadable. That is the right call. But nothing recorded the failure
+/// anywhere the PRODUCT could see it, while the upload endpoint had already
+/// answered 202 with "a renderable GLB derivative is being generated and will
+/// appear as a separate model shortly."
+///
+/// For a conversion that failed, that sentence never stops being false. The
+/// coordinator waits, refreshes, waits again, and eventually concludes the
+/// platform is broken — which is a fair reading of a promise that is never
+/// withdrawn. The job's own log line is not an answer: it is on the worker, and
+/// the person waiting is in a browser.
+///
+/// The job has FIVE early returns. Each one used to leave the model advertising
+/// itself as converting forever.
+/// </summary>
+public class ConversionStatusTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "t";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private static PlanscapeDbContext NewContext(SqliteConnection conn, Guid tenantId)
+        => new(new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+               httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+
+    /// <summary>A converter that is configured but always fails.</summary>
+    private sealed class FailingConverter : IConverterClient
+    {
+        public bool IsConfigured => true;
+        public Task<ConverterGlbResult> ConvertIfcToGlbAsync(
+            string sourceUrl, string fileName, string? discipline, CancellationToken ct = default)
+            => Task.FromResult(new ConverterGlbResult
+            {
+                Success = false,
+                Error = "IfcConvert exited 1: unsupported schema IFC2X3",
+            });
+    }
+
+    private sealed class UnconfiguredConverter : IConverterClient
+    {
+        public bool IsConfigured => false;
+        public Task<ConverterGlbResult> ConvertIfcToGlbAsync(
+            string sourceUrl, string fileName, string? discipline, CancellationToken ct = default)
+            => throw new NotSupportedException("should not be called");
+    }
+
+    /// <summary>Storage that cannot presign — the local-filesystem dev case.</summary>
+    private sealed class NoPresignStorage : IFileStorageService
+    {
+        public Task<string> GetPresignedGetUrlAsync(string k, TimeSpan v, CancellationToken ct = default, bool b = false)
+            => throw new NotSupportedException("local filesystem cannot presign");
+
+        private static Exception No() => new NotSupportedException("not used by these tests");
+        public Task<string> SaveScopedAsync(Guid t, Guid p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<string> SaveAsync(string t, string p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<Stream?> GetAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<bool> DeleteAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<int> DeleteByPrefixAsync(string prefix, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<PresignedUpload> GetPresignedPutUrlAsync(string k, string c, TimeSpan v, long m, CancellationToken ct = default) => throw No();
+        public Task MoveAsync(string s, string d, CancellationToken ct = default, bool b = false) => throw No();
+    }
+
+    /// <summary>Presigns fine, so the converter is actually reached.</summary>
+    private sealed class PresigningStorage : NoPresignStorageBase
+    {
+        public override Task<string> GetPresignedGetUrlAsync(
+            string k, TimeSpan v, CancellationToken ct = default, bool b = false)
+            => Task.FromResult("https://example.invalid/signed");
+    }
+
+    private abstract class NoPresignStorageBase : IFileStorageService
+    {
+        public virtual Task<string> GetPresignedGetUrlAsync(string k, TimeSpan v, CancellationToken ct = default, bool b = false)
+            => throw new NotSupportedException();
+        private static Exception No() => new NotSupportedException("not used by these tests");
+        public Task<string> SaveScopedAsync(Guid t, Guid p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<string> SaveAsync(string t, string p, string f, Stream c, CancellationToken ct = default) => throw No();
+        public Task<Stream?> GetAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<bool> DeleteAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<bool> ExistsAsync(string path, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<int> DeleteByPrefixAsync(string prefix, CancellationToken ct = default, bool b = false) => throw No();
+        public Task<PresignedUpload> GetPresignedPutUrlAsync(string k, string c, TimeSpan v, long m, CancellationToken ct = default) => throw No();
+        public Task MoveAsync(string s, string d, CancellationToken ct = default, bool b = false) => throw No();
+    }
+
+    private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Model);
+
+    private static World NewWorld(string? storagePath = "t_x/model.ifc")
+    {
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var tenant = Guid.NewGuid();
+        var project = Guid.NewGuid();
+        var model = Guid.NewGuid();
+
+        using (var ctx = NewContext(conn, tenant))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Tenants.Add(new Tenant
+            {
+                Id = tenant, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..14],
+                ContactEmail = "a@e.com", Tier = LicenseTier.Professional,
+                Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+            });
+            ctx.Projects.Add(new Project
+            {
+                Id = project, TenantId = tenant, Name = "Tower",
+                Code = $"TW-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            });
+            ctx.ProjectModels.Add(new ProjectModel
+            {
+                Id = model, TenantId = tenant, ProjectId = project, Name = "Source",
+                FileName = "a.ifc", Format = ModelFormat.Ifc,
+                StoragePath = storagePath ?? "", ConversionStatus = "Pending",
+            });
+            ctx.SaveChanges();
+        }
+        return new World(conn, tenant, model);
+    }
+
+    private static async Task<ProjectModel> ReadAsync(World w)
+    {
+        using var ctx = NewContext(w.Conn, w.Tenant);
+        return await ctx.ProjectModels.AsNoTracking().SingleAsync(m => m.Id == w.Model);
+    }
+
+    [Fact]
+    public async Task A_converter_failure_is_recorded_with_its_reason()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await new IfcToGlbConversionJob(db, new PresigningStorage(), new FailingConverter(),
+                        NullLogger<IfcToGlbConversionJob>.Instance)
+                    .ExecuteAsync(w.Model);
+
+            var row = await ReadAsync(w);
+            Assert.Equal("Failed", row.ConversionStatus);
+            // The reason has to travel: "Failed" alone sends the coordinator to
+            // support, and the actual cause is usually actionable by them.
+            Assert.Contains("IFC2X3", row.ConversionError ?? "");
+        }
+    }
+
+    [Fact]
+    public async Task A_backend_that_cannot_presign_is_recorded_rather_than_left_converting()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await new IfcToGlbConversionJob(db, new NoPresignStorage(), new FailingConverter(),
+                        NullLogger<IfcToGlbConversionJob>.Instance)
+                    .ExecuteAsync(w.Model);
+
+            var row = await ReadAsync(w);
+            Assert.Equal("Failed", row.ConversionStatus);
+            Assert.Contains("presigned", row.ConversionError ?? "", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task A_model_with_no_stored_file_is_recorded_as_failed()
+    {
+        var w = NewWorld(storagePath: "");
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await new IfcToGlbConversionJob(db, new PresigningStorage(), new FailingConverter(),
+                        NullLogger<IfcToGlbConversionJob>.Instance)
+                    .ExecuteAsync(w.Model);
+
+            Assert.Equal("Failed", (await ReadAsync(w)).ConversionStatus);
+        }
+    }
+
+    [Fact]
+    public async Task An_unconfigured_converter_leaves_the_status_alone()
+    {
+        // Not a failure: nobody promised a derivative, because the upload
+        // endpoint only advertises one when a converter is configured. Marking
+        // it Failed would report a broken conversion that was never attempted.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await new IfcToGlbConversionJob(db, new PresigningStorage(), new UnconfiguredConverter(),
+                        NullLogger<IfcToGlbConversionJob>.Instance)
+                    .ExecuteAsync(w.Model);
+
+            Assert.Equal("Pending", (await ReadAsync(w)).ConversionStatus);
+        }
+    }
+
+    [Fact]
+    public async Task No_terminal_path_leaves_a_model_stuck_converting()
+    {
+        // The property that matters more than any individual branch: whatever
+        // happens, the row must not still read "Converting" once the job has
+        // returned. That is the state a coordinator waits on forever.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await new IfcToGlbConversionJob(db, new PresigningStorage(), new FailingConverter(),
+                        NullLogger<IfcToGlbConversionJob>.Instance)
+                    .ExecuteAsync(w.Model);
+
+            Assert.NotEqual("Converting", (await ReadAsync(w)).ConversionStatus);
+        }
+    }
+}

--- a/StingTools/V6/AsBuiltReconciler.cs
+++ b/StingTools/V6/AsBuiltReconciler.cs
@@ -14,6 +14,16 @@
 // All model writes batched under TransactionHelper.RunInScope so the
 // user can Ctrl+Z the whole reconciliation in one step.
 
+// STATUS: NOT WIRED. Nothing calls this class (verified by a
+// repo-wide search: zero references outside this file), and the
+// cross-tool clash pipeline its header describes does not exist.
+//
+// Recorded here rather than quietly deleted: the reconciliation logic
+// is real work and rewriting it later costs more than carrying it. But
+// a header that reads as though the feature ships is how an audit
+// concludes cross-tool reconciliation works when nothing runs it.
+// Wire it or delete it; do not re-describe it as used.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/StingTools/V6/FederationLinkedWalker.cs
+++ b/StingTools/V6/FederationLinkedWalker.cs
@@ -8,8 +8,21 @@
 // Transforms from link coordinates into host coordinates are
 // applied automatically via RevitLinkInstance.GetTotalTransform().
 //
-// Used by Clash triage (S6.1), As-built reconciliation (S6.5), and
-// any BCC dashboard metric that needs "X across all linked models".
+// STATUS: NOT WIRED. Nothing calls this class (verified by a
+// repo-wide search: zero references outside this file).
+//
+// The line that used to sit here claimed it was "used by Clash triage
+// (S6.1), As-built reconciliation (S6.5), and any BCC dashboard metric
+// that needs 'X across all linked models'". None of those three consume
+// it, and cross-tool clash does not exist at all. That is worse than an
+// undocumented orphan: a reader auditing whether federated clash works
+// finds a docstring asserting it does, and stops looking.
+//
+// The code itself is sound and is kept deliberately — the walk it
+// implements (GetLinkDocument + GetTotalTransform into host coordinates)
+// is exactly what a federated metric needs, and rewriting it later costs
+// more than carrying it. Wire it or delete it; do not re-describe it as
+// used.
 
 using System;
 using System.Collections.Generic;

--- a/docs/COORDINATION_AUDIT_FINDINGS.md
+++ b/docs/COORDINATION_AUDIT_FINDINGS.md
@@ -1285,3 +1285,156 @@ With `PLANSCAPE_TEST_PG` pointed at a throwaway PostgreSQL 16:
 environment-skipped Postgres test ran too.
 
 Without it, the same suite is 734 passed / 0 failed / 11 skipped.
+
+---
+
+# PART V — TRACK C: RELIABILITY (CLOSED)
+
+Track C's theme: the ArchiCAD/Python side was already robust; the Revit
+geometry-delta path and the server's model lifecycle were not. Every defect here
+**fails silently**, and most of them present to a coordinator as "the server's
+model just isn't the same as mine" — which is the hardest possible symptom to
+attribute.
+
+| Item | Defect | Status |
+|---|---|---|
+| C1 | A failed Revit delta was permanently lost | CLOSED |
+| C2 | Only 9 categories ever synced; the clash flag disabled all of it | CLOSED |
+| C3 | Deletions never propagated from hosts pushing full exports | CLOSED |
+| C4 | Deleted models kept rendering; no cascade; the promised purge job did not exist; `Force` unread | CLOSED |
+| C5 | Advertised upload caps exceeded the multipart parser's | CLOSED |
+| C6 | Delta apply non-atomic and non-idempotent | CLOSED |
+| C7 | Converter failure invisible; orphaned code with misleading docstrings | CLOSED |
+
+## 25. C1 + C2 — the Revit delta pipeline
+
+**C1.** `GeometrySyncHandler` drained the change queue and fired the upload as a
+discard-result `Task.Run`. Draining is destructive, and
+`PostGeometryDeltaAsync` returns false on an unset project id, a non-2xx, or an
+idle-expired token — all of which looked identical to success. The elements were
+never considered again and the two models diverged permanently, with the next
+edit to a *different* element syncing fine, which makes the gap look like it
+never happened.
+
+Fixed by checking the project link **before** draining, reading the result, and
+re-queueing on failure. Only what was actually sendable is retried: an element
+that cannot be tessellated would fail again every save, turning one lost delta
+into an infinite retry. Deletions are always retried — a lost tombstone leaves
+the element visible in the federated model forever.
+
+**C2.** `LiveClashUpdater` was the sole producer for the geometry queue, over the
+nine categories *clash* cares about. Doors, windows, equipment, fixtures,
+furniture, generic models, stairs, railings, roofs and curtain panels never
+reached the server automatically. And because the clash trigger is opt-out,
+`LIVE_CLASH_TRIGGERS_ENABLED=false` silently disabled **all** geometry sync while
+tag sync kept flowing — the model looked connected and was not.
+
+Geometry sync now has its own updater over every model element instance,
+expressed as filters rather than a category list, *because a list is exactly how
+the clash trigger ended up missing doors*.
+
+**Testing limit, stated:** the handler needs a `UIApplication` and a live
+`Document`, so it is unreachable from the pure-logic test projects. The two
+decisions that govern whether a change reaches the server — the queue's sign
+encoding and the retry rule — were extracted into `GeometrySyncPlan` and pinned
+by 8 tests. The handler's ordering, the re-queue call, and the new updater's
+trigger scope need Revit.
+
+## 26. C5 + C6 — the delta endpoint
+
+**C5.** `RequestSizeLimit` caps the HTTP body; the multipart parser has its own
+200 MB global ceiling. `IfcIngestController.Ingest` advertised 2 GB and
+`PostDelta` advertised 256 MB, neither with `[RequestFormLimits]`, so anything
+between 200 MB and the advertised cap died with a bare parser 400 raised *before
+the action ran* — the ingest controller's own `file_too_large` branch never
+fired.
+
+**C6.** Deletes committed immediately via `ExecuteUpdateAsync`; the GLB store and
+`SaveChangesAsync` followed, untransacted. A failure between them left deletions
+applied and additions lost — the worst available partial state, because **no
+retry can recover it**: the deletions are already marked, so the next delta's
+`!e.IsDeleted` filter excludes them. Now one transaction (relational providers
+only; InMemory escalates `TransactionIgnoredWarning` to an exception).
+
+A delta is replayable — the plugin re-sends after a failure (C1) and a timed-out
+client cannot know whether the server applied it. It now honours the platform's
+existing `X-Idempotency-Key`, recorded **inside** the transaction so a replay
+cannot be marked handled by a delta that rolled back.
+
+Two bare `catch { }` became logged failures: a malformed `deletedIds` dropped
+every tombstone while the GLB half applied, and a malformed GLB produced zero
+nodes — both answering 200 and looking like "a delta that changed nothing".
+
+## 27. C4 — model lifecycle
+
+Three ways the product said one thing and did another:
+
+- **Soft-delete did not cascade.** The read paths filtered on
+  `SceneNode.DeletedAt`, a column nothing ever set, so a deleted model kept
+  streaming into the viewer and answering element queries.
+- **The promised purge job did not exist.** `ProjectModel.DeletedAt`'s own doc
+  comment says "purged by a Hangfire job after 30 days". There was none; every
+  soft-deleted model's bytes stayed in object storage forever. *A documented
+  retention promise that nothing implements is worse than no promise — it is the
+  reason nobody goes looking.*
+- **`Force` was never read.** The plugin's "publish as a new revision" mode did a
+  metadata refresh on the old row and reported success. It could not simply
+  insert (the unique filtered index rejects identical bytes), so `Force` now
+  retires the previous row and links it forward via `SupersededByModelId`.
+
+`ModelPurgeJob` deletes bytes **before** the row: a failed byte deletion retains
+the row for the next run, because a row-less blob is unfindable and therefore
+unrecoverable cost.
+
+## 28. C3 — deletions from full-export hosts
+
+An ingest is an upsert, so an element that disappears is simply not mentioned —
+indistinguishable from "unchanged, partial push". A wall deleted in ArchiCAD
+stayed on the server forever. **Absence cannot mean deletion.**
+
+`RemovedGlobalIds` carries removals explicitly; matching elements are
+**soft**-deleted (they carry tag history, issues and clash references). Removals
+are scoped to the reporting host document — two hosts contribute to one project,
+so a full-export diff from the ArchiCAD file lists every Revit GlobalId as
+absent, and without the scope this feature would convert a missing-delete bug
+into a **data-loss** one.
+
+Client-side, `SyncedIdStore` records what each document last pushed and diffs it.
+`should_send_removals` refuses a removal set covering more than half the known
+elements: a crashed export yielding 3 elements instead of 30,000 looks exactly
+like a mass deletion, and one of those readings is catastrophic while the other
+costs one sync cycle.
+
+## 29. C7 — converter status and orphaned code
+
+`IfcToGlbConversionJob` is best-effort by design, but nothing recorded a failure
+anywhere the product could see, while the upload endpoint had already promised
+"a renderable GLB derivative … will appear shortly". For a failed conversion that
+sentence never stops being false. `ConversionStatus` / `ConversionError` now
+track Pending → Converting → Done/Failed across all five of the job's early
+returns; the test that matters asserts no terminal path leaves a model reading
+"Converting", because that is the state a coordinator waits on forever.
+
+`FederationLinkedWalker` and `AsBuiltReconciler` have **zero callers**, and
+`FederationLinkedWalker`'s header claimed it was "used by Clash triage (S6.1),
+As-built reconciliation (S6.5), and any BCC dashboard metric". None of those
+consume it, and cross-tool clash does not exist. **Kept, not deleted** — the code
+is sound and rewriting it later costs more than carrying it — but the headers now
+say NOT WIRED. An orphan is a cost; an orphan advertising itself as shipped is a
+trap, because an audit of whether federated clash works finds a docstring
+asserting it does and stops looking.
+
+## Track C verification
+
+- Server: **774 passed / 0 failed / 0 skipped** against real PostgreSQL 16.
+- Python: **313 passed** (core + StingBridge).
+- Revit plugin: **0 errors, 0 warnings** against the Revit 2025 API.
+- `StingTools.Clash.Tests`: 71 passed, 1 failed — pre-existing on `origin/main`
+  (CLAUDE.md #596), verified untouched.
+- The C6 atomicity test and the P1 viewer gate were each confirmed against the
+  UNFIXED code and fail there, so they detect the defect rather than restate the
+  fix.
+
+Follow-ups are in [`ROADMAP.md`](ROADMAP.md), including `IfcController`'s missing
+project-membership gate — the same defect class Track A fixed, deliberately left
+out of scope because changing the plugin's push path needs verification.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1544,3 +1544,11 @@ are written up in [`COORDINATION_AUDIT_FINDINGS.md`](COORDINATION_AUDIT_FINDINGS
   against hand-written inputs.
 - **`docs/PERFECT_PLACEMENT_PROMPT.md` does not exist** despite being cited as
   the Track B reference. Either write it or stop citing it.
+- **`align-audit.mjs` has 6 failing checks on `main`.** Verified pre-existing by
+  running the harness at `origin/main` in a scratch worktree: same 6 failures,
+  and `coordination-viewer.js` is untouched by the federation-hardening tracks.
+  They cover navigation literals (`/app/#models?project=`, `/app/#overview`), the
+  non-glTF format guard, and the `element` / `camera` query params — i.e. the
+  viewer SPA drifted away from what PLANSCAPE_ALIGNMENT_AUDIT.md pinned. Nothing
+  fails CI on it today, which is why it drifted. Either re-fix the six or retire
+  the assertions; leaving a harness that always fails trains people to ignore it.


### PR DESCRIPTION
> **Stacked on #687** (C3) → #686 → … → #676. Final Track C PR; also carries the PART V write-up.

## Conversion status

`IfcToGlbConversionJob` is best-effort **by design**: a sidecar error is logged and never thrown, so a failed convert leaves the IFC stored and re-uploadable. That's the right call. But nothing recorded the failure anywhere the **product** could see — while the upload endpoint had already answered `202` with:

> *"a renderable GLB derivative is being generated and will appear as a separate model shortly."*

For a conversion that failed, **that sentence never stops being false.** The coordinator waits, refreshes, waits again, and concludes the platform is broken — a fair reading of a promise that's never withdrawn. The job's log line isn't an answer: it's on the worker, and the person waiting is in a browser.

`ProjectModel` gains `ConversionStatus` + `ConversionError`. The job marks `Converting` on entry and a **terminal** state on every one of its **five** early returns — each of which previously left the model advertising itself as converting forever.

An unconfigured converter is deliberately **not** marked failed: the upload endpoint only promises a derivative when a converter is configured, so reporting a broken conversion that was never attempted would be its own false statement.

Status is stored as **text, not an enum**, so a value written by a newer worker can't fail to deserialise on an older API instance mid-deploy. Writing it is best-effort by the same logic as the job — it must never turn a *successful* conversion into an exception.

## Two orphans that claimed to ship

`FederationLinkedWalker` and `AsBuiltReconciler` have **zero callers**. The former's header claimed it was *"used by Clash triage (S6.1), As-built reconciliation (S6.5), and any BCC dashboard metric that needs 'X across all linked models'"*. None of those consume it, and **cross-tool clash does not exist at all.**

Both are **kept, not deleted** — the code is sound and the walk `FederationLinkedWalker` implements is exactly what a federated metric needs, so rewriting it later costs more than carrying it. Their headers now say **NOT WIRED**.

*An orphan is a cost; an orphan advertising itself as shipped is a trap* — someone auditing whether federated clash works finds a docstring asserting it does, and stops looking.

## Verification

**5 tests.** The load-bearing one asserts that **no terminal path leaves a model reading "Converting"** — that's the state a coordinator waits on forever, and it matters more than any individual branch. Also: the failure *reason* travels (not just "Failed", which sends the coordinator to support when the cause is usually actionable by them), and an unconfigured converter leaves the status alone.

- Full suite against **real PostgreSQL 16: 774 passed / 0 failed / 0 skipped**
- Revit plugin: **0 errors, 0 warnings**

### Note on the DTO

`ModelMetaDto` is a **positional record**, so the new fields are appended with defaults rather than inserted — adding a parameter mid-list silently re-maps every argument after it. My first attempt did exactly that, and the compiler caught it only because a later argument happened to be named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)