### PR TITLE
Round order quantities, and stop selling openings

### DIFF
--- a/StingTools.Boq.Tests/DescriptionExclusionTests.cs
+++ b/StingTools.Boq.Tests/DescriptionExclusionTests.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — the first real export sold an OPENING 1,187 times.
+    /// `M_GM_OpeningWall_Instance — Opening` is a void; there is nothing to buy.
+    /// Alongside it came muntin patterns, window trims and a wardrobe.
+    ///
+    /// Category exclusion could not catch these: they are all `Generic Models`,
+    /// which legitimately holds real building elements in other projects, so
+    /// excluding the whole category would hide genuine work. The discriminator
+    /// is the description, not the category.
+    /// </summary>
+    public class DescriptionExclusionTests
+    {
+        private static AggregatorInputs Inputs(string[] patterns, params ConstituentInput[] rows) =>
+            new AggregatorInputs
+            {
+                Constituents = rows.ToList(),
+                Units = new SupplierUnitTable(),
+                StageDefs = { new StageDefinition { StageId = "superstructure", Title = "SUPERSTRUCTURE", Order = 10 } },
+                DefaultStageId = "superstructure",
+                ExcludedDescriptionPatterns = patterns.ToList(),
+                Rates = new CommodityRateResolver(null, null)
+            };
+
+        private static ConstituentInput Row(string description, string typeName = "") =>
+            new ConstituentInput
+            {
+                Category = "Generic Models", Description = description,
+                TypeName = typeName, Unit = "each", Quantity = 1
+            };
+
+        [Fact]
+        public void An_Opening_Is_Not_A_Material()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new[] { "opening" },
+                Row("M_GM_OpeningWall_Instance — Opening"),
+                Row("Precast lintel 900mm")));
+
+            var kept = doc.Stages.SelectMany(s => s.Commodities).Select(c => c.Description).ToList();
+            Assert.DoesNotContain(kept, d => d.Contains("Opening"));
+            Assert.Contains("Precast lintel 900mm", kept);
+        }
+
+        [Fact]
+        public void Pattern_Exclusions_Are_Counted_Like_Category_Ones()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new[] { "opening", "muntin" },
+                Row("M_GM_OpeningWall_Instance — Opening"),
+                Row("M_Muntin Pattern_2x2"),
+                Row("Precast lintel")));
+
+            Assert.Equal(2, doc.ExcludedRowCount);
+        }
+
+        [Fact]
+        public void Matching_Is_Case_Insensitive_And_Substring()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new[] { "OPENING" },
+                Row("m_gm_openingwall_instance — opening")));
+
+            Assert.Equal(1, doc.ExcludedRowCount);
+        }
+
+        [Fact]
+        public void The_Type_Name_Is_Checked_As_Well_As_The_Description()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new[] { "opening" },
+                Row("Generic model", typeName: "Wall Opening 900x2100")));
+
+            Assert.Equal(1, doc.ExcludedRowCount);
+        }
+
+        [Fact]
+        public void A_Blank_Pattern_Never_Matches_Everything()
+        {
+            // "".IndexOf on a haystack returns 0 — the trap that has now bitten
+            // this feature twice. A blank pattern must be inert, not a wildcard.
+            var doc = CommodityAggregator.Build(Inputs(
+                new[] { "", "   " },
+                Row("Precast lintel"), Row("Blockwork")));
+
+            Assert.Equal(0, doc.ExcludedRowCount);
+            Assert.Equal(2, doc.Stages.SelectMany(s => s.Commodities).Count());
+        }
+
+        [Fact]
+        public void An_Empty_Pattern_List_Changes_Nothing()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new string[0], Row("M_GM_OpeningWall_Instance — Opening")));
+
+            Assert.Equal(0, doc.ExcludedRowCount);
+        }
+
+        [Fact]
+        public void The_Shipped_Library_Excludes_Openings()
+        {
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<StageLibrary>(
+                System.IO.File.ReadAllText(System.IO.Path.Combine(
+                    System.AppContext.BaseDirectory, "Data", "STING_MATERIAL_STAGES.json")));
+
+            Assert.Contains(lib.ExcludedDescriptionPatterns,
+                p => p.Equals("opening", System.StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void The_Shipped_Patterns_Do_Not_Catch_Real_Materials()
+        {
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<StageLibrary>(
+                System.IO.File.ReadAllText(System.IO.Path.Combine(
+                    System.AppContext.BaseDirectory, "Data", "STING_MATERIAL_STAGES.json")));
+
+            // A shipped pattern that matched any of these would silently delete
+            // real purchasable work from every bill.
+            string[] mustSurvive =
+            {
+                "Cement (OPC 42.5N)", "Hollow blocks 8\"", "Bricks", "River and pit sand",
+                "Steel reinforcement bars", "Sawn timber for formwork", "In-situ concrete",
+                "Roofing sheets", "Exterior paint (weather-guard)", "Plaster (2 faces)",
+                "900x2400mm wooden door", "1200x1500mm steel casement window"
+            };
+
+            foreach (string d in mustSurvive)
+                foreach (string p in lib.ExcludedDescriptionPatterns)
+                    Assert.False(d.IndexOf(p, System.StringComparison.OrdinalIgnoreCase) >= 0,
+                        $"shipped pattern '{p}' would exclude the real material '{d}'");
+        }
+    }
+}

--- a/StingTools.Boq.Tests/OrderQuantityRoundingTests.cs
+++ b/StingTools.Boq.Tests/OrderQuantityRoundingTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — the first real export ordered "164.48145 m³" of concrete and
+    /// "350.3889 m²" of formwork timber, and one row read
+    /// "0.479999210217142 m³". Order quantity is what somebody buys and what the
+    /// amount is computed from, so raw binary floats leak into the money column
+    /// as fractions of a shilling.
+    ///
+    /// Countable units still round UP — you cannot buy 2.08 truck trips. Divisible
+    /// units round to 2 dp, which is as precise as a delivery note gets.
+    /// </summary>
+    public class OrderQuantityRoundingTests
+    {
+        private static SupplierUnitRule Divisible() => new SupplierUnitRule
+        {
+            CommodityKey = "concrete-ready",
+            SupplierUnit = "m³",
+            SourceUnit = "m3",
+            SourceUnitsPerSupplierUnit = 1.0,
+            RoundUpToWhole = false,
+            DefaultWastagePct = 5
+        };
+
+        private static SupplierUnitRule Countable() => new SupplierUnitRule
+        {
+            CommodityKey = "sand",
+            SupplierUnit = "Trips (Sino Truck)",
+            SourceUnit = "m3",
+            SourceUnitsPerSupplierUnit = 12.0,
+            RoundUpToWhole = true
+        };
+
+        [Fact]
+        public void A_Divisible_Unit_Rounds_To_Two_Decimals()
+        {
+            // 156.6490... + 5% = 164.48145 → 164.48
+            var r = SupplierUnitConverter.Convert(Divisible(), 156.649);
+
+            Assert.Equal(164.48, r.OrderQuantity, 6);
+        }
+
+        [Fact]
+        public void Binary_Noise_Does_Not_Survive()
+        {
+            // The 0.479999210217142 case: a value that is 0.48 in every sense
+            // that matters must not print sixteen digits of float residue.
+            var rule = Divisible();
+            rule.DefaultWastagePct = 0;
+
+            var r = SupplierUnitConverter.Convert(rule, 0.479999210217142);
+
+            Assert.Equal(0.48, r.OrderQuantity, 6);
+        }
+
+        [Fact]
+        public void A_Countable_Unit_Still_Rounds_Up_Not_To_Two_Decimals()
+        {
+            // 25 m³ ÷ 12 = 2.083 trips → 3, never 2.08.
+            var r = SupplierUnitConverter.Convert(Countable(), 25.0);
+
+            Assert.Equal(3, r.OrderQuantity);
+        }
+
+        [Fact]
+        public void A_Row_With_No_Rule_Is_Rounded_Too()
+        {
+            // The fallback path carried the measured quantity through untouched,
+            // so "610.614588311426 m²" reached the sheet.
+            var r = SupplierUnitConverter.Convert(null, 610.614588311426);
+
+            Assert.Equal(610.61, r.OrderQuantity, 6);
+        }
+
+        [Fact]
+        public void Net_Quantity_Keeps_Full_Precision()
+        {
+            // Net is the measured figure and stays exact — only the ORDER is a
+            // rounded, purchasable number.
+            var r = SupplierUnitConverter.Convert(Countable(), 25.0);
+
+            Assert.Equal(25.0 / 12.0, r.NetQuantity, 9);
+        }
+
+        [Fact]
+        public void Rounding_Never_Drops_Below_The_Net_Measured_Quantity()
+        {
+            // Rounding DOWN below what was measured would under-order. Half-up
+            // could do that on a divisible unit with no wastage, so the converter
+            // must not produce an order under the net.
+            var rule = Divisible();
+            rule.DefaultWastagePct = 0;
+
+            foreach (double q in new[] { 1.001, 2.004, 10.0049, 99.999 })
+            {
+                var r = SupplierUnitConverter.Convert(rule, q);
+                Assert.True(r.OrderQuantity >= System.Math.Round(r.NetQuantity, 2) - 1e-9,
+                    $"{q}: order {r.OrderQuantity} fell below net {r.NetQuantity}");
+            }
+        }
+
+        [Fact]
+        public void The_Amount_Derives_From_The_Rounded_Order()
+        {
+            var c = new MaterialCommodity { OrderQuantity = 164.48, RateUGX = 450000 };
+            Assert.Equal(74016000, c.AmountUGX);   // not 74,016,652.5
+        }
+    }
+}

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -50,6 +50,7 @@ namespace StingTools.BOQ.MaterialSchedule
             inputs.StageDefs = lib.Stages;
             inputs.DefaultStageId = lib.DefaultStageId;
             inputs.ExcludedCategories = lib.ExcludedCategories;
