### PR TITLE
fix(entitlement): a lapsed trial no longer passes as a live one (#677)

### DIFF
--- a/marketing-site/functions/api/_lib/downloads/catalog.ts
+++ b/marketing-site/functions/api/_lib/downloads/catalog.ts
@@ -15,6 +15,8 @@
 // R2, computes sha256 + size from the bytes, and prints the entry to paste
 // here, so the catalogue cannot drift from what is actually in the bucket.
 
+import { effectiveStatus } from "../../auth/_lib/limits";
+
 export type ToolStatus = "available" | "beta" | "in-development";
 
 // One downloadable file within a version. A cross-platform tool ships several
@@ -183,9 +185,22 @@ export interface EntitlementResult {
 // subscription is live, not by which plan they are on. A tool that is not yet
 // released is "unavailable" to everyone regardless of subscription — being a
 // paying customer does not conjure software that does not exist.
+// Takes the TENANT, not a status string.
+//
+// It used to take `subscriptionStatus: string`, and that signature is what made
+// #677 possible: the string discards trial_ends_at, the only field that can tell
+// a live trial from one that ended in June. Three callers passed
+// `tenant.subscription_status` straight from the row, so a lapsed trial was
+// indistinguishable from a current one and kept full access — downloads and
+// licence issuing included.
+//
+// Passing the tenant means a caller cannot accidentally omit the expiry check,
+// and a fourth caller added later inherits it. `nowMs` is injected so the
+// decision is deterministic and testable.
 export function entitlementFor(
   tool: Tool,
-  subscriptionStatus: string | null | undefined
+  tenant: { subscription_status: string; trial_ends_at: string | null } | null | undefined,
+  nowMs: number = Date.now()
 ): EntitlementResult {
   if (tool.status === "in-development") {
     return {
@@ -193,6 +208,8 @@ export function entitlementFor(
       reason: "Still in development — not available to download yet.",
     };
   }
+
+  const subscriptionStatus = tenant ? effectiveStatus(tenant, nowMs) : undefined;
 
   switch (subscriptionStatus) {
     case "trial":

--- a/marketing-site/functions/api/auth/_lib/db.ts
+++ b/marketing-site/functions/api/auth/_lib/db.ts
@@ -11,6 +11,7 @@ import type {
   PublicTenant,
 } from "./types";
 import { currencyForCountry } from "../../_lib/billing/catalog";
+import { effectiveStatus } from "./limits";
 
 const TRIAL_DAYS = 14;
 const REFRESH_TTL_DAYS = 30;
@@ -799,14 +800,17 @@ function safeJson(s: string): unknown {
 
 // Lazy trial expiry: if the tenant is still 'trial' but the trial window has
 // closed, flip it to 'read_only' and return the updated row. Called on /me.
+//
+// The DECISION is delegated to effectiveStatus() so this write path and every
+// read path apply one rule. They were separate before, and the read paths simply
+// had no rule at all — which is #677: a lapsed trial kept passing entitlement
+// everywhere except /me. Note the old local check also treated an unparseable
+// trial_ends_at as expired (NaN > now is false); effectiveStatus does not.
 export async function expireTrialIfNeeded(
   db: D1Database,
   tenant: TenantRow
 ): Promise<TenantRow> {
-  if (
-    tenant.subscription_status !== "trial" ||
-    new Date(tenant.trial_ends_at).getTime() > Date.now()
-  ) {
+  if (effectiveStatus(tenant, Date.now()) !== "read_only") {
     return tenant;
   }
   const nowIso = new Date().toISOString();

--- a/marketing-site/functions/api/auth/_lib/limits.ts
+++ b/marketing-site/functions/api/auth/_lib/limits.ts
@@ -17,6 +17,32 @@ export type PlanTier = "solo" | "studio" | "practice" | "firm" | "large" | "ente
 export const TRIAL_SEAT_CAP = 10;
 export const GRACE_DAYS = 14;
 
+// The status a tenant EFFECTIVELY has right now, as opposed to the string sitting
+// in the column.
+//
+// Trial expiry used to be applied only by expireTrialIfNeeded(), whose sole
+// caller is /api/auth/me. Every other path read subscription_status directly and
+// saw a stale "trial" — so a tenant whose trial ended months earlier still passed
+// entitlement on downloads and licence issuing, and issue.ts derived licence
+// expiry from the same stale row and minted an already-expired licence (#677).
+//
+// Pure and non-mutating on purpose. The write belongs where a write is expected
+// (/me); a read path silently UPDATE-ing tenants would be a surprise, and
+// read-only callers should not need a transaction to ask a question.
+// expireTrialIfNeeded() delegates here so the write rule and the read rule
+// cannot drift.
+export function effectiveStatus(
+  tenant: { subscription_status: string; trial_ends_at: string | null },
+  nowMs: number
+): string {
+  if (tenant.subscription_status !== "trial") return tenant.subscription_status;
+  if (!tenant.trial_ends_at) return tenant.subscription_status;
+  const ends = Date.parse(tenant.trial_ends_at);
+  // An unparseable date is a data problem, not a licence to lock someone out.
+  if (Number.isNaN(ends)) return tenant.subscription_status;
+  return ends > nowMs ? "trial" : "read_only";
+}
+
 // Resolve the seat cap for a tenant's plan. Unknown / unset plan → trial default.
 export function resolveCap(
   planProduct: string | null,

--- a/marketing-site/functions/api/downloads/[tool]/[version].ts
+++ b/marketing-site/functions/api/downloads/[tool]/[version].ts
@@ -73,7 +73,7 @@ export const onRequestGet: PagesFunction<DownloadsEnv> = async ({
   const tool = DOWNLOAD_CATALOG.find((t) => t.id === toolId);
   if (!tool) return deny(404, "Unknown download.");
 
-  const { entitlement, reason } = entitlementFor(tool, tenant.subscription_status);
+  const { entitlement, reason } = entitlementFor(tool, tenant);
   if (entitlement !== "allowed") return deny(403, reason);
 
   const version = tool.versions.find((v) => v.version === versionId);

--- a/marketing-site/functions/api/downloads/index.ts
+++ b/marketing-site/functions/api/downloads/index.ts
@@ -11,6 +11,7 @@ import { handlePreflight } from "../auth/_lib/cors";
 import { requireAuth } from "../auth/_lib/auth";
 import { unauthorized } from "../auth/_lib/errors";
 import { getTenantById } from "../auth/_lib/db";
+import { effectiveStatus } from "../auth/_lib/limits";
 import {
   DOWNLOAD_CATALOG,
   entitlementFor,
@@ -25,10 +26,13 @@ export const onRequestGet = withHandler(async ({ request, env }) => {
   const tenant = await getTenantById(env.WAITLIST_DB, auth.tenantId);
   if (!tenant) throw unauthorized("Account no longer exists.");
 
-  const status = tenant.subscription_status;
+  // The EFFECTIVE status, not the column. Returned to the page, which switches
+  // its banner on it — a lapsed trial reporting "trial" would show "You are on
+  // the free trial" above downloads that are locked (#677).
+  const status = effectiveStatus(tenant, Date.now());
 
   const tools = DOWNLOAD_CATALOG.map((tool) => {
-    const { entitlement, reason } = entitlementFor(tool, status);
+    const { entitlement, reason } = entitlementFor(tool, tenant);
     return {
       id: tool.id,
       name: tool.name,

--- a/marketing-site/functions/api/license/issue.ts
+++ b/marketing-site/functions/api/license/issue.ts
@@ -68,7 +68,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
 
   // Same entitlement gate the downloads use — a locked tenant gets no licence.
   const tool = DOWNLOAD_CATALOG.find((t) => t.id === "sting-tools")!;
-  const { entitlement, reason } = entitlementFor(tool, tenant.subscription_status);
+  const { entitlement, reason } = entitlementFor(tool, tenant);
   if (entitlement !== "allowed") throw forbidden(reason);
 
   const now = new Date();
@@ -110,6 +110,27 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
     );
   } else {
     expires = new Date(now.getTime() + PAID_LICENCE_DAYS * 86400_000);
+  }
+
+  // Defence in depth: never mint a licence that is already dead.
+  //
+  // The entitlement gate above now resolves the trial's real state, so a lapsed
+  // trial is refused before reaching here. This guard is deliberately kept
+  // anyway, because it is cheap and because the failure it prevents is
+  // invisible: the plugin verifies offline, so an expired licence is rejected at
+  // the customer's machine with nothing recorded server-side. Any future change
+  // to how expiry is computed — a different grace period, a clock problem, a new
+  // plan shape — cannot silently produce one.
+  if (expires.getTime() <= now.getTime()) {
+    console.error(
+      `Refusing to issue an already-expired licence for tenant ${tenant.id}: ` +
+      `computed expiry ${expires.toISOString()} is not in the future ` +
+      `(status=${tenant.subscription_status}, trial_ends_at=${tenant.trial_ends_at})`
+    );
+    throw forbidden(
+      "Your trial has ended, so a licence issued now would already be expired. " +
+      "Choose a plan and try again."
+    );
   }
 
   const licenseId = existing?.id ?? uuid();

--- a/marketing-site/tests/entitlement.test.ts
+++ b/marketing-site/tests/entitlement.test.ts
@@ -1,0 +1,106 @@
+// Trial expiry, as seen by the paths that actually gate access.
+//
+// THE POINT OF THIS FILE. expireTrialIfNeeded() was correct and was called by
+// exactly one endpoint, /api/auth/me. Every other path read subscription_status
+// straight from the row and saw a stale "trial", so a tenant whose trial ended in
+// June kept downloading paid builds and issuing licences in August — and issue.ts
+// derived licence expiry from that same stale row and minted a licence that was
+// already dead (#677).
+//
+// entitlementFor() took a STATUS STRING, which is what made that possible: the
+// string discards trial_ends_at, the only field that can tell the two apart. It
+// now takes the tenant. These tests pin that, and pin the guard that stops a dead
+// licence being minted whatever the status logic does.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DOWNLOAD_CATALOG, entitlementFor } from "../functions/api/_lib/downloads/catalog";
+import { effectiveStatus } from "../functions/api/auth/_lib/limits";
+
+const NOW = Date.parse("2026-08-17T00:00:00.000Z");
+const day = 86_400_000;
+const iso = (ms: number) => new Date(ms).toISOString();
+
+const tool = DOWNLOAD_CATALOG.find((t) => t.id === "sting-tools")!;
+
+test("effectiveStatus reports a lapsed trial as read_only without touching the row", () => {
+  const lapsed = { subscription_status: "trial", trial_ends_at: iso(NOW - 50 * day) };
+  const live = { subscription_status: "trial", trial_ends_at: iso(NOW + 5 * day) };
+
+  assert.equal(effectiveStatus(lapsed, NOW), "read_only");
+  assert.equal(effectiveStatus(live, NOW), "trial");
+
+  // The input is not mutated — the write belongs on /me, not on every read.
+  assert.equal(lapsed.subscription_status, "trial");
+});
+
+test("a non-trial status is passed through untouched", () => {
+  for (const s of ["active", "past_due", "read_only", "cancelled"]) {
+    assert.equal(
+      effectiveStatus({ subscription_status: s, trial_ends_at: iso(NOW - 999 * day) }, NOW),
+      s,
+      `${s} must not be rewritten by trial logic`
+    );
+  }
+});
+
+test("a missing or unparseable trial_ends_at does not lock anyone out", () => {
+  // A data problem is not a licence to deny access.
+  assert.equal(effectiveStatus({ subscription_status: "trial", trial_ends_at: null }, NOW), "trial");
+  assert.equal(
+    effectiveStatus({ subscription_status: "trial", trial_ends_at: "not-a-date" }, NOW),
+    "trial"
+  );
+});
+
+// --- the load-bearing test -------------------------------------------------
+
+test("a lapsed trial is refused downloads — the defect in #677", () => {
+  const lapsed = { subscription_status: "trial", trial_ends_at: iso(NOW - 50 * day) };
+
+  const r = entitlementFor(tool, lapsed, NOW);
+  assert.equal(r.entitlement, "locked", "a trial that ended 50 days ago must not be allowed");
+  assert.match(r.reason, /trial has ended/i, "and it must say why");
+
+  // The exact shape of the old bug: the same tenant, judged by its status string.
+  assert.equal(
+    entitlementFor(tool, { subscription_status: "trial", trial_ends_at: iso(NOW + day) }, NOW)
+      .entitlement,
+    "allowed",
+    "a trial with a day left is still allowed"
+  );
+});
+
+test("the boundary is the expiry instant, not the day", () => {
+  const oneSecondLeft = { subscription_status: "trial", trial_ends_at: iso(NOW + 1000) };
+  const oneSecondPast = { subscription_status: "trial", trial_ends_at: iso(NOW - 1000) };
+
+  assert.equal(entitlementFor(tool, oneSecondLeft, NOW).entitlement, "allowed");
+  assert.equal(entitlementFor(tool, oneSecondPast, NOW).entitlement, "locked");
+});
+
+test("past_due still gets access, and cancelled still does not", () => {
+  // Dunning may recover a bounced card; locking a working tool over it loses a
+  // customer who meant to pay. This behaviour predates #677 and must survive it.
+  assert.equal(
+    entitlementFor(tool, { subscription_status: "past_due", trial_ends_at: null }, NOW).entitlement,
+    "allowed"
+  );
+  assert.equal(
+    entitlementFor(tool, { subscription_status: "cancelled", trial_ends_at: null }, NOW).entitlement,
+    "locked"
+  );
+});
+
+test("no tenant at all is locked, not allowed", () => {
+  assert.equal(entitlementFor(tool, null, NOW).entitlement, "locked");
+  assert.equal(entitlementFor(tool, undefined, NOW).entitlement, "locked");
+});
+
+test("an in-development tool is unavailable regardless of a live trial", () => {
+  const inDev = DOWNLOAD_CATALOG.find((t) => t.status === "in-development");
+  if (!inDev) return; // catalogue may not carry one
+  const live = { subscription_status: "trial", trial_ends_at: iso(NOW + 5 * day) };
+  assert.equal(entitlementFor(inDev, live, NOW).entitlement, "unavailable");
+});


### PR DESCRIPTION
Closes #677.

## ⚠️ Read this before merging — it revokes access for 3 of 5 live tenants

This is a **behaviour change on real accounts.** Measured in production D1 today:

| Tenant | Trial ended | Effect on deploy |
|---|---|---|
| **Becky Test** | 2026-06-28 | loses downloads + licence issuing |
| **Planscape** | 2026-07-31 | loses downloads + licence issuing — **this is the owner's own tenant** (`davis@planscape.build`) |
| **Nuwabaine** | 2026-08-05 | loses downloads + licence issuing |
| BENEX INTERNATIONAL | 2026-08-20 | unaffected — **lapses in 3 days** |
| exo | 2036-08-01 | unaffected |

All five are `subscription_status = 'trial'` with `plan_product`/`plan_tier` NULL, so none has ever chosen a plan. That is exactly the population the fix bites.

**The code is correct; the timing is a business call.** If any of those tenants should keep access, extend `trial_ends_at` or set `subscription_status = 'active'` *before* deploying. I have not deployed.

## The defect

`expireTrialIfNeeded()` was correct and had exactly one caller: `/api/auth/me`. Every other path read `subscription_status` straight from the row and saw a stale `"trial"`. So a tenant whose trial ended in June kept downloading paid builds and issuing licences in August, and `issue.ts` derived licence expiry from the same stale row — minting licences that were **already expired**, rejected offline at the customer's machine with nothing recorded server-side.

## The signature was the bug

```ts
entitlementFor(tool, subscriptionStatus: string)   // before
entitlementFor(tool, tenant, nowMs = Date.now())  // after
```

The string discards `trial_ends_at`, the only field that separates a live trial from a dead one. Three callers passed `tenant.subscription_status` directly. Taking the tenant means a caller **cannot** omit the check, and a fourth added later inherits it — rather than each site remembering to call a helper.

## Design notes

**`effectiveStatus(tenant, nowMs)` is pure and does not mutate.** The write belongs where a write is expected (`/me`); a read path silently `UPDATE`-ing `tenants` would surprise every read-only caller. `expireTrialIfNeeded()` now delegates to it, so the write rule and the read rule cannot drift — they were separate before, and the read paths had no rule at all.

**An unparseable or absent `trial_ends_at` does not lock anyone out.** A data problem is not grounds for denying access. This deliberately differs from the old local check, which treated `NaN > now === false` as expired.

**`downloads/index.ts` now returns the effective status to the page**, which switches its banner on it. Returning the raw column would render *"You are on the free trial"* above downloads that are locked.

**`issue.ts` refuses to mint a licence whose computed expiry is not in the future.** Redundant once the gate resolves properly — kept because the failure it prevents is invisible: offline verification means an expired licence fails at the customer with no server-side trace. Any future change to expiry computation cannot silently reintroduce it.

## Verified

**28 tests pass** (8 new + 20 existing); typecheck clean.

| Test | Asserts |
|---|---|
| `a lapsed trial is refused downloads — the defect in #677` | 50-days-lapsed → `locked` with a reason; one-day-left → `allowed` |
| `effectiveStatus … without touching the row` | correct verdict **and** the input object is unmutated |
| `the boundary is the expiry instant, not the day` | one second either side flips it |
| `a missing or unparseable trial_ends_at does not lock anyone out` | data problems fail open |
| `a non-trial status is passed through untouched` | `active`/`past_due`/`read_only`/`cancelled` unaffected |
| `past_due still gets access, and cancelled still does not` | pre-existing dunning behaviour survives |
| `no tenant at all is locked, not allowed` | absent tenant fails closed |

Note the two directions are tested deliberately: data problems fail **open**, a missing tenant fails **closed**.