### PR TITLE
fix(csp): allow the Cloudflare Web Analytics beacon (#694)

### DIFF
--- a/marketing-site/_headers
+++ b/marketing-site/_headers
@@ -8,7 +8,21 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(self), microphone=(), camera=(self), payment=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.planscape.build https://api.mapbox.com https://events.mapbox.com https://client.crisp.chat wss://client.relay.crisp.chat; frame-ancestors 'none'
+  # CSP. Third-party origins are listed per-directive; each one is here because
+  # something we deliberately use needs it.
+  #
+  # cloudflareinsights.com is Cloudflare Web Analytics (#694). Cloudflare injects
+  # its beacon at the edge, so it appears in no page source in this repo — and the
+  # CSP blocked it, meaning the analytics have never collected a single page view.
+  # Two hosts, two directives, and both are required:
+  #   static.cloudflareinsights.com  script-src   loads beacon.min.js
+  #   cloudflareinsights.com         connect-src  the beacon POSTs to /cdn-cgi/rum
+  #
+  # Note the injection only happens for real browser navigations — curl does not
+  # trigger it even with a browser User-Agent, so this can only be verified in a
+  # browser. Check the console for a CSP violation, and the network tab for the
+  # POST to cloudflareinsights.com.
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.planscape.build https://api.mapbox.com https://events.mapbox.com https://client.crisp.chat wss://client.relay.crisp.chat https://cloudflareinsights.com; frame-ancestors 'none'
 
 # ---------- Long-lived static assets ----------
 /assets/*


### PR DESCRIPTION
Closes #694.

## The problem

Cloudflare injects its Web Analytics beacon at the edge, and our own CSP blocked it:

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/v4513226…'
violates the following Content Security Policy directive:
"script-src 'self' 'unsafe-inline' https://api.mapbox.com https://client.crisp.chat".
The action has been blocked.
```

**The analytics have never collected a single page view.** Not partial data, not sampled — the script never executed, on any page, for any visitor. Any figure on that dashboard is empty or is coming from somewhere else.

## The fix

Two hosts, two directives, both required:

| Host | Directive | Why |
|---|---|---|
| `static.cloudflareinsights.com` | `script-src` | loads `beacon.min.js` |
| `cloudflareinsights.com` | `connect-src` | the beacon POSTs to `/cdn-cgi/rum` |

Allowing only the first would have swapped a blocked script for a blocked POST — the same silent no-data outcome, one step later.

## Verified

**All six headers in the `/*` block still apply.** The comments I added are indented *inside* the block, which nothing in this file had done before. If Cloudflare parsed those as malformed header lines it would drop the whole block — taking HSTS, `X-Frame-Options` and the CSP with it. So I checked under `wrangler pages dev` rather than assuming:

```
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
content-security-policy:   default-src 'self'; script-src … static.cloudflareinsights.com …
permissions-policy:        geolocation=(self), microphone=(), camera=(self), payment=()
referrer-policy:           strict-origin-when-cross-origin
x-content-type-options:    nosniff
x-frame-options:           SAMEORIGIN
```

Also confirmed each origin landed in the *correct* directive, and that `static.` did not leak into `connect-src` (asserted 0 occurrences).

## A note on how to check this

**`curl` is the wrong instrument.** The injection only happens for real browser navigations — six consecutive requests with a Chrome User-Agent and `Accept: text/html` returned no beacon at all, while the browser reported the CSP violation on the same URL seconds later. One earlier `curl` did match, which made it look intermittent; it is not, `curl` simply cannot be trusted here.

So the post-deploy check is a browser one: console clean of the CSP violation, and a `POST` to `cloudflareinsights.com` in the network tab. I will run exactly that once this is deployed.

## If you would rather not have it

The alternative is to turn the injection off in the Cloudflare dashboard and accept no client-side analytics. The one option worth avoiding is the status quo — a request made and blocked on every page load, producing nothing. If you prefer that route, say so and I will revert this instead.
