### PR TITLE
Decompose columns and foundations

### DIFF
--- a/StingTools.Boq.Tests/RcColumnFoundationTests.cs
+++ b/StingTools.Boq.Tests/RcColumnFoundationTests.cs
@@ -1,0 +1,156 @@
+using System.Linq;
+using StingTools.BOQ.Takeoff;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — the first real export listed three RC columns as unpriced m³
+    /// lumps and produced no SUB-STRUCTURE section at all, because
+    /// CompoundTakeoffBuilder handled Walls, Floors and Structural Framing only:
+    /// "Columns/foundations retain the composite line for now."
+    ///
+    /// So the columns' and foundations' concrete, rebar and formwork never
+    /// reached the commodity totals — the bill was under-measured, which is the
+    /// one class of error that costs real money on site.
+    ///
+    /// Formwork is the part worth pinning: a column shutters on all four faces
+    /// with no soffit, and a foundation only shutters its sides — and only when
+    /// it is not cast against the excavation.
+    /// </summary>
+    public class RcColumnFoundationTests
+    {
+        // ── columns ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void A_Rectangular_Column_Shutters_Its_Perimeter_By_Its_Height()
+        {
+            // 0.2 × 0.2 × 3.0 → concrete 0.12 m³, formwork 2(0.2+0.2)×3 = 2.4 m²
+            var lines = CompoundTakeoff.RcColumn(new RcColumnInput
+            {
+                WidthM = 0.2, DepthM = 0.2, HeightM = 3.0, RebarBandKgPerM3 = 160
+            });
+
+            Assert.Equal(0.12, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.Equal(2.4, lines.Single(l => l.Kind == "formwork").Quantity, 4);
+            Assert.Equal(0.12 * 160, lines.Single(l => l.Kind == "rebar").Quantity, 4);
+        }
+
+        [Fact]
+        public void A_Round_Column_Uses_Its_Circumference_Not_A_Box()
+        {
+            // Ø0.152 × 3.0 → concrete πr²h, formwork πdh. Treating it as a square
+            // would over-order shuttering by ~27%.
+            double d = 0.152, h = 3.0;
+            var lines = CompoundTakeoff.RcColumn(new RcColumnInput
+            {
+                DiameterM = d, HeightM = h, RebarBandKgPerM3 = 160
+            });
+
+            // CompoundLine rounds every quantity to 4 dp, so the expectation is
+            // rounded the same way rather than asserting a precision the engine
+            // does not promise.
+            Assert.Equal(System.Math.Round(System.Math.PI * d * d / 4.0 * h, 4),
+                         lines.Single(l => l.Kind == "concrete").Quantity, 6);
+            Assert.Equal(System.Math.Round(System.Math.PI * d * h, 4),
+                         lines.Single(l => l.Kind == "formwork").Quantity, 6);
+        }
+
+        [Fact]
+        public void A_Measured_Volume_Overrides_The_Derived_One()
+        {
+            // Revit's own solid volume is authoritative when we have it; the
+            // dimensions are only there to derive formwork.
+            var lines = CompoundTakeoff.RcColumn(new RcColumnInput
+            {
+                WidthM = 0.2, DepthM = 0.2, HeightM = 3.0,
+                ConcreteM3Override = 0.1375, RebarBandKgPerM3 = 160
+            });
+
+            Assert.Equal(0.1375, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.Equal(2.4, lines.Single(l => l.Kind == "formwork").Quantity, 4);  // unchanged
+        }
+
+        [Fact]
+        public void A_Column_With_No_Usable_Dimensions_Emits_No_Formwork_Rather_Than_Guessing()
+        {
+            var lines = CompoundTakeoff.RcColumn(new RcColumnInput
+            {
+                ConcreteM3Override = 0.5, RebarBandKgPerM3 = 160
+            });
+
+            Assert.Equal(0.5, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.DoesNotContain(lines, l => l.Kind == "formwork");
+        }
+
+        // ── foundations ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void A_Pad_Foundation_Shutters_Only_Its_Sides()
+        {
+            // 1.5 × 1.5 × 0.4 → concrete 0.9 m³, sides 2(1.5+1.5)×0.4 = 2.4 m².
+            // No soffit: it bears on the ground.
+            var lines = CompoundTakeoff.RcFoundation(new RcFoundationInput
+            {
+                LengthM = 1.5, WidthM = 1.5, DepthM = 0.4,
+                RebarBandKgPerM3 = 100, FormworkToSides = true
+            });
+
+            Assert.Equal(0.9, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.Equal(2.4, lines.Single(l => l.Kind == "formwork").Quantity, 4);
+        }
+
+        [Fact]
+        public void A_Foundation_Cast_Against_The_Excavation_Needs_No_Formwork()
+        {
+            var lines = CompoundTakeoff.RcFoundation(new RcFoundationInput
+            {
+                LengthM = 1.5, WidthM = 1.5, DepthM = 0.4,
+                RebarBandKgPerM3 = 100, FormworkToSides = false
+            });
+
+            Assert.Equal(0.9, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.DoesNotContain(lines, l => l.Kind == "formwork");
+        }
+
+        [Fact]
+        public void Blinding_Carries_No_Reinforcement()
+        {
+            // Blinding is unreinforced by definition. Banding it would invent
+            // steel that nobody orders and nobody fixes.
+            var lines = CompoundTakeoff.RcFoundation(new RcFoundationInput
+            {
+                LengthM = 2.0, WidthM = 2.0, DepthM = 0.05,
+                RebarBandKgPerM3 = 100, IsBlinding = true
+            });
+
+            Assert.Equal(0.2, lines.Single(l => l.Kind == "concrete").Quantity, 4);
+            Assert.DoesNotContain(lines, l => l.Kind == "rebar");
+        }
+
+        [Fact]
+        public void Zero_Or_Negative_Dimensions_Produce_Nothing_Rather_Than_Negative_Quantities()
+        {
+            Assert.Empty(CompoundTakeoff.RcColumn(new RcColumnInput { WidthM = -1, HeightM = 3 }));
+            Assert.Empty(CompoundTakeoff.RcFoundation(new RcFoundationInput { LengthM = 0, WidthM = 0, DepthM = 0 }));
+        }
+
+        [Fact]
+        public void Constituent_Kinds_Match_The_Ones_Walls_And_Slabs_Already_Emit()
+        {
+            // They must route and convert through the SAME supplier-unit rules as
+            // wall and slab concrete — a new kind here would silently fail to
+            // match any rule and land unpriced.
+            var col = CompoundTakeoff.RcColumn(new RcColumnInput
+            { WidthM = .3, DepthM = .3, HeightM = 3, RebarBandKgPerM3 = 160 });
+            var fnd = CompoundTakeoff.RcFoundation(new RcFoundationInput
+            { LengthM = 2, WidthM = 2, DepthM = .5, RebarBandKgPerM3 = 100, FormworkToSides = true });
+
+            foreach (var kind in new[] { "concrete", "rebar", "formwork" })
+            {
+                Assert.Contains(col, l => l.Kind == kind);
+                Assert.Contains(fnd, l => l.Kind == kind);
+            }
+        }
+    }
+}

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -63,6 +63,38 @@ namespace StingTools.BOQ.Takeoff
         public double FormworkM2;     // soffit + sides / both wall faces
     }
 
+    /// <summary>
+    /// MAT-SCHED — RC column inputs (all m). A column shutters on ALL FOUR faces
+    /// and has no soffit, so its formwork is perimeter × height.
+    /// </summary>
+    public struct RcColumnInput
+    {
+        public double WidthM;             // rectangular b
+        public double DepthM;             // rectangular d
+        public double DiameterM;          // > 0 → round column; overrides W×D
+        public double HeightM;
+        public double ConcreteM3Override; // > 0 → Revit's own solid volume wins
+        public double RebarBandKgPerM3;
+    }
+
+    /// <summary>
+    /// MAT-SCHED — RC foundation inputs (all m). A pad or strip bears on the
+    /// ground, so there is no soffit shutter; only the SIDES are formed, and only
+    /// when it is not cast against a neat excavation.
+    /// </summary>
+    public struct RcFoundationInput
+    {
+        public double LengthM;
+        public double WidthM;
+        public double DepthM;
+        public double ConcreteM3Override;
+        public double RebarBandKgPerM3;
+        /// <summary>Blinding is unreinforced by definition.</summary>
+        public bool IsBlinding;
+        /// <summary>False when cast against the excavation face.</summary>
+        public bool FormworkToSides;
+    }
+
     /// <summary>MAT-4.3 — RC beam inputs (all m).</summary>
     public struct RcBeamInput
     {
@@ -239,6 +271,55 @@ namespace StingTools.BOQ.Takeoff
         }
 
         /// <summary>Constituent lines for an RC slab / beam / column / wall.</summary>
+        /// <summary>
+        /// Column constituents. Formwork is the perimeter × height — all four
+        /// faces, no soffit. A round column uses its circumference: treating
+        /// Ø152 as a 152 square would over-order shuttering by about 27%.
+        /// </summary>
+        public static List<CompoundLine> RcColumn(RcColumnInput c)
+        {
+            double h = Math.Max(0, c.HeightM);
+            bool round = c.DiameterM > 0;
+
+            double derivedM3 = round
+                ? Math.PI * c.DiameterM * c.DiameterM / 4.0 * h
+                : Math.Max(0, c.WidthM) * Math.Max(0, c.DepthM) * h;
+            double conc = c.ConcreteM3Override > 0 ? c.ConcreteM3Override : derivedM3;
+
+            double perimeter = round
+                ? Math.PI * c.DiameterM
+                : 2.0 * (Math.Max(0, c.WidthM) + Math.Max(0, c.DepthM));
+            double formwork = perimeter * h;
+
+            return RcElement(new RcElementInput
+            {
+                ElementKind = "column",
+                ConcreteM3Net = conc,
+                RebarBandKgPerM3 = c.RebarBandKgPerM3,
+                FormworkM2 = formwork
+            });
+        }
+
+        /// <summary>
+        /// Foundation constituents. Only the SIDES are shuttered — a pad bears on
+        /// the ground, so there is no soffit — and not even those when it is cast
+        /// against the excavation. Blinding carries no reinforcement.
+        /// </summary>
+        public static List<CompoundLine> RcFoundation(RcFoundationInput f)
+        {
+            double l = Math.Max(0, f.LengthM), w = Math.Max(0, f.WidthM), d = Math.Max(0, f.DepthM);
+            double conc = f.ConcreteM3Override > 0 ? f.ConcreteM3Override : l * w * d;
+            double formwork = f.FormworkToSides ? 2.0 * (l + w) * d : 0;
+
+            return RcElement(new RcElementInput
+            {
+                ElementKind = f.IsBlinding ? "blinding" : "foundation",
+                ConcreteM3Net = conc,
+                RebarBandKgPerM3 = f.IsBlinding ? 0 : f.RebarBandKgPerM3,
+                FormworkM2 = formwork
+            });
+        }
+
         public static List<CompoundLine> RcElement(RcElementInput r)
         {
             var lines = new List<CompoundLine>();

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -97,7 +97,10 @@ namespace StingTools.BOQ.Takeoff
                 if (cat.IndexOf("Structural Framing", StringComparison.OrdinalIgnoreCase) >= 0
                     || cat.IndexOf("Beam", StringComparison.OrdinalIgnoreCase) >= 0)
                     return BuildRcBeam(doc, el, csvRates);
-                // Columns/foundations retain the composite line for now.
+                if (cat.IndexOf("Column", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return BuildRcColumn(doc, el, csvRates);
+                if (cat.IndexOf("Foundation", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return BuildRcFoundation(doc, el, csvRates);
                 return null;
             }
             catch (Exception ex)
@@ -363,6 +366,121 @@ namespace StingTools.BOQ.Takeoff
                 case "formwork": return "Formwork";
                 default: return kind;
             }
+        }
+
+        // ── RC column ───────────────────────────────────────────────────────
+        //  MAT-SCHED — columns used to keep the composite line, so their
+        //  concrete, rebar and formwork never reached the material schedule and
+        //  the bill was under-measured.
+        private static List<BOQLineItem> BuildRcColumn(Document doc, Element el,
+            Dictionary<string, (double rate, string unit)> csvRates)
+        {
+            string material = (GetPrimaryMaterialName(doc, el) ?? "").ToLowerInvariant();
+            // A steel or timber column is not RC — leave it as the composite line
+            // rather than inventing concrete for it.
+            if (material.Contains("steel") || material.Contains("timber") || material.Contains("wood"))
+                return null;
+
+            double volM3 = ReadSolidVolumeM3(doc, el);
+            var (bx, by, hz) = ReadBoundingBoxM(el);
+            if (volM3 <= 0 && (bx <= 0 || by <= 0 || hz <= 0)) return null;
+
+            double band = PropOr("REBAR_ELEMENT COLUMN", "STEEL_KG_PER_M3", 160);
+            bool round = LooksRound(doc, el);
+
+            var constituents = CompoundTakeoff.RcColumn(new RcColumnInput
+            {
+                WidthM = bx, DepthM = by, HeightM = hz,
+                DiameterM = round ? Math.Min(bx, by) : 0,
+                ConcreteM3Override = volM3,
+                RebarBandKgPerM3 = band
+            });
+            return constituents.Count == 0 ? null : Materialise(doc, el, constituents, csvRates, "S", new Resolution());
+        }
+
+        // ── RC foundation ───────────────────────────────────────────────────
+        private static List<BOQLineItem> BuildRcFoundation(Document doc, Element el,
+            Dictionary<string, (double rate, string unit)> csvRates)
+        {
+            double volM3 = ReadSolidVolumeM3(doc, el);
+            var (bx, by, hz) = ReadBoundingBoxM(el);
+            if (volM3 <= 0 && (bx <= 0 || by <= 0 || hz <= 0)) return null;
+
+            string typeName = (el.Name ?? "").ToLowerInvariant();
+            bool blinding = typeName.Contains("blinding") || typeName.Contains("lean");
+            double band = PropOr("REBAR_ELEMENT FOUNDATION", "STEEL_KG_PER_M3", 100);
+
+            var constituents = CompoundTakeoff.RcFoundation(new RcFoundationInput
+            {
+                LengthM = bx, WidthM = by, DepthM = hz,
+                ConcreteM3Override = volM3,
+                RebarBandKgPerM3 = band,
+                IsBlinding = blinding,
+                // Formed by default. Omitting it silently under-measures, which is
+                // the failure this whole change exists to fix; a project casting
+                // against the excavation can zero the formwork rate instead.
+                FormworkToSides = true
+            });
+            return constituents.Count == 0 ? null : Materialise(doc, el, constituents, csvRates, "S", new Resolution());
+        }
+
+        /// <summary>Solid volume in m³, summed over the element's geometry.</summary>
+        private static double ReadSolidVolumeM3(Document doc, Element el)
+        {
+            try
+            {
+                var opt = new Options { ComputeReferences = false, DetailLevel = ViewDetailLevel.Fine };
+                var ge = el?.get_Geometry(opt);
+                if (ge == null) return 0;
+                double ft3 = SumSolidsFt3(ge);
+                return ft3 * 0.0283168;
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("RcVolume", $"ReadSolidVolumeM3 {el?.Id}: {ex.Message}");
+                return 0;
+            }
+        }
+
+        private static double SumSolidsFt3(GeometryElement ge)
+        {
+            double total = 0;
+            foreach (GeometryObject go in ge)
+            {
+                if (go is Solid s && s.Volume > 0) total += s.Volume;
+                else if (go is GeometryInstance gi)
+                {
+                    var inner = gi.GetInstanceGeometry();
+                    if (inner != null) total += SumSolidsFt3(inner);
+                }
+            }
+            return total;
+        }
+
+        /// <summary>Bounding-box extents in metres (x, y, z). Used for formwork
+        /// only — the solid volume, when available, is what prices the concrete.</summary>
+        private static (double x, double y, double z) ReadBoundingBoxM(Element el)
+        {
+            try
+            {
+                var bb = el?.get_BoundingBox(null);
+                if (bb == null) return (0, 0, 0);
+                return ((bb.Max.X - bb.Min.X) * 0.3048,
+                        (bb.Max.Y - bb.Min.Y) * 0.3048,
+                        (bb.Max.Z - bb.Min.Z) * 0.3048);
+            }
+            catch { return (0, 0, 0); }
+        }
+
+        /// <summary>Round columns shutter to their circumference, not a box.</summary>
+        private static bool LooksRound(Document doc, Element el)
+        {
+            try
+            {
+                string n = ((el?.Name ?? "") + " " + (doc?.GetElement(el.GetTypeId())?.Name ?? "")).ToLowerInvariant();
+                return n.Contains("round") || n.Contains("circular") || n.Contains("diameter") || n.Contains("dia.");
+            }
+            catch { return false; }
         }
 
         // ── Small Revit helpers ─────────────────────────────────────────────


### PR DESCRIPTION
The third and last gap from reviewing your real export. The first two (rounding, exclusions) shipped in #724.

## The under-measure

Your export listed three RC columns as **unpriced m³ lumps** and produced **no SUB-STRUCTURE section at all**. `CompoundTakeoffBuilder` handled Walls, Floors and Structural Framing only — its own comment said *"Columns/foundations retain the composite line for now."*

So their concrete, rebar and formwork never reached the commodity totals. That is an **under-measure**, the one class of error that costs money on site: the bill is short and nobody finds out until the pour.

## Formwork is the part that needed thinking about

It is also what the tests pin:

| element | shutter | formula |
|---|---|---|
| column | all four faces, no soffit | perimeter × height |
| round column | circumference, not a box | π × d × h |
| pad / strip | sides only — it bears on the ground | 2(L+W) × depth |
| blinding | unreinforced by definition | no rebar band |

Treating a Ø152 column as a 152 square would **over-order shuttering by ~27%**, so roundness is detected rather than assumed.

## Deliberate choices

**Revit’s own solid volume prices the concrete** whenever it can be read; the bounding box derives formwork only. A column with neither usable volume nor usable dimensions emits **no formwork rather than guessing one**, and a steel or timber column keeps its composite line rather than having concrete invented for it.

**Foundations are formed by default.** Omitting the shutter would silently under-measure — exactly the failure this change exists to fix — and a project casting against the excavation can zero the formwork rate instead. That is the safer direction to be wrong in: surplus timber is reusable, a short order stops the pour.

**The emitted kinds are the same `concrete` / `rebar` / `formwork`** the walls and slabs already produce, so they route and convert through the existing supplier-unit rules. A test asserts that, because a new kind here would silently match no rule and land unpriced — which is how this feature has failed before.

## Verification

- `dotnet build` → **0 errors, 0 warnings**
- `StingTools.Boq.Tests` → **328 passing**, up from 319

One test failed first time and the **test** was wrong, not the code: it asserted 6 dp on a round column while `CompoundLine` rounds every quantity to 4. Corrected to state that contract rather than loosening the engine.

## What to expect

Your grand total **will rise** — columns and foundations now contribute concrete, rebar and formwork that were previously missing. That is the fix working, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)