### PR TITLE
fix(visibility): temporary hide needs a transaction; imports misclassified

### DIFF
--- a/StingTools/Commands/Visibility/VisibilityCommandHelper.cs
+++ b/StingTools/Commands/Visibility/VisibilityCommandHelper.cs
@@ -151,8 +151,17 @@ namespace StingTools.Commands.Visibility
 
             if (set.Mode == VisibilityMode.Temporary)
             {
-                // No transaction — temporary view modes are not transactional.
+                // WRONG BELIEF, CORRECTED: this used to run with no transaction, on the claim
+                // that "temporary view modes are not transactional". They are.
+                // HideElementsTemporary / IsolateElementsTemporary modify the View element, so
+                // Revit throws "Attempt to modify the model outside of transaction" without one.
+                // The temporary state is not saved with the document, which is what makes it
+                // *temporary* — that is a different thing from not needing a transaction.
+                // One transaction spans every target view so a multi-view apply is atomic.
                 result = new VisibilityResult { Ok = true };
+                using (var t = new Transaction(doc, "STING Visibility — temporary"))
+                {
+                t.Start();
                 foreach (var v in targets)
                 {
                     var r = VisibilityEngine.Apply(doc, v, plan);
@@ -161,6 +170,8 @@ namespace StingTools.Commands.Visibility
                     foreach (var b in r.Blockers) if (!result.Blockers.Contains(b)) result.Blockers.Add(b);
                 }
                 result.Ok = result.ViewsAffected > 0;
+                if (result.Ok) t.Commit(); else t.RollBack();
+                }
             }
             else if (targets.Count > 1)
             {

--- a/StingTools/Core/Visibility/TokenValueHarvester.cs
+++ b/StingTools/Core/Visibility/TokenValueHarvester.cs
@@ -228,6 +228,15 @@ namespace StingTools.Core.Visibility
         {
             try
             {
+                // A category a DWG/DXF/DGN import brings in is created BY THE DOCUMENT, so its
+                // ElementId is positive. Every BuiltInCategory id is negative (the enum values
+                // are). That single test is what actually separates imports, and it is why the
+                // previous parent-walk to OST_ImportObjectStyles found nothing: a per-file
+                // import category reports Parent == null, so the walk never reached the root
+                // and every "ACAD-*.dxf" row fell through to Model while IMPORTS read (0).
+                long id = cat.Id.Value;
+                if (id > 0) return CategoryGroupKind.Imports;
+
                 var root = parent ?? cat;
                 for (int guard = 0; guard < 8 && root != null; guard++)
                 {

--- a/StingTools/Core/Visibility/VisibilityEngine.cs
+++ b/StingTools/Core/Visibility/VisibilityEngine.cs
@@ -332,35 +332,41 @@ namespace StingTools.Core.Visibility
             var result = new VisibilityResult { Ok = true };
             if (doc == null || view == null) { result.Ok = false; result.Error = "No active view."; return result; }
 
-            // Phase 1 — temporary hide/isolate, outside any transaction.
+            // Both halves inside ONE transaction. This previously split them, on the claim that
+            // disabling a temporary view mode throws inside a transaction. That claim came from
+            // the same wrong belief that made Apply fail with "Attempt to modify the model
+            // outside of transaction" — clearing a view's temporary mode is a model change on
+            // the View element, exactly like setting it. One transaction also makes Reset
+            // atomic, which matters because its whole promise is that ONE press clears both
+            // mechanisms; half a reset is the support ticket it exists to prevent.
             try
             {
-                if (view.IsTemporaryHideIsolateActive())
-                {
-                    view.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
-                    result.ElementsAffected++;
-                }
-            }
-            catch (Exception ex)
-            {
-                StingLog.Warn($"VisibilityEngine.Reset temporary: {ex.Message}");
-                result.Blockers.Add($"Could not clear the temporary hide: {ex.Message}");
-            }
-
-            // Phase 2 — saved filters, inside one.
-            try
-            {
-                using (var t = new Transaction(doc, "STING Visibility — reset filters"))
+                using (var t = new Transaction(doc, "STING Visibility — reset"))
                 {
                     t.Start();
+
+                    try
+                    {
+                        if (view.IsTemporaryHideIsolateActive())
+                        {
+                            view.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+                            result.ElementsAffected++;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"VisibilityEngine.Reset temporary: {ex.Message}");
+                        result.Blockers.Add($"Could not clear the temporary hide: {ex.Message}");
+                    }
+
                     result.FiltersReused = RemoveStingFilters(view, result);
                     t.Commit();
                 }
             }
             catch (Exception ex)
             {
-                StingLog.Error("VisibilityEngine.Reset filters", ex);
-                result.Blockers.Add($"Could not remove saved filters: {ex.Message}");
+                StingLog.Error("VisibilityEngine.Reset", ex);
+                result.Blockers.Add($"Could not reset this view: {ex.Message}");
             }
 
             result.ViewsAffected = 1;

--- a/StingTools/Data/STING_VISIBILITY_PRESETS.json
+++ b/StingTools/Data/STING_VISIBILITY_PRESETS.json
@@ -3,7 +3,7 @@
   "description": "STING Visibility Center — corporate baseline presets. Project-scoped presets layer on top from <project>/_BIM_COORD/visibility_presets.json and win by name. Categories may be named by BuiltInCategory ('OST_DuctCurves'); the plugin resolves the id and display name at load, so this file stays readable and Revit-version safe. Token VALUES here are the STING defaults (DISC: A E FLS FP G LV M P S · LOC: BLD1-3 EXT · ZONE: Z01-Z04 · LVL: GF LG B1 L01.. MZ RF XX) — edit them to match your project's codes. A preset may use Hide OR ShowOnly, never both: the two have opposite meanings and a mixed set is rejected with a message.",
 
   "_excludedCategories_note": "BuiltInCategory names left out of the dropdown's category list. These are view-management categories, not model content — 'hide Cameras' is never what anyone means, and on a real model they bury the categories that matter. Grids and Levels are deliberately NOT here: hiding those is a real, common request. A project overrides this by declaring its own 'excludedCategories' in <project>/_BIM_COORD/visibility_presets.json; an explicit empty list there means 'exclude nothing'. Nothing is silently dropped — excluded categories are counted and logged once per scan.",
-  "excludedCategories": [ "OST_Cameras", "OST_Views", "OST_SectionBox", "OST_ScopeBoxes" ],
+  "excludedCategories": [ "OST_Cameras", "OST_Views", "OST_Viewers", "OST_SectionBox", "OST_ScopeBoxes" ],
 
   "presets": [
 


### PR DESCRIPTION
Three defects found on the **first real use** of the Visibility Center in Revit, after #656 and #689 landed. All four files touched are Visibility-only; 47 insertions.

## 1. Blocker — temporary hide/isolate never worked

> `Temporary hide failed: Attempt to modify the model outside of transaction.`

`VisibilityCommandHelper` ran the temporary path with no transaction, carrying the comment *"temporary view modes are not transactional"*.

**That claim is wrong, and it originated in the runner spec, so the implementation had no reason to doubt it.** `HideElementsTemporary` / `IsolateElementsTemporary` modify the `View` element. What makes the state *temporary* is that it is not saved with the document — a different thing from not requiring a transaction.

Now wrapped in one transaction spanning every target view, so a multi-view apply is atomic.

**`Reset` carried the same wrong belief in reverse**: it deliberately split its two halves so `DisableTemporaryViewMode` ran *outside* a transaction while the filter removal ran inside one. Both halves now share a single transaction. That also makes Reset atomic, which matters because its entire promise is that **one** press clears **both** mechanisms — a half-completed reset is precisely the support ticket it exists to prevent.

Temporary mode is the default, so this meant the feature's main path had never once succeeded. It passed 102 unit tests and three code reviews because the defect lives in the Revit-bound layer that no test can reach — the same layer as every other bug on this feature.

### Related, deliberately not fixed here

The pre-existing inline helpers `ViewHide` / `ViewIsolate` / `ViewReset` ([`StingCommandHandler.cs:762-765`](StingTools/UI/StingCommandHandler.cs)) call the same three APIs with no transaction and are very likely broken the same way — they predate this work by a long way. Out of scope for this fix; flagged in the commit message so it is not lost.

## 2. Imports were classified as Model

`IMPORTS / LINKED CAD` read **(0)** while both `ACAD-*.dxf` rows and `Drawing1.dwg` sat under `MODEL CATEGORIES`.

The parent-walk to `OST_ImportObjectStyles` never reached the root, because a per-file import category reports `Parent == null`. Detection is now by ElementId sign: import categories are created by the document and are **positive**, while every `BuiltInCategory` id is **negative**. The parent-walk is kept as a fallback.

## 3. "Views" survived the exclusion list

The category Revit *displays* as "Views" is `OST_Viewers`, not `OST_Views`. Both are now excluded. Cameras had correctly disappeared, which is what made the survivor obvious.

## Verification

- `dotnet build StingTools/StingTools.csproj -c Release` → **0 errors, 0 warnings**.
- `StingTools.Visibility.Tests` → **102 passing, 0 failing**.
- Deployed and confirmed present in the shipped DLL by decoding the `#US` heap at both byte alignments, with a negative control needle to prove the check itself discriminates: `STING Visibility — temporary`, `STING Visibility — reset` and `STING Visibility — purge filters` all present; the control absent.

**In-Revit confirmation of the fix is the remaining gate** — the build is deployed and ready to test. Defect 1 in particular can only be proven by clicking Apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
