### PR TITLE
Wire a real ProjectModel ↔ FederatedElement linkage so model-delete retires federated elements

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/FederatedModelController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/FederatedModelController.cs
@@ -67,7 +67,11 @@ public class FederatedModelController : ControllerBase
     public async Task<ActionResult> PostDelta(
         Guid projectId,
         IFormFile? glb,
-        IFormFile? deletedIds)
+        IFormFile? deletedIds,
+        // The authoring document these elements came from — Revit's
+        // ProjectInformation.UniqueId. Optional for back-compat with plugins
+        // that predate it; see the resolution order at the docGuid assignment.
+        [FromForm] string? sourceDocGuid = null)
     {
         var tenantId = GetTenantId();
         var project  = await _db.Projects.AsNoTracking()
@@ -184,7 +188,19 @@ public class FederatedModelController : ControllerBase
                     "Delta for project {ProjectId}: GLB parsed but carried no node extras — " +
                     "the exporter may not be writing uniqueId/elementId.", projectId);
             }
-            var docGuid = User.FindFirst("source_doc_guid")?.Value ?? "revit-plugin";
+            // Resolution order: what the caller sent > a source_doc_guid claim >
+            // the shared placeholder.
+            //
+            // The form field is new, and it matters: nothing in this codebase
+            // has ever ISSUED a source_doc_guid claim, so every Revit delta to
+            // date landed in the placeholder bucket. That is why the placeholder
+            // cannot be treated as an identity — ModelsController.Delete refuses
+            // to cascade on it, and this is the field that lets a new delta be
+            // attributed to its real document instead.
+            var docGuid =
+                (!string.IsNullOrWhiteSpace(sourceDocGuid) ? sourceDocGuid.Trim() : null)
+                ?? User.FindFirst("source_doc_guid")?.Value
+                ?? FederatedElement.UnknownSourceDocGuid;
 
             foreach (var node in nodes)
             {

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -212,6 +212,17 @@ public class ModelsController : ControllerBase
             // view can ship a new ElementCount / Bounds / Revision label.
             if (req.ElementCount > 0) { existing.ElementCount = req.ElementCount; sidecarChanged = true; }
             if (!string.IsNullOrEmpty(req.Revision)) { existing.Revision = req.Revision; sidecarChanged = true; }
+            // Backfill the source-document link on rows published before this
+            // field existed: a republish from the authoring document is the one
+            // moment we can learn it for certain. Only ever fills a blank — it
+            // does not overwrite a link already recorded, because a different
+            // answer here would mean the same bytes came from two documents and
+            // the safe reading of that is "don't re-point the cascade".
+            if (string.IsNullOrWhiteSpace(existing.SourceDocGuid) && !string.IsNullOrWhiteSpace(req.SourceDocGuid))
+            {
+                existing.SourceDocGuid = req.SourceDocGuid!.Trim();
+                sidecarChanged = true;
+            }
             if (req.BoundsMaxX != 0 || req.BoundsMinX != 0)
             {
                 existing.BoundsMinX = req.BoundsMinX; existing.BoundsMinY = req.BoundsMinY; existing.BoundsMinZ = req.BoundsMinZ;
@@ -270,6 +281,10 @@ public class ModelsController : ControllerBase
             FileName = req.File.FileName,
             Format = format,
             StoragePath = geometryPath,
+            // The link to the geometry-delta pipeline — see ProjectModel
+            // .SourceDocGuid and the cascade in Delete. Blank is stored as null
+            // so "absent" has one representation, not two.
+            SourceDocGuid = string.IsNullOrWhiteSpace(req.SourceDocGuid) ? null : req.SourceDocGuid!.Trim(),
             ContentHash = hash,
             FileSizeBytes = req.File.Length,
             ThumbnailPath = thumbnailPath,
@@ -560,29 +575,66 @@ public class ModelsController : ControllerBase
         // so the geometry kept rendering after the model was "deleted". Retire the
         // chunks with it; ModelPurgeJob removes the bytes and the rows after the
         // 30-day grace the entity documents.
-        //
-        // FederatedElement rows are deliberately NOT retired here. They are keyed
-        // to their source by SourceDocGuid + a per-delta GlbStoragePath (written by
-        // FederatedModelController's delta path), whereas a ProjectModel is keyed by
-        // its uploaded-GLB StoragePath — there is no shared key between the two, so
-        // a model delete cannot identify "its" federated elements. The earlier
-        // attempt matched GlbStoragePath == ProjectModel.StoragePath, two keys from
-        // different pipelines that never coincide: it retired nothing while the log
-        // reported a count. Real federated-element retirement needs a proper linkage
-        // (a ProjectModelId or source-doc GUID on FederatedElement) — left as a
-        // follow-up rather than a join that silently matches nothing, or worse
-        // false-matches if the two key spaces ever collide.
         var chunks = await _db.SceneNodes
             .Where(n => n.SourceModelId == modelId && n.DeletedAt == null)
             .ToListAsync(ct);
         foreach (var chunk in chunks) chunk.DeletedAt = row.DeletedAt;
 
+        // Federated elements — the geometry the SAME authoring document pushed
+        // through the delta pipeline. They live in a different key space from
+        // ProjectModel (per-delta GlbStoragePath vs uploaded-GLB StoragePath),
+        // so the only honest join is the source-document GUID both pipelines now
+        // record. An earlier attempt joined the two storage paths, matched
+        // nothing, and reported a retirement count anyway.
+        //
+        // Three cases refuse the cascade rather than guess, because a wrong match
+        // retires geometry a live model still needs:
+        //   • no SourceDocGuid — published before the field existed, or by a
+        //     client that does not send it;
+        //   • the UnknownSourceDocGuid placeholder — a shared bucket, not an
+        //     identity: elements from different documents sit in it together;
+        //   • another LIVE model in this project claims the same document — a
+        //     second revision published with different bytes. Its elements are
+        //     the same elements, and it is not being deleted.
+        int retired = 0;
+        string? skipReason = null;
+        if (string.IsNullOrWhiteSpace(row.SourceDocGuid))
+            skipReason = "the model carries no source-document GUID";
+        else if (row.SourceDocGuid == FederatedElement.UnknownSourceDocGuid)
+            skipReason = $"the model's source-document GUID is the '{FederatedElement.UnknownSourceDocGuid}' placeholder, which is shared across documents";
+        else if (await _db.ProjectModels.AnyAsync(m =>
+                     m.Id != modelId && m.ProjectId == projectId &&
+                     m.SourceDocGuid == row.SourceDocGuid && m.DeletedAt == null, ct))
+            skipReason = "another live model in this project was published from the same document";
+
+        if (skipReason == null)
+        {
+            var elements = await _db.FederatedElements
+                .Where(e => e.TenantId == row.TenantId
+                         && e.ProjectId == projectId
+                         && e.SourceDocGuid == row.SourceDocGuid
+                         && !e.IsDeleted)
+                .ToListAsync(ct);
+            foreach (var el in elements)
+            {
+                el.IsDeleted = true;
+                el.UpdatedAt = DateTime.UtcNow;
+            }
+            retired = elements.Count;
+        }
+
         await _db.SaveChangesAsync(ct);
 
-        _logger.LogInformation(
-            "Model {ModelId} soft-deleted: {Chunks} scene chunk(s) retired with it. " +
-            "Federated elements are not linked to a ProjectModel and are left untouched (see Delete remarks).",
-            modelId, chunks.Count);
+        if (skipReason == null)
+            _logger.LogInformation(
+                "Model {ModelId} soft-deleted: {Chunks} scene chunk(s) and {Elements} federated element(s) " +
+                "retired with it (source document {DocGuid}).",
+                modelId, chunks.Count, retired, row.SourceDocGuid);
+        else
+            _logger.LogInformation(
+                "Model {ModelId} soft-deleted: {Chunks} scene chunk(s) retired with it. " +
+                "Federated elements were left untouched because {Reason}.",
+                modelId, chunks.Count, skipReason);
 
         return NoContent();
     }
@@ -902,6 +954,15 @@ public class UploadModelRequest
     /// revision (e.g. updated element map only).
     /// </summary>
     public bool Force { get; set; }
+
+    /// <summary>
+    /// The authoring document this GLB came from — Revit's
+    /// <c>ProjectInformation.UniqueId</c>. Optional, but supplying it is what
+    /// lets a later model delete retire the federated elements the same
+    /// document pushed through the geometry-delta pipeline; without it the
+    /// cascade is skipped rather than guessed at.
+    /// </summary>
+    public string? SourceDocGuid { get; set; }
 
     // ── B2 — georeferencing (optional) ──────────────────────────────────────
     //

--- a/Planscape.Server/src/Planscape.API/PlatformSchemaPatcher.cs
+++ b/Planscape.Server/src/Planscape.API/PlatformSchemaPatcher.cs
@@ -425,6 +425,18 @@ internal static class PlatformSchemaPatcher
         // for rounds whose real revision is unknown, which is exactly the confident-
         // wrong-answer this field exists to prevent.
         @"ALTER TABLE ""ApprovalChains"" ADD COLUMN IF NOT EXISTS ""RevisionSnapshot"" text",
+
+        // ── ProjectModel.SourceDocGuid — the ProjectModel ↔ FederatedElement link ──
+        // Additive and nullable. Existing rows land on NULL, and NULL is exactly
+        // the case ModelsController.Delete refuses to cascade on — so shipping
+        // this cannot retire anything on the strength of a value nobody set. New
+        // publishes carry the authoring document's GUID and get a real cascade.
+        //
+        // Per ADR 0001 this patcher, not an EF migration, is how the column
+        // reaches an existing production database.
+        @"ALTER TABLE ""ProjectModels"" ADD COLUMN IF NOT EXISTS ""SourceDocGuid"" character varying(100)",
+        @"CREATE INDEX IF NOT EXISTS ""IX_ProjectModels_ProjectId_SourceDocGuid""
+            ON ""ProjectModels"" (""ProjectId"", ""SourceDocGuid"")",
     };
 
     public static async Task ApplyAsync(DbConnection conn)

