### PR TITLE
Stop selling square metres as pieces; apply wastage once

### DIFF
--- a/StingTools.Boq.Tests/CompoundTakeoffTests.cs
+++ b/StingTools.Boq.Tests/CompoundTakeoffTests.cs
@@ -37,7 +37,7 @@ namespace StingTools.Boq.Tests
             Assert.Contains("blockwork", kinds);
             Assert.Contains("plaster", kinds);
             Assert.Contains("mortar", kinds);
-            Assert.Contains("units", kinds);
+            Assert.Contains("block_units", kinds);   // brick and block are distinct kinds now
             // No formwork for non-RC masonry.
             Assert.DoesNotContain("formwork", kinds);
         }
@@ -75,7 +75,10 @@ namespace StingTools.Boq.Tests
         public void Plaster_Cement_And_Sand_Derive_From_Plaster_Volume()
         {
             var lines = CompoundTakeoff.MasonryWall(BlockWall(2));
-            double vol = 40.0 * 0.013 * 1.20;                 // area×faces × thk × (1+waste)
+            // NET of waste: the supplier-unit rule owns the allowance, so the
+            // engine no longer multiplies by PlasterWastePct. Applying it here
+            // AND in the rule wasted the derived cement and sand twice.
+            double vol = 40.0 * 0.013;                        // area×faces × thickness
             double sand = lines.Single(l => l.Kind == "plaster_sand").Quantity;
             Assert.Equal(vol * 1.25, sand, 4);
         }

--- a/StingTools.Boq.Tests/PaintTakeoffTests.cs
+++ b/StingTools.Boq.Tests/PaintTakeoffTests.cs
@@ -87,9 +87,11 @@ namespace StingTools.Boq.Tests
             var lines = CompoundTakeoff.MasonryWall(Wall(faces: 2));
 
             Assert.Equal(40.0, lines.Single(l => l.Kind == "plaster").Quantity, 4);
-            // 40 m² × 0.013 m × 1.20 waste = 0.624 m³ → × 9 bags = 5.616
-            Assert.Equal(5.616, lines.Single(l => l.Kind == "plaster_cement").Quantity, 3);
-            Assert.Equal(0.78, lines.Single(l => l.Kind == "plaster_sand").Quantity, 3);
+            // 40 m² × 0.013 m = 0.52 m³ NET of waste → × 9 bags = 4.68.
+            // The 1.20 that used to sit here was engine-side waste, applied again
+            // by the supplier-unit rule; the rule is now the only place it lives.
+            Assert.Equal(4.68, lines.Single(l => l.Kind == "plaster_cement").Quantity, 3);
+            Assert.Equal(0.65, lines.Single(l => l.Kind == "plaster_sand").Quantity, 3);
         }
 
         [Fact]

