### PR TITLE
fix(mobile): send geofence coordinates where the server reads them

### DIFF
--- a/Planscape/package.json
+++ b/Planscape/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "main": "expo-router/entry",
   "scripts": {
-    "_doc": "Phase 184l \u2014 `predev`/`preandroid`/`preios` automatically run `npm install` when the lockfile changes (no-op when already in sync). Avoids the \"forgot to install the new dep\" trap after pulling a branch.",
-    "ensure-deps": "node -e \"const fs=require('fs');const p=require('path');const pkgMtime=fs.statSync('package.json').mtimeMs;const nm='node_modules/.package-lock.json';const stale=!fs.existsSync(nm)||fs.statSync(nm).mtimeMs<pkgMtime;if(stale){console.log('Dependencies out of date \u2014 running npm install...');require('child_process').execSync('npm install --no-audit --prefer-offline',{stdio:'inherit'});}else{console.log('Dependencies in sync.');}\"",
+    "_doc": "Phase 184l — `predev`/`preandroid`/`preios` automatically run `npm install` when the lockfile changes (no-op when already in sync). Avoids the \"forgot to install the new dep\" trap after pulling a branch.",
+    "ensure-deps": "node -e \"const fs=require('fs');const p=require('path');const pkgMtime=fs.statSync('package.json').mtimeMs;const nm='node_modules/.package-lock.json';const stale=!fs.existsSync(nm)||fs.statSync(nm).mtimeMs<pkgMtime;if(stale){console.log('Dependencies out of date — running npm install...');require('child_process').execSync('npm install --no-audit --prefer-offline',{stdio:'inherit'});}else{console.log('Dependencies in sync.');}\"",
     "prestart": "npm run ensure-deps",
     "preandroid": "npm run ensure-deps",
     "preios": "npm run ensure-deps",
@@ -19,7 +19,8 @@
     "test:queue": "node --experimental-transform-types tests/offlineQueue.terminal.test.mjs",
     "test:lint-rule": "node tests/lintRule.test.mjs",
     "test:forbidden": "node --experimental-transform-types tests/forbidden.states.test.mjs",
-    "test": "npm run test:queue && npm run test:lint-rule && npm run test:forbidden && npm run typecheck"
+    "test": "npm run test:queue && npm run test:lint-rule && npm run test:forbidden && npm run test:geofence && npm run typecheck",
+    "test:geofence": "node --experimental-transform-types tests/geofenceHeaders.test.mjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",

--- a/Planscape/src/api/endpoints.ts
+++ b/Planscape/src/api/endpoints.ts
@@ -204,10 +204,32 @@ export function createIssue(
   // idempotencyKey (offline-replay dedupe) travels as a header, not a body
   // field — the server dedupes on X-Idempotency-Key per (tenant, endpoint).
   const { idempotencyKey, ...body } = issue;
+
+  // #632 — GEOFENCE COORDINATES MUST ALSO TRAVEL AS HEADERS.
+  //
+  // The server never reads coordinates from the body. MobileContextMiddleware
+  // lifts X-Latitude / X-Longitude into HttpContext.Items, and
+  // IssuesController reads Items["Latitude"] for the boundary check. Sending
+  // them only in the body meant the server saw NO coordinates at all, so on a
+  // geofenced project every create was refused with
+  //   400 "Geofence enforcement is active. Location coordinates are required."
+  // — including for a user standing in the middle of the site. The real
+  // "outside the boundary" 403 was unreachable from mobile.
+  //
+  // They stay in the body as well: that is where the issue's own stored
+  // latitude/longitude come from. This is additive — nothing that worked
+  // before changes.
+  const headers: Record<string, string> = {};
+  if (idempotencyKey) headers['X-Idempotency-Key'] = idempotencyKey;
+  if (Number.isFinite(issue.latitude as number) && Number.isFinite(issue.longitude as number)) {
+    headers['X-Latitude'] = String(issue.latitude);
+    headers['X-Longitude'] = String(issue.longitude);
+  }
+
   return apiFetch(`/api/projects/${projectId}/issues`, {
     method: 'POST',
     body: JSON.stringify(body),
-    headers: idempotencyKey ? { 'X-Idempotency-Key': idempotencyKey } : undefined,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
   });
 }
 

--- a/Planscape/tests/geofenceHeaders.test.mjs
+++ b/Planscape/tests/geofenceHeaders.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * createIssue must send geofence coordinates where the server READS them.
+ *
+ * Regression cover for #632. Mobile put latitude/longitude in the request
+ * BODY. The server never looks there: MobileContextMiddleware lifts the
+ * X-Latitude / X-Longitude HEADERS into HttpContext.Items, and
+ * IssuesController reads Items["Latitude"] for the boundary check.
+ *
+ * The consequence was not a subtle one. On a geofenced project the server saw
+ * no coordinates at all, so EVERY create was refused with
+ *   400 "Geofence enforcement is active. Location coordinates are required."
+ * including for a user standing in the middle of the site — and the genuine
+ * "outside the boundary" 403 was unreachable from mobile entirely.
+ *
+ * Run: npm run test:geofence
+ */
+
+import assert from 'node:assert/strict';
+import './register.mjs';
+
+const captured = [];
+globalThis.fetch = async (url, init = {}) => {
+  const h = {};
+  const raw = init.headers ?? {};
+  if (typeof raw?.forEach === 'function') raw.forEach((v, k) => { h[String(k).toLowerCase()] = v; });
+  else for (const [k, v] of Object.entries(raw)) h[String(k).toLowerCase()] = v;
+  captured.push({ url: String(url), headers: h, body: init.body ? JSON.parse(init.body) : undefined });
+  return { ok: true, status: 200, headers: new Map(), json: async () => ({ id: 'issue-1' }), text: async () => '{}' };
+};
+
+const { createIssue } = await import('../src/api/endpoints.ts');
+
+// ── 1. coordinates present -> headers sent, body unchanged ──────────────────
+captured.length = 0;
+await createIssue('p1', { title: 'Cracked slab', latitude: 0.3136, longitude: 32.5811 });
+const withGps = captured.at(-1);
+
+assert.equal(withGps.headers['x-latitude'], '0.3136',
+  'X-Latitude header missing — the server reads coordinates from headers, not the body (#632)');
+assert.equal(withGps.headers['x-longitude'], '32.5811',
+  'X-Longitude header missing — see #632');
+
+// They must ALSO stay in the body: that is where the stored issue coordinates
+// come from. The fix is additive; removing them would break persistence.
+assert.equal(withGps.body.latitude, 0.3136, 'latitude must remain in the body for storage');
+assert.equal(withGps.body.longitude, 32.5811, 'longitude must remain in the body for storage');
+
+// ── 2. no coordinates -> no coordinate headers, and no crash ────────────────
+captured.length = 0;
+await createIssue('p1', { title: 'No GPS available' });
+const noGps = captured.at(-1);
+assert.equal(noGps.headers['x-latitude'], undefined, 'must not invent a coordinate header');
+assert.equal(noGps.headers['x-longitude'], undefined, 'must not invent a coordinate header');
+
+// ── 3. a non-finite reading must not be sent as the string "NaN" ────────────
+// The server parses these as doubles; "NaN" would either throw or be read as a
+// real position. Absent beats wrong.
+captured.length = 0;
+await createIssue('p1', { title: 'Bad fix', latitude: Number.NaN, longitude: 32.5811 });
+const badGps = captured.at(-1);
+assert.equal(badGps.headers['x-latitude'], undefined, 'NaN must not be stringified into a header');
+assert.equal(badGps.headers['x-longitude'], undefined, 'a partial fix must not be sent as a position');
+
+// ── 4. the idempotency header still works alongside ─────────────────────────
+captured.length = 0;
+await createIssue('p1', { title: 'Replayed', latitude: 1, longitude: 2, idempotencyKey: 'k-1' });
+const both = captured.at(-1);
+assert.equal(both.headers['x-idempotency-key'], 'k-1', 'idempotency header regressed');
+assert.equal(both.headers['x-latitude'], '1', 'coordinate header lost when idempotencyKey present');
+assert.equal(both.body.idempotencyKey, undefined, 'idempotencyKey must not leak into the body');
+
+console.log('geofenceHeaders: 11 assertions passed');


### PR DESCRIPTION
Closes #632.

## The mismatch

| | |
|---|---|
| mobile `createIssue` | puts `latitude`/`longitude` in the **body** |
| `MobileContextMiddleware:18-22` | reads the **`X-Latitude`/`X-Longitude` headers** |
| `IssuesController:241-243` | reads `HttpContext.Items["Latitude"]` |

The body is never consulted for the boundary check.

## What that did

On a geofenced project the server saw **no coordinates at all**, so every create was refused with `400 "Geofence enforcement is active. Location coordinates are required."` — including for a user standing in the middle of the site. The genuine *outside the boundary* 403 was **unreachable from mobile**.

Geofencing was failing **closed**, not open, which is why it read as a bug rather than a security gap and went unreported.

## The pattern already existed twenty lines away

The photo-capture call in this same file sends `X-Latitude`/`X-Longitude` and documents that it does. `createIssue` didn't follow it.

## Additive by design

Coordinates **stay in the body** — that's where the issue's stored latitude/longitude come from — and are now *also* lifted into headers, exactly as `idempotencyKey` already was in this function. Nothing that worked before changes.

Guarded with `Number.isFinite` rather than a presence check: the server parses these as doubles, and a `NaN` stringified to `"NaN"` would either throw or be read as a real position. **Absent beats wrong.**

## Verification

- 11 assertions, **RED proven** by removing the lift — fails on the `X-Latitude` assertion by name.
- Typecheck **0 errors**.
- Covers: coordinates present, absent, `NaN`, and coexisting with `idempotencyKey`.
- **Not** exercised against a geofenced project on a device — no emulator here — so #632's end-to-end claim stays open.