### PR TITLE
feat(model): surface AutoCreateRooms as an "Auto Rooms" button

### DIFF
--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -2553,6 +2553,7 @@
                                             ToolTip="Unified DWG Wizard — auto-detect whether the imported DWG is structural / architectural / MEP and dispatch to the right wizard."/>
                                     <Button Style="{StaticResource OrangeBtn}" Content="Building Shell" Tag="ModelBuildingShell" Click="Cmd_Click" ToolTip="Create complete building: 4 walls + floor + roof"/>
                                     <Button Style="{StaticResource OrangeBtn}" Content="Room" Tag="ModelCreateRoom" Click="Cmd_Click" ToolTip="Create rectangular room enclosure (4 walls + room)"/>
+                                    <Button Style="{StaticResource OrangeBtn}" Content="Auto Rooms" Tag="AutoCreateRooms" Click="Cmd_Click" ToolTip="Auto-place Rooms into every enclosed boundary on the active plan view's level. Skips circuits that already have a room; numbers new ones sequentially after the existing count."/>
                                 </WrapPanel>
                                 <Expander Header="Multi-building site (§B1-B6)" FontSize="10" Margin="0,4,0,0">
                                     <WrapPanel Margin="0,4">


### PR DESCRIPTION
## What

Adds an **Auto Rooms** button to the MODEL tab's QUICK BUILD row, next to the existing "Room" enclosure builder.

## Why

`AutoCreateRoomsCommand` (`StingTools/Temp/ModelCreationCommands.cs:644`) is the plugin's equivalent of Revit's *Place Rooms Automatically* — it walks `doc.get_PlanTopology(level, phase).Circuits` and creates a Room in every enclosed boundary that doesn't already have one.

It had a dispatch case in `StingCommandHandler.cs:3170`, but **no button anywhere in the XAML**. The only way to reach it was the NLP box, via the `"create room"` / `"auto room"` pattern in `NLPCommandProcessor.cs:173`. This is the silent-command class tracked in `SILENT_BUTTONS_TODO.md`.

The neighbouring "Room" button (`ModelCreateRoom`) does something different — it *builds* a new rectangular enclosure (4 walls + floor + room) from a preset. It does not place rooms into existing space, so it was not a substitute.

## Change

One line in `StingTools/UI/StingDockPanel.xaml`. Dispatch case and the `StingTools.Temp` namespace already matched, so nothing else needed wiring.

## Verification

- `dotnet build -c Debug` → **0 errors, 0 warnings**
- Release built and deployed to `C:\Dev\STINGTOOLS\CompiledPlugin`; `AutoCreateRooms` confirmed present in the compiled DLL (BAML tag + handler case)
- **Not yet exercised in Revit** — the button dispatches to pre-existing, unmodified command code, but the click path itself has not been run

## Notes for reviewers

Two pre-existing behaviours of the underlying command, unchanged by this PR:

- Requires a **plan view** — reads `ActiveView.GenLevel` and shows a TaskDialog if null
- Every room is named `Room` (hard-coded at `ModelCreationCommands.cs:694`); only the number varies, continuing after the existing room count on that level

🤖 Generated with [Claude Code](https://claude.com/claude-code)