### PR TITLE
Collapse the duplicate IsConfirmed check in AutoAlignService

### DIFF
--- a/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/AutoAlignService.cs
@@ -197,15 +197,6 @@ public sealed class AutoAlignService : IAutoAlignService
             SourceLabel   : "auto-align",
             MapConversionScale: targetReport.MapConversionScale);
 
-        // Read the pre-existing row BEFORE the write so a confirmed transform
-        // can be reported back to the caller rather than silently skipped.
-        var existing = await _db.Set<ProjectModelTransform>().AsNoTracking()
-            .FirstOrDefaultAsync(
-                t => t.ProjectModelId == targetModelId
-                  && t.ProjectId      == projectId
-                  && t.TenantId       == tenantId,
-                ct);
-
         // The writer owns the arithmetic and hands back what it computed —
         // including when it REFUSES to write, so a refusal can still tell the
         // coordinator what the survey data says. Recomputing it here is exactly
@@ -227,15 +218,21 @@ public sealed class AutoAlignService : IAutoAlignService
         // auto-align run silently destroyed the confirmed alignment and the
         // coordinator's only signal was the model jumping.
         //
+        // The rule itself lives in ModelGeorefWriter — the write it refused is
+        // the authority on whether it was refused, so this branch reads the
+        // writer's answer instead of re-reading the row and re-testing
+        // IsConfirmed. Two copies of a precedence rule is how they drift, and
+        // the drifted half here would be the one that overwrites.
+        //
         // Unlike the ingest path, which skips quietly because it is a side
         // effect of an upload, this one is an explicit user action: report the
         // refusal, so the coordinator can decide deliberately (delete the
         // transform, or PUT a new one).
-        if (existing is { IsConfirmed: true })
+        if (write.RefusedAsConfirmed)
         {
             _logger.LogInformation(
                 "AutoAlign skipped for model {ModelId}: an existing transform is manually confirmed (confirmed by {AppliedBy} at {AppliedAt}).",
-                targetModelId, existing.AppliedBy ?? "unknown", existing.AppliedAt);
+                targetModelId, write.ConfirmedBy ?? "unknown", write.ConfirmedAt);
 
             return new AutoAlignResult(
                 Success         : false,

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/ModelGeorefWriter.cs
@@ -70,7 +70,17 @@ public sealed record GeorefWriteResult(
     double TranslationZMm,
     double RotationDeg,
     double ScaleFactor,
-    string FrameSource)
+    string FrameSource,
+    // Why the write was refused, for the one caller that has to tell a human.
+    //
+    // Written=false has two causes — no survey origin, and a coordinator-
+    // confirmed transform — and only the second is something to report back.
+    // Saying which one it was here is what lets a caller act on the precedence
+    // rule without re-reading the row and re-implementing the test; two copies
+    // of that rule is exactly the drift this writer was centralised to remove.
+    bool RefusedAsConfirmed = false,
+    string? ConfirmedBy = null,
+    DateTime? ConfirmedAt = null)
 {
     public static GeorefWriteResult Nothing(TransformConfidence confidence = TransformConfidence.None)
         => new(confidence, false, 0, 0, 0, 0, 1.0, "none");
@@ -227,10 +237,14 @@ public sealed class ModelGeorefWriter : IModelGeorefWriter
             // A coordinator has asserted this alignment against evidence the
             // survey data does not carry. An automatic writer never overrules it.
             _logger.LogInformation(
-                "Georef for model {ModelId}: skipped — an existing transform is manually confirmed.",
-                projectModelId);
+                "Georef for model {ModelId}: skipped — an existing transform is manually confirmed "
+                + "(confirmed by {AppliedBy} at {AppliedAt}).",
+                projectModelId, existing.AppliedBy ?? "unknown", existing.AppliedAt);
             return new GeorefWriteResult(confidence, Written: false,
-                txMm, tyMm, tzMm, rotationDeg, scaleFactor, frame.Source);
+                txMm, tyMm, tzMm, rotationDeg, scaleFactor, frame.Source,
+                RefusedAsConfirmed: true,
+                ConfirmedBy: existing.AppliedBy,
+                ConfirmedAt: existing.AppliedAt);
         }
 
         if (existing == null)

--- a/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ModelGeorefWriterTests.cs
@@ -249,6 +249,59 @@ public class ModelGeorefWriterTests
     }
 
     [Fact]