--- a/StingTools.Boq.Tests/QuantityAccuracyTests.cs
+++ b/StingTools.Boq.Tests/QuantityAccuracyTests.cs
@@ -1,0 +1,193 @@
+using System.Linq;
+using StingTools.BOQ.Takeoff;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — three quantity defects found by cross-checking a real export
+    /// against the ratios that produced it.
+    ///
+    ///  1. "Bricks · No. · 364.31" was 364 SQUARE METRES of brickwork relabelled
+    ///     as a brick count. Nothing checked that a rule's sourceUnit matched the
+    ///     measured unit, so an area flowed into a piece-count commodity.
+    ///  2. blockwork (m²) and units (nr) both mapped to commodity "block", so the
+    ///     aggregator ADDED an area to a piece count. The export's block figure
+    ///     implied 2,024 m² of wall while its mortar implied 994 m² — both
+    ///     derive from the same area, so they could not honestly differ.
+    ///  3. Wastage was applied in the engine AND in the supplier-unit rule, so
+    ///     blocks carried ~10% and plaster cement ~23% instead of the stated
+    ///     5% and 2.5%.
+    /// </summary>
+    public class QuantityAccuracyTests
+    {
+        private static MasonryWallInput Wall(bool brick = false) => new MasonryWallInput
+        {
+            FaceAreaM2 = 100.0,
+            IsBrick = brick,
+            UnitsPerM2 = brick ? 60 : 12.5,
+            UnitWastePct = 5,          // retired — must have no effect
+            PlasterFaces = 2,
+            PlasterThicknessM = 0.013,
+            PlasterWastePct = 20,      // retired — must have no effect
+            MortarRatioM3PerM2 = 0.011,
+            MortarCementBagsPerM3 = 9,
+            MortarSandRatio = 1.25,
+            PlasterCementBagsPerM3 = 9,
+            PlasterSandRatio = 1.25
+        };
+
+        // ── 3. wastage lives in exactly one place ───────────────────────────
+
+        [Fact]
+        public void Unit_Counts_Are_Net_Of_Waste()
+        {
+            // 100 m² × 12.5 = 1,250 blocks. NOT 1,312.5 — the rule adds its 5%.
+            var lines = CompoundTakeoff.MasonryWall(Wall());
+            Assert.Equal(1250.0, lines.Single(l => l.Kind == "block_units").Quantity, 4);
+        }
+
+        [Fact]
+        public void Plaster_Derived_Cement_Is_Net_Of_Waste()
+        {
+            // 200 m² plastered × 0.013 = 2.6 m³ × 9 = 23.4 bags. NOT 28.08.
+            var lines = CompoundTakeoff.MasonryWall(Wall());
+            Assert.Equal(23.4, lines.Single(l => l.Kind == "plaster_cement").Quantity, 3);
+        }
+
+        [Fact]
+        public void The_Retired_Waste_Inputs_Have_No_Effect_At_All()
+        {
+            var withWaste = Wall();
+            var without = Wall();
+            without.UnitWastePct = 0;
+            without.PlasterWastePct = 0;
+
+            var a = CompoundTakeoff.MasonryWall(withWaste);
+            var b = CompoundTakeoff.MasonryWall(without);
+
+            foreach (var kind in new[] { "block_units", "plaster_cement", "plaster_sand", "mortar" })
+                Assert.Equal(b.Single(l => l.Kind == kind).Quantity,
+                             a.Single(l => l.Kind == kind).Quantity, 6);
+        }
+
+        // ── 2. bricks are not blocks ────────────────────────────────────────
+
+        [Fact]
+        public void A_Brick_Wall_Emits_Brick_Units_Not_Block_Units()
+        {
+            var lines = CompoundTakeoff.MasonryWall(Wall(brick: true));
+
+            Assert.Contains(lines, l => l.Kind == "brick_units");
+            Assert.DoesNotContain(lines, l => l.Kind == "block_units");
+        }
+
+        [Fact]
+        public void The_Area_Measure_And_The_Piece_Count_Are_Different_Kinds()
+        {
+            // blockwork is the m² a QS prices; block_units is what a site buys.
+            // Merging them added an area to a piece count.
+            var lines = CompoundTakeoff.MasonryWall(Wall());
+
+            Assert.Equal("m2", lines.Single(l => l.Kind == "blockwork").Unit);
+            Assert.Equal("nr", lines.Single(l => l.Kind == "block_units").Unit);
+        }
+
+        [Fact]
+        public void The_Shipped_Table_No_Longer_Maps_An_Area_Kind_To_A_Piece_Commodity()
+        {
+            var table = Newtonsoft.Json.JsonConvert.DeserializeObject<SupplierUnitTable>(
+                System.IO.File.ReadAllText(System.IO.Path.Combine(
+                    System.AppContext.BaseDirectory, "Data", "STING_SUPPLIER_UNITS.json")));
+
+            foreach (string areaKind in new[] { "blockwork", "brickwork" })
+                Assert.DoesNotContain(table.Rules,
+                    r => r.MatchKinds.Contains(areaKind, System.StringComparer.OrdinalIgnoreCase));
+
+            Assert.Contains(table.Rules, r => r.CommodityKey == "block"
+                && r.MatchKinds.Contains("block_units"));
+            Assert.Contains(table.Rules, r => r.CommodityKey == "brick"
+                && r.MatchKinds.Contains("brick_units"));
+        }
+
+        // ── 1. unlike units cannot convert ──────────────────────────────────
+
+        private static AggregatorInputs Inputs(SupplierUnitTable t, params ConstituentInput[] rows) =>
+            new AggregatorInputs
+            {
+                Constituents = rows.ToList(),
+                Units = t,
+                StageDefs = { new StageDefinition { StageId = "s", Title = "S", Order = 10 } },
+                DefaultStageId = "s",
+                Rates = new CommodityRateResolver(
+                    new[] { new CommodityRate { CommodityKey = "brick", RateUGX = 400 } }, null)
+            };
+
+        private static SupplierUnitTable BrickTable()
+        {
+            var t = new SupplierUnitTable();
+            t.Rules.Add(new SupplierUnitRule
+            {
+                CommodityKey = "brick", Description = "Bricks", SupplierUnit = "No.",
+                SourceUnit = "nr", SourceUnitsPerSupplierUnit = 1.0,
+                MatchKinds = { "brick_units", "brickwork" }   // deliberately wrong
+            });
+            return t;
+        }
+
+        [Fact]
+        public void A_Square_Metre_Quantity_Cannot_Become_A_Piece_Count()
+        {
+            // The exact defect: 364 m² of brickwork must not print as 364 bricks.
+            var doc = CommodityAggregator.Build(Inputs(BrickTable(),
+                new ConstituentInput { ConstituentKind = "brickwork", Description = "Brickwork wall",
+                                       Unit = "m2", Quantity = 364.31 }));
+
+            var row = doc.Stages.Single().Commodities.Single();
+            Assert.True(row.ConversionBlocked);
+            Assert.Equal("m2", row.SupplierUnit);          // kept its measured unit
+            Assert.Contains("unlike units", row.ConversionNote);
+        }
+
+        [Fact]
+        public void A_Matching_Unit_Still_Converts_Normally()
+        {
+            var doc = CommodityAggregator.Build(Inputs(BrickTable(),
+                new ConstituentInput { ConstituentKind = "brick_units", Description = "Bricks",
+                                       Unit = "nr", Quantity = 6000 }));
+
+            var row = doc.Stages.Single().Commodities.Single();
+            Assert.False(row.ConversionBlocked);
+            Assert.Equal("No.", row.SupplierUnit);
+            Assert.Equal(6000, row.OrderQuantity);
+        }
+
+        [Fact]
+        public void A_Rule_Declaring_No_Source_Unit_Is_Trusted()
+        {
+            // Existing rules that never declared a sourceUnit must keep working
+            // rather than being blocked wholesale.
+            var t = new SupplierUnitTable();
+            t.Rules.Add(new SupplierUnitRule
+            {
+                CommodityKey = "brick", SupplierUnit = "No.", SourceUnit = "",
+                SourceUnitsPerSupplierUnit = 1.0, MatchKinds = { "brick_units" }
+            });
+
+            var doc = CommodityAggregator.Build(Inputs(t,
+                new ConstituentInput { ConstituentKind = "brick_units", Unit = "nr", Quantity = 10 }));
+
+            Assert.False(doc.Stages.Single().Commodities.Single().ConversionBlocked);
+        }
+
+        [Fact]
+        public void The_Reconciler_Reports_An_Unlike_Unit_Conversion()
+        {
+            var doc = CommodityAggregator.Build(Inputs(BrickTable(),
+                new ConstituentInput { ConstituentKind = "brickwork", Unit = "m2", Quantity = 364.31 }));
+
+            Assert.Contains(Reconciler.Check(doc).Issues, i => i.Code == "R5");
+        }
+    }
+}

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -39,9 +39,12 @@ namespace StingTools.BOQ.Takeoff
         public double FaceAreaM2;        // one elevation (net) area of the wall
         public bool IsBrick;             // brickwork vs blockwork
         public double UnitsPerM2;        // BRICKS_PER_M2 / BLOCKS_PER_M2