+            inputs.ExcludedDescriptionPatterns = lib.ExcludedDescriptionPatterns;
             inputs.Rates = LoadRates(doc);
 
             foreach (var item in boq.AllItems.Where(i => i.Source == BOQRowSource.Model))

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -32,6 +32,8 @@ namespace StingTools.Core.MaterialSchedule
         public string DefaultStageId = "";
         /// <summary>Categories that are not materials — see StageLibrary.ExcludedCategories.</summary>
         public List<string> ExcludedCategories = new List<string>();
+        /// <summary>Description/type substrings that are never materials.</summary>
+        public List<string> ExcludedDescriptionPatterns = new List<string>();
         public CommodityRateResolver Rates;
         public MaterialScheduleOptions Options = new MaterialScheduleOptions();
     }
@@ -51,6 +53,9 @@ namespace StingTools.Core.MaterialSchedule
             // a List per row.
             var stageIndex = StageIndex.Build(input.StageDefs, input.DefaultStageId);
 
+            var patterns = (input.ExcludedDescriptionPatterns ?? new List<string>())
+                .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToList();
+
             var excluded = new HashSet<string>(
                 input.ExcludedCategories ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
 
@@ -67,6 +72,24 @@ namespace StingTools.Core.MaterialSchedule
                     doc.ExcludedByCategory.TryGetValue(c, out int n);
                     doc.ExcludedByCategory[c] = n + 1;
                     continue;
+                }
+
+                // Not a material despite a legitimate category — an opening, a
+                // muntin pattern, a trim. Blank patterns are skipped: "".IndexOf
+                // returns 0 and would exclude the entire model.
+                if (patterns.Count > 0)
+                {
+                    string hay = (row.Description ?? "") + " " + (row.TypeName ?? "");
+                    bool hit = false;
+                    foreach (string pat in patterns)
+                        if (hay.IndexOf(pat, StringComparison.OrdinalIgnoreCase) >= 0) { hit = true; break; }
+                    if (hit)
+                    {
+                        string c2 = string.IsNullOrWhiteSpace(row.Category) ? "(uncategorised)" : row.Category.Trim();
+                        doc.ExcludedByCategory.TryGetValue(c2, out int n2);
+                        doc.ExcludedByCategory[c2] = n2 + 1;
+                        continue;
+                    }
                 }
 
                 // Constituent kind first, then category (+ optional type pattern).

