### PR TITLE
fix(visibility): categories hide declaratively; live apply; view helpers get transactions

### DIFF
--- a/StingTools/Commands/Visibility/VisibilityCommandHelper.cs
+++ b/StingTools/Commands/Visibility/VisibilityCommandHelper.cs
@@ -5,9 +5,11 @@
 // report dialog, and the plan+apply sequence with its transaction rules.
 //
 // Transaction rules that are easy to get wrong and are therefore centralised here:
-//   · Temporary hide/isolate must run with NO open transaction (Revit throws inside one).
-//   · View filters need one.
-//   · VisibilityEngine.Reset sequences both halves itself — do not wrap it.
+//   · EVERYTHING here needs a transaction, temporary hide/isolate included. They modify the
+//     View element; "temporary" means the state is not saved with the document, NOT that it
+//     is transaction-free. Believing otherwise made Apply fail outright with "Attempt to
+//     modify the model outside of transaction".
+//   · VisibilityEngine.Reset opens its own — do not wrap it.
 
 using System;
 using System.Collections.Generic;
@@ -121,14 +123,24 @@ namespace StingTools.Commands.Visibility
         /// preset ("MEP only" would hide all MEP). Isolate passes ShowOnly explicitly, because
         /// that button *is* the user stating the action.</para>
         /// </summary>
-        internal static Result Run(ExternalCommandData cmd, VisibilityAction? forceAction)
+        /// <param name="quiet">
+        /// True for the live-apply path. Live apply fires on every tick, so a report dialog per
+        /// apply would make the feature unusable — the footer and badge already say what
+        /// happened. Blockers are still logged, and still surface on the next explicit Apply.
+        /// </param>
+        internal static Result Run(ExternalCommandData cmd, VisibilityAction? forceAction, bool quiet = false)
         {
             Document doc;
             var view = ActiveView(cmd, out doc);
             if (view == null) return Result.Cancelled;
 
             var set = VisibilitySession.Current;
-            if (set.Rules == null || set.Rules.Count == 0)
+
+            // An empty rule set is NOT necessarily nothing to do: re-ticking every category
+            // produces zero hide rules but a full VisibleCategoryIds list, and that apply is
+            // exactly how a user un-hides. Only bail when there is genuinely nothing either way.
+            bool hasRestoreWork = set.VisibleCategoryIds != null && set.VisibleCategoryIds.Count > 0;
+            if ((set.Rules == null || set.Rules.Count == 0) && !hasRestoreWork)
             {
                 TaskDialog.Show(Title,
                     "Nothing is selected yet.\n\nOpen 'Show / Hide' on the SELECT tab, tick the " +
@@ -192,7 +204,9 @@ namespace StingTools.Commands.Visibility
             // invalidates it first.
             StingTools.UI.VisibilityCenter.VisibilityBadge.Refresh(doc, view);
 
-            Report(plan.IsIsolate ? "Isolated" : "Hidden", result);
+            if (!quiet) Report(plan.IsIsolate ? "Isolated" : "Hidden", result);
+            else if (result.Blockers.Count > 0)
+                StingLog.Info("Vis live apply blockers: " + string.Join(" | ", result.Blockers.Distinct()));
             return result.Ok ? Result.Succeeded : Result.Failed;
         }
     }

--- a/StingTools/Commands/Visibility/VisibilityCommands.cs
+++ b/StingTools/Commands/Visibility/VisibilityCommands.cs
@@ -75,6 +75,19 @@ namespace StingTools.Commands.Visibility
             VisibilityCommandHelper.Run(cmd, null);   // respect the set's own action
     }
 
+    /// <summary>
+    /// Live apply — fired by the dropdown ~450 ms after the last tick when "Live" is on.
+    /// Identical to Apply except it reports nothing: a dialog per tick would make live
+    /// applying unusable. The footer and the hidden-count badge carry the feedback.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ApplyVisibilityLiveCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els) =>
+            VisibilityCommandHelper.Run(cmd, null, quiet: true);
+    }
+
     /// <summary>Show only what the current set matches.</summary>
     [Transaction(TransactionMode.Manual)]
     [Regeneration(RegenerationOption.Manual)]