+        /// <summary>RETIRED. Wastage belongs to the supplier-unit rule; leaving it
+        /// here as well double-counted it. Kept so existing callers still compile.</summary>
         public double UnitWastePct;      // cutting waste on the units
         public int PlasterFaces;         // 0 / 1 / 2 plastered faces
         public double PlasterThicknessM; // plaster coat thickness
+        /// <summary>RETIRED — see UnitWastePct.</summary>
         public double PlasterWastePct;
         public double MortarRatioM3PerM2;     // mortar volume per m² of wall
         public double MortarCementBagsPerM3;  // from MORTAR mix (MAT-2)
@@ -129,11 +132,21 @@ namespace StingTools.BOQ.Takeoff
             // 1. The walling itself, measured m² (the QS prices £/m² by type).
             lines.Add(new CompoundLine(masonryKind, $"{masonryWord} wall", "m2", area, SecMasonry));
 
-            // 2. Units (bricks/blocks) nr, incl. cutting waste.
+            // 2. Units (bricks/blocks) nr — NET of waste.
+            //
+            // Wastage lives in ONE place: the supplier-unit rule. It used to be
+            // applied here as well, so blocks and bricks carried cutting waste
+            // twice (engine ~5% then the rule's 5%, ≈10% effective) and nobody
+            // could see which allowance was which.
+            //
+            // Brick and block are DISTINCT kinds. A single "units" kind sent a
+            // brick wall's brick count into the block commodity, so bricks were
+            // ordered as blocks.
             if (m.UnitsPerM2 > 0)
             {
-                double units = area * m.UnitsPerM2 * (1.0 + Math.Max(0, m.UnitWastePct) / 100.0);
-                lines.Add(new CompoundLine("units", m.IsBrick ? "Bricks" : "Blocks", "nr", units, SecMasonry));
+                double units = area * m.UnitsPerM2;
+                lines.Add(new CompoundLine(m.IsBrick ? "brick_units" : "block_units",
+                    m.IsBrick ? "Bricks" : "Blocks", "nr", units, SecMasonry));
             }
 
             // 3. Mortar m³ and its cement (bags) + sand (m³) from the MAT-2 mix.
