### PR TITLE
Surface the Material Schedule export in the BOQ Cost Manager

### DIFF
--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -1325,6 +1325,18 @@ namespace StingTools.UI
                      "Per-line gross → net derivation: gross geometry, openings/voids deducted (NRM2/CESMM4 rules), wastage step, net measured quantity. Read-only.", false),
                 }));
 
+            sp.Children.Add(BuildActionGroup("Procurement (Material Schedule)",
+                "The buy-list, not the bill. Converts measured work into commodities in supplier " +
+                "units — bags of cement, trips of sand, No. of blocks — sectioned by construction stage.",
+                new[]
+                {
+                    ("★ Material Schedule", "MaterialSchedule_Export",
+                     "Export a stage-sectioned material schedule as XLSX. Commodities are aggregated across " +
+                     "the project, converted to supplier units with a visible wastage step, and priced from the " +
+                     "commodity rate list. Choose priced (Qty × Rate × Amount, contingency, grand total) or " +
+                     "quantities-only (a buy-list for the site team). Needs COST_COMPOUND_TAKEOFF enabled.", true),
+                }));
+
             sp.Children.Add(BuildActionGroup("IFC & ICMS3 Export",
                 "External tool round-trip and cost-plus-carbon ledger.",
                 new[]
@@ -4998,12 +5010,86 @@ namespace StingTools.UI
                 .Distinct();
         }
 
+        /// <summary>
+        /// MAT-SCHED — the Materials-tab action bar. One primary export plus a
+        /// one-line explanation of how a material schedule differs from the bill,
+        /// because "Materials" and "Material Schedule" are easy to conflate: this
+        /// tab shows measured work grouped by category, the schedule shows buyable
+        /// commodities in supplier units grouped by construction stage.
+        /// </summary>
+        private FrameworkElement BuildMaterialScheduleBar()
+        {
+            var bar = new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(0xF4, 0xF6, 0xF8)),
+                BorderBrush = BorderColor,
+                BorderThickness = new Thickness(1),
+                Padding = new Thickness(10, 8, 10, 8),
+                Margin = new Thickness(0, 0, 0, 12),
+                CornerRadius = new CornerRadius(3)
+            };
+
+            var row = new DockPanel { LastChildFill = true };
+
+            var btn = new Button
+            {
+                Content = "⬇ Export Material Schedule",
+                Tag = "MaterialSchedule_Export",
+                FontSize = 11,
+                FontWeight = FontWeights.Bold,
+                MinHeight = 30,
+                Padding = new Thickness(12, 5, 12, 5),
+                Margin = new Thickness(12, 0, 0, 0),
+                Cursor = Cursors.Hand,
+                ToolTip = "Export a stage-sectioned material schedule as XLSX — commodities in supplier units "
+                        + "(Bags / Trips / No.) with a visible wastage step, priced or quantities-only. "
+                        + "Needs COST_COMPOUND_TAKEOFF enabled."
+            };
+            try
+            {
+                var style = TryFindResource("GreenBtn") as Style;
+                if (style != null) { btn.Style = style; btn.FontSize = 11; btn.MinHeight = 30; btn.FontWeight = FontWeights.Bold; }
+                else
+                {
+                    btn.Background = new SolidColorBrush(Color.FromRgb(0x4C, 0xAF, 0x50));
+                    btn.Foreground = Brushes.White;
+                    btn.BorderBrush = new SolidColorBrush(Color.FromRgb(0x38, 0x8E, 0x3C));
+                    btn.BorderThickness = new Thickness(1);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildMaterialScheduleBar style: {ex.Message}"); }
+
+            btn.Click += (s, e) => DispatchAction("MaterialSchedule_Export");
+            DockPanel.SetDock(btn, Dock.Right);
+            row.Children.Add(Guarded(btn));
+
+            row.Children.Add(new TextBlock
+            {
+                Text = "This tab is what you MODELLED, by category. A material schedule is what you BUY — "
+                     + "cement in bags, sand in trips, blocks in No. — grouped by construction stage.",
+                FontSize = 11,
+                Foreground = Brushes.Gray,
+                TextWrapping = TextWrapping.Wrap,
+                VerticalAlignment = VerticalAlignment.Center
+            });
+
+            bar.Child = row;
+            return bar;
+        }
+
         private FrameworkElement BuildMaterialsContent()
         {
             if (_boq == null)
                 return new TextBlock { Text = "No data", Margin = new Thickness(14), Foreground = Brushes.Gray };
 
             var sp = new StackPanel { Margin = new Thickness(12) };
+
+            // MAT-SCHED — the export belongs where the user is already looking at
+            // materials. This tab answers "what did I model"; the schedule answers
+            // "what do I buy", so the two sit together rather than the export
+            // hiding behind a collapsed expander on the dock panel's BIM tab.
+            sp.Children.Add(BuildMaterialScheduleBar());
+
             var grouped = _boq.AllItems
                 .Where(i => i.Source == BOQRowSource.Model && i.Quantity > 0)
                 .GroupBy(i => i.Category ?? "(uncategorised)")

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -3229,7 +3229,11 @@
                                     <Button Style="{StaticResource OrangeBtn}" Content="✓ Prep Export" Tag="BOQPrepForExport" Click="Cmd_Click"
                                             ToolTip="Run the pre-export quality gate chain (compliance, containers, stale, BOQ data quality, warnings, placeholders). Only go to export when all gates are green."/>
                                 </WrapPanel>
-                                <Expander Header="BOQ + 5D ops" FontSize="10" Margin="0,2,0,0">
+                                <!-- Expanded by default: this group holds the BOQ and material-schedule
+                                     exports, which are the most-reached-for actions on this tab. A new
+                                     feature landing inside a collapsed expander is invisible, not merely
+                                     one click away. -->
+                                <Expander Header="BOQ + 5D ops" FontSize="10" Margin="0,2,0,0" IsExpanded="True">
                                     <WrapPanel Margin="0,4">
                                         <Button Style="{StaticResource BlueBtn}" Content="BCC Refresh" Tag="BOQBccRefresh" Click="Cmd_Click"
                                                 ToolTip="Refresh BOQ × BIM Coordination Center integrations: compute cost impact per open issue, remediation cost per clash, BOQ data-quality band, and synthetic BOQ-gap warnings. Auto-hooks (revision snapshot, meeting agenda, deliverable row, CDE routing) fire from their host commands."/>


### PR DESCRIPTION
The Material Schedule export shipped in #700 inside a **collapsed `<Expander>`** on the dock panel's BIM tab. `Expander` defaults to `IsExpanded="False"` and that tab stacks six of them, so the button wasn't one click away — it was invisible. It went unfound on first use.

A feature nobody can find hasn't really shipped, so this is a correctness fix, not polish.

## Where it belongs

The BOQ Cost Manager already has a **Materials** tab — a by-category rollup of modelled quantities, cost and carbon. That's the natural home: the tab answers *what did I model*, the schedule answers *what do I buy*.

Those two are easy to conflate, so the action bar says the difference out loud rather than assuming it's obvious:

> This tab is what you MODELLED, by category. A material schedule is what you BUY — cement in bags, sand in trips, blocks in No. — grouped by construction stage.

## Three surfaces, one command

All dispatch the single registered `MaterialSchedule_Export` tag through `StingDockPanel.DispatchCommand`, so there's no second code path to drift:

| Surface | Placement |
|---|---|
| **Cost Manager → Materials** | Action bar above the rollup — primary button, contextual |
| **Cost Manager → Actions** | New "Procurement (Material Schedule)" group, alongside every other cost workflow |
| **Dock panel → BIM** | "BOQ + 5D ops" expander now opens by default — it holds both exports |

The Materials-tab button is registered with `Guarded()`, so the panel's single in-flight dispatch guard greys it while a command runs — matching every other dispatching button rather than being the one that can double-fire.

## Verification

- `dotnet build` → **0 errors, 0 warnings**
- `StingTools.Boq.Tests` → **254 passing**, unchanged

Presentation only. No engine change, which is why the test count doesn't move.

## Still open

This does **not** close MATSCHED-1 — the export has never been run inside Revit, and making the button findable is what finally lets that happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