--- a/StingTools/Core/MaterialSchedule/StageMapper.cs
+++ b/StingTools/Core/MaterialSchedule/StageMapper.cs
@@ -45,6 +45,17 @@ namespace StingTools.Core.MaterialSchedule
         /// yet, which is a missing rate, not a reason to hide them.
         /// </summary>
         public List<string> ExcludedCategories = new List<string>();
+
+        /// <summary>
+        /// Description / type-name substrings that are never materials, for rows
+        /// whose CATEGORY is legitimate. The first real export sold an OPENING
+        /// 1,187 times: `M_GM_OpeningWall_Instance — Opening` is a void, but its
+        /// category is Generic Models, which elsewhere holds real building
+        /// elements — so excluding the category would hide genuine work.
+        ///
+        /// A blank pattern is inert, never a wildcard.
+        /// </summary>
+        public List<string> ExcludedDescriptionPatterns = new List<string>();
     }
 
     /// <summary>

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -155,13 +155,20 @@ namespace StingTools.Core.MaterialSchedule
 
     public static class SupplierUnitConverter
     {
+        /// <summary>
+        /// 2 dp, away from zero — so a divisible order never rounds DOWN below
+        /// what was measured and quietly under-orders.
+        /// </summary>
+        private static double RoundDivisible(double v)
+            => Math.Round(v, 2, MidpointRounding.AwayFromZero);
+
         public static SupplierUnitResult Convert(SupplierUnitRule rule, double sourceQuantity)
         {
             if (rule == null)
                 return new SupplierUnitResult
                 {
                     SupplierUnit = "", NetQuantity = sourceQuantity,
-                    WastagePct = 0, OrderQuantity = sourceQuantity
+                    WastagePct = 0, OrderQuantity = RoundDivisible(sourceQuantity)
                 };
 
             // Bad or missing conversion data must degrade to 1:1, never to
@@ -172,7 +179,12 @@ namespace StingTools.Core.MaterialSchedule
             double net = sourceQuantity / factor;
             double waste = Math.Max(0, rule.DefaultWastagePct);
             double order = net * (1.0 + waste / 100.0);
-            if (rule.RoundUpToWhole) order = Math.Ceiling(order - 1e-9);
+            // Countable units round UP — you cannot buy 2.08 truck trips.
+            // Divisible units round to 2 dp: order quantity is what someone
+            // purchases and what the amount is computed from, so raw binary
+            // floats would otherwise print as "164.48145 m³" and drag fractions
+            // of a shilling into the money column.
+            order = rule.RoundUpToWhole ? Math.Ceiling(order - 1e-9) : RoundDivisible(order);
 
             return new SupplierUnitResult
             {

--- a/StingTools/Data/STING_MATERIAL_STAGES.json
+++ b/StingTools/Data/STING_MATERIAL_STAGES.json
@@ -35,6 +35,15 @@
     "Analytical Panels",
     "Analytical Nodes"
   ],
+  "excludedDescriptionPatterns": [
+    "opening",
+    "muntin",
+    "trim-window",
+    "wardrobe",
+    "generic ramp",
+    "_amp_",
+    "muntin pattern"
+  ],
   "stages": [
     {
       "stageId": "tools",


### PR DESCRIPTION
Both findings come from reviewing the **first real export** — UGX 214,157,028, 43 validation issues — against the model that produced it.

## Order quantities were raw floats

The sheet ordered `164.48145 m³` of concrete, `350.3889 m²` of formwork timber and `0.479999210217142 m³` of column concrete.

Order quantity is what somebody **buys**, and what `AmountUGX` is computed from — so binary float residue was reaching the money column and dragging fractions of a shilling into the sub-totals.

- **Countable units still round UP** — you cannot buy 2.08 truck trips
- **Divisible units round to 2 dp**, away from zero, so an order can never fall *below* the measured net and quietly under-order
- **The no-rule fallback is rounded too** — that's where `610.614588311426` came from
- **Net quantity keeps full precision** — it's the measured figure, not the purchased one

## An opening was sold 1,187 times

`M_GM_OpeningWall_Instance — Opening` is a **void**. There is nothing to buy. It arrived alongside muntin patterns, window trims and a wardrobe.

Category exclusion couldn't catch any of them — they're all `Generic Models`, which legitimately holds real building elements in other projects, so excluding the category would hide genuine work. **The discriminator is the description, not the category.**

So the stage library gains `excludedDescriptionPatterns`, seeded with seven patterns every one of which is justified by a row in your actual export.

Two safeguards, both tested directly:

- **A blank pattern is inert, never a wildcard.** `"".IndexOf` returns 0 — the trap that has now bitten this feature twice.
- **The seven shipped patterns match none of twelve real commodities** — cement, blocks, bricks, sand, rebar, timber, concrete, roofing sheets, paint, plaster, a door and a window. A careless pattern would silently delete real work from every bill, so the test names the exact pattern and the material it would have hidden.

## Verification

- `dotnet build` → **0 errors, 0 warnings**
- `StingTools.Boq.Tests` → **319 passing**, up from 304

## Next

Column and foundation decomposition — the remaining accuracy gap, and the one that changes the totals. `CompoundTakeoffBuilder` handles Walls, Floors and Structural Framing only; its own comment says *"Columns/foundations retain the composite line for now"*, so their concrete, rebar and formwork never reach the commodity totals and the bill is under-measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
