### PR TITLE
Widen clash element ids to 64-bit so a large id can't outlive its own delete (#722)

### DIFF
--- a/StingTools.Clash.Tests/ClashElementId64BitTests.cs
+++ b/StingTools.Clash.Tests/ClashElementId64BitTests.cs
@@ -1,0 +1,270 @@
+// ClashElementId64BitTests.cs — issue #722.
+//
+// Revit 2024+ ElementId.Value is Int64 and a large or long-lived model mints
+// ids past int.MaxValue. The clash engine's identity (ClashElementKey) held
+// them as int, so every such id was truncated the moment it entered the clash
+// tree — and the truncation is not merely lossy, it COLLIDES: 2^32 + 7 and 7
+// both narrow to 7.
+//
+// That leaked into federation. GeometrySyncHandler builds a ClashElementKey per
+// changed element, GlbSerializer stamps that key's id into the GLB node extras,
+// and the server reads it with GetInt64 and keys FederatedElement on it. A
+// >int.MaxValue element was therefore STORED under a truncated id, while the
+// delete that followed (widened to 64-bit in #684) carried the real one — the
+// tombstone missed and stale geometry lingered in the federated scene.
+//
+// These tests pin the plugin half of that chain: the key preserves the id, the
+// persisted record round-trips it, the history/grouping keys don't collide on
+// it, and the GLB the plugin writes hands the full value to the reader the
+// server actually uses. The server half (extras → row → delete match) is pinned
+// by FederatedDeltaReliabilityTests
+// .A_deleted_id_beyond_int_range_round_trips_through_the_wire.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using StingTools.Commands.IFC;
+using StingTools.Core.Clash;
+using Xunit;
+
+namespace StingTools.Clash.Tests
+{
+    public class ClashElementId64BitTests
+    {
+        // 4,294,967,303 — narrows to 7 as int32, which is the collision that
+        // makes the truncation a correctness bug and not just a capacity limit.
+        private const long BigId = (1L << 32) + 7L;
+        private const long SmallTwin = 7L;
+
+        // ── identity ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ElementKey_Keeps_The_Full_64_Bit_Id()
+        {
+            var key = new ClashElementKey("doc", -1, BigId, "uid", "ifc");
+
+            Assert.Equal(BigId, key.ElementId);
+            Assert.Equal("doc:-1:" + BigId, key.ToString());
+        }
+
+        [Fact]
+        public void ElementKey_Distinguishes_Ids_That_Differ_Only_Above_Bit_31()
+        {
+            var big = new ClashElementKey("doc", -1, BigId, "uid-big", "ifc-big");
+            var small = new ClashElementKey("doc", -1, SmallTwin, "uid-small", "ifc-small");
+
+            Assert.NotEqual(big, small);
+            Assert.False(big.Equals(small));
+            // Not a contract of Equals, but the whole point of the key: these
+            // two must not share a dictionary bucket, or every _meshByEid /
+            // _obbByEid / sweep lookup for one answers with the other's mesh.
+            Assert.NotEqual(big.GetHashCode(), small.GetHashCode());
+        }
+
+        [Fact]
+        public void ElementKey_Distinguishes_Link_Instances_Above_Bit_31()
+        {
+            var a = new ClashElementKey("doc", (1L << 32) + 3L, 100, "uid", "ifc");
+            var b = new ClashElementKey("doc", 3L, 100, "uid", "ifc");
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Two_Big_Ids_Still_Key_A_Dictionary_Independently()
+        {
+            // The concrete failure the maps in ClashSession would have hit.
+            var map = new Dictionary<ClashElementKey, string>
+            {
+                [new ClashElementKey("doc", -1, BigId, "uid-big", "")] = "big",
+                [new ClashElementKey("doc", -1, SmallTwin, "uid-small", "")] = "small",
+            };
+
+            Assert.Equal(2, map.Count);
+            Assert.Equal("big", map[new ClashElementKey("doc", -1, BigId, "", "")]);
+            Assert.Equal("small", map[new ClashElementKey("doc", -1, SmallTwin, "", "")]);
+        }
+
+        // ── persistence ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void Persisted_Clash_Record_Round_Trips_A_64_Bit_Id()
+        {
+            var run = new ClashRunRecord { RunId = "run-1" };
+            run.Clashes.Add(new ClashRecord
+            {
+                Id = "CLH-20260817-00001",
+                Identity = "abc",
+                ElementA = new ClashElementRecord { ElementId = BigId, LinkInstanceId = -1, Category = "Ducts" },
+                ElementB = new ClashElementRecord { ElementId = SmallTwin, LinkInstanceId = -1, Category = "Walls" },
+            });
+
+            // Save mirrors into a sibling archive/ folder, so give it its own
+            // directory rather than littering %TEMP%.
+            string dir = Path.Combine(Path.GetTempPath(), "sting-clash-64-" + Guid.NewGuid().ToString("N"));
+            string path = Path.Combine(dir, "clashes.json");
+            try
+            {
+                ClashPersistence.Save(run, path);
+                var reloaded = ClashPersistence.Load(path);
+
+                Assert.NotNull(reloaded);
+                Assert.Equal(BigId, reloaded.Clashes[0].ElementA.ElementId);
+                Assert.Equal(SmallTwin, reloaded.Clashes[0].ElementB.ElementId);
+            }
+            finally
+            {
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch (IOException) { }
+            }
+        }
+
+        // ── history: the fuzzy bucket must not collide ──────────────────────
+
+        [Fact]
+        public void History_Does_Not_Fuzzy_Match_Across_A_Truncation_Collision()
+        {
+            // Prior run: a clash on the >int.MaxValue element.
+            // Current run: a DIFFERENT clash on the element whose id is that
+            // one's low 32 bits. Same matrix pair, same place — so under
+            // truncation they landed in the same fuzzy bucket and the new clash
+            // inherited the old one's identity, state and first-seen date,
+            // while the genuinely-gone clash was never reported resolved.
+            var prior = new ClashRunRecord { RunId = "prior" };
+            prior.Clashes.Add(new ClashRecord
+            {
+                Identity = "prior-identity",
+                Id = "CLH-20260101-00001",
+                State = "Active",
+                MatrixPairId = "DUCT:STR_BEAM",
+                FirstSeenUtc = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc),
+                ElementA = new ClashElementRecord { ElementId = BigId },
+                ElementB = new ClashElementRecord { ElementId = 500 },
+                Centroid = new[] { 0f, 0f, 0f },
+            });
+
+            var current = new ClashRunRecord { RunId = "current" };
+            current.Clashes.Add(new ClashRecord
+            {
+                Identity = "current-identity",
+                MatrixPairId = "DUCT:STR_BEAM",
+                ElementA = new ClashElementRecord { ElementId = SmallTwin },
+                ElementB = new ClashElementRecord { ElementId = 500 },
+                Centroid = new[] { 0f, 0f, 0f },
+            });
+
+            ClashHistory.MergeWithPrior(current, prior);
+
+            Assert.Equal("New", current.Clashes[0].State);
+            Assert.NotEqual("CLH-20260101-00001", current.Clashes[0].Id);
+            Assert.Equal(1, current.Stats.New);
+            // The prior clash really is gone and must be reported as such.
+            Assert.Equal(1, current.Stats.Resolved);
+        }
+
+        // ── grouping: the pattern key must not collide ──────────────────────
+
+        [Fact]
+        public void Grouper_Does_Not_Merge_Two_Elements_That_Share_Low_32_Bits()
+        {
+            // Two distinct ducts, each clashing with two beams. Neither reaches
+            // the 3-member element-pattern threshold on its own; only a
+            // truncation collision could fuse them into one 4-member group.
+            var clashes = new List<ClashRecord>();
+            for (int i = 0; i < 2; i++)
+            {
+                clashes.Add(NewPatternClash($"big-{i}", BigId, 900 + i, i * 40f));
+                clashes.Add(NewPatternClash($"small-{i}", SmallTwin, 950 + i, 500f + i * 40f));
+            }
+
+            var groups = ClashGrouper.Group(clashes);
+
+            Assert.DoesNotContain(groups, g => g.Kind == "element");
+        }
+
+        private static ClashRecord NewPatternClash(string identity, long anchorId, long otherId, float x) =>
+            new ClashRecord
+            {
+                Identity = identity,
+                MatrixPairId = "DUCT:STR_BEAM",
+                VolumeMm3 = 1000f,
+                ElementA = new ClashElementRecord { ElementId = anchorId, Category = "Ducts" },
+                ElementB = new ClashElementRecord { ElementId = otherId, Category = "Structural Framing" },
+                Centroid = new[] { x, 0f, 0f },
+                AabbMin = new[] { x, 0f, 0f },
+                AabbMax = new[] { x + 1f, 1f, 1f },
+            };
+
+        // ── the wire: what the plugin writes is what the server reads ───────
+
+        [Fact]
+        public void Glb_Node_Extras_Carry_The_Full_64_Bit_Element_Id()
+        {
+            // This is the federation leak itself: GlbSerializer.GltfExtras held
+            // elementId as int, so the value the server stored on add came from
+            // a narrowed field while the delete it later matched against was a
+            // full 64-bit id.
+            var buf = new ClashMeshBuffer(
+                new ClashElementKey("doc-guid", -1, BigId, "uid-big", "ifc-big"),
+                "Walls",
+                new[] { 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f },
+                new[] { 0, 1, 2 });
+
+            byte[] glb = GlbSerializer.Serialize(new[] { buf });
+            Assert.NotEmpty(glb);
+
+            var extras = ReadNodeExtrasTheWayTheServerDoes(glb);
+
+            var one = Assert.Single(extras);
+            Assert.Equal(BigId, one.ElementId);
+            Assert.Equal("uid-big", one.UniqueId);
+        }
+
+        [Fact]
+        public void Glb_Element_Id_Is_Serialized_As_A_Json_Number_Not_A_String()
+        {
+            // GetInt64 on the server throws on a quoted number, which would turn
+            // the widening into a different silent failure (a caught parse error
+            // and zero nodes). Assert the literal digits are unquoted.
+            var buf = new ClashMeshBuffer(
+                new ClashElementKey("doc-guid", -1, BigId, "uid-big", null),
+                "Walls",
+                new[] { 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f },
+                new[] { 0, 1, 2 });
+
+            string json = JsonChunk(GlbSerializer.Serialize(new[] { buf }));
+
+            Assert.Contains("\"elementId\":" + BigId, json);
+            Assert.DoesNotContain("\"elementId\":\"", json);
+        }
+
+        /// <summary>
+        /// Mirror of FederatedModelController.ParseGlbNodeExtras — same offsets,
+        /// same GetInt64 read. If the plugin's GLB is readable here it is
+        /// readable there, which is what makes the two halves one chain.
+        /// </summary>
+        private static List<(string UniqueId, long ElementId)> ReadNodeExtrasTheWayTheServerDoes(byte[] glbBytes)
+        {
+            var result = new List<(string, long)>();
+            int jsonLength = BitConverter.ToInt32(glbBytes, 12);
+            string json = Encoding.UTF8.GetString(glbBytes, 20, jsonLength).TrimEnd('\0', ' ');
+
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("nodes", out var nodes)) return result;
+            foreach (var node in nodes.EnumerateArray())
+            {
+                if (!node.TryGetProperty("extras", out var extras)) continue;
+                result.Add((
+                    extras.TryGetProperty("uniqueId", out var uid) ? uid.GetString() ?? "" : "",
+                    extras.TryGetProperty("elementId", out var eid) ? eid.GetInt64() : 0));
+            }
+            return result;
+        }
+
+        private static string JsonChunk(byte[] glbBytes)
+        {
+            int jsonLength = BitConverter.ToInt32(glbBytes, 12);
+            return Encoding.UTF8.GetString(glbBytes, 20, jsonLength).TrimEnd('\0', ' ');
+        }
+    }
+}