--- a/StingTools/Core/Visibility/VisibilityEngine.cs
+++ b/StingTools/Core/Visibility/VisibilityEngine.cs
@@ -187,16 +187,85 @@ namespace StingTools.Core.Visibility
                 : ApplyViewFilters(doc, view, plan, result);
         }
 
+        /// <summary>
+        /// Apply category rows through <c>View.SetCategoryHidden</c> — the same mechanism as
+        /// Revit's own V/G dialog. Returns how many categories changed.
+        /// <para><b>Why not temporary hide.</b> Temporary hide is one-way: it adds elements to a
+        /// hidden set and nothing takes them out again short of clearing the whole mode. That is
+        /// what made unticking a DWG import hide it while re-ticking never restored it, and it
+        /// also flipped the view into temporary-view-mode for what the user experienced as an
+        /// ordinary V/G change. <c>SetCategoryHidden</c> is declarative in both directions,
+        /// survives save, prints, and is undoable with Ctrl+Z.</para>
+        /// <para>Requires an open transaction.</para>
+        /// </summary>
+        internal static int ApplyCategoryVisibility(View view, VisibilityPlan plan, VisibilityResult result)
+        {
+            int changed = 0;
+            var set = plan?.Set;
+            if (view == null || set == null) return 0;
+
+            // Hide the unticked ones.
+            foreach (var rule in set.Rules ?? new List<VisibilityRule>())
+            {
+                if (rule == null || rule.Kind != VisibilityRuleKind.Category || rule.CategoryId == 0) continue;
+                if (rule.Action == VisibilityAction.ShowOnly) continue;   // isolate is handled elsewhere
+                changed += SetCategoryVisible(view, rule.CategoryId, false, rule.CategoryName, result) ? 1 : 0;
+            }
+
+            // Show the ticked ones. This half is the fix — without it an apply only ever hides.
+            foreach (int catId in set.VisibleCategoryIds ?? new List<int>())
+            {
+                if (catId == 0) continue;
+                changed += SetCategoryVisible(view, catId, true, null, result) ? 1 : 0;
+            }
+            return changed;
+        }
+
+        private static bool SetCategoryVisible(View view, int catId, bool visible, string name, VisibilityResult result)
+        {
+            try
+            {
+                var id = new ElementId((BuiltInCategory)catId);
+                if (catId > 0) id = new ElementId((long)catId);   // import categories are document-created
+
+                // CanCategoryBeHidden is the honest gate: a category the view cannot control
+                // must be reported, not silently skipped.
+                if (!view.CanCategoryBeHidden(id))
+                {
+                    result?.Blockers.Add($"'{name ?? id.ToString()}' cannot be hidden in this view " +
+                                         "(the view template or Revit itself controls it).");
+                    return false;
+                }
+                if (view.GetCategoryHidden(id) == !visible) return false;   // already right
+                view.SetCategoryHidden(id, !visible);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SetCategoryVisible({name ?? catId.ToString()}, visible={visible}): {ex.Message}");
+                result?.Blockers.Add($"Could not change visibility of '{name ?? catId.ToString()}': {ex.Message}");
+                return false;
+            }
+        }
+
         private static VisibilityResult ApplyTemporary(View view, VisibilityPlan plan, VisibilityResult result)
         {
+            // Categories go through SetCategoryHidden (declarative, reversible); only TOKEN
+            // matches fall through to temporary element hide.
+            int cats = ApplyCategoryVisibility(view, plan, result);
+
             var ids = plan.MatchedIds.Select(id => new ElementId(id)).ToList();
             try
             {
+                bool hasTokenWork = plan.Set?.Rules != null &&
+                                    plan.Set.Rules.Any(r => r != null && r.Kind == VisibilityRuleKind.Token);
+
                 if (plan.IsIsolate) view.IsolateElementsTemporary(ids);
-                else view.HideElementsTemporary(ids);
+                else if (hasTokenWork && ids.Count > 0) view.HideElementsTemporary(ids);
 
                 result.Ok = true;
                 result.ElementsAffected = ids.Count;
+                result.CategoriesAffected = cats;
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/Visibility/VisibilityPlan.cs
+++ b/StingTools/Core/Visibility/VisibilityPlan.cs
@@ -125,6 +125,10 @@ namespace StingTools.Core.Visibility
     {
         public bool Ok { get; set; }
         public int ElementsAffected { get; set; }
+
+        /// <summary>Categories whose per-view visibility changed via SetCategoryHidden.</summary>
+        public int CategoriesAffected { get; set; }
+
         public int FiltersCreated { get; set; }
         public int FiltersReused { get; set; }
         public int ViewsAffected { get; set; }
@@ -139,6 +143,7 @@ namespace StingTools.Core.Visibility
         {
             if (!string.IsNullOrEmpty(Error)) return Error;
             var parts = new List<string> { $"{ElementsAffected:N0} elements" };
+            if (CategoriesAffected > 0) parts.Add($"{CategoriesAffected} categor{(CategoriesAffected == 1 ? "y" : "ies")}");
             if (FiltersCreated > 0) parts.Add($"{FiltersCreated} filter(s) created");
             if (FiltersReused > 0) parts.Add($"{FiltersReused} reused");
             if (ViewsAffected > 1) parts.Add($"{ViewsAffected} views");

--- a/StingTools/Core/Visibility/VisibilityRule.cs
+++ b/StingTools/Core/Visibility/VisibilityRule.cs
@@ -102,6 +102,18 @@ namespace StingTools.Core.Visibility
         [JsonProperty("origin", NullValueHandling = NullValueHandling.Ignore)]
         public string Origin { get; set; } = "corporate";
 
+        /// <summary>
+        /// Categories the user has left TICKED, i.e. explicitly wants visible. Not serialised
+        /// with presets — it is live UI state, not a saved intent.
+        /// <para>This is what makes the panel declarative for categories. Without it a set says
+        /// only "hide these", so re-ticking a row sent an apply that no longer mentioned the
+        /// category and nothing brought it back — the reported bug where unticking a DWG import
+        /// hid it and re-ticking never restored it. With it, apply states the full desired
+        /// visibility of every category it knows about, so the same gesture reverses.</para>
+        /// </summary>
+        [JsonIgnore]
+        public List<int> VisibleCategoryIds { get; set; } = new List<int>();
+
         [JsonProperty("rules")]
         public List<VisibilityRule> Rules { get; set; } = new List<VisibilityRule>();
     }

--- a/StingTools/Core/Visibility/VisibilitySession.cs
+++ b/StingTools/Core/Visibility/VisibilitySession.cs
@@ -39,7 +39,8 @@ namespace StingTools.Core.Visibility
         }
 
         /// <summary>Replace the working set's rules and mode in one atomic swap.</summary>
-        public static void Snapshot(VisibilityMode mode, VisibilityTarget target, List<VisibilityRule> rules)
+        public static void Snapshot(VisibilityMode mode, VisibilityTarget target,
+                                    List<VisibilityRule> rules, List<int> visibleCategoryIds = null)
         {
             lock (_lock)
             {
@@ -49,7 +50,8 @@ namespace StingTools.Core.Visibility
                     Origin = "project",
                     Mode = mode,
                     Target = target,
-                    Rules = rules ?? new List<VisibilityRule>()
+                    Rules = rules ?? new List<VisibilityRule>(),
+                    VisibleCategoryIds = visibleCategoryIds ?? new List<int>()
                 };
             }
         }

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -777,6 +777,8 @@ namespace StingTools.UI
                     // the dock panel even when the panel is open.
                     case "Vis_OpenFloating": RunCommand<Commands.Visibility.OpenVisibilityDropdownFloatingCommand>(app); break;
                     case "Vis_Apply": RunCommand<Commands.Visibility.ApplyVisibilityCommand>(app); break;
+                    // Live tick apply — same path, no report dialog.
+                    case "Vis_ApplyLive": RunCommand<Commands.Visibility.ApplyVisibilityLiveCommand>(app); break;
                     case "Vis_Isolate": RunCommand<Commands.Visibility.IsolateVisibilityCommand>(app); break;
                     case "Vis_ResetAll": RunCommand<Commands.Visibility.ResetVisibilityCommand>(app); break;
                     case "Vis_PurgeFilters": RunCommand<Commands.Visibility.PurgeVisibilityFiltersCommand>(app); break;
@@ -4510,13 +4512,42 @@ namespace StingTools.UI
             _clonedSourceViewName = null;
         }
 