--- a/Planscape.Server/src/Planscape.Core/Entities/FederatedElement.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/FederatedElement.cs
@@ -20,6 +20,19 @@ public class FederatedElement : ITenantScoped
     public Guid TenantId  { get; set; }
     public Guid ProjectId { get; set; }
 
+    /// <summary>
+    /// Placeholder written when a delta arrives without a source-document GUID —
+    /// every Revit delta before the plugin started sending one, since the
+    /// endpoint's only other source was a <c>source_doc_guid</c> claim that
+    /// nothing has ever issued.
+    ///
+    /// <para>It is a bucket, not an identity: elements from DIFFERENT documents
+    /// share it. Anything keying off <see cref="SourceDocGuid"/> to decide what
+    /// belongs to what must refuse to match on this value — see
+    /// <c>ModelsController.Delete</c>.</para>
+    /// </summary>
+    public const string UnknownSourceDocGuid = "revit-plugin";
+
     /// <summary>Source document GUID (Revit ProjectInformation.UniqueId or IFC GUID).</summary>
     public string SourceDocGuid { get; set; } = "";
 

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectModel.cs
@@ -39,6 +39,27 @@ public class ProjectModel : ITenantScoped
     /// <summary>Storage path / key returned by IFileStorageService — opaque.</summary>
     public string StoragePath { get; set; } = "";
 