@@ -155,8 +168,10 @@ namespace StingTools.BOQ.Takeoff
                 double plasterArea = area * m.PlasterFaces;
                 lines.Add(new CompoundLine("plaster", $"Plaster ({m.PlasterFaces} face{(m.PlasterFaces > 1 ? "s" : "")})",
                     "m2", plasterArea, SecPlaster));
-                double plasterVol = plasterArea * Math.Max(0, m.PlasterThicknessM)
-                                    * (1.0 + Math.Max(0, m.PlasterWastePct) / 100.0);
+                // NET of waste — the supplier-unit rule owns the allowance. This
+                // used to multiply by PlasterWastePct (20%), so the cement and
+                // sand derived from it were wasted twice.
+                double plasterVol = plasterArea * Math.Max(0, m.PlasterThicknessM);
                 if (plasterVol > 0 && m.PlasterCementBagsPerM3 > 0)
                     lines.Add(new CompoundLine("plaster_cement", "Plaster — cement", "bag",
                         plasterVol * m.PlasterCementBagsPerM3, SecPlaster));

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -124,6 +124,22 @@ namespace StingTools.Core.MaterialSchedule
                     acc[k] = a;
                 }
 
+                // A rule whose sourceUnit does not match the row's measured unit
+                // must NOT convert. Without this guard a m2 quantity flowed into
+                // a piece-count commodity unchallenged: "Bricks · No. · 364.31"
+                // in a real export was 364 SQUARE METRES of brickwork relabelled
+                // as a brick count.
+                if (rule != null && !UnitsAlign(row.Unit, rule.SourceUnit))
+                {
+                    a.ConversionBlocked = true;
+                    if (string.IsNullOrEmpty(a.ConversionNote))
+                        a.ConversionNote = $"measured in '{row.Unit}' but commodity "
+                                         + $"'{rule.CommodityKey}' is bought per '{rule.SourceUnit}' "
+                                         + "— converting would compare unlike units";
+                    rule = null;   // keep the measured figure, do not convert
+                    a.Rule = null;
+                }
+
                 // A category hit whose type did not match is NOT converted. Record
                 // why, so the reconciler can name it and the QS can either fix the
                 // rule or price the measured row by hand.