+        /// <summary>
+        /// Run a temporary hide/isolate change inside a transaction.
+        /// <para><b>These need one.</b> `HideElementsTemporary`, `IsolateElementsTemporary` and
+        /// `DisableTemporaryViewMode` all modify the View element, so Revit throws "Attempt to
+        /// modify the model outside of transaction" without an open transaction. The state not
+        /// being SAVED with the document is what makes it temporary — that is a different thing
+        /// from not needing a transaction. These three helpers had no transaction, so Hide,
+        /// Isolate and Reset on the SELECT tab's VIEW row silently failed.</para>
+        /// </summary>
+        private static void InTempViewTransaction(UIApplication app, string name, Action<View> act)
+        {
+            var uidoc = app?.ActiveUIDocument;
+            if (uidoc?.ActiveView == null) return;
+            try
+            {
+                using (var t = new Transaction(uidoc.Document, name))
+                {
+                    t.Start();
+                    act(uidoc.ActiveView);
+                    t.Commit();
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error($"{name}", ex);
+                TaskDialog.Show("STING Tools", $"{name} failed: {ex.Message}");
+            }
+        }
+
         private static void ViewIsolateSelected(UIApplication app)
         {
             var uidoc = app.ActiveUIDocument;
             if (uidoc?.ActiveView == null) return;
             var ids = uidoc.Selection.GetElementIds();
             if (ids.Count == 0) { TaskDialog.Show("Isolate", "Select elements first."); return; }
-            uidoc.ActiveView.IsolateElementsTemporary(ids);
+            InTempViewTransaction(app, "STING Isolate", v => v.IsolateElementsTemporary(ids));
         }
 
         private static void ViewHideSelected(UIApplication app)
@@ -4525,7 +4556,7 @@ namespace StingTools.UI
             if (uidoc?.ActiveView == null) return;
             var ids = uidoc.Selection.GetElementIds();
             if (ids.Count == 0) { TaskDialog.Show("Hide", "Select elements first."); return; }
-            uidoc.ActiveView.HideElementsTemporary(ids);
+            InTempViewTransaction(app, "STING Hide", v => v.HideElementsTemporary(ids));
         }
 
         // Phase 74c: Removed unnecessary reflection — EnableTemporaryViewMode is a
