### PR TITLE
docs(deploy): render.yaml does not govern production, and name the pattern behind it (#717)

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -204,6 +204,23 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ── Deploy to Render.com ──────────────────────────────────────────────────────
+  #
+  # DO NOT DELETE THIS JOB TO STOP DUPLICATE DEPLOYS. It is the *filtered* one.
+  #
+  # Two triggers exist for the same service (#717): this job, which honours the
+  # `paths:` filter above and so only fires for Planscape.Server changes, and the
+  # Render dashboard's own Auto-Deploy, which fires on EVERY push to main —
+  # including docs- and marketing-site-only commits. That second trigger is what
+  # rebuilds the API when a Revit plugin file changes, and where the
+  # "deploy failed" emails come from.
+  #
+  # Removing this job would leave the UNFILTERED trigger as the only one: still
+  # rebuilding on everything, and now with no gated path at all. The correct
+  # order is to turn Auto-Deploy OFF in the Render dashboard first, after which
+  # this becomes the single, path-filtered trigger.
+  #
+  # Note render.yaml's `autoDeploy: true` is NOT that setting — the blueprint does
+  # not govern the live services (see the header of render.yaml).
   deploy:
     name: Deploy to Render.com
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2583,6 +2583,38 @@ the manifest had been on `CompiledPlugin` for some time and GOLD had sat unbuilt
 for 16 days. **Older runners that name GOLD as the deploy target are wrong** —
 use the manifest.
 
+### What the repo says is not what is serving — check the live thing
+
+> **Before concluding a change is broken, or that a fix worked, verify against the
+> thing actually running.** Five separate instances of this cost hours on
+> 2026-08-16/17 alone. In every one, a correct change had no effect, and the
+> absence of an error read as "the code is wrong".
+
+The pattern: a repo artefact *describes* a deployment, and something else *is* the
+deployment. The artefact is not lying so much as inert, and nothing warns you.
+
+| Surface | The trap | The check |
+|---|---|---|
+| **Revit plugin** | The `.addin` `<Assembly>` path moves between checkouts — it changed **five times** in two days, twice to another agent's worktree. Building the right code into the wrong folder succeeds silently. | `grep -h "<Assembly>" "$APPDATA/Autodesk/Revit/Addins"/*/StingTools.addin \| sort -u` |
+| **marketing-site** | No git-connected Pages build (#651). **Merging deploys nothing** — a human must run `npm run deploy`. Pages' static fallback then makes an undeployed Function return 405/200-HTML, indistinguishable from a route that never existed. | Probe a known-good Function, the new one, and a nonsense path; compare all three |
+| **Pages secrets** | Bindings are captured at **deployment** time (#674). `wrangler pages secret list` showing a name proves it is **stored**, not **bound**. Setting a secret and re-probing yields the *old* behaviour. | Set it, **redeploy**, then probe |
+| **Render** | `render.yaml` declares `planscape-api`; production is `planscape-api-free` (#717). The blueprint governs **nothing** — editing `autoDeploy` there changes no behaviour. Dashboard Auto-Deploy is the real trigger, and it is unfiltered, so a Revit-plugin commit rebuilds the .NET API. | `curl -o /dev/null -w "%{http_code}" https://planscape-api.onrender.com/` → 404 |
+| **D1 schema** | A new table in `schema.sql` does **not** exist in production until applied. Deploying first gives a runtime `no such table`. Never re-run the whole file — it holds bare `ALTER TABLE`s that fail on re-run. | Apply only the new DDL, **before** deploying |
+
+**Two corollaries worth internalising.**
+
+*An absent side effect never tells you why.* A silent no-op looks identical to a
+wrong fix, a bad credential, and a command that never ran. When something
+reportedly done has no observable effect, stop re-running it and get the error —
+a log, a tail, a screenshot. Prefer making the next attempt self-recording over
+asking for the same output twice.
+
+*Verify the instrument before trusting its silence.* A `wrangler pages deployment
+tail` binds to one deployment id, so **any deploy invalidates it** — watching a
+superseded deployment reports zero requests forever. Prove the tail is alive
+(generate a request, watch the line count move) before reading "no traffic" as
+evidence of anything.
+
 ### Branching
 
 - The default branch is `main`

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,38 @@
 # render.yaml — Render.com Blueprint (Infrastructure-as-Code) for Planscape.
 #
+# ⚠ THIS FILE DOES NOT GOVERN THE LIVE SERVICES. Verified 2026-08-17 (#717).
+#
+# The services actually running were created outside this blueprint and carry
+# different names, so EDITING THIS FILE CHANGES NOTHING IN PRODUCTION:
+#
+#   declared here          reality
+#   planscape-api    web   -> planscape-api.onrender.com  404 (no such service)
+#                             the live API is planscape-api-free.onrender.com (200)
+#   planscape-web    web   -> planscape-web.onrender.com   404 (no such service)
+#                             yet app.planscape.build serves 200, so it exists
+#                             under some other name
+#   planscape-worker       -> private service, no public hostname: untestable
+#   planscape-converter    -> private service, no public hostname: untestable
+#
+# Re-check any time, no credentials needed:
+#   curl -s -o /dev/null -w "%{http_code}\n" https://planscape-api.onrender.com/
+#   curl -s -o /dev/null -w "%{http_code}\n" https://planscape-api-free.onrender.com/
+#
+# CONSEQUENCES, both of which have already cost time:
+#
+#   * autoDeploy: true below is NOT why the live estate rebuilds on every push.
+#     That is the dashboard's own Auto-Deploy setting on the real services.
+#     Setting autoDeploy: false here fixes nothing (#717).
+#   * The custom domain api.planscape.build was never attached, and it is
+#     NXDOMAIN today (#705). The CNAME target in DEPLOY_RUNBOOK.md names
+#     planscape-api, which does not exist.
+#
+# Treat this file as the INTENDED shape, useful if the blueprint is ever applied
+# for real. Until then, production settings live in the Render dashboard, and
+# changes have to be made there. Same failure family as #651 (merging deploys
+# nothing) and #674 (a stored secret is not a bound secret): what the repo says
+# is not what is serving.
+#
 # MUST live at the REPOSITORY ROOT — Render only auto-detects a blueprint here,
 # and the Docker build context (and the Dockerfile's COPY paths) are relative to
 # the repo root. The API Dockerfile copies both Planscape/assets/viewer/** and


### PR DESCRIPTION
Comments and documentation only. No service definition, trigger, or binding changed. Both YAML files verified to still parse; all six service declarations unchanged.

Two commits: the specific finding, and the general pattern it belongs to.

---

## 1 — #717's prerequisite is settled, and it inverts the fix

I could not fix #717 in code, because **`render.yaml` does not govern the live services.** Measured, no credentials needed:

| Declared | Type | Reality |
|---|---|---|
| `planscape-api` | web | `planscape-api.onrender.com` → **404**; the live API is `planscape-api-free.onrender.com` → **200** |
| `planscape-web` | web | `planscape-web.onrender.com` → **404**; yet `app.planscape.build` → **200**, so it exists under another name |
| `planscape-worker`, `planscape-converter` | worker / pserv | no public hostname by design — untestable either way |

Both testable web services are absent under their declared names. The estate was created outside this blueprint, so **editing `render.yaml` cannot change any deploy behaviour.**

Consequence: `autoDeploy: true` in that file is **not** why the estate rebuilds on every push. The dashboard's own Auto-Deploy on the real services is. Setting `autoDeploy: false` there would look like a fix, change nothing, and close the issue falsely.

### The change that would have made things worse

`planscape-server.yml`'s deploy job is the **path-filtered** trigger — it honours `paths: Planscape.Server/**` and correctly never ran for #696. The dashboard's Auto-Deploy is the unfiltered one.

So "delete the duplicate deploy job" — the obvious tidy-up — would remove the *filtered* trigger and leave the unfiltered one as the only one: still rebuilding on every commit, now with no gate. There is now a comment on that job saying so, and naming the correct order: **turn Auto-Deploy off in the dashboard first.**

---

## 2 — The pattern, named in CLAUDE.md

This was the fifth instance in two days of one failure family: a repo artefact *describes* a deployment while something else *is* the deployment. The artefact is inert rather than wrong, and nothing warns you — so a correct change has no effect, and the absence of an error reads as "the code is wrong".

A new `### What the repo says is not what is serving` section tabulates all five with the check for each:

| Surface | Trap |
|---|---|
| Revit plugin | the `.addin` `<Assembly>` path moved **five times** in two days, twice into another agent's worktree |
| marketing-site | no git-connected build — merging deploys nothing (#651) |
| Pages secrets | bind at **deployment** time — `secret list` proves stored, not bound (#674) |
| Render | blueprint declares one name, production runs another (#717) |
| D1 schema | a new table does not exist until applied, and the file cannot be re-run |

Plus two corollaries that generalise beyond this repo:

- **An absent side effect never tells you why.** A silent no-op is indistinguishable from a wrong fix, a bad credential, and a command that never ran. Stop re-running; get the error. Prefer making the next attempt self-recording over asking for the same output twice.
- **Verify the instrument before trusting its silence.** A `wrangler pages deployment tail` binds to one deployment id, so any deploy invalidates it — and it then reports zero requests forever.

---

## What still needs you

The actual fix for #717 is one dashboard toggle I cannot reach: **Render → `planscape-api-free` → Settings → Auto-Deploy off.** After that `planscape-server.yml` is the only trigger and it is path-filtered, so a docs or marketing-site commit stops rebuilding the API — and a deploy-failure email starts meaning something.

**#717 is deliberately left open.** This PR removes the trap and records the lesson; it does not change the behaviour.