### PR TITLE
refactor(limits): split the seat cap into members and machines (#693)

### DIFF
--- a/marketing-site/account.html
+++ b/marketing-site/account.html
@@ -94,7 +94,12 @@ table.inv tr:last-child td { border-bottom: 0; }
         <div><dd id="v-trial">—</dd></div>
         <div><dt>Plan</dt></div>
         <div><dd id="v-plan">—</dd></div>
-        <div><dt>Seats</dt></div>
+        <!-- "Team members", not "Seats". This row counts ACCOUNTS (members plus
+             pending invitations) and is unaffected by licences. Labelled "Seats"
+             it read as a licence count — a firm with one account and one
+             licensed machine saw "Seats 1 of 10" on both this page and
+             /licences, two different tens for two different things (#693). -->
+        <div><dt>Team members</dt></div>
         <div><dd id="v-seats">—</dd></div>
         <div><dt>Billing currency</dt></div>
         <div><dd id="v-currency">—</dd></div>

--- a/marketing-site/functions/api/auth/_lib/limits.ts
+++ b/marketing-site/functions/api/auth/_lib/limits.ts
@@ -1,20 +1,51 @@
 // Soft-block-at-cap: the single source of truth for plan seat caps and the
 // 14-day grace logic. Encoded once here, called by the invite gate and by login.
 
-// Seat caps per product × tier. Matches marketing-site/pricing.html. A "seat"
-// is an active (non-deleted) member PLUS a pending invitation — a pending invite
-// reserves a seat so you can't out-invite the cap and only discover it on accept.
-export const PLAN_CAPS = {
+// TWO AXES, TWO TABLES. There used to be one `PLAN_CAPS` and one `resolveCap()`,
+// and that single number independently bounded two unrelated quantities (#693):
+//
+//   * team ACCOUNTS   — login.ts, tenants/me.ts, tenants/me/invitations.ts
+//   * licensed MACHINES — license/issue.ts, license/index.ts, license/present.ts
+//
+// So a `sting-tools/studio` tenant got 5 accounts AND, separately, 5 machines from
+// a figure written to mean one thing. Nothing decided that; it fell out of
+// countLicensedSeats() reusing the member helper. The two are genuinely different:
+// present.ts notes that most licensed machines have no Planscape login at all, and
+// one engineer with a desktop and a laptop is 1 account but 2 machines.
+//
+// THE NUMBERS BELOW ARE UNCHANGED — machines currently mirror members exactly, so
+// this split is behaviour-preserving. Diverging them is a PRICING decision and a
+// one-line edit to PLAN_MACHINE_CAPS; it is deliberately not made here.
+
+// Team-account caps per product × tier. Matches marketing-site/pricing.html.
+// One unit is an active (non-deleted) member PLUS a pending invitation — a pending
+// invite reserves a place so you can't out-invite the cap and only discover it on
+// accept.
+export const PLAN_MEMBER_CAPS = {
   "sting-tools": { solo: 1, studio: 5, practice: 15, firm: 40, enterprise: Infinity },
   "planscape": { solo: 3, studio: 10, practice: 25, firm: 50, large: 100, enterprise: Infinity },
 } as const;
 
-export type PlanProduct = keyof typeof PLAN_CAPS;
+// Licensed-machine caps per product × tier. One unit is a non-revoked, unexpired
+// row in `licenses` — see license/_lib/seats.ts. Counted per WORKSTATION, not per
+// person, and a machine needs no Planscape account at all.
+//
+// Identical to PLAN_MEMBER_CAPS today. Kept as its own table so that changing what
+// a plan includes in machines does not silently change how many colleagues a firm
+// may invite, and vice versa.
+export const PLAN_MACHINE_CAPS = {
+  "sting-tools": { solo: 1, studio: 5, practice: 15, firm: 40, enterprise: Infinity },
+  "planscape": { solo: 3, studio: 10, practice: 25, firm: 50, large: 100, enterprise: Infinity },
+} as const;
+
+export type PlanProduct = keyof typeof PLAN_MEMBER_CAPS;
 export type PlanTier = "solo" | "studio" | "practice" | "firm" | "large" | "enterprise";
 
 // Before a plan is chosen (trial), apply a generous default so teams can build
 // out during the trial. B3 sets plan_product/plan_tier and the real cap kicks in.
-export const TRIAL_SEAT_CAP = 10;
+// Separate constants for the same reason the tables are separate.
+export const TRIAL_MEMBER_CAP = 10;
+export const TRIAL_MACHINE_CAP = 10;
 export const GRACE_DAYS = 14;
 
 // The status a tenant EFFECTIVELY has right now, as opposed to the string sitting
@@ -43,16 +74,49 @@ export function effectiveStatus(
   return ends > nowMs ? "trial" : "read_only";
 }
 
-// Resolve the seat cap for a tenant's plan. Unknown / unset plan → trial default.
-export function resolveCap(
+function resolve(
+  table: Record<string, Record<string, number>>,
+  fallback: number,
   planProduct: string | null,
   planTier: string | null
 ): number {
-  if (!planProduct || !planTier) return TRIAL_SEAT_CAP;
-  const product = (PLAN_CAPS as Record<string, Record<string, number>>)[planProduct];
-  if (!product) return TRIAL_SEAT_CAP;
+  if (!planProduct || !planTier) return fallback;
+  const product = table[planProduct];
+  if (!product) return fallback;
   const cap = product[planTier];
-  return typeof cap === "number" ? cap : TRIAL_SEAT_CAP;
+  return typeof cap === "number" ? cap : fallback;
+}
+
+// How many team ACCOUNTS this plan includes (members + pending invitations).
+// Unknown / unset plan → trial default.
+export function resolveMemberCap(
+  planProduct: string | null,
+  planTier: string | null
+): number {
+  return resolve(
+    PLAN_MEMBER_CAPS as unknown as Record<string, Record<string, number>>,
+    TRIAL_MEMBER_CAP,
+    planProduct,
+    planTier
+  );
+}
+
+// How many licensed MACHINES this plan includes.
+//
+// There is deliberately no `resolveCap()` any more. An ambiguous name is what let
+// six call sites share one number for two different things (#693); a seventh
+// caller added later now has to say which axis it means, and picking wrong is
+// visible in the diff rather than invisible in the behaviour.
+export function resolveMachineCap(
+  planProduct: string | null,
+  planTier: string | null
+): number {
+  return resolve(
+    PLAN_MACHINE_CAPS as unknown as Record<string, Record<string, number>>,
+    TRIAL_MACHINE_CAP,
+    planProduct,
+    planTier
+  );
 }
 
 export interface CapResult {

--- a/marketing-site/functions/api/auth/login.ts
+++ b/marketing-site/functions/api/auth/login.ts
@@ -15,7 +15,7 @@ import {
   toPublicTenant,
 } from "./_lib/db";
 import { issueTokens, refreshCookie } from "./_lib/session";
-import { resolveCap, evaluateCap } from "./_lib/limits";
+import { resolveMemberCap, evaluateCap } from "./_lib/limits";
 
 interface Body {
   email?: string;
@@ -52,7 +52,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
   // the UI can show an upgrade banner once the grace period has ended.
   const members = await countActiveMembers(env.WAITLIST_DB, tenant.id);
   const pending = await countPendingInvites(env.WAITLIST_DB, tenant.id);
-  const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+  const cap = resolveMemberCap(tenant.plan_product, tenant.plan_tier);
   const capState = evaluateCap(members + pending, cap, tenant.cap_exceeded_since, Date.now());
   const capExceeded = !capState.within;
   const readOnlyMode = capExceeded && capState.graceEnded;

--- a/marketing-site/functions/api/license/index.ts
+++ b/marketing-site/functions/api/license/index.ts
@@ -1,7 +1,7 @@
 // GET /api/license — what this tenant has licensed, and how much of its cap
 // that uses.
 //
-// The numbers come from resolveCap + countLicensedSeats, the SAME pair issue.ts
+// The numbers come from resolveMachineCap + countLicensedSeats, the SAME pair issue.ts
 // consults before refusing at cap and present.ts reports back. A second query
 // here would be a second definition of "in use", and two definitions in two
 // files is exactly how the server-side seat meter drifted (see _lib/seats.ts).
@@ -19,7 +19,7 @@ import { handlePreflight } from "../auth/_lib/cors";
 import { requireAuth } from "../auth/_lib/auth";
 import { unauthorized } from "../auth/_lib/errors";
 import { getTenantById } from "../auth/_lib/db";
-import { resolveCap } from "../auth/_lib/limits";
+import { resolveMachineCap } from "../auth/_lib/limits";
 import { countLicensedSeats } from "./_lib/seats";
 import type { Env } from "../auth/_lib/types";
 
@@ -54,7 +54,7 @@ export const onRequestGet = withHandler(async ({ request, env }) => {
     .bind(auth.tenantId)
     .all<LicenseRow>();
 
-  const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+  const cap = resolveMachineCap(tenant.plan_product, tenant.plan_tier);
 
   return {
     // Infinity is not JSON. null means unlimited — the same convention

--- a/marketing-site/functions/api/license/issue.ts
+++ b/marketing-site/functions/api/license/issue.ts
@@ -19,7 +19,7 @@ import { requireAuth } from "../auth/_lib/auth";
 import { bad, forbidden, serverError, unauthorized } from "../auth/_lib/errors";
 import { getTenantById, audit } from "../auth/_lib/db";
 import { uuid } from "../auth/_lib/tokens";
-import { resolveCap } from "../auth/_lib/limits";
+import { resolveMachineCap } from "../auth/_lib/limits";
 import { DOWNLOAD_CATALOG, entitlementFor } from "../_lib/downloads/catalog";
 import { signLicense } from "./_lib/crypto";
 import { countLicensedSeats } from "./_lib/seats";
@@ -85,7 +85,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
     .first<{ id: string }>();
 
   if (!existing) {
-    const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+    const cap = resolveMachineCap(tenant.plan_product, tenant.plan_tier);
     if (cap !== Infinity) {
       // Same helper present.ts reports from — see _lib/seats.ts for why this is
       // one function and not one query per caller.

--- a/marketing-site/functions/api/license/present.ts
+++ b/marketing-site/functions/api/license/present.ts
@@ -28,7 +28,7 @@ import { withHandler, readJson } from "../auth/_lib/handler";
 import { handlePreflight } from "../auth/_lib/cors";
 import { bad, notFound, serverError, unauthorized } from "../auth/_lib/errors";
 import { getTenantById, audit } from "../auth/_lib/db";
-import { resolveCap } from "../auth/_lib/limits";
+import { resolveMachineCap } from "../auth/_lib/limits";
 import { verifyLicense } from "./_lib/crypto";
 import { countLicensedSeats } from "./_lib/seats";
 import type { Env } from "../auth/_lib/types";
@@ -166,7 +166,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
   }
 
   const tenant = await getTenantById(db, row.tenant_id);
-  const cap = resolveCap(tenant?.plan_product ?? null, tenant?.plan_tier ?? null);
+  const cap = resolveMachineCap(tenant?.plan_product ?? null, tenant?.plan_tier ?? null);
   const inUse = await countLicensedSeats(db, row.tenant_id, nowIso);
 
   // Everything below is information, not instruction. The plugin logs it and

--- a/marketing-site/functions/api/tenants/me.ts
+++ b/marketing-site/functions/api/tenants/me.ts
@@ -13,7 +13,7 @@ import {
   toPublicTenant,
   audit,
 } from "../auth/_lib/db";
-import { resolveCap, evaluateCap } from "../auth/_lib/limits";
+import { resolveMemberCap, evaluateCap } from "../auth/_lib/limits";
 import { clip, normCountry } from "../auth/_lib/validate";
 
 export const onRequestOptions: PagesFunction = async ({ request }) =>
@@ -26,7 +26,7 @@ export const onRequestGet = withHandler(async ({ request, env }) => {
 
   const members = await countActiveMembers(env.WAITLIST_DB, tenant.id);
   const pending = await countPendingInvites(env.WAITLIST_DB, tenant.id);
-  const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+  const cap = resolveMemberCap(tenant.plan_product, tenant.plan_tier);
   const capState = evaluateCap(members + pending, cap, tenant.cap_exceeded_since, Date.now());
 
   return {

--- a/marketing-site/functions/api/tenants/me/invitations.ts
+++ b/marketing-site/functions/api/tenants/me/invitations.ts
@@ -8,7 +8,7 @@ import { requireRole, roleLevel, ASSIGNABLE_ROLES } from "../../auth/_lib/auth";
 import { bad, conflict, unauthorized } from "../../auth/_lib/errors";
 import { normEmail } from "../../auth/_lib/validate";
 import { randomToken, sha256Hex, uuid } from "../../auth/_lib/tokens";
-import { resolveCap, GRACE_DAYS } from "../../auth/_lib/limits";
+import { resolveMemberCap, GRACE_DAYS } from "../../auth/_lib/limits";
 import {
   getTenantById,
   getUserById,
@@ -80,7 +80,7 @@ export const onRequestPost = withHandler(async ({ request, env }) => {
   const pending = await countPendingInvites(env.WAITLIST_DB, tenant.id);
   const committed = members + pending;
   const wouldBe = committed + 1; // this invite reserves a seat
-  const cap = resolveCap(tenant.plan_product, tenant.plan_tier);
+  const cap = resolveMemberCap(tenant.plan_product, tenant.plan_tier);
   const now = Date.now();
 
   let warning: { code: string; upgradeBy: string } | null = null;

--- a/marketing-site/tests/caps.test.ts
+++ b/marketing-site/tests/caps.test.ts
@@ -1,0 +1,78 @@
+// Member caps vs machine caps.
+//
+// THE POINT OF THIS FILE. One `resolveCap()` used to bound two unrelated
+// quantities (#693): team ACCOUNTS in login/me/invitations, and licensed MACHINES
+// in license/issue|index|present. A `sting-tools/studio` tenant therefore got 5
+// accounts AND, separately, 5 machines from a figure written to mean one thing.
+// Nobody decided that — countLicensedSeats() reused the member helper.
+//
+// The two axes measure different things: a machine needs no account (present.ts
+// says most licensed machines have no Planscape login), and one engineer with a
+// desktop and a laptop is 1 account but 2 machines.
+//
+// These tests do two jobs. They pin that the axes are now independently
+// resolvable, and they pin that the numbers are currently EQUAL — so that the day
+// someone diverges pricing, the failing assertion tells them which axis they
+// changed instead of leaving it to be discovered in production.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  PLAN_MEMBER_CAPS,
+  PLAN_MACHINE_CAPS,
+  TRIAL_MEMBER_CAP,
+  TRIAL_MACHINE_CAP,
+  resolveMemberCap,
+  resolveMachineCap,
+} from "../functions/api/auth/_lib/limits";
+
+test("the two axes are resolved by separate functions", () => {
+  // Same inputs, independently answered. Equal today by intent, not by sharing.
+  assert.equal(resolveMemberCap("sting-tools", "studio"), 5);
+  assert.equal(resolveMachineCap("sting-tools", "studio"), 5);
+  assert.equal(resolveMemberCap("planscape", "large"), 100);
+  assert.equal(resolveMachineCap("planscape", "large"), 100);
+});
+
+test("machine caps mirror member caps EXACTLY today — diverging them is a pricing change", () => {
+  // If this fails, someone changed one table and not the other. That may be
+  // entirely correct — but it is a pricing decision, so it should be a deliberate
+  // edit to this assertion rather than a surprise in production.
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(PLAN_MACHINE_CAPS)),
+    JSON.parse(JSON.stringify(PLAN_MEMBER_CAPS)),
+    "PLAN_MACHINE_CAPS and PLAN_MEMBER_CAPS have diverged — intended?"
+  );
+  assert.equal(TRIAL_MACHINE_CAP, TRIAL_MEMBER_CAP);
+});
+
+test("an unset plan falls back to the trial default on both axes", () => {
+  assert.equal(resolveMemberCap(null, null), TRIAL_MEMBER_CAP);
+  assert.equal(resolveMachineCap(null, null), TRIAL_MACHINE_CAP);
+  assert.equal(resolveMemberCap("sting-tools", null), TRIAL_MEMBER_CAP);
+  assert.equal(resolveMachineCap(null, "studio"), TRIAL_MACHINE_CAP);
+});
+
+test("an unknown product or tier falls back rather than returning undefined", () => {
+  // The old implementation guarded this; keep it guarded. Returning undefined
+  // here would make `used >= cap` false and silently uncap machine issuing.
+  assert.equal(resolveMemberCap("no-such-product", "studio"), TRIAL_MEMBER_CAP);
+  assert.equal(resolveMachineCap("sting-tools", "no-such-tier"), TRIAL_MACHINE_CAP);
+  assert.equal(resolveMachineCap("no-such-product", "no-such-tier"), TRIAL_MACHINE_CAP);
+});
+
+test("enterprise is unlimited on both axes, and stays a number", () => {
+  // Infinity, not null and not undefined — callers compare with `!==` and
+  // serialise it as null themselves (see license/index.ts).
+  assert.equal(resolveMemberCap("sting-tools", "enterprise"), Infinity);
+  assert.equal(resolveMachineCap("sting-tools", "enterprise"), Infinity);
+  assert.equal(typeof resolveMachineCap("sting-tools", "enterprise"), "number");
+});
+
+test("solo means one machine — the case the machine cap exists to enforce", () => {
+  // issue.ts's own note: without this, one Solo subscriber could licence
+  // unlimited machines. It is the only enforcement point, because an issued
+  // licence cannot be revoked remotely.
+  assert.equal(resolveMachineCap("sting-tools", "solo"), 1);
+});


### PR DESCRIPTION
Closes #693.

## The defect

One `resolveCap()` independently bounded two unrelated quantities:

| Axis | Callers |
|---|---|
| team **ACCOUNTS** (members + pending invitations) | `auth/login.ts`, `tenants/me.ts`, `tenants/me/invitations.ts` |
| licensed **MACHINES** | `license/issue.ts`, `license/index.ts`, `license/present.ts` |

So a `sting-tools/studio` tenant got 5 accounts **and, separately, 5 machines** from a figure written to mean one thing. Nobody decided that — `countLicensedSeats()` reused the member helper and the ambiguity propagated.

The two genuinely measure different things. `present.ts` states in its own header that most licensed machines have no Planscape login at all; one engineer with a desktop and a laptop is **1 account but 2 machines**; and a free viewer consumes an account, so it ate the same number that bounded machines.

## The change

`PLAN_MEMBER_CAPS` + `resolveMemberCap()`, and `PLAN_MACHINE_CAPS` + `resolveMachineCap()`.

**`resolveCap()` is deleted, not kept as an alias.** The ambiguous name is precisely what let six call sites share one number; a seventh caller added later now has to say which axis it means, and choosing wrong shows up in the diff instead of hiding in the behaviour.

## The numbers are unchanged — deliberately

Machines mirror members exactly, so **this is behaviour-preserving**. No tenant's limits move.

Diverging them is a **pricing decision**, and it is a one-line edit to one table rather than a refactor. I have not made it: choosing how many machines versus how many accounts each of 11 product×tier combinations includes is commercial, not technical.

A test asserts the two tables are currently identical:

```
✔ machine caps mirror member caps EXACTLY today — diverging them is a pricing change
```

So the day you change one, the failure names which axis moved — rather than the divergence being discovered in production.

## The visible symptom, fixed

The account row said **"Seats"** while counting accounts. A firm with one account and one licensed machine saw:

- `/account` → **Seats — 1 of 10**
- `/licences` → **1 of 10 machines licensed**

Two different tens, for two different things, agreeing only by coincidence. That is what made "Seats 1 of 10" read as a licence count when the `licenses` table was empty across every tenant. The row is now **"Team members"**.

## Verified

**34 tests pass** (6 new + 28 existing); `npm run typecheck` clean.

| Test | Asserts |
|---|---|
| `the two axes are resolved by separate functions` | same inputs, independently answered |
| `machine caps mirror member caps EXACTLY today` | the divergence tripwire above |
| `an unset plan falls back to the trial default on both axes` | trial defaults per axis |
| `an unknown product or tier falls back rather than returning undefined` | guards the case where `used >= cap` would be false and silently uncap issuing |
| `enterprise is unlimited on both axes, and stays a number` | `Infinity`, not `null`/`undefined` — callers compare with `!==` and serialise it themselves |
| `solo means one machine` | the case the machine cap exists for: without it one Solo subscriber could licence unlimited machines, and an issued licence cannot be revoked remotely |

The `v-seats` element id is unchanged, so the existing binding is untouched — only the visible label moved.

## Deliberately not done

The internal `v-seats` id and the `seatsUsed` field in `tenants/me.ts`'s response still use the old word. Both are developer-facing rather than user-facing, and renaming the API field is a contract change for marginal gain. #693's acceptance is about the UI label, which is fixed. Happy to follow up if you want the vocabulary consistent all the way down.