@@ -187,6 +203,20 @@ namespace StingTools.Core.MaterialSchedule
 
             StageMapper.AssignLetters(doc.Stages);
             return doc;
+        }
+
+        /// <summary>
+        /// True when a measured unit and a rule's source unit denote the same
+        /// dimension. An empty sourceUnit means the rule declares no expectation
+        /// and is trusted, so existing rules keep working.
+        /// </summary>
+        private static bool UnitsAlign(string measured, string ruleSource)
+        {
+            if (string.IsNullOrWhiteSpace(ruleSource)) return true;
+            if (string.IsNullOrWhiteSpace(measured)) return true;   // nothing to contradict
+            return string.Equals(StingTools.BOQ.BoqUnits.Normalise(measured),
+                                 StingTools.BOQ.BoqUnits.Normalise(ruleSource),
+                                 StringComparison.OrdinalIgnoreCase);
         }
 
         private sealed class Accum

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -43,9 +43,7 @@
       "roundUpToWhole": true,
       "defaultWastagePct": 5.0,
       "matchKinds": [
-        "blockwork",
-        "units",
-        "infill_block"
+        "block_units"
       ],
       "matchCategories": [],
       "matchTypePatterns": [],
@@ -60,7 +58,7 @@
       "roundUpToWhole": true,
       "defaultWastagePct": 5.0,
       "matchKinds": [
-        "brickwork"
+        "brick_units"
       ],
       "matchCategories": [],
       "matchTypePatterns": [],


### PR DESCRIPTION
Three quantity defects, found by cross-checking the real export's numbers against the ratios that produced them. All three inflate quantities.

## 1 · Square metres were sold as pieces

Your sheet read **"Bricks · No. · 364.31"**. That is not 364 bricks — it is **364 square metres of brickwork relabelled as a piece count**.

`MasonryWall` emits `brickwork` in **m²**; the `brick` rule buys per **nr**; and nothing checked that a rule's `sourceUnit` matched the measured unit. The aggregator now **refuses to convert unlike units**, keeps the measured figure, and reports it as **R5** rather than printing a confident wrong number.

## 2 · An area was added to a piece count

`blockwork` (m²) and `units` (nr) **both mapped to commodity `block`**, so the aggregator summed them.

The arithmetic proves it: the export's block figure implies **2,024 m²** of wall, its mortar implies **994 m²**. Both derive from the same `area` in the same function, so they cannot honestly differ.

`brickwork` / `blockwork` are QS **area measures**, not purchases, and are no longer commodities. Only the piece counts are.

A single `units` kind also sent a **brick** wall's brick count into the **block** commodity — bricks ordered as blocks. Brick and block now emit distinct kinds.

## 3 · Wastage was applied twice

| commodity | engine | rule | was | should be |
|---|---|---|---|---|
| blocks / bricks | `UnitWastePct` | +5% | ~10% | 5% |
| plaster cement | 20% on volume | +2.5% | ~23% | 2.5% |
| plaster sand | 20% on volume | +5% | ~26% | 5% |

Wastage now lives in **exactly one place** — the supplier-unit rule — which is what the converter's own documentation already claimed. `UnitWastePct` and `PlasterWastePct` are kept as **retired no-ops** so existing callers compile, and a test asserts they change nothing.

## This moves BOQ numbers, deliberately

The previous figures were wrong in a direction that **over-ordered**. Three existing tests encoded the old behaviour; they are **corrected, not loosened** — each now carries the arithmetic and why it changed.

## What stays correct

Verified unchanged: plaster area → volume → cement → sand still reconciles exactly (1062.06 m² × 0.013 = 13.81 m³ × 9 = 124.3 bags), concrete/rebar/paint were always single-wasted, and the ratios themselves (12.5 blocks/m², 0.011 m³ mortar/m², 60 bricks/m² stretcher) match the shipped lookup tables.

## Verification

- `dotnet build` → **0 errors, 0 warnings**
- `StingTools.Boq.Tests` → **338 passing**, up from 328

🤖 Generated with [Claude Code](https://claude.com/claude-code)