+    public async Task A_confirmed_refusal_says_so_and_names_who_confirmed_it()
+    {
+        // The result has to distinguish the two ways a write can be refused, or
+        // a caller can only infer the reason from Written=false — and that
+        // inference is wrong for the no-survey-origin case. AutoAlignService is
+        // the caller that has to tell a human WHY, and this is what lets it do
+        // that without re-reading the row and re-testing IsConfirmed itself.
+        var confirmedAt = new DateTime(2026, 3, 4, 9, 30, 0, DateTimeKind.Utc);
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            using (var seed = NewContext(w.Conn, w.Tenant))
+            {
+                seed.ProjectModelTransforms.Add(new ProjectModelTransform
+                {
+                    TenantId = w.Tenant, ProjectId = w.Project, ProjectModelId = w.Model,
+                    IsConfirmed = true,
+                    AppliedBy = "coordinator@example.com", AppliedAt = confirmedAt,
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var write = await NewWriter(w).WriteAsync(
+                w.Project, w.Model, w.Tenant, RevitGeoref(), "PASS");
+
+            Assert.False(write.Written);
+            Assert.True(write.RefusedAsConfirmed);
+            Assert.Equal("coordinator@example.com", write.ConfirmedBy);
+            Assert.Equal(confirmedAt, write.ConfirmedAt);
+            // Still reports what it WOULD have written, so the refusal is useful.
+            Assert.Equal(432_000_000.0, write.TranslationXMm, 3);
+        }
+    }
+
+    [Fact]
+    public async Task A_refusal_for_want_of_a_survey_origin_is_not_a_confirmed_refusal()
+    {
+        // The distinction that makes `!Written` an unsafe proxy for "confirmed":
+        // both refusals share Written=false, and reporting this one as "manually
+        // confirmed by a coordinator" would be a confident wrong answer.
+        var w = NewWorld();
+        using (w.Conn)
+        {
+            var georef = RevitGeoref() with { EastingM = null, NorthingM = null };
+            var write = await NewWriter(w).WriteAsync(w.Project, w.Model, w.Tenant, georef, "PASS");
+
+            Assert.False(write.Written);
+            Assert.False(write.RefusedAsConfirmed);
+            Assert.Null(write.ConfirmedBy);
+        }
+    }
+
+    [Fact]
     public async Task Re_publishing_updates_the_existing_transform_rather_than_duplicating_it()
     {
         // ProjectModelTransform has a UNIQUE index on ProjectModelId — a second


### PR DESCRIPTION
Follow-up #3 (the optional cleanup) from the federation review. **Based on the stack tip `claude/federation-converter-status`**; retarget to `main` once the stack merges.

## What was there

`AutoAlignService.ComputeAsync` read the `ProjectModelTransform` row a second time — its own `AsNoTracking` query — purely to re-test `IsConfirmed` and build a refusal message, *after* `ModelGeorefWriter.WriteAsync` had already applied the same rule and returned a `GeorefWriteResult`. One extra query per auto-align run, and a second copy of a precedence rule that `ModelGeorefWriter` was centralised to hold exactly once. Copies drift, and the half that drifts here is the one that overwrites a coordinator's hand-set alignment.

## Why it isn't just `!write.Written`

The brief suggested driving the branch off the writer's result. Checking that against the code first: **`Written == false` has two causes** —

1. `!georef.HasSurveyOrigin` → `GeorefWriteResult.Nothing()`;
2. an existing transform with `IsConfirmed == true`.

Only the second is something to report to a human. Reporting the first as "manually confirmed by a coordinator" would be a confident wrong answer, and knowing case 1 can't reach the writer from here depends on a guard ~150 lines earlier in `ComputeAsync` — exactly the implicit coupling this change is meant to remove.

The deleted read also supplied `AppliedBy` / `AppliedAt` for the log line ("confirmed by X at Y"), which a bare `Written` flag cannot replace.

So instead of inferring the reason, **the writer states it**: `GeorefWriteResult` gains `RefusedAsConfirmed`, `ConfirmedBy` and `ConfirmedAt`, set at the confirmed-refusal return. All three are optional record parameters with defaults, so the other construction sites (`Nothing()`, the success return) are untouched. `ModelGeorefWriter`'s own log line gains the same attribution it was previously logging without.

Net: one fewer query, one copy of the rule, and the log keeps the detail a coordinator needs to act on the refusal.

## Tests

`ModelGeorefWriterTests` — 2 new cases:

- `A_confirmed_refusal_says_so_and_names_who_confirmed_it` — `RefusedAsConfirmed` true, `ConfirmedBy` / `ConfirmedAt` populated, and the result still carries what auto-align *would* have applied.
- `A_refusal_for_want_of_a_survey_origin_is_not_a_confirmed_refusal` — the distinction that makes `!Written` an unsafe proxy.

The existing `AutoAlignConfirmedTransformTests` (6 cases incl. a `[Theory]`) are **unchanged and still pass** — behaviour is identical, only the derivation moved.

## Build / test status

- `dotnet build Planscape.Server/src/Planscape.API/Planscape.API.csproj` → **0 errors** (8 warnings, all pre-existing NU1603 OpenTelemetry version-resolution notices).
- Full server suite: **772 passed, 15 skipped, 0 failed**.
- Targeted (`ModelGeorefWriterTests` + `AutoAlign*` + `FederationFrameTests` + `ModelTransformMathTests`): **30 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)