### PR TITLE
fix(d1): give preview its own database so it cannot write live licences (#652)

### DIFF
--- a/marketing-site/WAITLIST_SETUP.md
+++ b/marketing-site/WAITLIST_SETUP.md
@@ -35,7 +35,27 @@ database_name = "planscape-waitlist"
 database_id   = "b7029da2-6019-4ceb-bd87-22870a313db7"
 ```
 
-If you ever re-create the D1 database, update the `database_id` here (and in the `[[env.preview.d1_databases]]` + `[[env.production.d1_databases]]` blocks at the bottom) before the next deploy.
+If you ever re-create the D1 database, update the `database_id` here (and in the `[[env.production.d1_databases]]` block at the bottom) before the next deploy.
+
+> **`env.preview` deliberately points at a DIFFERENT database** —
+> `planscape-waitlist-preview` (`75855f69-…`), created 2026-08-17. Do not "fix"
+> the mismatch by pointing it back at `planscape-waitlist`.
+>
+> All three blocks used to share one id, so a preview deployment read and wrote
+> live licence data: issuing real licences against a real tenant's cap, revoking
+> them, stamping `last_seen_at` — none of it distinguishable afterwards from
+> legitimate activity, because it landed in the same rows the production path
+> writes (#652). That mattered more once #621 made `licenses` the seat-entitlement
+> source of truth.
+>
+> **When you change `schema.sql`, apply it to both** or preview breaks in ways
+> production does not:
+> ```
+> npx wrangler d1 execute planscape-waitlist         --remote --file=./functions/api/schema.sql
+> npx wrangler d1 execute planscape-waitlist-preview --remote --file=./functions/api/schema.sql
+> ```
+> Careful with the first one on an existing database: `schema.sql` contains bare
+> `ALTER TABLE` statements that fail on re-run. Apply only new DDL to production.
 
 > Note: the Cloudflare dashboard's **+ Add binding** button is greyed out for projects using `wrangler.toml` — that's intentional. The toml is the source of truth; the dashboard shows the binding as read-only after the next deploy.
 

--- a/marketing-site/wrangler.toml
+++ b/marketing-site/wrangler.toml
@@ -91,8 +91,19 @@ SITE_URL = "https://planscape.build"
 #                 SELECT * FROM contacts WHERE notified_at IS NULL;
 #               Setting it requires a redeploy (see #674), like every var here.
 
-# D1 binding for the waitlist Function (functions/api/waitlist.ts)
+# D1 binding, shared by every Function (waitlist, auth, billing, licence, contact).
 # Created via: wrangler d1 create planscape-waitlist
+#
+# THIS IS THE PRODUCTION DATABASE. Which binding a deployment actually gets:
+#
+#   wrangler pages deploy --branch=main   -> [env.production] (same DB as here)
+#   wrangler pages deploy --branch=other  -> [env.preview]    (the SEPARATE DB)
+#   wrangler pages dev                    -> local SQLite, via the --d1 flag in
+#                                            the `dev` script; never touches either
+#
+# The three blocks used to name the same database_id, which is how a preview
+# deployment could write live licence data (#652). If you add a binding, add it to
+# all three and make preview's point somewhere disposable.
 [[d1_databases]]
 binding       = "WAITLIST_DB"
 database_name = "planscape-waitlist"
@@ -116,10 +127,26 @@ name = "planscape-marketing-preview"
 [env.preview.vars]
 SITE_URL = "https://preview.planscape.build"
 
+# SEPARATE DATABASE — do not point this back at planscape-waitlist (#652).
+#
+# All three environments used to share one D1, so a preview deployment read and
+# wrote LIVE licence data: it could issue real licences against a real tenant's
+# cap, revoke them, and stamp last_seen_at, none of it distinguishable afterwards
+# from legitimate activity because it landed in the rows the production path
+# writes. The blast radius grew when #621 made `licenses` the seat-entitlement
+# source of truth — the table stopped being a waitlist and started deciding what
+# customers can do and what they are billed for.
+#
+# Created 2026-08-17 and seeded from functions/api/schema.sql. It is empty by
+# design; preview exercises the real code against disposable data.
+#
+# After changing schema.sql, apply it here too or preview breaks in ways
+# production does not:
+#   npx wrangler d1 execute planscape-waitlist-preview --remote --file=./functions/api/schema.sql
 [[env.preview.d1_databases]]
 binding       = "WAITLIST_DB"
-database_name = "planscape-waitlist"
-database_id   = "b7029da2-6019-4ceb-bd87-22870a313db7"
+database_name = "planscape-waitlist-preview"
+database_id   = "75855f69-2950-4378-b591-18e33af3e5bf"
 
 [[env.preview.r2_buckets]]
 binding     = "DOWNLOADS"


### PR DESCRIPTION
Closes #652.

## The gap

All three wrangler environments named the same `database_id`, so a preview deployment read and wrote **live licence data**. It could issue real licences against a real tenant's cap, revoke them, and stamp `last_seen_at` — and none of it would be distinguishable afterwards from legitimate activity, because it landed in the same rows the production path writes.

That mattered more than it used to. Once #621 made `licenses` the seat-entitlement source of truth, the table stopped being a waitlist and started deciding what customers can do and what they are billed for.

## First, the good news: this was latent, not active

**The project has zero preview deployments, ever.** So nothing has written production rows by this route. Production still holds its single licence row, confirmed after the change.

Worth stating plainly rather than implying a narrow escape — but also worth closing, because the first preview deployment anyone creates would have had write access to the billing table.

## The change

Created **`planscape-waitlist-preview`** (`75855f69-…`) and pointed `env.preview` at it. Seeded from `functions/api/schema.sql`:

| Check | Result |
|---|---|
| Tables created | **18** |
| `licenses.last_seen_at` / `_plugin_version` / `_revit_version` | present — these come from `ALTER` statements, so worth confirming rather than assuming a fresh apply covered them |
| Rows in `licenses` / `contacts` / `email_log` | **0** — empty by design; preview exercises the real code against disposable data |
| Production `licenses` after the change | **1** — untouched |

## Also: which binding does a deployment actually get?

This ambiguity is *how* three blocks came to share one id, so the top-level block now spells it out:

```
wrangler pages deploy --branch=main   -> [env.production]  (production DB)
wrangler pages deploy --branch=other  -> [env.preview]     (the separate DB)
wrangler pages dev                    -> local SQLite, via the --d1 flag in the
                                         dev script; never touches either
```

Plus a standing note that adding a binding means adding it to all three, with preview's pointed somewhere disposable.

## One operational consequence

**Schema changes now need applying twice**, or preview breaks in ways production does not. Documented in both `wrangler.toml` and `WAITLIST_SETUP.md`, including the caveat that `schema.sql` contains bare `ALTER TABLE` statements that fail on re-run — so production gets only the new DDL, while a fresh preview DB can take the whole file.

`marketing-site-cron` keeps the production database, which is correct: it is a production worker, not a preview surface.

## Verified

TOML parses; the three bindings resolve to preview-vs-production as intended (checked by parsing the file, not by reading it); 34 tests pass; typecheck clean.

## Not done

The issue's option 3 also suggested a code guard refusing mutating licence writes outside production. I have left that out deliberately: with a separate database, a hard environment guard would stop preview from exercising `issue.ts` at all — which is the path most worth testing, and the issue itself notes that cost. If you want defence-in-depth against a future misconfiguration, the sound version is a self-identifying row in each database that the Function asserts against, rather than an environment check. Happy to add it as a follow-up.