+    /// <summary>
+    /// The authoring document this model was published from — Revit's
+    /// <c>ProjectInformation.UniqueId</c>, the same string the geometry-delta
+    /// pipeline writes as <see cref="FederatedElement.SourceDocGuid"/>.
+    ///
+    /// <para><b>Why it exists.</b> It is the ONE key shared between the two
+    /// ingest pipelines. A ProjectModel is keyed by its uploaded-GLB
+    /// <see cref="StoragePath"/>; a FederatedElement is keyed by its per-delta
+    /// <c>GlbStoragePath</c>. Those are different key spaces and never coincide,
+    /// so before this field a model delete had no way to identify "its"
+    /// federated elements — an earlier attempt joined the two storage paths,
+    /// matched nothing, and logged a retirement count anyway.</para>
+    ///
+    /// <para>Nullable on purpose. Rows published before this shipped, and any
+    /// ingest that genuinely has no source document, carry null — and
+    /// <c>ModelsController.Delete</c> skips the federated cascade rather than
+    /// guessing, because a wrong match here retires geometry a live model still
+    /// needs.</para>
+    /// </summary>
+    public string? SourceDocGuid { get; set; }
+
     /// <summary>SHA-256 of the file — used for client-side dedup + cache-busting.</summary>
     public string? ContentHash { get; set; }
 

--- a/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Data/PlanscapeDbContext.cs
@@ -379,6 +379,10 @@ public class PlanscapeDbContext : DbContext
             e.Property(x => x.FileName).HasMaxLength(260);
             e.Property(x => x.StoragePath).HasMaxLength(600);
             e.Property(x => x.ContentHash).HasMaxLength(64);
+            // Same width as FederatedElement.SourceDocGuid — they hold the same
+            // string and the model-delete cascade joins on it.
+            e.Property(x => x.SourceDocGuid).HasMaxLength(100);
+            e.HasIndex(x => new { x.ProjectId, x.SourceDocGuid });
             e.Property(x => x.ThumbnailPath).HasMaxLength(600);
             e.Property(x => x.ElementMapPath).HasMaxLength(600);
             e.Property(x => x.Units).HasMaxLength(8);

--- a/Planscape.Server/tests/Planscape.Tests/FederatedDeltaReliabilityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/FederatedDeltaReliabilityTests.cs
@@ -404,4 +404,45 @@ public class FederatedDeltaReliabilityTests
             Assert.True(await IsDeletedAsync(w));
         }
     }
