### PR TITLE
Fix build.bat and deploy.bat: resolve Git Bash explicitly

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -34,12 +34,44 @@ if errorlevel 1 (
     exit /b 1
 )
 
-:: ── Deploy ────────────────────────────────────────────────────────
+:: ── Locate Git Bash ───────────────────────────────────────────────
+:: NOT plain `bash`. On Windows that resolves to C:\Windows\System32\bash.exe —
+:: the WSL launcher — which dies with "execvpe(/bin/bash) failed" when no WSL
+:: distro is installed, AFTER a perfectly good compile. Git ships bash at
+:: <git>\bin\bash.exe but only puts <git>\cmd on PATH, so System32 always wins
+:: and Git Bash must be resolved explicitly.
+set "GIT_BASH="
+if exist "%ProgramFiles%\Git\bin\bash.exe" set "GIT_BASH=%ProgramFiles%\Git\bin\bash.exe"
+if not defined GIT_BASH if exist "%ProgramFiles(x86)%\Git\bin\bash.exe" set "GIT_BASH=%ProgramFiles(x86)%\Git\bin\bash.exe"
+if not defined GIT_BASH if exist "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" set "GIT_BASH=%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
+
+:: Fall back to deriving it from wherever git.exe lives (git\cmd\ -> git\bin\).
+if not defined GIT_BASH (
+    for /f "delims=" %%G in ('where git 2^>nul') do (
+        if not defined GIT_BASH (
+            if exist "%%~dpG..\bin\bash.exe" set "GIT_BASH=%%~dpG..\bin\bash.exe"
+        )
+    )
+)
+
+if not defined GIT_BASH (
+    echo.
+    echo ERROR: Git Bash not found. extract_plugin.sh needs it.
+    echo        Looked in: %%ProgramFiles%%\Git\bin, %%ProgramFiles^(x86^)%%\Git\bin,
+    echo                   %%LOCALAPPDATA%%\Programs\Git\bin, and beside git.exe on PATH.
+    echo.
+    echo        Install Git for Windows, or stage manually with:
+    echo          "C:\path\to\Git\bin\bash.exe" extract_plugin.sh
+    exit /b 1
+)
+echo Found Git Bash at: !GIT_BASH!
+
+:: ── Stage (and, when STING_DEPLOY=1, install into Revit) ──────────
 echo.
-bash "%SCRIPT_DIR%extract_plugin.sh"
+"!GIT_BASH!" "%SCRIPT_DIR%extract_plugin.sh"
 if errorlevel 1 (
     echo.
-    echo DEPLOY FAILED.
+    if "%STING_DEPLOY%"=="1" (echo DEPLOY FAILED.) else (echo STAGING FAILED.)
     exit /b 1
 )
 

--- a/deploy.bat
+++ b/deploy.bat
@@ -8,8 +8,18 @@
 ::  explicit, opt-in step that installs THIS checkout's build into Revit.
 ::
 ::  Run this in whichever checkout you want active, then restart Revit.
+::
+::  Close Revit AND the Planscape Companion tray app first — both hold
+::  StingTools.dll and its dependencies, and the copy half-fails silently.
+::
+::  Git Bash is resolved inside build.bat (plain `bash` hits the WSL launcher
+::  in System32 and fails after the compile succeeds).
 :: ──────────────────────────────────────────────────────────────────
 setlocal
 set "STING_DEPLOY=1"
 call "%~dp0build.bat"
+if errorlevel 1 (
+    endlocal
+    exit /b 1
+)
 endlocal


### PR DESCRIPTION
`build.bat` and `deploy.bat` have been failing on Windows machines without a WSL distro — and failing in the worst possible way.

## The bug

Both scripts called plain `bash`. On Windows that resolves to `C:\Windows\System32\bash.exe` — the **WSL launcher**, not Git Bash. With no distro installed it dies:

```
<3>WSL (1195602 - Relay) ERROR: CreateProcessCommon:818: execvpe(/bin/bash) failed: No such file or directory
DEPLOY FAILED.
```

Git *does* ship bash, at `<git>\bin\bash.exe`. But Git for Windows only puts `<git>\cmd` on PATH — and `bash.exe` isn't in `cmd`, it's in `bin`. So System32 always wins and Git Bash is unreachable by name.

## Why it matters more than it looks

The failure happens **after `dotnet build` succeeds**. So the script prints `DEPLOY FAILED` over a clean 0-error / 0-warning compile, stages nothing to `CompiledPlugin/`, and installs nothing into Revit.

The plugin then silently stays at whatever the previous deploy left there. You edit code, build "successfully", restart Revit, and debug a DLL that never contained your change. That's the same silent-stale-plugin class of bug the retired `STING_PLACEMENT_GOLD` folder used to cause.

## The fix

Resolve Git Bash explicitly — three standard install locations, then a fallback deriving it from wherever `git.exe` sits on PATH (`git\cmd\` → `git\bin\`):

```
%ProgramFiles%\Git\bin\bash.exe
%ProgramFiles(x86)%\Git\bin\bash.exe
%LOCALAPPDATA%\Programs\Git\bin\bash.exe
<dir of git.exe>\..\bin\bash.exe
```

If none hit, it fails with a message naming every location it checked and how to stage by hand, instead of an opaque WSL relay error.

Two smaller things while in there:

- `build.bat` now reports **`STAGING FAILED`** rather than `DEPLOY FAILED` when `STING_DEPLOY` isn't set — a plain build deliberately doesn't touch Revit, so the old wording implied a deploy that was never attempted.
- `deploy.bat` propagates a non-zero exit instead of swallowing it.

No change to `extract_plugin.sh`, which was always fine — it just needed a shell that exists.

## Verified

On a machine where `C:\Windows\System32\bash.exe` exists and WSL is broken:

- `build.bat` → `Found Git Bash at: C:\Program Files\Git\bin\bash.exe`, 47 DLLs staged, **exit 0**, manifest untouched
- `deploy.bat` → exit 0, manifest installed into Revit **2025, 2026 and 2027**
- Re-verified from a clean worktree off `main` — exit 0, and it correctly did **not** touch the add-in slot on a plain build

Split out of #700, where it was found. Unrelated to that feature and wanted sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
