### PR TITLE
fix(web): a full plan says which limit and how to fix it, not "quota_exceeded"

### DIFF
--- a/planscape-web/app/projects/new/page.tsx
+++ b/planscape-web/app/projects/new/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { createProject } from '@/lib/data';
+import { describeFailure } from '@/lib/api';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,13 +15,13 @@ export default function NewProjectPage() {
   const [code, setCode] = useState('');
   const [description, setDescription] = useState('');
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [failure, setFailure] = useState<ReturnType<typeof describeFailure> | null>(null);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) return;
     setBusy(true);
-    setError(null);
+    setFailure(null);
     try {
       const p = await createProject({
         name: name.trim(),
@@ -29,7 +30,16 @@ export default function NewProjectPage() {
       });
       router.push(`/projects/${p.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create project');
+      // #670 — a 402 is a PLAN limit, not a failure and not a refusal. Rendering
+      // `error` showed the owner the literal token `quota_exceeded`, which reads
+      // as an expired account. describeFailure surfaces the server's own
+      // sentence plus the way out.
+      setFailure(
+        describeFailure(err, {
+          forbidden: 'Only an Owner or Admin can create projects in this firm.',
+          fallback: 'Failed to create project',
+        }),
+      );
       setBusy(false);
     }
   }
@@ -43,7 +53,31 @@ export default function NewProjectPage() {
         <h1 className="text-xl font-semibold">New project</h1>
       </div>
 
-      {error && <p className="mb-3 rounded bg-danger-subtle px-3 py-2 text-sm text-danger">{error}</p>}
+      {failure && (
+        <p
+          className={
+            'mb-3 rounded px-3 py-2 text-sm ' +
+            (failure.tone === 'quota'
+              ? 'bg-warning-subtle text-warning'
+              : failure.tone === 'forbidden'
+                ? 'bg-warning-subtle text-warning'
+                : 'bg-danger-subtle text-danger')
+          }
+        >
+          {failure.tone === 'quota' && <span aria-hidden="true">📈 </span>}
+          {failure.tone === 'forbidden' && <span aria-hidden="true">🔒 </span>}
+          {failure.message}
+          {failure.actionHref && (
+            <>
+              {' '}
+              <a href={failure.actionHref} className="underline">
+                Upgrade your plan
+              </a>
+              .
+            </>
+          )}
+        </p>
+      )}
 
       <form onSubmit={submit} className="max-w-lg space-y-3 rounded-lg border border-border bg-surface p-4">
         <label className="block">

--- a/planscape-web/components/ui/toast.tsx
+++ b/planscape-web/components/ui/toast.tsx
@@ -19,7 +19,13 @@ import { cn } from '@/lib/cn';
  * permission answer that vanishes after four seconds leaves the user believing
  * the action worked.
  */
-export type ToastTone = 'success' | 'error' | 'info' | 'forbidden';
+/**
+ * `quota` is deliberately its own tone rather than a shade of `error` or
+ * `forbidden`. A refusal is resolved by asking someone; a full plan is resolved
+ * by upgrading — different actions, so they must not look alike. Same rule
+ * #558 used to split forbidden out of error. See #670.
+ */
+export type ToastTone = 'success' | 'error' | 'info' | 'forbidden' | 'quota';
 
 interface ToastItem {
   id: number;
@@ -46,7 +52,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       setItems((xs) => [...xs, { id, tone, message }]);
       // Errors persist until dismissed — a failed save that vanishes after four
       // seconds is how a user ends up believing a value saved when it didn't.
-      if (tone !== 'error' && tone !== 'forbidden') setTimeout(() => dismiss(id), 4000);
+      // A quota notice is actionable (upgrade) and must not vanish mid-read,
+      // for the same reason an error or a refusal does not auto-dismiss.
+      if (tone !== 'error' && tone !== 'forbidden' && tone !== 'quota') setTimeout(() => dismiss(id), 4000);
     },
     [dismiss],
   );
@@ -69,10 +77,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               t.tone === 'success' && 'border-success/40 bg-success-subtle text-success',
               t.tone === 'error' && 'border-danger/40 bg-danger-subtle text-danger',
               t.tone === 'forbidden' && 'border-warning/40 bg-warning-subtle text-warning',
+              t.tone === 'quota' && 'border-info/40 bg-info-subtle text-info',
               t.tone === 'info' && 'border-border bg-surface text-fg',
             )}
           >
             {t.tone === 'forbidden' && <span aria-hidden="true">🔒</span>}
+            {t.tone === 'quota' && <span aria-hidden="true">📈</span>}
             <span className="flex-1">{t.message}</span>
             <button
               type="button"

--- a/planscape-web/lib/api.quota.test.ts
+++ b/planscape-web/lib/api.quota.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError, describeFailure } from './api';
+
+/**
+ * #670 — the owner met the literal token `quota_exceeded` on
+ * /projects/new in production and read it as an expired account.
+ *
+ * RED WITNESS: every assertion below fails if `describeFailure` drops the 402
+ * branch, because the fallback path returns tone 'error' and the message
+ * `ApiError.message` — which is the machine token. That is the regression this
+ * file exists to catch, not a restatement of the fix.
+ */
+const opts = { forbidden: 'Only an Owner or Admin can create projects.', fallback: 'Failed' };
+
+describe('describeFailure — quota (#670)', () => {
+  it('shows the server reason, not the machine code', () => {
+    const e = new ApiError(402, 'quota_exceeded', {
+      error: 'quota_exceeded', axis: 'Projects', current: 5, max: 5,
+      reason: 'Projects cap reached (5 of 5).', upgrade_url: '/settings/billing',
+    }, 'quota_exceeded');
+    const r = describeFailure(e, opts);
+    expect(r.message).toBe('Projects cap reached (5 of 5).');
+    expect(r.message).not.toContain('quota_exceeded');
+    expect(r.tone).toBe('quota');
+    expect(r.actionHref).toBe('/settings/billing');
+  });
+
+  it('never surfaces the raw token even when the server sends no reason', () => {
+    const e = new ApiError(402, 'quota_exceeded', { error: 'quota_exceeded', axis: 'Authors' });
+    const r = describeFailure(e, opts);
+    expect(r.message).toBe('Authors limit reached for your plan.');
+    expect(r.message).not.toContain('quota_exceeded');
+    expect(r.actionHref).toBeUndefined();
+  });
+
+  it('falls back to a sentence when there is no reason and no axis', () => {
+    const e = new ApiError(402, 'quota_exceeded', { error: 'quota_exceeded' });
+    expect(describeFailure(e, opts).message).toBe('Your plan limit has been reached.');
+  });
+
+  it('is keyed off status + discriminator, never off the message text', () => {
+    // A 402 whose body is not a quota refusal must NOT be dressed as one, and a
+    // message that merely CONTAINS the token must not trigger it either - that
+    // string-sniffing is #624/#646.
+    expect(describeFailure(new ApiError(402, 'boom', { error: 'card_declined' }), opts).tone).toBe('error');
+    expect(describeFailure(new ApiError(500, 'quota_exceeded happened', undefined), opts).tone).toBe('error');
+  });
+
+  it('leaves 403 as forbidden, unchanged', () => {
+    expect(describeFailure(new ApiError(403, 'x', undefined, undefined), opts).tone).toBe('forbidden');
+  });
+});

--- a/planscape-web/lib/api.ts
+++ b/planscape-web/lib/api.ts
@@ -93,11 +93,50 @@ export function isForbidden(e: unknown): boolean {
 export function describeFailure(
   e: unknown,
   { forbidden, fallback }: { forbidden: string; fallback: string },
-): { message: string; tone: 'error' | 'forbidden' } {
+): { message: string; tone: 'error' | 'forbidden' | 'quota'; actionHref?: string } {
   if (e instanceof ApiError && e.status === 403) {
     return { message: e.serverMessage?.trim() || forbidden, tone: 'forbidden' };
   }
+  const quota = readQuota(e);
+  if (quota) return { message: quota.reason, tone: 'quota', actionHref: quota.upgradeUrl };
   return { message: e instanceof Error ? e.message : fallback, tone: 'error' };
+}
+
+/**
+ * A quota refusal is NOT a forbidden state, and giving it its own tone is the
+ * point rather than a detail. "You lack this capability" is resolved by asking
+ * someone; "your plan is full" is resolved by upgrading — different actions, so
+ * they must not look the same. That is the same rule #558 applied to separate
+ * *forbidden* from *error*.
+ *
+ * The server already sends everything needed:
+ * `{ error: 'quota_exceeded', axis, current, max, reason, upgrade_url }`. The
+ * useful sentence is `reason` ("Projects cap reached (5 of 5)"), and
+ * `upgrade_url` is the way out. #670 was filed because the new-project page
+ * rendered `error` — the machine code — and dropped both, so the owner met the
+ * bare string `quota_exceeded` in production and read it as an expired account.
+ *
+ * Keyed off the STATUS plus the discriminator, never off the message text: on a
+ * 402 with an empty body `message` is our own placeholder, which is exactly the
+ * string-sniffing trap #624 and #646 were filed for.
+ */
+function readQuota(e: unknown): { reason: string; upgradeUrl?: string } | null {
+  if (!(e instanceof ApiError) || e.status !== 402) return null;
+  const b = e.body;
+  if (!b || typeof b !== 'object') return null;
+  const r = b as Record<string, unknown>;
+  if (r.error !== 'quota_exceeded') return null;
+
+  // Fall back to the axis when the server sent no sentence, so the worst case is
+  // still "Authors limit reached" and never the literal token `quota_exceeded`.
+  const reason =
+    typeof r.reason === 'string' && r.reason.trim()
+      ? r.reason.trim()
+      : typeof r.axis === 'string' && r.axis.trim()
+        ? `${r.axis} limit reached for your plan.`
+        : 'Your plan limit has been reached.';
+  const upgradeUrl = typeof r.upgrade_url === 'string' && r.upgrade_url.trim() ? r.upgrade_url : undefined;
+  return { reason, upgradeUrl };
 }
 
 export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {


### PR DESCRIPTION
Closes #670.

## What the owner saw

Creating a project on `app.planscape.build/projects/new`, the whole page-level error was:

    quota_exceeded

Read as an expired account. It is a plan cap.

## The fix is rendering, not plumbing

The 402 body already carries `{ error, axis, current, max, reason, upgrade_url }`, and `ApiError.body` exists **for this case** — its docstring says *"whose useful sentence is `reason`, not `error`"*. The page rendered `error` and dropped the sentence and the link.

`settings/team/page.tsx:249` already carried a comment about exactly this failure, so it had been diagnosed and fixed **on one page**. This routes it through the shared `describeFailure` instead of adding a second bespoke handler.

## Quota is its own tone

Not a shade of `error`, not a shade of `forbidden`. A refusal is resolved by asking someone; a full plan is resolved by upgrading — different actions, so they must not look alike. Same rule #558 used to split forbidden out of error.

Info colouring, distinct icon, and **no auto-dismiss** — a notice you are meant to act on must not vanish mid-read.

## Keyed off status, never text

On a 402 with an empty body, `message` is our own placeholder — the string-sniffing trap of #624/#646. Asserted: a 402 that is **not** a quota refusal stays `error`, and a 500 whose message merely contains the token stays `error`.

Degrades in steps: server `reason` → `"<axis> limit reached for your plan."` → generic. **The raw token cannot reach a user by any path.**

## Verification

- 5 tests; **RED proven** by removing the 402 branch — 3 fail. The 2 that still pass are the negative cases, which is correct.
- Typecheck **holds at main's 69-error baseline**, measured against `origin/main` rather than assumed. Those 69 are pre-existing `Badge`/`Button` prop-type errors this does not touch.
- **Not** rendered on screen.