### PR TITLE
fix(email): stop logging the sender value, and record every send attempt

### DIFF
--- a/marketing-site/functions/api/auth/_lib/email.ts
+++ b/marketing-site/functions/api/auth/_lib/email.ts
@@ -10,10 +10,57 @@ function appOrigin(env: Env): string {
   return env.APP_ORIGIN || "https://planscape.build";
 }
 
+// NEVER log the sender VALUE. This line used to interpolate env.EMAIL_FROM, and
+// that variable had been set to a 44-character base64 string — so every failed
+// send wrote a secret-shaped value into Cloudflare's Function logs (#711).
+//
+// Classifying it is also strictly more useful: it names the fault ("not an
+// email address") instead of asking a human to eyeball 44 characters and notice
+// they are not an address.
+function describeFrom(env: Env): string {
+  const raw = (env.EMAIL_FROM || "").trim();
+  if (!raw) return "default";
+  const looksLikeAddress =
+    /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(raw) ||
+    /^[^<>]*<[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+>$/.test(raw);
+  return looksLikeAddress
+    ? "EMAIL_FROM"
+    : "EMAIL_FROM (NOT an email address — Resend will reject every send)";
+}
+
+// One row per attempt, so "did that email actually go out?" is a query rather
+// than an appeal to logs nobody reads.
+//
+// This lives in send() and not at the six call sites on purpose: every sender
+// gets it with no change of its own, and a sender added later cannot forget to
+// opt in. That absence is exactly what let a total email outage go unnoticed —
+// the contact form was the first sender to record its result, and it found the
+// outage on its first submission.
+//
+// Never throws: a ledger failure must not break an email, and an email failure
+// must not break a signup.
+async function record(
+  env: Env,
+  to: string,
+  subject: string,
+  ok: boolean,
+  error: string | null
+): Promise<void> {
+  try {
+    await env.WAITLIST_DB.prepare(
+      `INSERT INTO email_log (to_address, subject, ok, error, created_at)
+       VALUES (?,?,?,?,?)`
+    )
+      .bind(to, subject.slice(0, 200), ok ? 1 : 0, error ? error.slice(0, 300) : null, new Date().toISOString())
+      .run();
+  } catch (e) {
+    console.error("email_log write failed", e);
+  }
+}
+
 // Returns whether Resend accepted the message. Every existing caller ignores
 // it — an auth email failing must not fail the request. The contact form uses
-// it to record notified_at, so a silent Resend failure is visible in the data
-// rather than only in a log nobody reads.
+// it to record notified_at; every sender is now recorded in email_log too.
 async function send(
   env: Env,
   to: string,
@@ -24,6 +71,7 @@ async function send(
   if (!env.RESEND_API_KEY) {
     // Non-fatal: the surrounding flow (signup/login) must still succeed.
     console.error(`Email skipped (RESEND_API_KEY unset): "${subject}" → ${to}`);
+    await record(env, to, subject, false, "RESEND_API_KEY unset");
     return false;
   }
   try {
@@ -42,20 +90,21 @@ async function send(
       }),
     });
     if (!res.ok) {
-      // Log Resend's own message, not just the status. The status alone is not
-      // actionable: 401 means a bad API key, 422 usually means the From: domain
-      // is unverified — and since a failed send never surfaces to the user
-      // (see the catch below), this log is the ONLY evidence anything is wrong.
-      const detail = await res.text().catch(() => "");
-      console.error(
-        `Resend send failed (${res.status}) for "${subject}" from "${env.EMAIL_FROM || DEFAULT_FROM}": ${detail.slice(0, 300)}`
-      );
+      // Resend's own message, plus a classification of the sender — the status
+      // alone is not actionable (401 = bad API key, 422 = malformed or
+      // unverified sender).
+      const detail = (await res.text().catch(() => "")).slice(0, 300);
+      const summary = `Resend send failed (${res.status}) for "${subject}" [from=${describeFrom(env)}]: ${detail}`;
+      console.error(summary);
+      await record(env, to, subject, false, summary);
       return false;
     }
+    await record(env, to, subject, true, null);
     return true;
   } catch (e) {
     // Never let an email failure break the request.
     console.error("Resend request threw", e);
+    await record(env, to, subject, false, `threw: ${String(e).slice(0, 200)}`);
     return false;
   }
 }

