### PR TITLE
fix(licences): link /licences from account and downloads

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -102,6 +102,7 @@ table.inv tr:last-child td { border-bottom: 0; }
 
       <div class="acct-actions">
         <a class="btn-primary" href="/downloads">Downloads</a>
+        <a class="btn-secondary" href="/licences">Licences</a>
         <button type="button" class="btn-secondary" id="cloud-btn">Open Planscape cloud</button>
         <button type="button" class="link-btn" id="logout-btn">Log out</button>
       </div>

--- a/marketing-site/downloads.html
+++ b/marketing-site/downloads.html
@@ -61,7 +61,8 @@
   <div class="state" id="ready">
     <div class="dl-head">
       <h1>Downloads</h1>
-      <p class="sub" id="head-sub">Everything your plan includes.</p>
+      <p class="sub" id="head-sub">Everything your plan includes. Downloaded STING Tools?
+        <a href="/licences">Licence this machine</a> to activate it.</p>
     </div>
     <div id="banner-slot"></div>
     <div id="tools"></div>


### PR DESCRIPTION
The page shipped in #690 with **nothing linking to it**.

```bash
grep -rIn "licences" --include=*.html marketing-site | grep -v "^marketing-site/licences.html"
# (no output)
```

Signing in and landing on `/account` offered Downloads, Open Planscape cloud, Log out. A customer had no route to the page and no reason to guess the URL — so "self-serve licensing" was self-serve only for someone who already knew it existed. Found by @beckykyomugisha signing in and looking.

## Changes

- `account.html` — a **Licences** button beside Downloads, in the static `.acct-actions` row inside the authenticated `ready` block.
- `downloads.html` — the header sub now reads *"Downloaded STING Tools? Licence this machine to activate it."* — the point at which activation is actually on the user's mind.

## Verified

`npm run typecheck` clean. Checked that nothing overwrites either insertion point: `head-sub` has no JS references at all, and the `.acct-actions` container at `account.html:103` is static (the JS-populated one is `#sub-actions` at :117, a different element).

Not browser-verified — both pages gate behind `/api/auth/refresh`, so the markup is unreachable without a session.