@@ -4550,9 +4581,8 @@ namespace StingTools.UI
 
         private static void ViewResetIsolate(UIApplication app)
         {
-            var uidoc = app.ActiveUIDocument;
-            if (uidoc?.ActiveView == null) return;
-            uidoc.ActiveView.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            InTempViewTransaction(app, "STING Reset hide/isolate",
+                v => v.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate));
         }
 
         private static void SelectAllVisible(UIApplication app)

--- a/StingTools/UI/Visibility/VisibilityDropdown.xaml
+++ b/StingTools/UI/Visibility/VisibilityDropdown.xaml
@@ -37,6 +37,10 @@
                 <RadioButton x:Name="rbSaved" DockPanel.Dock="Left" GroupName="VisMode"
                              Content="Saved to view" FontSize="11" Checked="Mode_Changed"
                              ToolTip="Temporary hide is not undoable with Ctrl+Z and does not print. Saved to view is undoable and prints.&#10;&#10;Creates 'STING VIS - ' view filters. Persists in the view and can be pushed to a view template."/>
+                <CheckBox x:Name="chkLive" DockPanel.Dock="Left" Content="Live" IsChecked="True"
+                          FontSize="11" Margin="12,0,8,0" VerticalAlignment="Center"
+                          Checked="Live_Changed" Unchecked="Live_Changed"
+                          ToolTip="Apply each tick straight to the view, about half a second after you stop clicking.&#10;&#10;Off: nothing changes until you press Apply.&#10;Unavailable in 'Saved to view' mode, which mints view filters — one per tick would litter the project."/>
                 <ComboBox x:Name="cboTarget" DockPanel.Dock="Right" Width="118" FontSize="10"
                           SelectedIndex="0" SelectionChanged="Target_Changed">
                     <ComboBoxItem Content="Active view"/>