+
+    // ── the source-document link ────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_delta_records_the_source_document_it_was_sent_with()
+    {
+        // This is the key ModelsController.Delete joins on to retire a deleted
+        // model's federated elements. Before the plugin sent it, the endpoint's
+        // only other source was a source_doc_guid claim that nothing issues, so
+        // every element landed in the shared placeholder bucket.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(w, db, new StubStorage())
+                    .PostDelta(w.Project, Glb("uid-arch", 501), null, "doc-guid-arch");
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var row = await check.FederatedElements.SingleAsync(e => e.ElementId == 501);
+            Assert.Equal("doc-guid-arch", row.SourceDocGuid);
+        }
+    }
+
+    [Fact]
+    public async Task A_delta_without_a_source_document_still_applies_under_the_placeholder()
+    {
+        // Back-compat: an older plugin sends no field. It must keep working, and
+        // it must land somewhere identifiable as "unattributed" rather than be
+        // rejected or silently attributed to a real document.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(w, db, new StubStorage())
+                    .PostDelta(w.Project, Glb("uid-legacy", 502), null);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            var row = await check.FederatedElements.SingleAsync(e => e.ElementId == 502);
+            Assert.Equal(FederatedElement.UnknownSourceDocGuid, row.SourceDocGuid);
+        }
+    }
 }

--- a/Planscape.Server/tests/Planscape.Tests/ModelLifecycleTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ModelLifecycleTests.cs
@@ -1,6 +1,10 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.API.Controllers;
 using Planscape.Core.Entities;
 using Planscape.Core.Interfaces;
 using Planscape.Infrastructure.Data;
@@ -69,6 +73,46 @@ public class ModelLifecycleTests
         public Task<PresignedUpload> GetPresignedPutUrlAsync(string k, string c, TimeSpan v, long m, CancellationToken ct = default) => throw No();
         public Task<string> GetPresignedGetUrlAsync(string k, TimeSpan v, CancellationToken ct = default, bool b = false) => throw No();
         public Task MoveAsync(string s, string d, CancellationToken ct = default, bool b = false) => throw No();
+    }
+
+    /// <summary>Neither Delete nor the purge job georeferences anything.</summary>
+    private sealed class UnusedGeorefWriter : IModelGeorefWriter
+    {
+        public Task<GeorefWriteResult> WriteAsync(
+            Guid projectId, Guid projectModelId, Guid tenantId,
+            ModelGeoref georef, string? verdict, CancellationToken ct = default)
+            => throw new NotSupportedException("Delete does not georeference");
+    }
+
+    private sealed class UnusedConverter : IConverterClient
+    {
+        public bool IsConfigured => false;
+        public Task<ConverterGlbResult> ConvertIfcToGlbAsync(
+            string sourceUrl, string fileName, string? discipline, CancellationToken ct = default)
+            => throw new NotSupportedException("Delete does not convert");
+    }
+
+    private static ModelsController NewController(PlanscapeDbContext db, Guid tenantId)
+    {
+        var ctrl = new ModelsController(
+            db,
+            new RecordingStorage(),
+            new UnusedConverter(),
+            new UnusedGeorefWriter(),
+            NullLogger<ModelsController>.Instance);
+
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim("tenant_id", tenantId.ToString()),
+                    new Claim("user_id", Guid.NewGuid().ToString()),
+                }, "test")),
+            },
+        };
+        return ctrl;
     }
 
     private sealed record World(SqliteConnection Conn, Guid Tenant, Guid Project, Guid Model);
@@ -197,6 +241,218 @@ public class ModelLifecycleTests
             using var check = NewContext(w.Conn, w.Tenant);
             Assert.True(await check.ProjectModels.IgnoreQueryFilters().AnyAsync(m => m.Id == w.Model),
                 "the row was purged even though its bytes could not be deleted — the storage is now orphaned");