--- a/StingTools.Clash.Tests/StingTools.Clash.Tests.csproj
+++ b/StingTools.Clash.Tests/StingTools.Clash.Tests.csproj
@@ -48,6 +48,13 @@
     <Compile Include="..\StingTools\Clash\ClashGrouper.cs"         Link="Clash\ClashGrouper.cs" />
     <Compile Include="..\StingTools\Clash\ResolutionHeuristics.cs" Link="Clash\ResolutionHeuristics.cs" />
     <Compile Include="..\StingTools\Clash\BcfMarkupBuilder.cs"     Link="Clash\BcfMarkupBuilder.cs" />
+    <!-- #722: GlbSerializer is the plugin end of the federation wire — it
+         stamps the clash key's element id into the GLB node extras the server
+         reads with GetInt64. It imports Autodesk.Revit.DB but uses nothing from
+         it (namespace-only, same as the four files RevitStubs already covers),
+         so it links here and the 64-bit contract can be tested on the real
+         serializer instead of a hand-written GLB. -->
+    <Compile Include="..\StingTools\Commands\IFC\GlbSerializer.cs" Link="IFC\GlbSerializer.cs" />
     <!-- AabbSweep logs via StingTools.Core.StingLog. TestHelpers/StingLogShim.cs
          is auto-included by the net8.0 SDK default Compile glob; no explicit
          <Compile> entry needed. -->