--- a/StingTools/UI/Visibility/VisibilityDropdown.xaml.cs
+++ b/StingTools/UI/Visibility/VisibilityDropdown.xaml.cs
@@ -98,7 +98,49 @@ namespace StingTools.UI.VisibilityCenter
 
         // ── Tick handling ───────────────────────────────────────────────
 
-        private void Row_Click(object sender, RoutedEventArgs e) => UpdateFooter();
+        private void Row_Click(object sender, RoutedEventArgs e) { UpdateFooter(); QueueLiveApply(); }
+
+        // ── Live apply ──────────────────────────────────────────────────
+        //
+        // Ticking a box changes the view directly; the Apply button becomes a confirmation
+        // rather than the only way to make anything happen. Debounced because each apply is a
+        // transaction and a Revit regeneration — All / None / Invert flip dozens of rows in one
+        // gesture, and firing per row would queue dozens of transactions and lock the UI.
+        // One apply lands ~450 ms after the last click instead.
+        private System.Windows.Threading.DispatcherTimer _liveTimer;
+
+        /// <summary>Off for Saved-to-view mode: that path creates ParameterFilterElements, and
+        /// minting filter elements on every tick would litter the project.</summary>
+        private bool LiveEnabled => chkLive?.IsChecked == true && CurrentMode == VisibilityMode.Temporary;
+
+        private void QueueLiveApply()
+        {
+            if (_initialising || !LiveEnabled) return;
+
+            if (_liveTimer == null)
+            {
+                _liveTimer = new System.Windows.Threading.DispatcherTimer
+                {
+                    Interval = System.TimeSpan.FromMilliseconds(450)
+                };
+                _liveTimer.Tick += (s, e) =>
+                {
+                    _liveTimer.Stop();
+                    if (!LiveEnabled) return;
+                    Snapshot(VisibilityAction.Hide);
+                    ActionRequested?.Invoke("Vis_ApplyLive");
+                };
+            }
+            _liveTimer.Stop();
+            _liveTimer.Start();
+        }
+
+        private void Live_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_initialising) return;
+            if (LiveEnabled) QueueLiveApply();
+            else _liveTimer?.Stop();
+        }
 
         private void All_Click(object sender, RoutedEventArgs e) => SetGroup(sender, g => g.SetAll(true));
         private void None_Click(object sender, RoutedEventArgs e) => SetGroup(sender, g => g.SetAll(false));
@@ -180,8 +222,26 @@ namespace StingTools.UI.VisibilityCenter
         }
 
         /// <summary>Push the current tick state into the session for the API-thread commands.</summary>
+        /// <remarks>
+        /// Ticked categories travel alongside the rules so the apply is DECLARATIVE for
+        /// categories — it states what should be visible as well as what should be hidden.
+        /// Sending only "hide these" is why re-ticking a row never brought it back.
+        /// </remarks>
         public void Snapshot(VisibilityAction action) =>
-            VisibilitySession.Snapshot(CurrentMode, CurrentTarget, BuildRules(action));
+            VisibilitySession.Snapshot(CurrentMode, CurrentTarget, BuildRules(action), VisibleCategoryIds());
+
+        /// <summary>Category ids the user has left ticked — everything they want visible.</summary>
+        private List<int> VisibleCategoryIds()
+        {
+            var ids = new List<int>();
+            foreach (var g in _groups)
+            {
+                if (g.TokenKey != null) continue;           // categories only
+                foreach (var row in g.Checked())
+                    if (row.CategoryId != 0) ids.Add(row.CategoryId);
+            }
+            return ids;
+        }
 
         // ── Live footer ─────────────────────────────────────────────────
 