+        }
+    }
+
+    // ── the federated-element cascade, and its false-positive guards ────────
+    //
+    // ModelsController.Delete used to try to retire a model's federated
+    // elements by matching FederatedElement.GlbStoragePath ==
+    // ProjectModel.StoragePath. Those are keys from different pipelines — the
+    // per-delta GLB key vs the uploaded-GLB key — so it matched nothing while
+    // the log reported a count. That join was removed and the gap documented;
+    // ProjectModel.SourceDocGuid is the real linkage, and these pin both what
+    // it must retire and what it must not touch.
+
+    private const string DocGuid = "doc-guid-arch";
+
+    private static void SeedFederatedElement(
+        PlanscapeDbContext ctx, Guid tenant, Guid project, string sourceDocGuid, long elementId)
+        => ctx.FederatedElements.Add(new FederatedElement
+        {
+            TenantId = tenant, ProjectId = project,
+            SourceDocGuid = sourceDocGuid, Source = "revit-plugin",
+            ElementId = elementId, UniqueId = $"uid-{elementId}",
+            GlbStoragePath = $"t_x/{elementId}-delta.glb", IsDeleted = false,
+        });
+
+    private static async Task<bool> IsElementDeletedAsync(World w, long elementId)
+    {
+        using var ctx = NewContext(w.Conn, w.Tenant);
+        return await ctx.FederatedElements
+            .Where(e => e.ElementId == elementId).Select(e => e.IsDeleted).SingleAsync();
+    }
+
+    [Fact]
+    public async Task Deleting_a_model_retires_the_federated_elements_its_document_pushed()
+    {
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                (await seed.ProjectModels.SingleAsync(m => m.Id == w.Model)).SourceDocGuid = DocGuid;
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 101);
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 102);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+            {
+                var result = await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+                Assert.IsType<NoContentResult>(result);
+            }
+
+            Assert.True(await IsElementDeletedAsync(w, 101));
+            Assert.True(await IsElementDeletedAsync(w, 102));
+        }
+    }
+
+    [Fact]
+    public async Task Deleting_a_model_leaves_another_documents_elements_alone()
+    {
+        // The false-positive guard. A federated element from a DIFFERENT source
+        // document — a second discipline model federated into the same project —
+        // must survive; retiring it would blank live geometry the coordinator
+        // never asked to remove.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                (await seed.ProjectModels.SingleAsync(m => m.Id == w.Model)).SourceDocGuid = DocGuid;
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 101);
+                SeedFederatedElement(seed, w.Tenant, w.Project, "doc-guid-mech", 202);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+
+            Assert.True(await IsElementDeletedAsync(w, 101));
+            Assert.False(await IsElementDeletedAsync(w, 202),
+                "another document's federated elements were retired by this model's delete");
+        }
+    }
+
+    [Fact]
+    public async Task Deleting_a_model_leaves_another_projects_elements_alone()
+    {
+        // Same guard across the project boundary — the join is scoped by tenant
+        // and project as well as document, so a doc GUID that recurs in a second
+        // project (a template model copied between them) cannot leak.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var otherProject = Guid.NewGuid();
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                (await seed.ProjectModels.SingleAsync(m => m.Id == w.Model)).SourceDocGuid = DocGuid;
+                seed.Projects.Add(new Project
+                {
+                    Id = otherProject, TenantId = w.Tenant, Name = "Annex",
+                    Code = $"AX-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+                });
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 101);
+                SeedFederatedElement(seed, w.Tenant, otherProject, DocGuid, 303);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+
+            Assert.True(await IsElementDeletedAsync(w, 101));
+            Assert.False(await IsElementDeletedAsync(w, 303),
+                "another project's federated elements were retired by this model's delete");
+        }
+    }
+
+    [Fact]
+    public async Task A_model_with_no_source_document_retires_nothing()
+    {
+        // Every model published before SourceDocGuid existed carries null. The
+        // cascade must skip rather than fall back to some looser match — a
+        // wrong match here retires geometry a live model still needs.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 101);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                Assert.IsType<NoContentResult>(
+                    await NewController(db, w.Tenant).Delete(w.Project, w.Model, default));
+
+            Assert.False(await IsElementDeletedAsync(w, 101));
+        }
+    }
+
+    [Fact]
+    public async Task The_placeholder_source_document_retires_nothing()
+    {
+        // "revit-plugin" is what every delta landed under before the plugin
+        // started sending a real GUID — a shared bucket holding elements from
+        // many documents. Treating it as an identity would let one model's
+        // delete wipe every Revit-sourced element in the project.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                (await seed.ProjectModels.SingleAsync(m => m.Id == w.Model)).SourceDocGuid =
+                    FederatedElement.UnknownSourceDocGuid;
+                SeedFederatedElement(
+                    seed, w.Tenant, w.Project, FederatedElement.UnknownSourceDocGuid, 101);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+
+            Assert.False(await IsElementDeletedAsync(w, 101),
+                "the shared placeholder was treated as a document identity");
+        }
+    }
+
+    [Fact]
+    public async Task A_second_live_model_from_the_same_document_holds_the_elements()
+    {
+        // Two live revisions of the same document (published with different
+        // bytes, so both rows exist). They describe the SAME elements, and one
+        // of them is not being deleted — so nothing is retired.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                (await seed.ProjectModels.SingleAsync(m => m.Id == w.Model)).SourceDocGuid = DocGuid;
+                seed.ProjectModels.Add(new ProjectModel
+                {
+                    Id = Guid.NewGuid(), TenantId = w.Tenant, ProjectId = w.Project,
+                    Name = "ARCH rev B", FileName = "b.glb", StoragePath = "t_x/b.glb",
+                    SourceDocGuid = DocGuid,
+                });
+                SeedFederatedElement(seed, w.Tenant, w.Project, DocGuid, 101);
+                await seed.SaveChangesAsync();
+            }
+
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+
+            Assert.False(await IsElementDeletedAsync(w, 101),
+                "elements were retired while a live sibling model still publishes the same document");
+        }
+    }
+
+    [Fact]
+    public async Task The_model_and_its_scene_chunks_are_still_retired_when_the_cascade_is_skipped()
+    {
+        // The mirror case: skipping the federated half must not skip the halves
+        // that always worked.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var db = NewContext(w.Conn, w.Tenant))
+                await NewController(db, w.Tenant).Delete(w.Project, w.Model, default);
+
+            using var check = NewContext(w.Conn, w.Tenant);
+            Assert.NotNull((await check.ProjectModels.IgnoreQueryFilters()
+                .SingleAsync(m => m.Id == w.Model)).DeletedAt);
+            Assert.NotNull((await check.SceneNodes.IgnoreQueryFilters()
+                .SingleAsync(n => n.SourceModelId == w.Model)).DeletedAt);
         }
     }
 

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -1504,7 +1504,17 @@ public sealed partial class PlanscapeServerClient : IDisposable
     /// deletedElementIds are tombstoned on the server.
     /// Uses <see cref="CurrentProjectId"/> — silently no-ops if not set.
     /// </summary>