--- a/StingTools/Clash/ClashExportContext.cs
+++ b/StingTools/Clash/ClashExportContext.cs
@@ -106,7 +106,7 @@ namespace StingTools.Core.Clash
                 var key = new ClashElementKey(
                     _currentDocGuid,
                     _currentLinkInstanceId,
-                    (int)elementId.Value,
+                    elementId.Value,
                     _currentUniqueId,
                     _currentIfcGuid);
 

--- a/StingTools/Clash/ClashGrouper.cs
+++ b/StingTools/Clash/ClashGrouper.cs
@@ -118,7 +118,7 @@ namespace StingTools.Core.Clash
             //     Prior code built two parallel dictionaries (byPairAndA,
             //     byPairAndB) then concatenated them — twice the dictionary
             //     work, twice the bucket allocations. One dict, one pass.
-            var byPairSideEid = new Dictionary<(string Pair, string Side, int Eid), List<ClashRecord>>();
+            var byPairSideEid = new Dictionary<(string Pair, string Side, long Eid), List<ClashRecord>>();
             foreach (var c in clashes)
             {
                 string pair = c.MatrixPairId ?? "";

--- a/StingTools/Clash/ClashHistory.cs
+++ b/StingTools/Clash/ClashHistory.cs
@@ -32,7 +32,7 @@ namespace StingTools.Core.Clash
             //     re-mints the identity, surfacing as "Resolved + New" with all
             //     state lost. Index is keyed on a canonical (smaller-id-first)
             //     pair so the order in ElementA/ElementB doesn't break matches.
-            var fuzzyIndex = new Dictionary<(int A, int B, string Pair), List<ClashRecord>>();
+            var fuzzyIndex = new Dictionary<(long A, long B, string Pair), List<ClashRecord>>();
             if (prior?.Clashes != null)
             {
                 foreach (var pc in prior.Clashes)
@@ -172,12 +172,12 @@ namespace StingTools.Core.Clash
         /// E1: Canonical (elementA, elementB, pairId) key with sorted ids
         /// so (A,B) and (B,A) hit the same fuzzy bucket.
         /// </summary>
-        private static (int A, int B, string Pair) MakeFuzzyKey(ClashRecord c)
+        private static (long A, long B, string Pair) MakeFuzzyKey(ClashRecord c)
         {
-            int a = c.ElementA?.ElementId ?? 0;
-            int b = c.ElementB?.ElementId ?? 0;
-            int lo = Math.Min(a, b);
-            int hi = Math.Max(a, b);
+            long a = c.ElementA?.ElementId ?? 0;
+            long b = c.ElementB?.ElementId ?? 0;
+            long lo = Math.Min(a, b);
+            long hi = Math.Max(a, b);
             return (lo, hi, c.MatrixPairId ?? "");
         }
 

--- a/StingTools/Clash/ClashIssueSyncCommand.cs
+++ b/StingTools/Clash/ClashIssueSyncCommand.cs
@@ -113,8 +113,8 @@ namespace StingTools.Core.Clash
                         desc.AppendLine($"source_hash: {hash}");
 
                         var elemIds = new List<ElementId>();
-                        if (clash.ElementA != null && clash.ElementA.ElementId > 0) elemIds.Add(new ElementId((long)clash.ElementA.ElementId));
-                        if (clash.ElementB != null && clash.ElementB.ElementId > 0) elemIds.Add(new ElementId((long)clash.ElementB.ElementId));
+                        if (clash.ElementA != null && clash.ElementA.ElementId > 0) elemIds.Add(new ElementId(clash.ElementA.ElementId));
+                        if (clash.ElementB != null && clash.ElementB.ElementId > 0) elemIds.Add(new ElementId(clash.ElementB.ElementId));
 
                         string disc = DiscFor(catA);
                         int before = batch.Created.Count;

--- a/StingTools/Clash/ClashMeshBuffer.cs
+++ b/StingTools/Clash/ClashMeshBuffer.cs
@@ -58,12 +58,16 @@ namespace StingTools.Core.Clash
     public sealed class ClashElementKey : IEquatable<ClashElementKey>
     {
         public string DocGuid { get; }
-        public int LinkInstanceElementId { get; }   // -1 for host
-        public int ElementId { get; }
+        // Revit 2024+ ElementId.Value is Int64 and a long-lived model can mint
+        // ids past int.MaxValue. Narrowing here truncated the identity, so an
+        // add stored one id and the matching delete carried another — the
+        // tombstone missed and stale geometry lingered (issue #722).
+        public long LinkInstanceElementId { get; }   // -1 for host
+        public long ElementId { get; }
         public string UniqueId { get; }
         public string IfcGuid { get; }
 
-        public ClashElementKey(string docGuid, int linkInstanceElementId, int elementId, string uniqueId, string ifcGuid)
+        public ClashElementKey(string docGuid, long linkInstanceElementId, long elementId, string uniqueId, string ifcGuid)
         {
             DocGuid = docGuid ?? "";
             LinkInstanceElementId = linkInstanceElementId;
@@ -87,8 +91,11 @@ namespace StingTools.Core.Clash
             unchecked
             {
                 int h = DocGuid?.GetHashCode() ?? 0;
-                h = (h * 397) ^ LinkInstanceElementId;
-                h = (h * 397) ^ ElementId;
+                // Hash the full 64 bits — folding the high word in rather than
+                // letting an implicit narrowing drop it, so two ids that differ
+                // only above bit 31 land in different buckets.
+                h = (h * 397) ^ LinkInstanceElementId.GetHashCode();
+                h = (h * 397) ^ ElementId.GetHashCode();
                 return h;
             }
         }

--- a/StingTools/Clash/ClashNotifications.cs
+++ b/StingTools/Clash/ClashNotifications.cs
@@ -31,8 +31,8 @@ namespace StingTools.Core.Clash
         public string Assignee { get; set; }
         public int RecurrenceCount { get; set; }
         public double TriageScore { get; set; }
-        public int ElementAId { get; set; }
-        public int ElementBId { get; set; }
+        public long ElementAId { get; set; }
+        public long ElementBId { get; set; }
         public string ProjectGuid { get; set; }
     }
 

--- a/StingTools/Clash/ClashRecord.cs
+++ b/StingTools/Clash/ClashRecord.cs
@@ -10,9 +10,11 @@ namespace StingTools.Core.Clash
     {
         public string IfcGuid;
         public string UniqueId;
-        public int ElementId;
+        // 64-bit to match Revit 2024+ ElementId.Value (issue #722). JSON numbers
+        // widen without a schema break, so an existing clashes.json still reads.
+        public long ElementId;
         public string DocGuid;
-        public int LinkInstanceId;
+        public long LinkInstanceId;
         public string Category;
         public string System;
     }

--- a/StingTools/Clash/ClashRunCommand.cs
+++ b/StingTools/Clash/ClashRunCommand.cs
@@ -383,7 +383,7 @@ namespace StingTools.Core.Clash
                 {
                     // Build the ElementId list once. Revit 2024+: ElementId(long).
                     var ids = new List<ElementId>(keys.Count);
-                    foreach (var k in keys) ids.Add(new ElementId((long)k.ElementId));
+                    foreach (var k in keys) ids.Add(new ElementId(k.ElementId));
                     // Single-collector pass scoped to these ids; constructs
                     // an Id → Element map without per-mesh API hits.
                     var byId = new Dictionary<long, Element>(keys.Count);
@@ -711,7 +711,7 @@ namespace StingTools.Core.Clash
         private static void WriteColdInitLiveFlags(Document doc, ClashRunRecord run)
         {
             if (doc == null || run?.Clashes == null) return;
-            var flagged = new HashSet<int>();
+            var flagged = new HashSet<long>();
             foreach (var c in run.Clashes)
             {
                 if (c.State == "Resolved" || c.State == "Void") continue;
@@ -724,7 +724,7 @@ namespace StingTools.Core.Clash
             // Empty cleared list — clearing is owned by the live session's
             // RefreshElement / RemoveElement and was already handled by
             // SeedFromRun's diff. We only need to assert flag=1 here.
-            LiveClashFlag.Apply(doc, flagged, Array.Empty<int>());
+            LiveClashFlag.Apply(doc, flagged, Array.Empty<long>());
             StingLog.Info($"WriteColdInitLiveFlags: wrote CLASH_LIVE_FLAG=1 on {flagged.Count} elements");
         }
 

--- a/StingTools/Clash/ClashSession.cs
+++ b/StingTools/Clash/ClashSession.cs
@@ -33,20 +33,20 @@ namespace StingTools.Core.Clash
 
         private readonly Document _doc;
         private readonly object _lock = new object();
-        private readonly Dictionary<int, ClashMeshBuffer> _meshByEid = new Dictionary<int, ClashMeshBuffer>();
+        private readonly Dictionary<long, ClashMeshBuffer> _meshByEid = new Dictionary<long, ClashMeshBuffer>();
         // rec-1: Cache OBB trees by element id so the live narrow-phase can descend
         // rather than brute-force. Rebuilt on RefreshElement, dropped on RemoveElement.
-        private readonly Dictionary<int, ObbTree> _obbByEid = new Dictionary<int, ObbTree>();
+        private readonly Dictionary<long, ObbTree> _obbByEid = new Dictionary<long, ObbTree>();
         // A1: Per-element neighbour index — element id → set of element ids it
         // currently clashes with. Lets RefreshElement compute the diff for ONE
         // element without nuking flags on unrelated elements. Maintained
         // symmetrically: when (a,b) clashes, both _clashNeighbours[a] and
         // _clashNeighbours[b] contain each other.
-        private readonly Dictionary<int, HashSet<int>> _clashNeighbours = new Dictionary<int, HashSet<int>>();
+        private readonly Dictionary<long, HashSet<long>> _clashNeighbours = new Dictionary<long, HashSet<long>>();
         // A4: Lazily-built per-element ElementFacts cache so the live path can
         // populate System/Workset alongside Category. Invalidated on
         // RefreshElement / RemoveElement for the affected element id.
-        private readonly Dictionary<int, ElementFacts> _factsCache = new Dictionary<int, ElementFacts>();
+        private readonly Dictionary<long, ElementFacts> _factsCache = new Dictionary<long, ElementFacts>();
         // B3: Volatile timestamp of the last dirty mark — read by ClashRunEvent
         // to gate hourly full runs. Defaults to "now" so the very first
         // scheduled run always fires (previous-baseline state).
@@ -63,11 +63,11 @@ namespace StingTools.Core.Clash
         //     normal _clashNeighbours map (e.g. the matrix doesn't
         //     normally consider its category). Useful when iteratively
         //     fixing a hard-to-pin-down clash.
-        private readonly HashSet<int> _watchedElements = new HashSet<int>();
-        public void Watch(int elementId)    { lock (_lock) _watchedElements.Add(elementId); }
-        public void Unwatch(int elementId)  { lock (_lock) _watchedElements.Remove(elementId); }
-        public bool IsWatched(int elementId) { lock (_lock) return _watchedElements.Contains(elementId); }
-        public IReadOnlyCollection<int> WatchedSnapshot()
+        private readonly HashSet<long> _watchedElements = new HashSet<long>();
+        public void Watch(long elementId)    { lock (_lock) _watchedElements.Add(elementId); }
+        public void Unwatch(long elementId)  { lock (_lock) _watchedElements.Remove(elementId); }
+        public bool IsWatched(long elementId) { lock (_lock) return _watchedElements.Contains(elementId); }
+        public IReadOnlyCollection<long> WatchedSnapshot()
         {
             lock (_lock) return _watchedElements.ToArray();
         }
@@ -86,7 +86,7 @@ namespace StingTools.Core.Clash
         // live-clash observer; compiler can't see the delegation path so it
         // warns CS0067. Suppress rather than delete — the contract is used.
 #pragma warning disable CS0067
-        public event Action<int, bool> OnElementFlagChanged;   // (eid, isFlagged)
+        public event Action<long, bool> OnElementFlagChanged;   // (eid, isFlagged)
         public event Action<ClashRunRecord> OnRunCompleted;    // raised by SeedFromRun
 #pragma warning restore CS0067
 
@@ -139,15 +139,14 @@ namespace StingTools.Core.Clash
         /// runs narrow-phase on its neighbours, and returns the new flag set for this element
         /// plus any neighbours whose flag state changed.
         /// </summary>
-        public LiveClashResult RefreshElement(int elementId)
+        public LiveClashResult RefreshElement(long elementId)
         {
             var result = new LiveClashResult();
             try
             {
                 // B3: dirty-model tracking for the scheduler.
                 MarkDirty();
-                // ElementId(int) ctor is obsolete in Revit 2024+; use Int64 overload.
-                var element = _doc.GetElement(new ElementId((long)elementId));
+                var element = _doc.GetElement(new ElementId(elementId));
                 if (element == null) return RemoveElement(elementId);
 
                 var fresh = TryExtractOneElement(element);
@@ -174,10 +173,10 @@ namespace StingTools.Core.Clash
                     // Each hit pair contains target (this elementId) and other.
                     // Skip any "other" hit that is a self-clash (shouldn't
                     // happen — guarded by ReferenceEquals — but be defensive).
-                    var newNeighbours = new HashSet<int>();
+                    var newNeighbours = new HashSet<long>();
                     foreach (var h in hits)
                     {
-                        int otherId = h.A.ElementId == elementId ? h.B.ElementId : h.A.ElementId;
+                        long otherId = h.A.ElementId == elementId ? h.B.ElementId : h.A.ElementId;
                         if (otherId == elementId) continue;
                         newNeighbours.Add(otherId);
                     }
@@ -189,7 +188,7 @@ namespace StingTools.Core.Clash
                     // back-edge. This keeps the map consistent and lets us
                     // ask "does element X still clash with anything?" in O(1).
                     _clashNeighbours.TryGetValue(elementId, out var oldNeighbours);
-                    oldNeighbours = oldNeighbours ?? new HashSet<int>();
+                    oldNeighbours = oldNeighbours ?? new HashSet<long>();
 
                     foreach (var oldId in oldNeighbours)
                     {
@@ -206,7 +205,7 @@ namespace StingTools.Core.Clash
                         if (oldNeighbours.Contains(newId)) continue;
                         if (!_clashNeighbours.TryGetValue(newId, out var otherSet))
                         {
-                            otherSet = new HashSet<int>();
+                            otherSet = new HashSet<long>();
                             _clashNeighbours[newId] = otherSet;
                         }
                         otherSet.Add(elementId);
@@ -262,7 +261,7 @@ namespace StingTools.Core.Clash
             return result;
         }
 
-        public LiveClashResult RemoveElement(int elementId)
+        public LiveClashResult RemoveElement(long elementId)
         {
             var result = new LiveClashResult();
             // B3: dirty-model tracking for the scheduler.
@@ -318,7 +317,7 @@ namespace StingTools.Core.Clash
             var result = new LiveClashResult();
             lock (_lock)
             {
-                var newFlagged = new HashSet<int>();
+                var newFlagged = new HashSet<long>();
                 foreach (var c in run.Clashes)
                 {
                     if (c.State == "Resolved" || c.State == "Void") continue;
@@ -357,7 +356,7 @@ namespace StingTools.Core.Clash
             }
         }
 
-        private HashSet<int> _flaggedIds = new HashSet<int>();
+        private HashSet<long> _flaggedIds = new HashSet<long>();
 
         // D10: Thread-static reusable buffers for the per-element extractor.
         //      LiveClashHandler can fire many times per second during dragging
@@ -396,7 +395,7 @@ namespace StingTools.Core.Clash
                 // clash-kernel's per-element identity hash.
                 string ifc = element.UniqueId ?? "";
 
-                var key = new ClashElementKey(docGuid, -1, (int)element.Id.Value, element.UniqueId, ifc);
+                var key = new ClashElementKey(docGuid, -1, element.Id.Value, element.UniqueId, ifc);
                 // ToArray copies — necessary because the mesh buffer outlives the
                 // pooled lists (next extraction reuses the same backing storage).
                 return new ClashMeshBuffer(key, element.Category?.Name ?? "", verts.ToArray(), indices.ToArray());
@@ -526,14 +525,14 @@ namespace StingTools.Core.Clash
         private ElementFacts ResolveFacts(ClashMeshBuffer m)
         {
             if (m == null) return new ElementFacts();
-            int eid = m.Key?.ElementId ?? 0;
+            long eid = m.Key?.ElementId ?? 0;
             if (_factsCache.TryGetValue(eid, out var cached)) return cached;
             var facts = new ElementFacts { Category = m.Category ?? "" };
             try
             {
                 if (eid != 0 && _doc != null)
                 {
-                    var el = _doc.GetElement(new ElementId((long)eid));
+                    var el = _doc.GetElement(new ElementId(eid));
                     if (el != null)
                     {
                         facts.System = ReadElementSystem(el);
@@ -674,7 +673,7 @@ namespace StingTools.Core.Clash
     public sealed class LiveClashResult
     {
         public List<ClashHit> CurrentHits { get; } = new List<ClashHit>();
-        public HashSet<int> NewlyFlagged { get; } = new HashSet<int>();
-        public HashSet<int> NewlyCleared { get; } = new HashSet<int>();
+        public HashSet<long> NewlyFlagged { get; } = new HashSet<long>();
+        public HashSet<long> NewlyCleared { get; } = new HashSet<long>();
     }
 }

--- a/StingTools/Clash/ClashSlaIntegration.cs
+++ b/StingTools/Clash/ClashSlaIntegration.cs
@@ -124,7 +124,7 @@ namespace StingTools.Core.Clash
                 }
                 // Cache owner-name lookups so the same element doesn't pay
                 // the GetWorksharingTooltipInfo cost twice across groups.
-                var ownerCache = new Dictionary<int, string>();
+                var ownerCache = new Dictionary<long, string>();
                 int i = 0;
                 foreach (var g in run.Groups ?? new List<ClashGroupRecord>())
                 {
@@ -160,14 +160,14 @@ namespace StingTools.Core.Clash
         }
 
         private static string ResolveOwnerForElementSide(Document doc, ClashElementRecord side,
-            Dictionary<int, string> cache)
+            Dictionary<long, string> cache)
         {
             if (side == null || side.LinkInstanceId != -1 || side.ElementId <= 0) return "";
             if (cache.TryGetValue(side.ElementId, out var cached)) return cached;
             string owner = "";
             try
             {
-                var el = doc.GetElement(new ElementId((long)side.ElementId));
+                var el = doc.GetElement(new ElementId(side.ElementId));
                 if (el != null)
                 {
                     var info = WorksharingUtils.GetWorksharingTooltipInfo(doc, el.Id);
@@ -186,11 +186,11 @@ namespace StingTools.Core.Clash
                 if (c == null) return "";
                 // Prefer a host element (LinkInstanceId == -1) so we resolve
                 // worksets in the active document, not in a linked-doc.
-                int eid = -1;
+                long eid = -1;
                 if (c.ElementA != null && c.ElementA.LinkInstanceId == -1) eid = c.ElementA.ElementId;
                 else if (c.ElementB != null && c.ElementB.LinkInstanceId == -1) eid = c.ElementB.ElementId;
                 if (eid <= 0) return "";
-                var el = doc.GetElement(new ElementId((long)eid));
+                var el = doc.GetElement(new ElementId(eid));
                 if (el == null) return "";
                 var info = WorksharingUtils.GetWorksharingTooltipInfo(doc, el.Id);
                 string owner = info?.Owner ?? "";

--- a/StingTools/Clash/LiveClashFlag.cs
+++ b/StingTools/Clash/LiveClashFlag.cs
@@ -15,16 +15,16 @@ namespace StingTools.Core.Clash
         //     view templates beyond the binary FLAG.
         public const string CountParamName = "CLASH_COUNT_INT";
 
-        public static void Apply(Document doc, IEnumerable<int> flaggedElementIds, IEnumerable<int> clearedElementIds)
+        public static void Apply(Document doc, IEnumerable<long> flaggedElementIds, IEnumerable<long> clearedElementIds)
         {
             // F2: Default to count=1 for newly-flagged, count=0 for cleared.
             // ApplyWithCounts is the richer entry point.
-            var flagged = flaggedElementIds == null ? null : new List<int>(flaggedElementIds);
-            var cleared = clearedElementIds == null ? null : new List<int>(clearedElementIds);
-            Dictionary<int, int> counts = null;
+            var flagged = flaggedElementIds == null ? null : new List<long>(flaggedElementIds);
+            var cleared = clearedElementIds == null ? null : new List<long>(clearedElementIds);
+            Dictionary<long, int> counts = null;
             if (flagged != null)
             {
-                counts = new Dictionary<int, int>(flagged.Count);
+                counts = new Dictionary<long, int>(flagged.Count);
                 foreach (var id in flagged) counts[id] = 1;
             }
             ApplyWithCounts(doc, flagged, cleared, counts);
@@ -36,9 +36,9 @@ namespace StingTools.Core.Clash
         /// Cleared elements get count=0.
         /// </summary>
         public static void ApplyWithCounts(Document doc,
-            IEnumerable<int> flaggedElementIds,
-            IEnumerable<int> clearedElementIds,
-            IDictionary<int, int> counts)
+            IEnumerable<long> flaggedElementIds,
+            IEnumerable<long> clearedElementIds,
+            IDictionary<long, int> counts)
         {
             if (doc == null) return;
             try
@@ -89,10 +89,9 @@ namespace StingTools.Core.Clash
             }
         }
 
-        private static void SetParam(Document doc, int elementId, bool value)
+        private static void SetParam(Document doc, long elementId, bool value)
         {
-            // ElementId(int) ctor is obsolete in Revit 2024+; use Int64 overload.
-            var el = doc.GetElement(new ElementId((long)elementId));
+            var el = doc.GetElement(new ElementId(elementId));
             if (el == null) return;
             var p = el.LookupParameter(ParamName);
             if (p == null || p.IsReadOnly) return;
@@ -103,11 +102,11 @@ namespace StingTools.Core.Clash
         }
 
         /// <summary>F2: Set CLASH_COUNT_INT on an element. Best-effort.</summary>
-        private static void SetCountParam(Document doc, int elementId, int count)
+        private static void SetCountParam(Document doc, long elementId, int count)
         {
             try
             {
-                var el = doc.GetElement(new ElementId((long)elementId));
+                var el = doc.GetElement(new ElementId(elementId));
                 if (el == null) return;
                 var p = el.LookupParameter(CountParamName);
                 if (p == null || p.IsReadOnly) return;

--- a/StingTools/Clash/LiveClashHandler.cs
+++ b/StingTools/Clash/LiveClashHandler.cs
@@ -56,8 +56,8 @@ namespace StingTools.Core.Clash
                 }
 
                 var sw = Stopwatch.StartNew();
-                var toFlag = new HashSet<int>();
-                var toClear = new HashSet<int>();
+                var toFlag = new HashSet<long>();
+                var toClear = new HashSet<long>();
                 int processed = 0;
 
                 while (LiveClashUpdater.DirtyQueue.TryDequeue(out var entry) && sw.ElapsedMilliseconds < 200)
@@ -110,7 +110,7 @@ namespace StingTools.Core.Clash
                         {
                             if (sw.ElapsedMilliseconds >= 200) break;
                             int idx = (start + i) % ordered.Count;
-                            int watchedId = ordered[idx];
+                            long watchedId = ordered[idx];
                             try
                             {
                                 var r = session.RefreshElement(watchedId);

--- a/StingTools/Clash/LiveClashUpdater.cs
+++ b/StingTools/Clash/LiveClashUpdater.cs
@@ -15,8 +15,11 @@ namespace StingTools.Core.Clash
             new AddInId(new Guid("3C9A4E2D-5F7B-4A12-9B8F-C1D2E3F4A5B6")),
             new Guid("3C9A4E2D-5F7B-4A12-9B8F-C1D2E3F4A5B7"));
 
-        public static readonly ConcurrentQueue<(string DocGuid, int ElementId)> DirtyQueue =
-            new ConcurrentQueue<(string, int)>();
+        // 64-bit element ids: Revit 2024+ ElementId.Value is Int64 and the
+        // deletion sentinel below negates the id, so a narrowing cast could
+        // both truncate the identity and flip the sentinel's meaning (#722).
+        public static readonly ConcurrentQueue<(string DocGuid, long ElementId)> DirtyQueue =
+            new ConcurrentQueue<(string, long)>();
 
         // Parallel queue consumed by GeometrySyncHandler (delta geometry push to Planscape).
         // Kept separate from DirtyQueue so clash detection and geometry sync can drain
@@ -64,19 +67,18 @@ namespace StingTools.Core.Clash
             {
                 var doc = data.GetDocument();
                 string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
-                // ElementId.IntegerValue is obsolete in Revit 2024+; use Value (Int64).
                 // C2 - this updater feeds CLASH only. It no longer pushes to
                 // GeometrySyncQueue: GeometrySyncUpdater owns that queue and
                 // covers every model category, whereas this trigger covers the
                 // nine categories clash cares about. Enqueuing from both would
                 // simply duplicate work for those nine.
                 foreach (var id in data.GetModifiedElementIds())
-                    DirtyQueue.Enqueue((docGuid, (int)id.Value));
+                    DirtyQueue.Enqueue((docGuid, id.Value));
                 foreach (var id in data.GetAddedElementIds())
-                    DirtyQueue.Enqueue((docGuid, (int)id.Value));
-                // Deleted elements: pushed with -1 sentinel to trigger removal from BVH.
+                    DirtyQueue.Enqueue((docGuid, id.Value));
+                // Deleted elements: pushed negated as a sentinel to trigger removal from BVH.
                 foreach (var id in data.GetDeletedElementIds())
-                    DirtyQueue.Enqueue((docGuid, -(int)id.Value));
+                    DirtyQueue.Enqueue((docGuid, -id.Value));
             }
             catch (Exception ex)
             {

--- a/StingTools/Commands/IFC/GeometrySyncHandler.cs
+++ b/StingTools/Commands/IFC/GeometrySyncHandler.cs
@@ -236,7 +236,7 @@ namespace StingTools.Commands.IFC
                 // skip-don't-mis-key rule. Run "Stabilize IFC GUIDs" for cross-host.
                 string ifcGuid = ParameterHelpers.GetString(el, "IFC_GLOBAL_ID_TXT");
 
-                var key = new ClashElementKey(docGuid, -1, (int)el.Id.Value, el.UniqueId, ifcGuid);
+                var key = new ClashElementKey(docGuid, -1, el.Id.Value, el.UniqueId, ifcGuid);
                 return new ClashMeshBuffer(key, el.Category.Name, verts.ToArray(), indices.ToArray());
             }
             catch (Exception ex)

--- a/StingTools/Commands/IFC/GlbSerializer.cs
+++ b/StingTools/Commands/IFC/GlbSerializer.cs
@@ -180,7 +180,10 @@ namespace StingTools.Commands.IFC
         {
             public string uniqueId;
             public string ifcGuid;
-            public int    elementId;
+            // 64-bit: the server reads this with GetInt64 and keys
+            // FederatedElement on it, so a narrowed id here would store one
+            // value on add and never match the delete that follows (#722).
+            public long   elementId;
             public string category;
         }
         private class GltfMesh      { public string name; public GltfPrimitive[] primitives; }


### PR DESCRIPTION
Closes #722. Follow-up carved out of the 12-PR federation-hardening stack (#676 → #688); **based on the stack tip `claude/federation-converter-status`**, since the stack has not merged to `main` yet. Retarget to `main` once it does.

## The defect

Revit 2024+ `ElementId.Value` is `Int64` and a large or long-lived model mints ids past `int.MaxValue`. `ClashElementKey.ElementId` / `LinkInstanceElementId` were `int`, so every such id was truncated the moment it entered the clash tree — and the truncation is not merely lossy, it **collides**: `2^32 + 7` and `7` both narrow to `7`.

That leaked into federation:

`GeometrySyncHandler.TryExtractElement` builds a `ClashElementKey` per changed element → `GlbSerializer` stamps that key's id into the GLB node extras → the server reads it with `GetInt64` and keys `FederatedElement` on it. `GlbSerializer.GltfExtras.elementId` was `int`, so a `>int.MaxValue` element was **stored under a truncated id**, while the delete that followed carried the real one (the delta path was widened to `long` in #684 — `a87277f3a` + `e43a20209`). The tombstone missed and stale geometry lingered in the federated scene.

## What changed

Widened `int → long` across the whole clash-engine identity path in one pass, so nothing is left half-narrow (a partial widening compiles and still truncates):

| File | What |
|---|---|
| `Clash/ClashMeshBuffer.cs` | `ClashElementKey` fields, ctor, `Equals`, `GetHashCode` (now folds the high word in via `long.GetHashCode()` instead of dropping it) |
| `Clash/ClashRecord.cs` | `ClashElementRecord.ElementId` + `.LinkInstanceId` |
| `Clash/ClashSession.cs` | `_meshByEid` / `_obbByEid` / `_clashNeighbours` / `_factsCache` / `_watchedElements` / `_flaggedIds`, `RefreshElement` / `RemoveElement` / `Watch` / `Unwatch` / `IsWatched` / `WatchedSnapshot`, `OnElementFlagChanged`, `LiveClashResult` |
| `Clash/LiveClashUpdater.cs` | `DirtyQueue` — worth calling out: the deletion sentinel **negates** the id, so the narrowing cast could flip the sentinel's meaning, not just truncate |
| `Clash/LiveClashHandler.cs`, `Clash/LiveClashFlag.cs` | the flag/clear sets and the `CLASH_LIVE_FLAG` / `CLASH_COUNT_INT` writers |
| `Clash/ClashHistory.cs` | the fuzzy-match bucket key |
| `Clash/ClashGrouper.cs` | the `(pair, side, eid)` element-pattern key |
| `Clash/ClashNotifications.cs`, `Clash/ClashRunCommand.cs`, `Clash/ClashSlaIntegration.cs`, `Clash/ClashIssueSyncCommand.cs` | DTOs, cold-init flag set, owner cache |
| `Commands/IFC/GlbSerializer.cs` | `GltfExtras.elementId` — the federation wire itself |

Dropped the `(int)…Value` casts at the three points ids enter: `ClashSession.TryExtractOneElement`, `ClashExportContext.OnElementEnd`, `GeometrySyncHandler.TryExtractElement`. Grepped the rest of `StingTools/Clash` + the clash handlers: the only remaining `(int)` casts are unrelated (HTTP status, `Math.Round` bins, buffer offsets) or already guarded (`CategoryHelper` narrows a category id only after proving it round-trips).

**No server-side change was needed** — `FederatedElement.ElementId` is already `long` (#684), and the server's own `ClashRecord` entity keys elements on IFC GUID **strings**, not numeric ids. Verified rather than assumed.

## Tests

Nine new cases in `StingTools.Clash.Tests/ClashElementId64BitTests.cs`, all using `2^32 + 7` against its low-32-bit twin `7` so each test fails on a *collision*, not merely on capacity:

- **`Glb_Node_Extras_Carry_The_Full_64_Bit_Element_Id`** — the load-bearing one. Serializes a real `ClashMeshBuffer` through `GlbSerializer` and reads the node extras back with the **same offsets and `GetInt64`** that `FederatedModelController.ParseGlbNodeExtras` uses. So the plugin end of the wire is proven against the reader that actually consumes it, not a hand-written GLB. Paired with the existing `FederatedDeltaReliabilityTests.A_deleted_id_beyond_int_range_round_trips_through_the_wire` (extras → row → delete match), that closes the chain end to end.
- `Glb_Element_Id_Is_Serialized_As_A_Json_Number_Not_A_String` — a quoted number would throw in `GetInt64` and turn the widening into a *different* silent failure (caught parse error, zero nodes).
- `ElementKey_Keeps_The_Full_64_Bit_Id`, `ElementKey_Distinguishes_Ids_That_Differ_Only_Above_Bit_31`, `ElementKey_Distinguishes_Link_Instances_Above_Bit_31`, `Two_Big_Ids_Still_Key_A_Dictionary_Independently` — identity + hash, and the dictionary behaviour `ClashSession`'s maps depend on.
- `Persisted_Clash_Record_Round_Trips_A_64_Bit_Id` — `clashes.json` through `ClashPersistence`.
- `History_Does_Not_Fuzzy_Match_Across_A_Truncation_Collision` — under truncation a new clash inherited a *different* clash's id, state and first-seen date, and the genuinely-gone one was never reported resolved.
- `Grouper_Does_Not_Merge_Two_Elements_That_Share_Low_32_Bits`.

`GlbSerializer.cs` is now `<Compile Include>`d into the clash test project — it imports `Autodesk.Revit.DB` but uses nothing from it, the same namespace-only case the existing `RevitStubs.cs` already covers for four other files.

## Build / test status

- `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings** (Windows + Revit 2025 + .NET 8). Baseline on this branch's base was also 0/0, so the widening is compile-clean end to end.
- `dotnet test StingTools.Clash.Tests` → **81 passed, 1 failed**. The failure is `ClashWireupRegressionTests.DuplicateLiveClashUpdater_FileIsRemoved`, which is **pre-existing on the base** (issue #596) and untouched here — the same 1 failure with 72 passing before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)