### PR DESCRIPTION
Three reported problems, one root cause between the first two. Nine files, 225 insertions — all Visibility Center plus one shared helper in `StingCommandHandler`.

## 1. Re-ticking never restored — the reported bug

Unticking a DWG import hid it; re-ticking and pressing Apply reported:

> No element matched these rules — nothing was changed *(scanned 89)*.

A set said only *"hide these"*, so with every row re-ticked it carried **zero rules** and the apply genuinely had nothing to say. `Apply` was additive — `HideElementsTemporary` adds to a hidden set and nothing takes elements out again. Nothing could ever un-hide. This was logged as VIS-2 on #689 and deferred; it turned out to be the first thing a user hit.

**Categories now go through `View.SetCategoryHidden`** — the same mechanism as Revit's own V/G — instead of temporary element hide. That is declarative in both directions, survives save, prints, and undoes with Ctrl+Z. It also stops an ordinary category tick throwing the view into **Temporary Hide/Isolate** mode, which is what the banner in the report screenshot was.

`VisibilitySet` gains `VisibleCategoryIds` — ticked rows, i.e. what the user wants *visible*. `[JsonIgnore]`, because it is live UI state and not a saved intent. An apply now states the full desired visibility of every category it knows about rather than only the subtractions.

The `"Nothing is selected yet"` guard in `Run()` was itself part of the bug: it bailed before a restore-only apply could run. It now checks for restore work too.

**Not addressed here:** token rows (DISCIPLINE / ZONE / LEVEL …) still use temporary hide and remain one-way. Making them declarative means clearing the temporary mode and re-hiding a recomputed set, which would also clear individual elements hidden with Revit's own HH — that needs the element-hide preservation VIS-2 describes. Categories were the reported case and are separable.

## 2. Checkboxes act immediately

A **Live** toggle (on by default) applies ~450 ms after the last tick.

Debounced deliberately: each apply is a transaction plus a Revit regeneration, and All / None / Invert flip dozens of rows in a single gesture — firing per row would queue dozens of transactions and lock the UI.

Live is **unavailable in Saved-to-view mode**, which mints `ParameterFilterElement`s; one per tick would litter the project.

The live path is a separate command (`Vis_ApplyLive` → `Run(quiet: true)`) that reports nothing. A `TaskDialog` per tick would make the feature unusable, and the footer and hidden-count badge already carry the feedback. Blockers are still logged and still surface on an explicit Apply.

## 3. `ViewHide` / `ViewIsolate` / `ViewReset` had the #697 bug

Flagged in #697 as likely broken and left out of scope; confirmed and fixed here. All three called `HideElementsTemporary` / `IsolateElementsTemporary` / `DisableTemporaryViewMode` with no transaction, so the SELECT tab's VIEW row buttons had been silently failing — long predating the Visibility Center. They now route through one `InTempViewTransaction` helper that carries the explanation, so the next person does not re-derive it.

## Verification

- `dotnet build StingTools/StingTools.csproj -c Release` → **0 errors, 0 warnings**.
- `StingTools.Visibility.Tests` → **102 passing, 0 failing**.
- Deployed and confirmed in the shipped DLL, both metadata heaps, each with a negative control needle: `ApplyCategoryVisibility` / `SetCategoryHidden` / `VisibleCategoryIds` / `ApplyVisibilityLiveCommand` / `InTempViewTransaction` present; `Vis_ApplyLive`, `STING Hide`, `STING Reset hide/isolate` present as literals; both controls absent.

**In-Revit confirmation is the remaining gate** — the build is deployed and ready. The gesture to check is the one that failed: untick a DWG import (no temporary-mode banner), then re-tick it and watch it return without pressing Apply.

## Known gap

**"Reset all" does not un-hide categories.** It clears temporary hide and STING filters, but `SetCategoryHidden` state is indistinguishable from a category the user or a view template hid deliberately, so clearing it wholesale would quietly undo real V/G work. Re-ticking restores them, which now works. Logged rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
