### PR TITLE
feat(contact): the contact form works again — same-origin Pages Function

### DIFF
--- a/marketing-site/contact.html
+++ b/marketing-site/contact.html
@@ -169,7 +169,10 @@ function handleContact(e){
   new FormData(form).forEach(function(v,k){ data[k]=v; });
   btn.disabled = true;
   btn.textContent = 'Sending…';
-  fetch('https://api.planscape.build/marketing/contact', {
+  // Same-origin Pages Function. Was https://api.planscape.build/marketing/contact,
+  // which is NXDOMAIN (#705) — every submission failed and the visitor was told
+  // to email us instead.
+  fetch('/api/contact', {
     method: 'POST',
     headers: {'Content-Type':'application/json'},
     body: JSON.stringify(data)

--- a/marketing-site/functions/api/auth/_lib/email.ts
+++ b/marketing-site/functions/api/auth/_lib/email.ts
@@ -10,16 +10,21 @@ function appOrigin(env: Env): string {
   return env.APP_ORIGIN || "https://planscape.build";
 }
 
+// Returns whether Resend accepted the message. Every existing caller ignores
+// it — an auth email failing must not fail the request. The contact form uses
+// it to record notified_at, so a silent Resend failure is visible in the data
+// rather than only in a log nobody reads.
 async function send(
   env: Env,
   to: string,
   subject: string,
-  html: string
-): Promise<void> {
+  html: string,
+  replyTo?: string
+): Promise<boolean> {
   if (!env.RESEND_API_KEY) {
     // Non-fatal: the surrounding flow (signup/login) must still succeed.
     console.error(`Email skipped (RESEND_API_KEY unset): "${subject}" → ${to}`);
-    return;
+    return false;
   }
   try {
     const res = await fetch("https://api.resend.com/emails", {
@@ -33,6 +38,7 @@ async function send(
         to: [to],
         subject,
         html,
+        ...(replyTo ? { reply_to: replyTo } : {}),
       }),
     });
     if (!res.ok) {
@@ -44,10 +50,13 @@ async function send(
       console.error(
         `Resend send failed (${res.status}) for "${subject}" from "${env.EMAIL_FROM || DEFAULT_FROM}": ${detail.slice(0, 300)}`
       );
+      return false;
     }
+    return true;
   } catch (e) {
     // Never let an email failure break the request.
     console.error("Resend request threw", e);
+    return false;
   }
 }
 
@@ -130,4 +139,39 @@ export async function sendWelcomeEmail(
      <p style="margin:0;font-size:13px;color:#8a8f99;line-height:1.5;">Questions? Just reply to this email.</p>`
   );
   await send(env, to, "Welcome to Planscape", html);
+}
+
+// Notification for a public contact-form submission. Distinct from the senders
+// above in three ways, all deliberate:
+//
+//   * It goes to US, not to the submitter, so it is not wrapped in shell() —
+//     that template ends with "if you didn't expect this email, ignore it",
+//     which is wrong for a message you asked to receive.
+//   * reply_to is the submitter, so hitting Reply in a mail client answers the
+//     person rather than noreply@.
+//   * The body is escaped. Everything in it is attacker-controlled text from an
+//     unauthenticated public form.
+export async function sendContactNotification(
+  env: Env,
+  to: string,
+  from: { name: string; email: string; firm: string; topic: string; message: string }
+): Promise<boolean> {
+  const e = (s: string) =>
+    s.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c] as string));
+
+  const html = `<!doctype html><html><body style="margin:0;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#1a1a2e;">
+  <div style="max-width:560px;margin:0 auto;padding:24px;">
+    <h1 style="margin:0 0 4px;font-size:18px;">Contact form — ${e(from.topic)}</h1>
+    <p style="margin:0 0 20px;font-size:13px;color:#8a8f99;">Reply to this email to answer ${e(from.name)} directly.</p>
+    <table style="width:100%;border-collapse:collapse;font-size:14px;">
+      <tr><td style="padding:6px 0;color:#8a8f99;width:80px;">Name</td><td style="padding:6px 0;">${e(from.name)}</td></tr>
+      <tr><td style="padding:6px 0;color:#8a8f99;">Email</td><td style="padding:6px 0;">${e(from.email)}</td></tr>
+      <tr><td style="padding:6px 0;color:#8a8f99;">Firm</td><td style="padding:6px 0;">${e(from.firm) || "—"}</td></tr>
+      <tr><td style="padding:6px 0;color:#8a8f99;">Topic</td><td style="padding:6px 0;">${e(from.topic)}</td></tr>
+    </table>
+    <div style="margin-top:18px;padding:16px;background:#f4f5f7;border-radius:8px;white-space:pre-wrap;font-size:14px;line-height:1.5;">${e(from.message)}</div>
+  </div>
+</body></html>`;
+
+  return send(env, to, `[Contact] ${from.topic} — ${from.name}`, html, from.email);
 }

--- a/marketing-site/functions/api/contact.ts
+++ b/marketing-site/functions/api/contact.ts
@@ -1,0 +1,143 @@
+// Cloudflare Pages Function — POST /api/contact
+//
+// The contact form used to post to https://api.planscape.build/marketing/contact.
+// That hostname is NXDOMAIN (#705), so every submission failed and the form told
+// the visitor "Something went wrong. Email us at hello@planscape.build instead."
+// Same-origin now: no DNS to attach, no CORS, and nothing in the CSP to change
+// (connect-src already allows 'self').
+//
+// PUBLIC AND UNAUTHENTICATED, and it sends email — so it is an abuse surface in
+// a way the auth endpoints are not. Hence the per-IP flood check below.
+//
+// THE ROW IS THE DELIVERABLE, NOT THE EMAIL. The insert happens first and the
+// submitter is told it worked as long as it lands. A Resend outage must not lose
+// an enquiry, and must not tell a prospective customer the site is broken —
+// which is exactly the failure this endpoint exists to end.
+
+interface Env {
+  WAITLIST_DB: D1Database;
+  RESEND_API_KEY?: string;
+  EMAIL_FROM?: string;
+  CONTACT_TO?: string;
+}
+
+import { sendContactNotification } from "./auth/_lib/email";
+import type { Env as AuthEnv } from "./auth/_lib/types";
+
+// The address the form itself already offers as the fallback, so a reply comes
+// from where the visitor was told to write.
+const DEFAULT_CONTACT_TO = "hello@planscape.build";
+
+// Topics are a fixed <select> in contact.html. Anything else is a forged post.
+const ALLOWED_TOPICS = new Set([
+  "demo", "trial", "pricing", "enterprise", "migration",
+  "education", "partner", "support", "press", "other",
+]);
+
+// Enough for a genuine burst (someone resubmitting after a typo, a shared
+// office NAT) while stopping a script from using us as a mail relay.
+const MAX_PER_IP_PER_HOUR = 5;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function bad(msg: string, status = 400): Response {
+  return json({ error: msg }, status);
+}
+
+function clip(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.slice(0, max).trim();
+}
+
+function isEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return bad("Invalid JSON");
+  }
+
+  const name = clip(body.name, 120);
+  const email = clip(body.email, 200).toLowerCase();
+  const firm = clip(body.firm, 160);
+  const topic = clip(body.topic, 32);
+  const message = clip(body.message, 5000);
+
+  if (!name) return bad("Please tell us your name.");
+  if (!isEmail(email)) return bad("That email address doesn't look right.");
+  if (!ALLOWED_TOPICS.has(topic)) return bad("Please choose what your message is about.");
+  if (!message) return bad("Please write a message.");
+
+  const ip = request.headers.get("CF-Connecting-IP") || "";
+  const userAgent = clip(request.headers.get("User-Agent"), 300);
+  const referrer = clip(request.headers.get("Referer"), 300);
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  // Flood check. Skipped when the IP header is absent (local dev) rather than
+  // treated as one shared bucket, which would rate-limit every local request
+  // against every other.
+  if (ip) {
+    const since = new Date(now.getTime() - 3600_000).toISOString();
+    const recent = await env.WAITLIST_DB
+      .prepare(`SELECT COUNT(*) AS n FROM contacts WHERE ip = ? AND submitted_at > ?`)
+      .bind(ip, since)
+      .first<{ n: number }>();
+    if ((recent?.n ?? 0) >= MAX_PER_IP_PER_HOUR) {
+      return bad(
+        `That's several messages in a short time. Email ${env.CONTACT_TO || DEFAULT_CONTACT_TO} directly and we'll pick it up.`,
+        429
+      );
+    }
+  }
+
+  // Insert BEFORE emailing: the record is what must not be lost.
+  let id: number | null = null;
+  try {
+    const res = await env.WAITLIST_DB
+      .prepare(
+        `INSERT INTO contacts (name, email, firm, topic, message, ip, user_agent, referrer, submitted_at)
+         VALUES (?,?,?,?,?,?,?,?,?)`
+      )
+      .bind(name, email, firm, topic, message, ip, userAgent, referrer, nowIso)
+      .run();
+    id = (res.meta?.last_row_id as number) ?? null;
+  } catch (e) {
+    // A failed insert is the one case worth refusing on — otherwise we would
+    // report success for a message that exists nowhere.
+    console.error("contact insert failed", e);
+    return bad("We couldn't record that message. Please try again shortly.", 500);
+  }
+
+  // Best-effort notification. Never gates the response.
+  const to = env.CONTACT_TO || DEFAULT_CONTACT_TO;
+  const sent = await sendContactNotification(env as unknown as AuthEnv, to, {
+    name, email, firm, topic, message,
+  });
+
+  if (sent && id != null) {
+    try {
+      await env.WAITLIST_DB
+        .prepare(`UPDATE contacts SET notified_at = ? WHERE id = ?`)
+        .bind(new Date().toISOString(), id)
+        .run();
+    } catch (e) {
+      // The message is safe and the email went out; only the bookkeeping failed.
+      console.error("contact notified_at update failed", e);
+    }
+  } else if (!sent) {
+    // notified_at stays NULL, which is the queryable record of this.
+    console.error(`Contact ${id}: stored but notification not sent — check RESEND_API_KEY`);
+  }
+
+  return json({ ok: true });
+};

--- a/marketing-site/functions/api/schema.sql
+++ b/marketing-site/functions/api/schema.sql
@@ -412,3 +412,30 @@ CREATE INDEX IF NOT EXISTS idx_licenses_tenant ON licenses(tenant_id);
 --   wrangler d1 execute planscape-waitlist --remote \
 --     --command="ALTER TABLE licenses ADD COLUMN last_seen_revit_version TEXT;"
 -- ---------------------------------------------------------------------------
+
+-- Contact form (functions/api/contact.ts). Public, unauthenticated.
+--
+-- No UNIQUE on email, unlike waitlist: the same person may legitimately write
+-- more than once, and collapsing those would silently drop an enquiry.
+--
+-- notified_at records whether Resend ACCEPTED the notification, not merely that
+-- we tried. A send that fails is logged and nowhere else — this column makes
+-- "submitted but never reached a human" a query rather than an archaeology
+-- exercise:  SELECT * FROM contacts WHERE notified_at IS NULL;
+CREATE TABLE IF NOT EXISTS contacts (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  name          TEXT    NOT NULL,
+  email         TEXT    NOT NULL,
+  firm          TEXT,
+  topic         TEXT    NOT NULL,
+  message       TEXT    NOT NULL,
+  ip            TEXT,
+  user_agent    TEXT,
+  referrer      TEXT,
+  submitted_at  TEXT    NOT NULL,             -- ISO 8601 UTC
+  notified_at   TEXT,                         -- set when Resend accepted the email
+  status        TEXT    NOT NULL DEFAULT 'new' -- new | replied | closed | spam
+);
+CREATE INDEX IF NOT EXISTS idx_contacts_submitted ON contacts(submitted_at DESC);
+-- Supports the per-IP flood check in contact.ts.
+CREATE INDEX IF NOT EXISTS idx_contacts_ip_time ON contacts(ip, submitted_at);

--- a/marketing-site/tests/contact.test.ts
+++ b/marketing-site/tests/contact.test.ts
@@ -1,0 +1,186 @@
+// POST /api/contact, against a real D1 (miniflare) and the real schema.sql.
+//
+// THE POINT OF THIS FILE. This endpoint replaced a fetch to a hostname that does
+// not resolve, which failed every submission and told prospects the site was
+// broken (#705). The property that matters is therefore not "returns 200" — it
+// is that a submission SURVIVES. Specifically: the row is written before the
+// email is attempted, and a failing notification neither loses the enquiry nor
+// reports failure to the visitor.
+//
+// So the assertions are about the contacts table, not the status code. Resend is
+// never reachable here (RESEND_API_KEY is unset), which means every test runs the
+// notification-failed path by default — the path that used to lose data.
+
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { Miniflare } from "miniflare";
+
+import { onRequestPost as contact } from "../functions/api/contact";
+
+function statements(sql: string): string[] {
+  return sql
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+interface Harness {
+  db: D1Database;
+  env: Record<string, unknown>;
+}
+
+let shared: { h: Harness; dispose: () => Promise<void> } | null = null;
+
+async function harness(): Promise<Harness> {
+  if (!shared) {
+    const mf = new Miniflare({
+      modules: true,
+      script: "export default { fetch() { return new Response('ok') } }",
+      d1Databases: { WAITLIST_DB: ":memory:" },
+    });
+    const db = (await mf.getD1Database("WAITLIST_DB")) as unknown as D1Database;
+    const schema = readFileSync("functions/api/schema.sql", "utf8");
+    await db.batch(statements(schema).map((s) => db.prepare(s)));
+    // RESEND_API_KEY deliberately absent — see the header comment.
+    shared = { h: { db, env: { WAITLIST_DB: db } }, dispose: () => mf.dispose() };
+  }
+  await shared.h.db.prepare(`DELETE FROM contacts`).run();
+  return shared.h;
+}
+
+after(async () => {
+  await shared?.dispose();
+});
+
+const VALID = {
+  name: "Sentongo",
+  email: "sentongo@example.com",
+  firm: "M&E Associates",
+  topic: "demo",
+  message: "We would like a demo for our MEP team.",
+};
+
+function post(
+  h: Harness,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  const request = new Request("https://planscape.build/api/contact", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  return (contact as unknown as (ctx: unknown) => Promise<Response>)({
+    request,
+    env: h.env,
+    params: {},
+  });
+}
+
+const rows = async (h: Harness) =>
+  (await h.db.prepare(`SELECT * FROM contacts ORDER BY id`).all<Record<string, unknown>>())
+    .results ?? [];
+
+// --- the load-bearing test -------------------------------------------------
+
+test("a submission is stored even though the notification cannot be sent", async (t) => {
+  const h = await harness();
+
+  const res = await post(h, VALID, { "CF-Connecting-IP": "203.0.113.10" });
+
+  // The visitor is told it worked, because for them it did — we have it.
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { ok: true });
+
+  const all = await rows(h);
+  assert.equal(all.length, 1, "the enquiry must exist regardless of email");
+  assert.equal(all[0].name, VALID.name);
+  assert.equal(all[0].email, VALID.email);
+  assert.equal(all[0].topic, VALID.topic);
+  assert.equal(all[0].message, VALID.message);
+  assert.equal(all[0].ip, "203.0.113.10");
+  assert.equal(all[0].status, "new");
+
+  // And the failed notification is recorded as data, not just a log line, so
+  // "stored but nobody was told" is a query.
+  assert.equal(all[0].notified_at, null, "no email was sent, so this stays NULL");
+});
+
+test("email is lowercased and oversized input is clipped, not rejected", async (t) => {
+  const h = await harness();
+
+  await post(h, {
+    ...VALID,
+    email: "  Sentongo@Example.COM  ",
+    message: "x".repeat(6000),
+  });
+
+  const all = await rows(h);
+  assert.equal(all[0].email, "sentongo@example.com");
+  assert.equal((all[0].message as string).length, 5000, "clipped to the cap");
+});
+
+// --- validation: nothing malformed reaches the table -----------------------
+
+test("malformed submissions are refused and write nothing", async (t) => {
+  const h = await harness();
+
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ["no name", { ...VALID, name: "" }],
+    ["bad email", { ...VALID, email: "not-an-email" }],
+    ["no message", { ...VALID, message: "   " }],
+    ["topic not in the select", { ...VALID, topic: "spam-topic" }],
+    ["missing topic", { ...VALID, topic: "" }],
+  ];
+
+  for (const [label, body] of cases) {
+    const res = await post(h, body);
+    assert.equal(res.status, 400, `${label} should be refused`);
+    const b = (await res.json()) as { error: string };
+    assert.ok(b.error && b.error.length > 0, `${label} should say why`);
+  }
+
+  assert.equal((await rows(h)).length, 0, "no partial rows from refused input");
+});
+
+// --- abuse -----------------------------------------------------------------
+
+test("one IP cannot use the endpoint as a mail relay", async (t) => {
+  const h = await harness();
+  const ip = { "CF-Connecting-IP": "198.51.100.7" };
+
+  for (let i = 0; i < 5; i++) {
+    const res = await post(h, { ...VALID, message: `message ${i}` }, ip);
+    assert.equal(res.status, 200, `submission ${i + 1} of 5 should be allowed`);
+  }
+
+  const blocked = await post(h, VALID, ip);
+  assert.equal(blocked.status, 429, "the 6th within the hour is refused");
+
+  // Refused, but still told where to go — the endpoint never dead-ends someone.
+  const body = (await blocked.json()) as { error: string };
+  assert.match(body.error, /hello@planscape\.build/);
+
+  assert.equal((await rows(h)).length, 5, "the refused one is not stored");
+
+  // A different IP is unaffected — the cap is per-origin, not global.
+  const other = await post(h, VALID, { "CF-Connecting-IP": "198.51.100.8" });
+  assert.equal(other.status, 200);
+});
+
+test("a submission with no IP header still works", async (t) => {
+  const h = await harness();
+
+  // Local dev and some proxies send no CF-Connecting-IP. Treating absent as one
+  // shared bucket would rate-limit every such caller against every other.
+  for (let i = 0; i < 7; i++) {
+    const res = await post(h, { ...VALID, message: `no-ip ${i}` });
+    assert.equal(res.status, 200);
+  }
+  assert.equal((await rows(h)).length, 7);
+});

--- a/marketing-site/tests/run.mjs
+++ b/marketing-site/tests/run.mjs
@@ -10,8 +10,25 @@
 
 import * as esbuild from "esbuild";
 import { spawn } from "node:child_process";
+import { readdirSync } from "node:fs";
 
-const entry = process.argv[2] ?? "tests/license.test.ts";
+// Every tests/*.test.ts, unless one is named explicitly. Previously this
+// defaulted to a single hard-coded file, so a newly added test file ran
+// nowhere — present in the repo, absent from CI, and indistinguishable from
+// coverage. That is the failure mode CLAUDE.md §3 records for the Clash and
+// Routing projects, where 97 test methods were counted for months while
+// compiling nowhere.
+const entries = process.argv[2]
+  ? [process.argv[2]]
+  : readdirSync("tests")
+      .filter((f) => f.endsWith(".test.ts"))
+      .sort()
+      .map((f) => `tests/${f}`);
+
+if (entries.length === 0) {
+  console.error("No tests/*.test.ts files found.");
+  process.exit(1);
+}
 // Inside the project, not a temp dir: miniflare is left external and has to
 // resolve from node_modules.
 //
@@ -23,26 +40,41 @@ const entry = process.argv[2] ?? "tests/license.test.ts";
 // seats.ts / crypto.ts / auth.ts / jwt.ts as one downloadable file (#691).
 // node_modules IS excluded by Pages, and module resolution still finds
 // miniflare from here — marketing-site/node_modules is an ancestor.
-const outfile = "node_modules/.cache/planscape/bundle.test.mjs";
+const outdir = "node_modules/.cache/planscape";
 
-await esbuild.build({
-  entryPoints: [entry],
-  bundle: true,
-  outfile,
-  format: "esm",
-  platform: "node",
-  target: "node22",
-  external: ["miniflare"],
-  logLevel: "info",
-});
+// One bundle + one process per file. Each file owns a Miniflare instance, and
+// sharing a process between them would let one file's D1 leak into another's.
+let failed = 0;
+for (const entry of entries) {
+  const outfile = `${outdir}/${entry.replace(/[\/\\]/g, "_")}.mjs`;
 
-// Run the bundle directly rather than via `--test`. Node's test runner skips
-// anything under node_modules even when named explicitly, and node:test executes
-// its tests on plain import anyway — same reporter, and a failing test still
-// exits non-zero (asserted by tests/run.mjs's own failure path; see #691).
-const child = spawn(process.execPath, [outfile], {
-  stdio: "inherit",
-  // Bundled code reads functions/api/schema.sql by relative path.
-  cwd: process.cwd(),
-});
-child.on("exit", (code) => process.exit(code ?? 1));
+  await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    outfile,
+    format: "esm",
+    platform: "node",
+    target: "node22",
+    external: ["miniflare"],
+    logLevel: "info",
+  });
+
+  // Run the bundle directly rather than via `--test`. Node's test runner skips
+  // anything under node_modules even when named explicitly, and node:test
+  // executes its tests on plain import anyway — same reporter, and a failing
+  // test still exits non-zero (#691).
+  const code = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [outfile], {
+      stdio: "inherit",
+      // Bundled code reads functions/api/schema.sql by relative path.
+      cwd: process.cwd(),
+    });
+    child.on("exit", (c) => resolve(c ?? 1));
+  });
+
+  if (code !== 0) failed++;
+}
+
+// Non-zero if ANY file failed — not just the last one, which would let an
+// earlier failure pass unnoticed behind a later success.
+process.exit(failed === 0 ? 0 : 1);

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -49,6 +49,16 @@ SITE_URL = "https://planscape.build"
 #                     No redeploy required either way — Pages secrets are
 #                     runtime bindings.
 
+# Contact form (functions/api/contact.ts) — reuses the WAITLIST_DB binding below.
+#   CONTACT_TO  Plain var, optional. Where contact-form notifications go.
+#               Defaults to hello@planscape.build, the address contact.html
+#               already offers as its fallback. Sending reuses RESEND_API_KEY.
+#               If that is unset the submission is STILL STORED and
+#               `contacts.notified_at` stays NULL — the queryable record of
+#               "someone wrote in and no email went out":
+#                 SELECT * FROM contacts WHERE notified_at IS NULL;
+#               Setting it requires a redeploy (see #674), like every var here.
+
 # D1 binding for the waitlist Function (functions/api/waitlist.ts)
 # Created via: wrangler d1 create planscape-waitlist
 [[d1_databases]]


### PR DESCRIPTION
Addresses the customer-facing half of #705, without waiting on DNS or Render.

## The problem

`contact.html` posted to `https://api.planscape.build/marketing/contact`. That hostname is **NXDOMAIN**, so every submission failed and the handler told the visitor:

> Something went wrong. Email us at hello@planscape.build instead.

That has been the experience of every prospect who used the form since at least 2026-07-20, the date `SERVER_GO_LIVE.md` records the domain as not resolving.

## The fix

`POST /api/contact` — same-origin, so there is no DNS to attach, no CORS, and `connect-src 'self'` already covers it in the CSP. It has no dependency on the Render service or the missing domain, so it works now and keeps working if either changes.

**The row is the deliverable, not the email.** The insert happens first and success is reported once it lands. A Resend outage cannot lose an enquiry, and — more to the point — cannot tell a paying prospect that the site is broken, which is the exact failure this replaces.

`contacts.notified_at` records whether Resend *accepted* the notification, not merely that we tried. So "stored but nobody was told" is a query rather than an archaeology exercise:

```sql
SELECT * FROM contacts WHERE notified_at IS NULL;
```

Public, unauthenticated, and it sends email — an abuse surface the auth endpoints are not. Hence 5 per IP per hour, with a refusal that still names the address to write to. An absent IP header skips the check rather than putting every such caller in one shared bucket.

`Reply-To` is the submitter, so replying in a mail client answers the person rather than `noreply@`. The notification body is escaped — all of it is attacker-controlled text from a public form.

## Also fixes the test runner

It defaulted to one hard-coded file, so `tests/contact.test.ts` would have run **nowhere** — present in the repo, absent from CI, indistinguishable from coverage. That is precisely the failure CLAUDE.md §3 records for the Clash and Routing projects, where 97 test methods were counted for months while compiling nowhere.

Now: every `tests/*.test.ts`, one process each so D1 cannot leak between files, and non-zero exit if **any** file fails.

## Verified

| Check | Result |
|---|---|
| `npm test` | **16 pass, 0 fail** (5 new + 11 existing) |
| `npm run typecheck` | clean |
| Deliberately failing *first* file | **exit 1** — not masked by later passes |
| Real form in a browser | `POST /api/contact` → **200**, green success shown |
| Row in D1 | every field intact, `notified_at` NULL, `status: new` |

The load-bearing test asserts the property the design rests on: with `RESEND_API_KEY` unset — the notification-failed path — the submission is still stored, still returns `ok`, and records the failure as data.

## Note on #675

While editing `wrangler.toml` I found **[#675](https://github.com/beckykyomugisha/STINGTOOLS/pull/675) is still open**, so `main` still carries the incorrect *"No redeploy required either way — Pages secrets are runtime bindings"* note, and `LICENSE_PRIVATE_KEY` remains undocumented there. My `CONTACT_TO` block is deliberately placed away from the lines #675 touches, so the two merge without conflict in either order. #675 is still worth merging.