### PR TITLE
docs(deploy): the CNAME target in the runbook does not exist (#705)

### DIFF
--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -215,16 +215,36 @@ npx wrangler pages secret put CLOUD_APP_ORIGIN --project-name=planscape-marketin
 For each public service: Render → service → **Settings → Custom Domains → Add**,
 then create the matching record at the `planscape.build` registrar.
 
-| Host | Service | Record | Target |
+> **The service names below are NOT the ones in `render.yaml`.** Verified
+> 2026-08-17 (#705, #717): the blueprint declares `planscape-api`, but
+> `planscape-api.onrender.com` returns **404** — no such service. The live API is
+> **`planscape-api-free`**. Following the old table would CNAME a domain at a
+> service that does not exist, and the failure would look like a DNS or TLS
+> problem rather than a wrong target.
+>
+> Always take the CNAME target from **what Render shows you** on the Custom
+> Domains screen, not from this table or the blueprint.
+
+| Host | Service | Record | Status (2026-08-17) |
 |---|---|---|---|
-| `api.planscape.build` | planscape-api | CNAME | `<planscape-api>.onrender.com` (shown by Render) |
-| `app.planscape.build` | planscape-web | CNAME | `<planscape-web>.onrender.com` |
-| `planscape.build` (apex, if used for marketing) | (marketing/site) | A/ALIAS | per registrar |
+| `api.planscape.build` | **planscape-api-free** | CNAME | ❌ **NXDOMAIN — not attached.** This is the outstanding action (#705) |
+| `app.planscape.build` | planscape-web-free *(name per `marketing-site/wrangler.toml`; not independently verified)* | CNAME | ✅ **already attached and serving** — 200 in ~1.2s. Nothing to do |
+| `planscape.build` (apex) | Cloudflare Pages `planscape-marketing` | — | ✅ live. Not Render at all — see `marketing-site/` |
 
 `api.planscape.build` and `app.planscape.build` are already in the API CORS
 allow-list, and `NEXT_PUBLIC_API_BASE` is baked to `https://api.planscape.build`,
-so no code change is needed once DNS resolves. (TLS is issued automatically by
-Render once the CNAME verifies.)
+so no code change is needed once DNS resolves — the CNAME really is the whole fix
+for the remaining references. (TLS is issued automatically by Render once the
+CNAME verifies.)
+
+> **Know what you are attaching it to.** `planscape-api-free` is a **free
+> instance: it spins down when idle.** Measured 2026-08-17 — a cold
+> `/health/live` took **53.6 seconds**; the same call warm is sub-second. Pointing
+> a production API domain at it means the first request after a quiet period
+> appears to hang, for mobile clients, the plugin's update check, and anything
+> server-side. `app.planscape.build` answers in ~1.2s by comparison. Consider
+> moving the API to a paid always-on instance *before* advertising the domain,
+> rather than debugging "the API is slow" afterwards.
 
 ---
 

--- a/docs/SERVER_GO_LIVE.md
+++ b/docs/SERVER_GO_LIVE.md
@@ -4,9 +4,21 @@ Short, ordered path from "nothing deployed" to "`api.planscape.build` answers".
 For the long-form reference (per-secret tables, cost notes, optional feature
 smoke tests) see **[DEPLOY_RUNBOOK.md](DEPLOY_RUNBOOK.md)**.
 
-> **Status as of 2026-07-20:** `api.planscape.build` does not resolve — the
-> server is not deployed. The Cloudflare side (marketing site, auth/billing on
-> D1, gated downloads on R2) *is* in production and independent of this.
+> **Status as of 2026-08-17 (#705):** `api.planscape.build` still does not
+> resolve (NXDOMAIN) — but **the server IS deployed.** Those are two different
+> problems, and the earlier wording conflated them.
+>
+> The live API is **`planscape-api-free`**, not the `planscape-api` this document
+> and `render.yaml` name: `planscape-api-free.onrender.com/health/live` → 200,
+> while `planscape-api.onrender.com` → 404. It auto-deploys from `main` and its
+> `/health/ready` passes, so the database is reachable too.
+>
+> What is missing is only the **custom domain attachment**, and it is the last
+> step here. Note the instance is free-tier and spins down: a cold
+> `/health/live` measured **53.6s** on 2026-08-17.
+>
+> The Cloudflare side (marketing site, auth/billing on D1, gated downloads on R2)
+> *is* in production and independent of this.
 
 Secrets live outside the repo and are never committed. The go-live package
 (`SECRETS.txt` + `GO-LIVE-CHECKLIST.md`) is generated locally for the owner.
@@ -36,10 +48,12 @@ Secrets live outside the repo and are never committed. The go-live package
    (converter internal URL, set on **both** api and worker). Redeploy after.
 4. **Handoff secret** — `PLANSCAPE_HANDOFF_SECRET` is shared with the marketing
    site and must be set on **both** sides (see below).
-5. **DNS** — `api.planscape.build` → planscape-api, `app.planscape.build` →
-   planscape-web, both CNAME to the `.onrender.com` host Render shows. TLS is
-   automatic once the CNAME verifies. Both hosts are already in the CORS
-   allow-list and `NEXT_PUBLIC_API_BASE` is baked to `https://api.planscape.build`.
+5. **DNS** — `api.planscape.build` → **planscape-api-free** (NOT `planscape-api`,
+   which does not exist), CNAME to the `.onrender.com` host Render shows on the
+   Custom Domains screen. TLS is automatic once the CNAME verifies. Both hosts are
+   already in the CORS allow-list and `NEXT_PUBLIC_API_BASE` is baked to
+   `https://api.planscape.build`, so no code change is needed.
+   **`app.planscape.build` is already attached and serving — skip it.**
 6. **Smoke test** — runbook §5.
 
 ### The handoff secret spans two providers


### PR DESCRIPTION
Docs only. Addresses the part of #705 I can reach: the instructions you would follow to fix it were wrong.

## The landmine

Both go-live docs told you to point `api.planscape.build` at **`planscape-api`**. That service returns **404 — it does not exist.** Following them would have attached a domain to nothing, and the failure would have presented as a DNS or TLS problem rather than a wrong target.

## Three corrections, each measured today

**1. The service name.** `planscape-api` → **`planscape-api-free`**.

```
planscape-api-free.onrender.com/health/live  -> 200
planscape-api.onrender.com                   -> 404
```

**2. `app.planscape.build` is already attached and serving** — 200 in ~1.2s. Both docs listed it as a to-do, so half the DNS work was already complete and being presented as outstanding. Now marked done, with the web service name attributed to `marketing-site/wrangler.toml` and explicitly flagged as **not independently verified** (its `.onrender.com` hostname didn't answer, so I'm not asserting it).

**3. The live API is a free instance that spins down.**

```
cold  /health/live -> 200 in 53.6s
warm  /health/live -> sub-second
```

This is new information and it changes the shape of #705. Attaching a production API domain to that instance means the first request after a quiet period *appears to hang* — for mobile clients, for the plugin's update check, for anything server-side. `app.planscape.build` answers in ~1.2s by comparison. Worth deciding whether to move the API to an always-on instance **before** advertising the domain, rather than debugging "the API is slow" afterwards.

I found this by accident: a probe with a 20-second timeout returned `000`, which looks exactly like an outage. Retrying with a longer timeout got the 200. Had I written up the first result, I would have reported the API as down.

## Also corrected

`SERVER_GO_LIVE.md`'s status header said *"`api.planscape.build` does not resolve — the server is not deployed."* The first half is still true; **the second half is not.** The server is deployed, auto-deploys from `main`, and its `/health/ready` passes — so the database is reachable. Only the domain attachment is missing. Conflating the two made the remaining work look much larger than it is.

## Guidance added

Take the CNAME target from **what Render shows on the Custom Domains screen** — never from these docs or `render.yaml`, since the blueprint does not govern the live estate (#717).

## What still needs you

The attachment itself: Render → `planscape-api-free` → Settings → Custom Domains → add `api.planscape.build`, then the CNAME at Cloudflare with the target Render displays, **DNS-only (grey cloud)** so certificate validation can complete. My wrangler token is `zone (read)` and I have no Render access, so I cannot do either.

**#705 stays open.** This removes the trap from the procedure; it does not attach the domain.