--- a/marketing-site/functions/api/schema.sql
+++ b/marketing-site/functions/api/schema.sql
@@ -439,3 +439,32 @@ CREATE TABLE IF NOT EXISTS contacts (
 CREATE INDEX IF NOT EXISTS idx_contacts_submitted ON contacts(submitted_at DESC);
 -- Supports the per-IP flood check in contact.ts.
 CREATE INDEX IF NOT EXISTS idx_contacts_ip_time ON contacts(ip, submitted_at);
+
+-- Email delivery ledger (functions/api/auth/_lib/email.ts). One row per ATTEMPT,
+-- written by send() itself so every sender is covered without opting in.
+--
+-- Why this exists: EMAIL_FROM was set to a base64 random string, so Resend
+-- rejected every send with a 422 — signup verification, password reset, welcome
+-- and invitations included — and nothing recorded it. Each sender awaits send()
+-- and discards the result by design (an email must not fail a signup), so the
+-- only trace was a Function log. A total email outage was therefore invisible
+-- until the contact form became the first sender to record its result (#711).
+--
+-- Find failures:
+--   SELECT * FROM email_log WHERE ok = 0 ORDER BY created_at DESC;
+-- Did a specific person get their email?
+--   SELECT * FROM email_log WHERE to_address = ? ORDER BY created_at DESC;
+--
+-- `error` holds Resend's message plus a CLASSIFICATION of the sender, never the
+-- sender value — that is how a secret-shaped EMAIL_FROM reached the logs.
+CREATE TABLE IF NOT EXISTS email_log (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  to_address  TEXT    NOT NULL,
+  subject     TEXT    NOT NULL,
+  ok          INTEGER NOT NULL,          -- 1 = Resend accepted it, 0 = it did not
+  error       TEXT,                      -- NULL when ok = 1
+  created_at  TEXT    NOT NULL           -- ISO 8601 UTC
+);
+CREATE INDEX IF NOT EXISTS idx_email_log_created ON email_log(created_at DESC);
+-- Supports "show me everything that failed" without scanning the successes.
+CREATE INDEX IF NOT EXISTS idx_email_log_failures ON email_log(ok, created_at DESC);

--- a/marketing-site/tests/email.test.ts
+++ b/marketing-site/tests/email.test.ts
@@ -1,0 +1,148 @@
+// The email delivery ledger, against a real D1 (miniflare) and the real schema.
+//
+// THE POINT OF THIS FILE. EMAIL_FROM was set to a base64 random string, so Resend
+// 422'd every send — signup verification, password reset, welcome, invitations —
+// and nothing anywhere recorded it. Every sender awaits send() and discards the
+// result by design, so the only trace was a Function log, and a total email
+// outage stayed invisible for months (#711).
+//
+// So these tests assert two things that would have caught it:
+//   1. a failed send leaves a row saying so;
+//   2. the sender VALUE never appears in what gets recorded — because the log
+//      line that used to print it wrote a secret-shaped value into Cloudflare's
+//      logs on every failure.
+
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { Miniflare } from "miniflare";
+
+import { sendContactNotification } from "../functions/api/auth/_lib/email";
+import type { Env } from "../functions/api/auth/_lib/types";
+
+function statements(sql: string): string[] {
+  return sql
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+let shared: { db: D1Database; dispose: () => Promise<void> } | null = null;
+
+async function db(): Promise<D1Database> {
+  if (!shared) {
+    const mf = new Miniflare({
+      modules: true,
+      script: "export default { fetch() { return new Response('ok') } }",
+      d1Databases: { WAITLIST_DB: ":memory:" },
+    });
+    const d = (await mf.getD1Database("WAITLIST_DB")) as unknown as D1Database;
+    await d.batch(statements(readFileSync("functions/api/schema.sql", "utf8")).map((s) => d.prepare(s)));
+    shared = { db: d, dispose: () => mf.dispose() };
+  }
+  await shared.db.prepare(`DELETE FROM email_log`).run();
+  return shared.db;
+}
+
+after(async () => {
+  await shared?.dispose();
+});
+
+// The base64 blob EMAIL_FROM actually held. Shortened, but the same shape: not
+// an email address, and secret-looking.
+const BAD_FROM = "v14gO53fqhK3RyAdzI7b+qUHN8fU8gtcmtoEtHE2M";
+
+const PERSON = {
+  name: "Sentongo",
+  email: "sentongo@example.com",
+  firm: "M&E Associates",
+  topic: "demo",
+  message: "Hello",
+};
+
+const rows = async (d: D1Database) =>
+  (await d.prepare(`SELECT * FROM email_log ORDER BY id`).all<Record<string, unknown>>()).results ?? [];
+
+// --- the load-bearing test -------------------------------------------------
+
+test("a send that cannot happen is recorded, not merely logged", async (t) => {
+  const d = await db();
+  // RESEND_API_KEY absent — the shape of a misconfigured environment.
+  const env = { WAITLIST_DB: d } as unknown as Env;
+
+  const ok = await sendContactNotification(env, "hello@planscape.build", PERSON);
+
+  assert.equal(ok, false, "send reports failure to its caller");
+
+  const all = await rows(d);
+  assert.equal(all.length, 1, "the attempt left a row");
+  assert.equal(all[0].ok, 0);
+  assert.equal(all[0].to_address, "hello@planscape.build");
+  assert.match(String(all[0].subject), /Contact/);
+  assert.match(String(all[0].error), /RESEND_API_KEY unset/);
+
+  // This is the query that would have surfaced the outage on day one.
+  const failures = await d
+    .prepare(`SELECT COUNT(*) AS n FROM email_log WHERE ok = 0`)
+    .first<{ n: number }>();
+  assert.equal(failures?.n, 1);
+});
+
+test("the recorded failure never contains the sender value", async (t) => {
+  const d = await db();
+  // A misconfigured EMAIL_FROM, exactly the bug from #711.
+  const env = { WAITLIST_DB: d, EMAIL_FROM: BAD_FROM } as unknown as Env;
+
+  await sendContactNotification(env, "hello@planscape.build", PERSON);
+
+  const all = await rows(d);
+  assert.equal(all.length, 1);
+
+  // The whole row, not just the error column — nothing may carry the value.
+  const serialised = JSON.stringify(all[0]);
+  assert.equal(
+    serialised.includes(BAD_FROM),
+    false,
+    "the sender value must never be recorded — that is how it reached the logs"
+  );
+});
+
+test("a ledger row is written for every attempt, so silence means no attempt", async (t) => {
+  const d = await db();
+  const env = { WAITLIST_DB: d } as unknown as Env;
+
+  await sendContactNotification(env, "one@example.com", PERSON);
+  await sendContactNotification(env, "two@example.com", PERSON);
+  await sendContactNotification(env, "three@example.com", PERSON);
+
+  const all = await rows(d);
+  assert.equal(all.length, 3);
+  assert.deepEqual(
+    all.map((r) => r.to_address),
+    ["one@example.com", "two@example.com", "three@example.com"]
+  );
+});
+
+test("a broken ledger does not break sending", async (t) => {
+  const d = await db();
+
+  // Drop the table out from under it: record() must swallow the failure, and
+  // send() must still return its verdict. An observability failure that breaks
+  // signup would be worse than the blindness it replaces.
+  await d.prepare(`DROP TABLE email_log`).run();
+
+  const env = { WAITLIST_DB: d } as unknown as Env;
+  const ok = await sendContactNotification(env, "hello@planscape.build", PERSON);
+  assert.equal(ok, false, "still returns a verdict rather than throwing");
+
+  // Restore for the shared harness.
+  await d.batch(
+    statements(readFileSync("functions/api/schema.sql", "utf8"))
+      .filter((s) => /email_log/.test(s))
+      .map((s) => d.prepare(s))
+  );
+});


### PR DESCRIPTION
The two items left open in #711 after the outage itself was fixed.

## 1 — The failure log was printing a secret

`_lib/email.ts` interpolated `env.EMAIL_FROM` into its error message. That variable had been set to a 44-character base64 string, so **every failed send wrote a secret-shaped value into Cloudflare's Function logs** — continuously, for as long as it was misconfigured.

It now logs a classification, which is also strictly more useful:

```
Resend send failed (422) for "[Contact] other — …"
  [from=EMAIL_FROM (NOT an email address — Resend will reject every send)]: …
```

That names the fault. The old line asked a human to look at 44 characters and notice they were not an address — which is exactly what nobody did.

Residual risk, stated rather than hidden: `detail` is Resend's own message, truncated to 300 chars. Resend's validation messages are generic and did not echo the value in this case, but a future message theoretically could.

## 2 — `email_log`: one row per attempt

```sql
SELECT * FROM email_log WHERE ok = 0 ORDER BY created_at DESC;   -- what failed
SELECT * FROM email_log WHERE to_address = ?;                    -- did they get it
```

**Written inside `send()`, not at the six call sites.** Every sender — signup verification, resend-verify, password reset, welcome, invitations, contact — is covered without opting in, and a sender added later cannot forget to.

That absence is the whole reason a total outage went unnoticed. Each caller `await`s `send()` and discards the result *by design*: an email failing must not fail a signup. Correct, but it meant the only trace was a Function log. The contact form was the first sender to record its result, and it found the outage on its very first submission.

`error` stores Resend's message plus the sender **classification**, never the sender value.

## Verified

**20 tests pass** (4 new + 16 existing); typecheck clean.

The new tests assert the two properties that would have caught the outage:

| Test | Asserts |
|---|---|
| `a send that cannot happen is recorded, not merely logged` | the attempt leaves `ok = 0` with a reason, and the failure query returns it |
| `the recorded failure never contains the sender value` | the base64 blob appears nowhere in the serialised row — the *whole* row, not just `error` |
| `a ledger row is written for every attempt` | three sends, three rows, in order — so silence means no attempt was made |
| `a broken ledger does not break sending` | table dropped mid-test; `send()` still returns its verdict rather than throwing |

That last one matters: an observability failure that broke signup would be worse than the blindness it replaces.

## Deploying this needs one extra step

The `email_log` table must exist in production D1 **before** the deploy, or every send will log a `no such table` warning (harmless — `record()` swallows it — but it defeats the point):

```
wrangler d1 execute planscape-waitlist --remote --command "CREATE TABLE IF NOT EXISTS email_log (id INTEGER PRIMARY KEY AUTOINCREMENT, to_address TEXT NOT NULL, subject TEXT NOT NULL, ok INTEGER NOT NULL, error TEXT, created_at TEXT NOT NULL)"
```

Plus the two indexes — or apply the tail of `schema.sql`. Do **not** re-run the whole schema file; it contains bare `ALTER TABLE` statements that fail on re-run.