### PR TITLE
fix(tests): stop the test bundle landing in the Pages deploy (#691)

### DIFF
--- a/marketing-site/tests/run.mjs
+++ b/marketing-site/tests/run.mjs
@@ -13,8 +13,17 @@ import { spawn } from "node:child_process";
 
 const entry = process.argv[2] ?? "tests/license.test.ts";
 // Inside the project, not a temp dir: miniflare is left external and has to
-// resolve from node_modules. Gitignored.
-const outfile = "tests/.bundle.test.mjs";
+// resolve from node_modules.
+//
+// Inside node_modules SPECIFICALLY, and not in tests/, because this directory is
+// also the Pages build output — `wrangler pages deploy .` uploads whatever is
+// sitting here. It does not honour .gitignore, and it does not skip dotfiles:
+// the old `tests/.bundle.test.mjs` was gitignored, dot-prefixed, and published
+// to production anyway, where it served a bundle of issue.ts / present.ts /
+// seats.ts / crypto.ts / auth.ts / jwt.ts as one downloadable file (#691).
+// node_modules IS excluded by Pages, and module resolution still finds
+// miniflare from here — marketing-site/node_modules is an ancestor.
+const outfile = "node_modules/.cache/planscape/bundle.test.mjs";
 
 await esbuild.build({
   entryPoints: [entry],
@@ -27,7 +36,11 @@ await esbuild.build({
   logLevel: "info",
 });
 
-const child = spawn(process.execPath, ["--test", outfile], {
+// Run the bundle directly rather than via `--test`. Node's test runner skips
+// anything under node_modules even when named explicitly, and node:test executes
+// its tests on plain import anyway — same reporter, and a failing test still
+// exits non-zero (asserted by tests/run.mjs's own failure path; see #691).
+const child = spawn(process.execPath, [outfile], {
   stdio: "inherit",
   // Bundled code reads functions/api/schema.sql by relative path.
   cwd: process.cwd(),


### PR DESCRIPTION
Partially addresses #691 — the recurring half.

## The problem

`tests/run.mjs` wrote its esbuild output to `tests/.bundle.test.mjs`, inside the directory `wrangler pages deploy .` publishes. **Pages does not honour `.gitignore` and does not skip dotfiles**, so a file that was both got uploaded and served as `application/javascript`: 35,601 bytes bundling `issue.ts`, `present.ts`, `_lib/seats.ts`, `_lib/crypto.ts`, `_lib/auth.ts` and `_lib/jwt.ts` into one public download.

Not a one-off — deployment `4dc78180`, from three days before this was noticed, served its own 30,593-byte copy. Any deploy following `npm test` republished it, which is precisely the order a careful person works in.

## The fix

Bundle goes to `node_modules/.cache/planscape/bundle.test.mjs`:

- **Pages excludes `node_modules`**, so it cannot be published.
- **miniflare still resolves** — `marketing-site/node_modules` is an ancestor of the bundle, so Node's resolution algorithm reaches it. It has to stay resolvable; that is why the original comment put the bundle inside the project rather than in a temp dir.

One consequence, handled: **Node's test runner skips anything under `node_modules`**, even a path named explicitly — `node --test node_modules/.../bundle.test.mjs` reports `Could not find`. `node:test` executes its tests on plain import, so the bundle is now spawned directly. Same reporter, same output.

## Verified, not assumed

The risk in dropping `--test` is a runner that reports red but exits 0, which would make CI green on failing tests. Both paths checked:

| | exit code |
|---|---|
| Full suite (11 tests, all passing) | **0** |
| A deliberately failing test | **1** |

```
ℹ tests 11 · pass 11 · fail 0
```

`npm run typecheck` clean. `tests/` now contains only `license.test.ts` and `run.mjs`.

## Still open in #691

`tests/license.test.ts` is tracked and still published — that predates this session and needs the directory moved out of `pages_build_output_dir`, which is a larger change. Left for the issue.