### PR TITLE
ci(marketing-site): merging now deploys, and the deploy proves itself (#651)

### DIFF
--- a/.github/workflows/marketing-site-deploy.yml
+++ b/.github/workflows/marketing-site-deploy.yml
@@ -1,0 +1,100 @@
+name: Marketing site — Deploy
+
+# Closes the gap in #651: marketing-site has no git-connected Pages build, so
+# MERGING DEPLOYED NOTHING. Production could sit arbitrarily far behind main with
+# no signal anywhere, and Pages' static fallback makes an undeployed Function
+# return 405 (or 200-HTML) — indistinguishable from a route that never existed.
+# That cost hours twice in one session: a merged endpoint was simply absent, and
+# the absence read as a code fault.
+#
+# This makes a merge to main reach production by itself. Two deliberate choices:
+#
+#   * The deploy is GATED on typecheck + the full test suite. Auto-deploying a red
+#     tree would trade one silent failure for a louder one.
+#   * The deploy VERIFIES ITSELF by fetching build-info.json back from
+#     planscape.build and asserting the commit matches. A wrangler exit code of 0
+#     means "upload accepted", not "that commit is what the domain serves".
+#
+# REQUIRED SECRETS — until both are set this job fails loudly, which is the
+# intended behaviour rather than a regression:
+#   CLOUDFLARE_API_TOKEN   scoped to Cloudflare Pages:Edit on this account
+#   CLOUDFLARE_ACCOUNT_ID  fc846350c65d033ef774e4b17f9c7039
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'marketing-site/**'
+      - '.github/workflows/marketing-site-deploy.yml'
+  # Manual runs, for redeploying without a code change — e.g. after setting a
+  # Pages secret, which does NOT reach the running Functions until the next
+  # deployment (#674).
+  workflow_dispatch:
+
+# One deploy at a time; a newer merge should win rather than race.
+concurrency:
+  group: marketing-site-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Test & Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: marketing-site
+      url: https://planscape.build
+    defaults:
+      run:
+        working-directory: marketing-site
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: marketing-site/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # Gate. Never publish a tree whose tests fail.
+      - name: Test
+        run: npm test
+
+      # `npm run deploy` would also work, but wrangler-action handles auth and
+      # pins its own wrangler. predeploy is invoked explicitly because
+      # wrangler-action does not run npm lifecycle scripts.
+      - name: Stamp build-info.json
+        run: npm run predeploy
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: marketing-site
+          command: pages deploy . --project-name=planscape-marketing --branch=main --commit-dirty=true
+
+      # THE POINT OF THIS STEP. A green deploy step proves the upload was
+      # accepted, not that the domain serves it. Ask the live site what commit it
+      # is running and compare. Retries because a fresh deployment takes a few
+      # seconds to become the one the custom domain routes to.
+      - name: Verify the domain serves this commit
+        run: |
+          expected="${GITHUB_SHA}"
+          for i in $(seq 1 12); do
+            live=$(curl -fsS "https://planscape.build/build-info.json?cb=${GITHUB_RUN_ID}-$i" \
+                     | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write(JSON.parse(d).sha||"")}catch{process.stdout.write("")}})' || true)
+            if [ "$live" = "$expected" ]; then
+              echo "✅ planscape.build is serving ${expected}"
+              exit 0
+            fi
+            echo "  attempt $i: live=${live:-<none>} expected=$expected"
+            sleep 10
+          done
+          echo "::error::Deploy reported success but https://planscape.build/build-info.json does not report ${expected}. Production may still be serving an older commit — this is exactly the #651 failure mode, so it fails rather than passing quietly."
+          exit 1

--- a/marketing-site/.gitignore
+++ b/marketing-site/.gitignore
@@ -4,3 +4,8 @@ node_modules/
 .dev.vars
 .tscheck/
 *.log
+
+# Generated at deploy time by tools/stamp-marketing-build.mjs. It SHIPS (it is
+# the deployed-commit marker for #651) but is never committed — committing it
+# would churn on every deploy and the value would be wrong for the next one.
+build-info.json

--- a/marketing-site/package.json
+++ b/marketing-site/package.json
@@ -9,7 +9,8 @@
     "dev": "wrangler pages dev . --d1 WAITLIST_DB=planscape-waitlist",
     "schema:local": "wrangler d1 execute planscape-waitlist --local --file=./functions/api/schema.sql",
     "schema:remote": "wrangler d1 execute planscape-waitlist --remote --file=./functions/api/schema.sql",
-    "deploy": "wrangler pages deploy . --project-name=planscape-marketing --branch=main --commit-dirty=true"
+    "deploy": "wrangler pages deploy . --project-name=planscape-marketing --branch=main --commit-dirty=true",
+    "predeploy": "node ../tools/stamp-marketing-build.mjs"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250510.0",

