### PR TITLE
fix(docmgr): two defects found testing the restore round-trip in Revit

### DIFF
--- a/StingTools/UI/DocumentManagementDialog.cs
+++ b/StingTools/UI/DocumentManagementDialog.cs
@@ -4106,6 +4106,13 @@ namespace StingTools.UI
             return btn;
         }
 
+        /// <summary>
+        /// "a" or "an" for a following word. The category is interpolated at runtime, so a fixed
+        /// "a" produced "a activity record" for ACTIVITY / ISSUE — seen in Revit.
+        /// </summary>
+        private static string Article(string word)
+            => !string.IsNullOrEmpty(word) && "aeiou".IndexOf(char.ToLowerInvariant(word[0])) >= 0 ? "an" : "a";
+
         /// <summary>Null for a blank tooltip, so WPF shows no popup instead of an empty one.</summary>
         private static string NullIfBlank(string s) => string.IsNullOrWhiteSpace(s) ? null : s;
 
@@ -4324,8 +4331,11 @@ namespace StingTools.UI
                     foreach (string f in Directory.GetFiles(bin))
                     {
                         string name = Path.GetFileName(f);
-                        // Bookkeeping sidecar, not a recycled deliverable.
-                        if (string.Equals(name, "recycle_index.json", StringComparison.OrdinalIgnoreCase)) continue;
+                        // Bookkeeping sidecar, not a recycled deliverable. StartsWith, not
+                        // equality: WriteAllTextAtomic leaves "recycle_index.json.bak" beside it
+                        // (and a ".tmp" mid-write), and an exact-match filter offered those as
+                        // restorable files — observed in Revit, the picker listed the .bak.
+                        if (name.StartsWith("recycle_index.json", StringComparison.OrdinalIgnoreCase)) continue;
                         // Now that several bins are scanned, the same recycled name can appear
                         // twice. Disambiguate rather than letting the first bin hide the rest.
                         string key = name;
@@ -4476,8 +4486,9 @@ namespace StingTools.UI
             if (item.Category != "ISSUE")
             {
                 StingLog.Info($"DocMgr {verb}: row '{item.Title}' is category {item.Category}, not ISSUE.");
+                string kind = string.IsNullOrEmpty(item.Category) ? "register" : item.Category.ToLowerInvariant();
                 MessageBox.Show($"'{item.Title}' is not an issue.\n\n" +
-                    $"It is a {(string.IsNullOrEmpty(item.Category) ? "register" : item.Category.ToLowerInvariant())} row, " +
+                    $"It is {Article(kind)} {kind} row, " +
                     $"and {verb} only applies to issues (RFI, NCR, SI and the like).\n\n" +
                     "Filter the list to ISSUE rows, or raise one from the ISSUES tab.",
                     $"STING {verb}", MessageBoxButton.OK, MessageBoxImage.Information);
@@ -4500,7 +4511,8 @@ namespace StingTools.UI
             if (string.IsNullOrEmpty(item.FilePath))
             {
                 StingLog.Info($"DocMgr {verb}: row '{item.Title}' (category {item.Category}) has no file path.");
-                MessageBox.Show($"'{item.Title}' is not a file.\n\nIt is a {(string.IsNullOrEmpty(item.Category) ? "register" : item.Category.ToLowerInvariant())} " +
+                string kind = string.IsNullOrEmpty(item.Category) ? "register" : item.Category.ToLowerInvariant();
+                MessageBox.Show($"'{item.Title}' is not a file.\n\nIt is {Article(kind)} {kind} " +
                     $"record with no file attached, so it cannot be {verb.ToLowerInvariant()}d.\n\n" +
                     "File actions work on rows that have a file on disk — the Size and Date columns are filled in for those.",
                     $"STING {verb}", MessageBoxButton.OK, MessageBoxImage.Information);


### PR DESCRIPTION
Two defects found by driving the repaired Document Manager in Revit 2025 against a live project (KIBALE NP / KNP26), not by inspection. Follow-up to #662.

## Fixes

**The restore picker offered `recycle_index.json.bak` as a restorable file.** The filter skipped the bookkeeping sidecar by *exact* name, but `WriteAllTextAtomic` leaves a `.bak` beside it (and a `.tmp` mid-write). Now matches by prefix.

**"It is a activity record".** The category is interpolated at runtime, so a fixed article was wrong for every vowel-initial category (ACTIVITY, ISSUE). Added an `Article()` helper and used it in both guard messages.

## Runtime verification of #662

This is the in-Revit testing that #662 could only partly claim. Against the live project:

- **Delete on a non-file row** — the originally reported failure — now explains itself instead of doing nothing.
- **Delete of a real file** recycled to the **canonical** bin, which was the whole point of the repair:
  ```
  Recycled warnings_baseline.json → D:\...\KNP26\_data\recycle
  ```
  Documents 10 → 9, activity row logged, list refreshed.
- **Restore** listed the file, offered `(original location)`, and put it back at
  `17_BRIEFCASE_KNP26/PRJ/_data/warnings_baseline.json` — 82 bytes, timestamp prefix stripped, origin resolved through `recycle_index.json`. Documents 9 → 10. **Round-trip closed.**
- The **"1 selected, none usable"** report was *correct*, not a bug: the log shows those rows were `COMPLIANCE` category, never documents. The new message exposed a pre-existing mismatch rather than introducing one.
- All 9 tabs render; the `SystemParameters.WorkArea` clamp keeps the dialog inside a 1366x768 screen.

## Verification

Release build 0 errors / 0 warnings. `main` merged in (the branch had fallen 11 commits behind; that merge touches `StingTools/UI/ActivationDialog.cs` plus marketing-site files and built clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