-    public async Task<bool> PostGeometryDeltaAsync(byte[] glbBytes, IList<long> deletedElementIds)
+    /// <param name="sourceDocGuid">
+    /// The authoring document these elements came from
+    /// (<see cref="StingTools.Core.SourceDocumentId.For"/>). The server records
+    /// it on every FederatedElement, and it is the only key a later model
+    /// delete has for identifying which federated geometry to retire — without
+    /// it the elements land in a shared placeholder bucket the cascade refuses
+    /// to act on. Optional so an older server that ignores the field still
+    /// accepts the delta.
+    /// </param>
+    public async Task<bool> PostGeometryDeltaAsync(
+        byte[] glbBytes, IList<long> deletedElementIds, string? sourceDocGuid = null)
     {
         if (CurrentProjectId == Guid.Empty) return false;
         if (!await EnsureAuthenticatedAsync()) return false;
@@ -1529,6 +1539,12 @@ public sealed partial class PlanscapeServerClient : IDisposable
                     Newtonsoft.Json.JsonConvert.SerializeObject(deletedElementIds),
                     System.Text.Encoding.UTF8, "application/json");
                 content.Add(jsonContent, "deletedIds");
+            }
+
+            if (!string.IsNullOrWhiteSpace(sourceDocGuid))
+            {
+                content.Add(new System.Net.Http.StringContent(
+                    sourceDocGuid, System.Text.Encoding.UTF8), "sourceDocGuid");
             }
 
             var resp = await http.PostAsync(
@@ -2141,6 +2157,12 @@ public sealed partial class PlanscapeServerClient : IDisposable
         int? elementCount = null,
         double[]? bounds = null,
         bool force = false,
+        // The authoring document this GLB was exported from
+        // (StingTools.Core.SourceDocumentId.For). The server stores it on the
+        // ProjectModel and matches it against the FederatedElement rows the
+        // geometry-delta pipeline wrote, so deleting the model actually retires
+        // its federated geometry. Omit it and the server skips that cascade.
+        string? sourceDocGuid = null,
         // B2 — optional georeferencing. Sent as METADATA beside the geometry,
         // never baked into the mesh: a site at easting 432,000 m would put every
         // vertex ~432 km from the origin, where 32-bit float loses millimetre
@@ -2189,6 +2211,7 @@ public sealed partial class PlanscapeServerClient : IDisposable
             AddField("Discipline", discipline);
             AddField("Revision", revision);
             AddField("Units", units);
+            AddField("SourceDocGuid", sourceDocGuid);
             if (force) AddField("Force", "true");
             if (elementCount.HasValue) AddField("ElementCount", elementCount.Value.ToString());
             // B2 — georef block. Field names match UploadModelRequest exactly.

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -263,6 +263,10 @@ namespace StingTools.BIMManager
                 elementCount: elementCount,
                 bounds: bounds,
                 force: force,
+                // Same string GeometrySyncHandler sends with every delta — it is
+                // what lets a later delete of this model retire the federated
+                // elements this document pushed.
+                sourceDocGuid: StingTools.Core.SourceDocumentId.For(doc),
                 georefEastingM:     hasGeoref ? georef!.EastingM     : (double?)null,
                 georefNorthingM:    hasGeoref ? georef!.NorthingM    : (double?)null,
                 georefElevationM:   hasGeoref ? georef!.ElevationM   : (double?)null,

--- a/StingTools/Commands/IFC/GeometrySyncHandler.cs
+++ b/StingTools/Commands/IFC/GeometrySyncHandler.cs
@@ -98,7 +98,7 @@ namespace StingTools.Commands.IFC
                 // Extract mesh geometry on the Revit API thread (required)
                 var buffers = new List<ClashMeshBuffer>(changedIds.Count);
                 var extractedIds = new List<long>(changedIds.Count);
-                string docGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
+                string docGuid = SourceDocumentId.For(doc);
                 foreach (long eid in changedIds)
                 {
                     var buf = TryExtractElement(doc, eid, docGuid);
@@ -140,7 +140,7 @@ namespace StingTools.Commands.IFC
                             // C1 - the return value was previously discarded, so
                             // a non-2xx, an expired token or an unset project id
                             // all looked identical to success.
-                            delivered = await c.PostGeometryDeltaAsync(glb, capturedDeleted);
+                            delivered = await c.PostGeometryDeltaAsync(glb, capturedDeleted, capturedDocGuid);
                             if (delivered)
                                 StingLog.Info($"GeometrySyncHandler: delta uploaded ({glb.Length / 1024} kB, {capturedDeleted.Count} tombstones)");
                             else

--- a/StingTools/Commands/IFC/IFC_PushModelCommand.cs
+++ b/StingTools/Commands/IFC/IFC_PushModelCommand.cs
@@ -98,7 +98,7 @@ namespace StingTools.Commands.IFC
             // are skipped (skip-don't-mis-key) — run "Stabilize IFC GUIDs" first
             // to populate the canonical 22-char key.
             var ifcElements = BuildIfcElements(doc);
-            string hostDocGuid = doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host";
+            string hostDocGuid = StingTools.Core.SourceDocumentId.For(doc);
             string revitUser = uiApp.Application?.Username ?? "";
             StingLog.Info($"IFC_PushModel: built {ifcElements.Count} IFC-data element(s) with a stabilised GlobalId.");
 
@@ -110,7 +110,7 @@ namespace StingTools.Commands.IFC
                     byte[] glb = GlbSerializer.Serialize(buffers);
                     StingLog.Info($"IFC_PushModel: GLB serialised ({glb.Length / 1024:N0} kB), uploading…");
 
-                    bool ok = await client.PostGeometryDeltaAsync(glb, System.Array.Empty<long>());
+                    bool ok = await client.PostGeometryDeltaAsync(glb, System.Array.Empty<long>(), hostDocGuid);
                     StingLog.Info(ok
                         ? $"IFC_PushModel: geometry upload succeeded ({glb.Length / 1024:N0} kB)"
                         : $"IFC_PushModel: geometry upload failed — {client.LastError}");

--- a/StingTools/Core/SourceDocumentId.cs
+++ b/StingTools/Core/SourceDocumentId.cs
@@ -1,0 +1,33 @@
+// SourceDocumentId.cs — the ONE derivation of "which authoring document is this".
+//
+// The server links a published ProjectModel to the FederatedElement rows the
+// geometry-delta pipeline pushed by comparing the source-document GUID the two
+// requests carry. That link is only as good as the two strings being identical,
+// and the two are produced by different commands in different folders — a
+// classic place for a silent drift (one falls back to PathName, the other to
+// Title, and a model delete quietly stops retiring anything).
+//
+// So both call this. It is deliberately the same expression the clash tree has
+// always used for ClashElementKey.DocGuid, because the delta's element ids come
+// from those keys.
+using Autodesk.Revit.DB;
+
+namespace StingTools.Core
+{
+    public static class SourceDocumentId
+    {
+        /// <summary>
+        /// Stable per-document identity: <c>ProjectInformation.UniqueId</c>,
+        /// falling back to the model path, then to a literal so callers never
+        /// have to null-check.
+        ///
+        /// <para>The UniqueId survives Save-As and renames, which is what makes
+        /// it usable as a cross-request key. The PathName fallback covers an
+        /// unsaved or family-less document within a single session only —
+        /// it is not stable across a move, and a link built on it is best
+        /// effort.</para>
+        /// </summary>
+        public static string For(Document doc)
+            => doc?.ProjectInformation?.UniqueId ?? doc?.PathName ?? "host";
+    }
+}


### PR DESCRIPTION
Follow-up #2 from the federation review. **Based on the stack tip `claude/federation-converter-status`** (the 12-PR stack #676 → #688 has not merged to `main` yet). Retarget to `main` once it does.

## The gap

A "deleted" model's federated elements kept answering clash, compliance and element queries.

`ModelsController.Delete` had no way to find them. A `ProjectModel` is keyed by its uploaded-GLB `StoragePath`; a `FederatedElement` by its per-delta `GlbStoragePath` — different key spaces, written by different pipelines, that never coincide. The earlier attempt joined those two anyway, matched nothing, and logged a retirement count regardless. **#686 removed that join and documented the gap** (Option A in the follow-up brief). This PR adds the linkage that fix was waiting on.

## What changed

**The key.** `ProjectModel.SourceDocGuid` — nullable, the authoring document's `ProjectInformation.UniqueId`, the same string the delta pipeline already writes as `FederatedElement.SourceDocGuid`. Populated on **both** ingest pipelines:

- **publish** — `UploadModelRequest.SourceDocGuid`, stored on insert; on the content-hash dedup path it backfills a row that has none (fill-if-blank only — it never re-points an existing link, because a different answer there would mean the same bytes came from two documents).
- **delta** — `FederatedModelController.PostDelta` gains an optional `sourceDocGuid` form field, preferred over the existing claim.

**Worth calling out about the delta path:** its only prior source of a doc GUID was a `source_doc_guid` JWT claim, and **nothing in this codebase issues that claim** (grepped: one read site, zero writers). So every Revit delta to date landed under the literal `"revit-plugin"`. That value is a shared bucket, not an identity — it is now the named constant `FederatedElement.UnknownSourceDocGuid`, and the cascade refuses to act on it. Without that check, Option A would have been a *worse* bug than the one it fixes: one model's delete would tombstone every Revit-sourced element in the project.

**Plugin.** `PublishModelCommand` and `GeometrySyncHandler` (and `IFC_PushModelCommand`) now send it, derived from one shared helper `StingTools/Core/SourceDocumentId.cs` rather than two hand-copied `doc.ProjectInformation?.UniqueId ?? doc.PathName ?? "host"` expressions. The whole linkage rests on the two requests producing an *identical* string, so that derivation should not exist twice.

**The cascade.** `Delete` retires `FederatedElement` rows matching tenant + project + source document (`IsDeleted = true`, `UpdatedAt`) and logs the real count. It **skips, naming which reason applies**, when:

| Case | Why skipping is right |
|---|---|
| no `SourceDocGuid` | published before the field existed, or by a client that doesn't send it — there is nothing to match on |
| the `UnknownSourceDocGuid` placeholder | a shared bucket holding several documents' elements |
| another **live** model in the project shares the doc GUID | two revisions of one document describe the same elements, and one of them is not being deleted |

## PROD SCHEMA / migration step

Per [`docs/adr/0001-schema-management.md`](docs/adr/0001-schema-management.md), **EF migrations in this repo are inert** — they carry no `[Migration]` attribute and no Designer companions, so `Database.Migrate()` applies nothing. The supported mechanism is `EnsureCreated` (fresh DBs) plus the idempotent `PlatformSchemaPatcher` (pre-existing DBs). So:

- **No EF migration was authored** — one would be decorative and would imply a mechanism that does not run.
- The column reaches production through `PlatformSchemaPatcher.Statements`:
  ```sql
  ALTER TABLE "ProjectModels" ADD COLUMN IF NOT EXISTS "SourceDocGuid" character varying(100);
  CREATE INDEX IF NOT EXISTS "IX_ProjectModels_ProjectId_SourceDocGuid" ON "ProjectModels" ("ProjectId", "SourceDocGuid");
  ```
  which runs on every boot and is safe on any DB state. `SchemaDriftChecker` will confirm it landed.
- **Existing rows land on NULL**, which is precisely the case the cascade refuses — so deploying this cannot retire anything on the strength of a value nobody set. Behaviour changes only for models published after the plugin starts sending the field.
- **No bulk backfill.** The source-document GUID cannot be recovered from anything already stored (neither storage path encodes it), so a backfill would have to guess. A republish from the authoring document fills it in for real, and that path is wired above.

## Tests

`ModelLifecycleTests` (SQLite, the real `ModelsController.Delete`) — 7 new cases:

- `Deleting_a_model_retires_the_federated_elements_its_document_pushed` — the acceptance case.
- `Deleting_a_model_leaves_another_documents_elements_alone` — the false-positive guard: a second discipline model federated into the same project must survive.
- `Deleting_a_model_leaves_another_projects_elements_alone` — the same guard across the project boundary.
- `A_model_with_no_source_document_retires_nothing`
- `The_placeholder_source_document_retires_nothing`
- `A_second_live_model_from_the_same_document_holds_the_elements`
- `The_model_and_its_scene_chunks_are_still_retired_when_the_cascade_is_skipped` — the mirror case, so skipping the federated half can't quietly skip the halves that always worked.

`FederatedDeltaReliabilityTests` — 2 new cases: a delta records the `sourceDocGuid` it was sent with, and a delta without one still applies, landing under the placeholder (back-compat with an older plugin).

## Build / test status

- `dotnet build Planscape.Server/src/Planscape.API/Planscape.API.csproj` → **0 errors** (8 warnings, all pre-existing NU1603 OpenTelemetry version-resolution notices).
- `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings** (Windows + Revit 2025 + .NET 8).
- Full server suite: **776 passed, 15 skipped, 1 failed** — `LiveKitRoomServiceTests.Real_LiveKit_accepts_the_room_admin_grant`, a `[SkippableFact]` integration test that needs the docker-compose LiveKit on :7880, which is not running on this box. Nothing in this diff touches LiveKit.
- Targeted: `ModelLifecycleTests` + `FederatedDeltaReliabilityTests` → **22 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)