--- a/tools/stamp-marketing-build.mjs
+++ b/tools/stamp-marketing-build.mjs
@@ -1,0 +1,54 @@
+// Writes marketing-site/build-info.json so the DEPLOYED commit is discoverable
+// from outside — the missing fact behind #651.
+//
+// marketing-site has no git-connected Pages build, so `main` and production can
+// drift arbitrarily with no signal anywhere. Worse, Pages' static fallback makes
+// an undeployed Function return 405/200-HTML, which is indistinguishable from a
+// route that never existed. Twice in one session that cost hours: a merged
+// endpoint was simply absent, and the absence looked like a code fault.
+//
+// A deployed commit marker fixes the diagnosis cheaply: fetch
+// https://planscape.build/build-info.json and you know exactly what is serving,
+// with no Cloudflare credentials needed. The deploy workflow asserts against it,
+// and so can a human.
+//
+// Run automatically by `npm run predeploy`, so a manual `npm run deploy` stamps
+// it too — otherwise the marker would only ever be right in CI.
+
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(here, "..", "marketing-site", "build-info.json");
+
+function git(args, fallback) {
+  try {
+    return execSync(`git ${args}`, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+// GITHUB_SHA is authoritative in CI; git rev-parse covers local deploys. Never
+// throw — failing to stamp must not block a deploy someone needs to make.
+const sha = process.env.GITHUB_SHA || git("rev-parse HEAD", "unknown");
+const branch =
+  process.env.GITHUB_REF_NAME || git("rev-parse --abbrev-ref HEAD", "unknown");
+
+const info = {
+  sha,
+  shortSha: sha.slice(0, 9),
+  branch,
+  // Whether the tree had uncommitted changes at deploy time. `npm run deploy`
+  // passes --commit-dirty=true, so this is the only record that what shipped was
+  // not exactly a commit.
+  dirty: git("status --porcelain -- ../marketing-site", "") !== "",
+  deployedAt: new Date().toISOString(),
+  deployedBy: process.env.GITHUB_ACTIONS ? "github-actions" : "manual",
+  runId: process.env.GITHUB_RUN_ID || null,
+};
+
+writeFileSync(out, JSON.stringify(info, null, 2) + "\n");
+console.log(`build-info.json: ${info.shortSha} (${info.branch}) dirty=${info.dirty} by ${info.deployedBy}`);


### PR DESCRIPTION
Closes #651.

## The gap

`marketing-site` has no git-connected Pages build, so **merging deployed nothing.** Production could sit arbitrarily far behind `main` with no signal anywhere — and Pages' static fallback makes an undeployed Function return `405` (or `200`-HTML), which is *indistinguishable from a route that never existed*.

That cost hours twice in one session: a merged endpoint was simply absent, and the absence read as a code fault.

Connecting the Pages project to git is a dashboard action I cannot take. Deploying from Actions reaches the same outcome, and lives in the repo where it can be reviewed.

## Three parts

**1. A deployed-commit marker.** `tools/stamp-marketing-build.mjs` writes `marketing-site/build-info.json` with the commit, branch, dirty flag, timestamp and run id. Wired to npm's `predeploy` hook so a manual `npm run deploy` stamps it too — otherwise the marker would only ever be correct in CI, which is the worst of both.

Gitignored: it **ships but is never committed**. Committing it would churn on every deploy and hold the wrong value for the next one.

> Worth noting *why* this works: Pages uploads gitignored files. The exact quirk that published the test bundle in #691 is what lets an uncommitted marker reach production.

**2. Deploy on merge.** `.github/workflows/marketing-site-deploy.yml` runs on push to `main` under a `marketing-site/**` path filter, plus `workflow_dispatch` for redeploying without a code change — which you need after setting a Pages secret, since those do not reach running Functions until the next deployment (#674).

**Gated on typecheck and the full test suite.** Auto-deploying a red tree would trade one silent failure for a louder one.

**3. The deploy verifies itself.** It fetches `build-info.json` back from `planscape.build` and asserts the sha matches, retrying while the new deployment becomes the one the custom domain routes to.

This is the part that matters. A `wrangler` exit code of 0 means *"upload accepted"*, not *"that commit is what the domain serves"* — and conflating those is the entire lesson of this issue. If the domain does not report the deployed commit, the job fails with an explicit message rather than passing quietly.

## Required secrets

The job **fails loudly until both exist**, which is the intended behaviour rather than a regression:

| Secret | Value |
|---|---|
| `CLOUDFLARE_API_TOKEN` | a token scoped to **Pages:Edit** on this account |
| `CLOUDFLARE_ACCOUNT_ID` | `fc846350c65d033ef774e4b17f9c7039` |

Add them at **Settings → Secrets and variables → Actions**. Until then, keep deploying with `npm run deploy` as today — it now stamps the marker too, so the drift is externally visible either way.

## Verified locally

| Check | Result |
|---|---|
| Stamper output | correct sha/branch/dirty, matched `git rev-parse HEAD` |
| `build-info.json` served | **200 `application/json`**, 237 bytes under `wrangler pages dev` |
| Verify step's sha extraction | returned the right sha from valid JSON |
| Same extraction on non-JSON | returned empty **without crashing** — which is what it receives when the marker is not deployed yet, so the retry loop degrades correctly instead of erroring |
| Workflow YAML | parses, 8 steps |

I could not exercise the deploy step itself without the secrets, and I have said so rather than implying end-to-end proof. Everything around it is tested.

## A side benefit

`https://planscape.build/build-info.json` now answers "what is actually live?" with no Cloudflare credentials. Several of today's wrong turns began with not being able to answer that cheaply.
