### PR TITLE
Quantify site tools from gang sizes

### DIFF
--- a/StingTools.Boq.Tests/ShippedDataIntegrityTests.cs
+++ b/StingTools.Boq.Tests/ShippedDataIntegrityTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
@@ -101,9 +102,20 @@ namespace StingTools.Boq.Tests
             var rates = CommodityRateResolver.ParseCsv(
                 File.ReadAllLines(DataFile("STING_COMMODITY_RATES.csv")), out _);
 
+            // A rate is legitimate if SOMETHING can produce it. Site tools are
+            // priced but never unit-converted, so they are reachable through the
+            // tools library rather than the supplier-unit table. The invariant is
+            // "no unreachable rate", not "every rate is a converted commodity".
+            var tools = JsonConvert.DeserializeObject<SiteToolsLibrary>(
+                File.ReadAllText(DataFile("STING_SITE_TOOLS.json")));
+            var toolKeys = new HashSet<string>(tools.Rules.Select(r => r.ToolKey),
+                                               StringComparer.OrdinalIgnoreCase);
+
             foreach (var rate in rates)
-                Assert.True(table.ResolveByCommodityKey(rate.CommodityKey) != null,
-                    $"rate '{rate.CommodityKey}' has no supplier-unit rule — nothing can ever produce it");
+                Assert.True(table.ResolveByCommodityKey(rate.CommodityKey) != null
+                            || toolKeys.Contains(rate.CommodityKey),
+                    $"rate '{rate.CommodityKey}' is reachable by neither a supplier-unit "
+                    + "rule nor a tool rule — nothing can ever produce it");
         }
     }
 }

--- a/StingTools.Boq.Tests/SiteToolsTests.cs
+++ b/StingTools.Boq.Tests/SiteToolsTests.cs
@@ -1,0 +1,202 @@
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED-9 — site tools.
+    ///
+    /// HONESTY FIRST: there is no published standard for this. NRM2 puts tools
+    /// and plant in PRELIMINARIES, priced as a lump or a percentage — there is no
+    /// "wheelbarrows per mason" rule anywhere in the measurement standards. What
+    /// follows is East African contractor practice, expressed as an editable
+    /// table and calibrated against the PATMAC reference sample. It must never be
+    /// presented as a code-derived figure.
+    ///
+    /// The chain is work → trade-days → gang → tools. Every step is measured or
+    /// declared; nothing is a magic constant in code.
+    /// </summary>
+    public class SiteToolsTests
+    {
+        private static SiteToolsInput Patmac() => new SiteToolsInput
+        {
+            // Roughly the PATMAC mall: ~2,000 m² of walling, a modest frame,
+            // built over a 6-month programme.
+            BlockworkM2 = 2000,
+            RebarKg = 12000,
+            FormworkM2 = 900,
+            ConcreteM3 = 160,
+            DurationDays = 180,
+            Storeys = 3
+        };
+
+        // ── gangs ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Gang_Sizes_Come_From_Work_Divided_By_Productivity_And_Time()
+        {
+            // 2,000 m² ÷ 8 m² per mason-day = 250 mason-days.
+            // Walling runs over 40% of a 180-day programme = 72 days.
+            // 250 ÷ 72 = 3.47 → 4 masons.
+            var g = SiteToolsCalculator.DeriveGangs(Patmac(), TradeRates.Default());
+
+            Assert.Equal(4, g.Masons);
+            Assert.Equal(6, g.Helpers);       // 4 × 1.5
+        }
+
+        [Fact]
+        public void A_Longer_Programme_Needs_A_Smaller_Gang()
+        {
+            var slow = Patmac();
+            slow.DurationDays = 360;
+
+            var fast = SiteToolsCalculator.DeriveGangs(Patmac(), TradeRates.Default());
+            var slower = SiteToolsCalculator.DeriveGangs(slow, TradeRates.Default());
+
+            Assert.True(slower.Masons < fast.Masons,
+                $"360 days should need fewer masons than 180: {slower.Masons} vs {fast.Masons}");
+        }
+
+        [Fact]
+        public void A_Project_With_No_Programme_Cannot_Guess_A_Gang()
+        {
+            // Duration is the denominator. Without it the whole model is
+            // meaningless, so it reports nothing rather than inventing a crew.
+            var noDuration = Patmac();
+            noDuration.DurationDays = 0;
+
+            var g = SiteToolsCalculator.DeriveGangs(noDuration, TradeRates.Default());
+
+            Assert.False(g.IsUsable);
+            Assert.Equal(0, g.Masons);
+        }
+
+        [Fact]
+        public void No_Measured_Work_Means_No_Gang_For_That_Trade()
+        {
+            var noSteel = Patmac();
+            noSteel.RebarKg = 0;
+
+            Assert.Equal(0, SiteToolsCalculator.DeriveGangs(noSteel, TradeRates.Default()).BarBenders);
+        }
+
+        // ── tools ───────────────────────────────────────────────────────────
+
+        private static ToolRule Rule(string key, string driver, double per, double fixedQty = 0, double min = 0)
+            => new ToolRule
+            {
+                ToolKey = key, Description = key, SupplierUnit = "No.",
+                Driver = driver, PerDriver = per, FixedQuantity = fixedQty, Minimum = min
+            };
+
+        [Fact]
+        public void A_Per_Helper_Tool_Scales_With_The_Helper_Gang()
+        {
+            var g = new GangSizes { Helpers = 6, IsUsable = true };
+            var tools = SiteToolsCalculator.Quantify(g, new[] { Rule("spade", "helpers", 1.0) }, storeys: 1);
+
+            Assert.Equal(6, tools.Single().Quantity);
+        }
+
+        [Fact]
+        public void A_Shared_Tool_Rounds_Up_So_Nobody_Waits()
+        {
+            // One barrow per three helpers: 6 helpers → 2. A part barrow is not
+            // a thing, and rounding down leaves a labourer idle.
+            var g = new GangSizes { Helpers = 7, IsUsable = true };
+            var tools = SiteToolsCalculator.Quantify(g, new[] { Rule("wheelbarrow", "helpers", 1.0 / 3.0) }, storeys: 1);
+
+            Assert.Equal(3, tools.Single().Quantity);   // ceil(7/3)
+        }
+
+        [Fact]
+        public void A_Fixed_Site_Tool_Does_Not_Scale()
+        {
+            var g = new GangSizes { Helpers = 40, IsUsable = true };
+            var tools = SiteToolsCalculator.Quantify(g, new[] { Rule("sledge", "site", 0, fixedQty: 1) }, storeys: 1);
+
+            Assert.Equal(1, tools.Single().Quantity);
+        }
+
+        [Fact]
+        public void A_Storey_Driven_Tool_Follows_The_Building()
+        {
+            // One water tank, plus one per storey above the second.
+            var g = new GangSizes { Helpers = 6, IsUsable = true };
+            var rule = Rule("water-tank", "storeys", 1.0, fixedQty: 1);
+
+            // 1 storey → just the base tank. 3 storeys → base + 1 for the storey
+            // above the second. My first version of this test asserted 2 and 4,
+            // which contradicted the sentence above it.
+            Assert.Equal(1, SiteToolsCalculator.Quantify(g, new[] { rule }, storeys: 1).Single().Quantity);
+            Assert.Equal(2, SiteToolsCalculator.Quantify(g, new[] { rule }, storeys: 3).Single().Quantity);
+        }
+
+        [Fact]
+        public void A_Minimum_Applies_Even_To_A_Tiny_Gang()
+        {
+            var g = new GangSizes { Helpers = 1, IsUsable = true };
+            var tools = SiteToolsCalculator.Quantify(g, new[] { Rule("spade", "helpers", 1.0, min: 4) }, storeys: 1);
+
+            Assert.Equal(4, tools.Single().Quantity);
+        }
+
+        [Fact]
+        public void A_Tool_Whose_Driver_Is_Absent_Is_Not_Ordered()
+        {
+            // No steel on site means no bar-bending gang, so no hacksaws.
+            var g = new GangSizes { Helpers = 6, BarBenders = 0, IsUsable = true };
+            var tools = SiteToolsCalculator.Quantify(g, new[] { Rule("hacksaw", "barbenders", 0.5) }, storeys: 1);
+
+            Assert.Empty(tools);
+        }
+
+        [Fact]
+        public void An_Unusable_Gang_Produces_No_Tools_At_All()
+        {
+            var tools = SiteToolsCalculator.Quantify(new GangSizes { IsUsable = false },
+                new[] { Rule("spade", "helpers", 1.0, fixedQty: 2) }, storeys: 3);
+
+            Assert.Empty(tools);
+        }
+
+        // ── calibration against the reference sample ────────────────────────
+
+        [Fact]
+        public void The_Shipped_Rules_Reproduce_The_Reference_Sample_Within_Reason()
+        {
+            // The PATMAC schedule listed 4 wheelbarrows, 8 spades, 10 jerrycans
+            // and 3 water tanks. These are practice heuristics, not a standard,
+            // so the test allows a sensible band rather than pretending to an
+            // exactness nobody can justify — but a model that produced 1 barrow
+            // or 40 spades would be wrong and this catches it.
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<SiteToolsLibrary>(
+                System.IO.File.ReadAllText(System.IO.Path.Combine(
+                    System.AppContext.BaseDirectory, "Data", "STING_SITE_TOOLS.json")));
+
+            var gangs = SiteToolsCalculator.DeriveGangs(Patmac(), lib.TradeRates);
+            var tools = SiteToolsCalculator.Quantify(gangs, lib.Rules, Patmac().Storeys);
+
+            double Q(string key) => tools.FirstOrDefault(t => t.ToolKey == key)?.Quantity ?? 0;
+
+            Assert.InRange(Q("wheelbarrow"), 2, 6);
+            Assert.InRange(Q("spade"), 5, 12);
+            Assert.InRange(Q("jerrycan"), 5, 14);
+            Assert.InRange(Q("water-tank"), 2, 5);
+            Assert.InRange(Q("sledge-hammer"), 1, 2);
+        }
+
+        [Fact]
+        public void Every_Shipped_Rule_Names_A_Driver_The_Calculator_Understands()
+        {
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<SiteToolsLibrary>(
+                System.IO.File.ReadAllText(System.IO.Path.Combine(
+                    System.AppContext.BaseDirectory, "Data", "STING_SITE_TOOLS.json")));
+
+            foreach (var r in lib.Rules)
+                Assert.True(SiteToolsCalculator.IsKnownDriver(r.Driver),
+                    $"tool '{r.ToolKey}' names unknown driver '{r.Driver}' — it would silently never be ordered");
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\CommodityAggregator.cs" Link="MaterialSchedule\CommodityAggregator.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\Reconciler.cs" Link="MaterialSchedule\Reconciler.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ManualRowPlacer.cs" Link="MaterialSchedule\ManualRowPlacer.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\SiteToolsCalculator.cs" Link="MaterialSchedule\SiteToolsCalculator.cs" />
     <Compile Include="..\StingTools\Core\ExportRouteMerge.cs" Link="ExportRouteMerge.cs" />
   </ItemGroup>
 
@@ -70,6 +71,9 @@
     </None>
     <!-- MAT-SCHED — the shipped stage library; unique orders and single-routing
          kinds are what keep body and summary in step. -->
+    <None Include="..\StingTools\Data\STING_SITE_TOOLS.json" Link="Data\STING_SITE_TOOLS.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="..\StingTools\Data\STING_MATERIAL_STAGES.json" Link="Data\STING_MATERIAL_STAGES.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -31,6 +31,10 @@ namespace StingTools.BOQ.MaterialSchedule
 
     internal static class MaterialScheduleBuilder
     {
+        /// <summary>Programme length for the tools model. 0 = not stated; the
+        /// command asks the user rather than the builder guessing.</summary>
+        public static int DurationDaysOverride;
+
         public static MaterialScheduleBuildResult Build(Document doc, MaterialScheduleOptions options)
         {
             var result = new MaterialScheduleBuildResult();
@@ -76,6 +80,7 @@ namespace StingTools.BOQ.MaterialSchedule
             msDoc.ProjectCode = doc.ProjectInformation?.Number ?? "";
 
             AppendManualRows(doc, msDoc, boq, lib.Stages, result);
+            AppendSiteTools(doc, msDoc, lib, inputs.Rates, result);
             Reconciler.Check(msDoc);
 
             result.Document = msDoc;
@@ -99,6 +104,96 @@ namespace StingTools.BOQ.MaterialSchedule
                         + $"{msDoc.Stages.Sum(s => s.Commodities.Count)} commodity row(s), "
                         + $"{msDoc.Reconciliation.Issues.Count} reconciliation issue(s).");
             return result;
+        }
+
+        /// <summary>
+        /// MATSCHED-9 — site tools, derived from the gang sizes the measured work
+        /// implies. Needs a programme duration: without one there is no
+        /// denominator, so nothing is produced and the reason is reported.
+        /// </summary>
+        private static void AppendSiteTools(Document doc, MaterialScheduleDocument msDoc,
+            StageLibrary lib, CommodityRateResolver rates, MaterialScheduleBuildResult result)
+        {
+            try
+            {
+                int days = DurationDaysOverride > 0
+                    ? DurationDaysOverride
+                    : SiteToolsGatherer.ReadDurationDays(doc);
+                if (days <= 0)
+                {
+                    result.Warnings.Add(
+                        "Site tools omitted: no programme duration. Set "
+                      + $"{SiteToolsGatherer.DurationParam} on Project Information, or enter it when "
+                      + "prompted. Gang sizes divide by the programme, so without it every tool "
+                      + "quantity would be invented.");
+                    return;
+                }
+
+                var toolLib = LoadTools(doc);
+                if (toolLib?.Rules == null || toolLib.Rules.Count == 0) return;
+
+                int storeys = SiteToolsGatherer.CountStoreys(doc);
+                var input = SiteToolsGatherer.FromDocument(msDoc, days, storeys);
+                var gangs = SiteToolsCalculator.DeriveGangs(input, toolLib.TradeRates);
+                var tools = SiteToolsCalculator.Quantify(gangs, toolLib.Rules, storeys);
+                if (tools.Count == 0) return;
+
+                var def = lib.Stages.FirstOrDefault(d =>
+                    string.Equals(d.StageId, "tools", StringComparison.OrdinalIgnoreCase));
+                var section = new StageSection
+                {
+                    StageId = "tools",
+                    Title = def?.Title ?? "TOOLS AND EQUIPMENT",
+                    Preamble = def?.Preamble ?? "Site establishment tools and small plant."
+                };
+
+                foreach (var t in tools)
+                {
+                    var rate = rates?.Resolve(t.ToolKey)
+                               ?? new CommodityRate { RateUGX = 0, Source = "unpriced" };
+                    section.Commodities.Add(new MaterialCommodity
+                    {
+                        CommodityKey = t.ToolKey,
+                        Description = t.Description,
+                        SupplierUnit = t.SupplierUnit,
+                        NetQuantity = t.Quantity,
+                        OrderQuantity = t.Quantity,
+                        RateUGX = rate.RateUGX,
+                        RateSource = rate.Source
+                    });
+                }
+
+                ManualRowPlacer.InsertByDefinitionOrder(msDoc.Stages, lib.Stages, section);
+                StageMapper.AssignLetters(msDoc.Stages);
+
+                result.Warnings.Add(
+                    $"Site tools estimated from a {days}-day programme and {storeys} storey(s): "
+                  + $"{gangs.Masons} mason(s), {gangs.Helpers} helper(s), {gangs.BarBenders} bar-bender(s), "
+                  + $"{gangs.Carpenters} carpenter(s). These are PRACTICE HEURISTICS, not a standard "
+                  + "— NRM2 prices tools in preliminaries. Review before issue.");
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"MaterialScheduleBuilder.AppendSiteTools: {ex.Message}");
+                result.Warnings.Add($"Site tools could not be estimated: {ex.Message}");
+            }
+        }
+
+        private static SiteToolsLibrary LoadTools(Document doc)
+        {
+            var libr = ReadJson<SiteToolsLibrary>(StingToolsApp.FindDataFile("STING_SITE_TOOLS.json"))
+                       ?? new SiteToolsLibrary();
+            var over = ReadJson<SiteToolsLibrary>(StingPaths.MetaFile(doc, "_BIM_COORD", "site_tools.json"));
+            if (over != null)
+            {
+                if (over.TradeRates != null) libr.TradeRates = over.TradeRates;
+                foreach (var r in over.Rules ?? new List<ToolRule>())
+                {
+                    libr.Rules.RemoveAll(x => string.Equals(x.ToolKey, r.ToolKey, StringComparison.OrdinalIgnoreCase));
+                    libr.Rules.Add(r);
+                }
+            }
+            return libr;
         }
 
         /// <summary>

--- a/StingTools/BOQ/MaterialSchedule/SiteToolsGatherer.cs
+++ b/StingTools/BOQ/MaterialSchedule/SiteToolsGatherer.cs
@@ -1,0 +1,93 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SiteToolsGatherer.cs — MAT-SCHED-9 Revit-side inputs for the tools model.
+//
+//  Two facts the model cannot measure: how long the job runs, and how many
+//  storeys it has. Duration comes from a ProjectInformation parameter, storeys
+//  are counted from the model's own Levels, and the command prompts when the
+//  duration is missing rather than guessing one.
+//
+//  Duration is the denominator of every gang size. Defaulting it would produce
+//  a confident tool list for a programme nobody stated, so a missing duration
+//  yields NOTHING and says so.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+using StingTools.Core.MaterialSchedule;
+
+namespace StingTools.BOQ.MaterialSchedule
+{
+    internal static class SiteToolsGatherer
+    {
+        /// <summary>The ProjectInformation parameter carrying programme length.</summary>
+        public const string DurationParam = "PRJ_DURATION_DAYS";
+
+        /// <summary>Programme length in days from ProjectInformation, or 0 when
+        /// absent/unparseable — the caller then asks the user.</summary>
+        public static int ReadDurationDays(Document doc)
+        {
+            try
+            {
+                var pi = doc?.ProjectInformation;
+                if (pi == null) return 0;
+                var p = pi.LookupParameter(DurationParam);
+                if (p == null || !p.HasValue) return 0;
+
+                if (p.StorageType == StorageType.Integer) return Math.Max(0, p.AsInteger());
+                if (p.StorageType == StorageType.Double) return (int)Math.Max(0, Math.Round(p.AsDouble()));
+                return int.TryParse((p.AsString() ?? "").Trim(), out int v) ? Math.Max(0, v) : 0;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SiteToolsGatherer.ReadDurationDays: {ex.Message}");
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Storeys counted from the model's own Levels — real data beats a typed
+        /// number. Levels below the project base (basements, and the datum-only
+        /// levels people leave lying around) are excluded, and the count never
+        /// drops below 1.
+        /// </summary>
+        public static int CountStoreys(Document doc)
+        {
+            try
+            {
+                if (doc == null) return 1;
+                int n = new FilteredElementCollector(doc)
+                    .OfClass(typeof(Level)).Cast<Level>()
+                    .Count(l => l != null && l.Elevation > -0.01);
+                return Math.Max(1, n);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"SiteToolsGatherer.CountStoreys: {ex.Message}");
+                return 1;
+            }
+        }
+
+        /// <summary>Measured work for the gang model, taken from the commodities
+        /// the schedule has already produced — so the tools follow the same
+        /// quantities the bill does, not a second parallel take-off.</summary>
+        public static SiteToolsInput FromDocument(MaterialScheduleDocument msDoc,
+                                                  int durationDays, int storeys)
+        {
+            var input = new SiteToolsInput { DurationDays = durationDays, Storeys = storeys };
+            if (msDoc == null) return input;
+
+            double Sum(string key) => msDoc.Stages
+                .SelectMany(s => s.Commodities)
+                .Where(c => string.Equals(c.CommodityKey, key, StringComparison.OrdinalIgnoreCase))
+                .Sum(c => c.OrderQuantity);
+
+            input.BlockworkM2 = Sum("block") / 12.5;      // pieces back to wall area
+            input.BrickworkM2 = Sum("brick") / 60.0;
+            input.RebarKg = Sum("rebar");
+            input.FormworkM2 = Sum("formwork-timber");
+            input.ConcreteM3 = Sum("concrete-ready");
+            return input;
+        }
+    }
+}

--- a/StingTools/Commands/MaterialSchedule/MaterialScheduleCommands.cs
+++ b/StingTools/Commands/MaterialSchedule/MaterialScheduleCommands.cs
@@ -72,6 +72,33 @@ namespace StingTools.Commands.MaterialSchedule
                     forceCompound = cr == TaskDialogResult.CommandLink1;
                 }
 
+                // MATSCHED-9 — the tools model divides by the programme, so a
+                // missing duration means no tools at all. Ask once rather than
+                // silently dropping a section the reference schedule opens with.
+                MaterialScheduleBuilder.DurationDaysOverride = 0;
+                if (SiteToolsGatherer.ReadDurationDays(doc) <= 0)
+                {
+                    var dd = new TaskDialog("Material Schedule — site tools")
+                    {
+                        MainInstruction = "How long is the programme?",
+                        MainContent =
+                            "Site tools are sized from the gangs the measured work implies, and gang "
+                          + "size divides by the programme length. Project Information carries no "
+                          + $"{SiteToolsGatherer.DurationParam}, so pick the nearest below or skip.  "
+                          + "These figures are contractor practice, not a measurement standard — "
+                          + "NRM2 prices tools in preliminaries.",
+                        CommonButtons = TaskDialogCommonButtons.Cancel
+                    };
+                    dd.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "6 months (180 days)");
+                    dd.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "12 months (360 days)");
+                    dd.AddCommandLink(TaskDialogCommandLinkId.CommandLink3, "Skip site tools",
+                        "The schedule is produced without a tools section.");
+                    var dr = dd.Show();
+                    if (dr == TaskDialogResult.Cancel) return Result.Cancelled;
+                    if (dr == TaskDialogResult.CommandLink1) MaterialScheduleBuilder.DurationDaysOverride = 180;
+                    else if (dr == TaskDialogResult.CommandLink2) MaterialScheduleBuilder.DurationDaysOverride = 360;
+                }
+
                 MaterialScheduleBuildResult built;
                 if (forceCompound)
                 {

--- a/StingTools/Core/MaterialSchedule/SiteToolsCalculator.cs
+++ b/StingTools/Core/MaterialSchedule/SiteToolsCalculator.cs
@@ -1,0 +1,194 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SiteToolsCalculator.cs — MAT-SCHED-9 site tools and small plant.
+//
+//  THERE IS NO STANDARD FOR THIS. NRM2 puts tools and plant in PRELIMINARIES,
+//  priced as a lump sum or a percentage of the contract; no measurement
+//  standard publishes a "wheelbarrows per mason" ratio. What follows is East
+//  African contractor practice, expressed as an editable table and calibrated
+//  against the PATMAC reference schedule.
+//
+//  It must never be presented to a client as a code-derived quantity. It is a
+//  defensible starting point that a site manager corrects, which is still far
+//  more useful to them than a percentage.
+//
+//  The chain is:  measured work → trade-days → gang size → tools.
+//  Every step is measured or declared. Nothing is a constant buried in code.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    /// <summary>Measured work and programme facts the gang model needs.</summary>
+    public sealed class SiteToolsInput
+    {
+        public double BlockworkM2;
+        public double BrickworkM2;
+        public double RebarKg;
+        public double FormworkM2;
+        public double ConcreteM3;
+        /// <summary>Programme length. The denominator of the whole model — with
+        /// no duration there is no gang size and nothing is produced.</summary>
+        public int DurationDays;
+        public int Storeys = 1;
+    }
+
+    /// <summary>
+    /// Output rates per trade, and the fraction of the programme each trade
+    /// actually occupies. Walling does not run for the whole job, so dividing
+    /// its work by the full duration would understate the gang.
+    /// </summary>
+    public sealed class TradeRates
+    {
+        public double BlockworkM2PerMasonDay = 8.0;
+        public double RebarKgPerBenderDay = 120.0;
+        public double FormworkM2PerCarpenterDay = 10.0;
+        public double ConcreteM3PerMixerDay = 8.0;
+        public double HelpersPerMason = 1.5;
+
+        public double MasonryPhaseFraction = 0.40;
+        public double SteelPhaseFraction = 0.35;
+        public double FormworkPhaseFraction = 0.35;
+        public double ConcretePhaseFraction = 0.30;
+
+        public static TradeRates Default() => new TradeRates();
+    }
+
+    public sealed class GangSizes
+    {
+        public int Masons;
+        public int Helpers;
+        public int BarBenders;
+        public int Carpenters;
+        public int Mixers;
+        /// <summary>False when there is no programme to divide by.</summary>
+        public bool IsUsable;
+
+        public int Of(string driver)
+        {
+            switch ((driver ?? "").Trim().ToLowerInvariant())
+            {
+                case "masons":     return Masons;
+                case "helpers":    return Helpers;
+                case "barbenders": return BarBenders;
+                case "carpenters": return Carpenters;
+                case "mixers":     return Mixers;
+                default:           return 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One tool rule. Quantity = max(Minimum, FixedQuantity + ceil(driver × PerDriver)).
+    /// A rule whose driver resolves to zero produces nothing — no steel on site
+    /// means no hacksaws.
+    /// </summary>
+    public sealed class ToolRule
+    {
+        public string ToolKey = "";
+        public string Description = "";
+        public string SupplierUnit = "No.";
+        /// <summary>masons / helpers / barbenders / carpenters / mixers / storeys / site</summary>
+        public string Driver = "site";
+        public double PerDriver;
+        public double FixedQuantity;
+        public double Minimum;
+    }
+
+    public sealed class ToolQuantity
+    {
+        public string ToolKey = "";
+        public string Description = "";
+        public string SupplierUnit = "No.";
+        public double Quantity;
+    }
+
+    public sealed class SiteToolsLibrary
+    {
+        public string SchemaVersion = "1.0";
+        public TradeRates TradeRates = new TradeRates();
+        public List<ToolRule> Rules = new List<ToolRule>();
+    }
+
+    public static class SiteToolsCalculator
+    {
+        private static readonly HashSet<string> KnownDrivers =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "masons", "helpers", "barbenders", "carpenters", "mixers", "storeys", "site" };
+
+        public static bool IsKnownDriver(string driver)
+            => !string.IsNullOrWhiteSpace(driver) && KnownDrivers.Contains(driver.Trim());
+
+        /// <summary>
+        /// Gang sizes from work ÷ (output rate × phase duration). Rounded UP: a
+        /// crew of 3.47 masons is 4 people, and rounding down leaves work unbuilt.
+        /// </summary>
+        public static GangSizes DeriveGangs(SiteToolsInput input, TradeRates rates)
+        {
+            var g = new GangSizes();
+            if (input == null || rates == null || input.DurationDays <= 0) return g;
+            g.IsUsable = true;
+
+            int Crew(double work, double perDay, double phaseFraction)
+            {
+                if (work <= 0 || perDay <= 0) return 0;
+                double phaseDays = input.DurationDays * Math.Max(0.01, phaseFraction);
+                double tradeDays = work / perDay;
+                return (int)Math.Ceiling(tradeDays / phaseDays - 1e-9);
+            }
+
+            g.Masons = Crew(input.BlockworkM2 + input.BrickworkM2,
+                            rates.BlockworkM2PerMasonDay, rates.MasonryPhaseFraction);
+            g.BarBenders = Crew(input.RebarKg, rates.RebarKgPerBenderDay, rates.SteelPhaseFraction);
+            g.Carpenters = Crew(input.FormworkM2, rates.FormworkM2PerCarpenterDay, rates.FormworkPhaseFraction);
+            g.Mixers = Crew(input.ConcreteM3, rates.ConcreteM3PerMixerDay, rates.ConcretePhaseFraction);
+
+            // Helpers serve the whole site, so they follow the trades they carry
+            // for — masons above all.
+            g.Helpers = (int)Math.Ceiling(g.Masons * Math.Max(0, rates.HelpersPerMason) - 1e-9);
+            return g;
+        }
+
+        /// <summary>
+        /// Apply the tool rules to a gang. An unusable gang produces NOTHING —
+        /// inventing a tool list without a programme would be a fabricated
+        /// number wearing the costume of a calculation.
+        /// </summary>
+        public static List<ToolQuantity> Quantify(GangSizes gangs, IEnumerable<ToolRule> rules, int storeys)
+        {
+            var outList = new List<ToolQuantity>();
+            if (gangs == null || !gangs.IsUsable || rules == null) return outList;
+
+            foreach (var r in rules)
+            {
+                if (r == null || string.IsNullOrWhiteSpace(r.ToolKey)) continue;
+                string driver = (r.Driver ?? "site").Trim().ToLowerInvariant();
+                if (!KnownDrivers.Contains(driver)) continue;
+
+                double driverValue;
+                if (driver == "site") driverValue = 0;
+                else if (driver == "storeys") driverValue = Math.Max(0, storeys - 2);   // above the 2nd
+                else
+                {
+                    driverValue = gangs.Of(driver);
+                    // A trade that is not on this project orders no tools for it.
+                    if (driverValue <= 0) continue;
+                }
+
+                double qty = r.FixedQuantity + Math.Ceiling(driverValue * r.PerDriver - 1e-9);
+                qty = Math.Max(qty, r.Minimum);
+                if (qty <= 0) continue;
+
+                outList.Add(new ToolQuantity
+                {
+                    ToolKey = r.ToolKey,
+                    Description = string.IsNullOrWhiteSpace(r.Description) ? r.ToolKey : r.Description,
+                    SupplierUnit = string.IsNullOrWhiteSpace(r.SupplierUnit) ? "No." : r.SupplierUnit,
+                    Quantity = qty
+                });
+            }
+            return outList;
+        }
+    }
+}

--- a/StingTools/Data/STING_COMMODITY_RATES.csv
+++ b/StingTools/Data/STING_COMMODITY_RATES.csv
@@ -13,3 +13,19 @@ roof-sheet,No.,35000,Corrugated roofing sheet IT4 gauge 28 per sheet
 roof-tile,No.,3900,Roof tile (Max pan / clay) per tile
 paint-interior,Bkts,280000,Silk / vinyl matt interior paint 20L bucket
 paint-exterior,Bkts,200000,Weather-guard exterior paint 20L bucket
+# --- site tools (MATSCHED-9). Rates are the PATMAC reference schedule's own
+#     figures, Kampala mid-2026. Indicative: re-price before tender.
+wheelbarrow,No.,150000,Wheel barrow
+spade,No.,15000,Spade
+head-pan,No.,7000,Head pan
+jerrycan,No.,7000,Jerrycan 20L
+hoe,No.,10000,Hoe
+pick-axe,No.,20000,Pick axe
+hacksaw-frame,No.,20000,Hack saw frame
+hacksaw-blade,Bdle,40000,Hack saw blades (bundle)
+bow-saw-frame,No.,20000,Bow saw frame
+bow-saw-blade,No.,11000,Bow saw blade
+panga,No.,10000,Panga
+sledge-hammer,No.,100000,Sledge hammer
+string-rope,Rolls,10000,Strings and ropes
+water-tank,No.,75000,Water tank 200 litre

--- a/StingTools/Data/STING_SITE_TOOLS.json
+++ b/StingTools/Data/STING_SITE_TOOLS.json
@@ -1,0 +1,143 @@
+{
+  "schemaVersion": "1.0",
+  "note": "PRACTICE HEURISTICS, NOT A STANDARD. NRM2 puts tools in Preliminaries as a lump or percentage; no measurement standard publishes gang-to-tool ratios. Calibrated against the PATMAC reference schedule. Project override: <project>/_data/coord/site_tools.json",
+  "tradeRates": {
+    "blockworkM2PerMasonDay": 8.0,
+    "rebarKgPerBenderDay": 120.0,
+    "formworkM2PerCarpenterDay": 10.0,
+    "concreteM3PerMixerDay": 8.0,
+    "helpersPerMason": 1.5,
+    "masonryPhaseFraction": 0.4,
+    "steelPhaseFraction": 0.35,
+    "formworkPhaseFraction": 0.35,
+    "concretePhaseFraction": 0.3
+  },
+  "rules": [
+    {
+      "toolKey": "wheelbarrow",
+      "description": "Wheel barrows",
+      "supplierUnit": "No.",
+      "driver": "helpers",
+      "perDriver": 0.3333,
+      "fixedQuantity": 0,
+      "minimum": 2
+    },
+    {
+      "toolKey": "spade",
+      "description": "Spades",
+      "supplierUnit": "No.",
+      "driver": "helpers",
+      "perDriver": 1.0,
+      "fixedQuantity": 2,
+      "minimum": 4
+    },
+    {
+      "toolKey": "head-pan",
+      "description": "Head pans",
+      "supplierUnit": "No.",
+      "driver": "helpers",
+      "perDriver": 1.0,
+      "fixedQuantity": 0,
+      "minimum": 4
+    },
+    {
+      "toolKey": "jerrycan",
+      "description": "Jerrycans",
+      "supplierUnit": "No.",
+      "driver": "helpers",
+      "perDriver": 1.5,
+      "fixedQuantity": 0,
+      "minimum": 5
+    },
+    {
+      "toolKey": "hoe",
+      "description": "Hoes",
+      "supplierUnit": "No.",
+      "driver": "mixers",
+      "perDriver": 1.0,
+      "fixedQuantity": 0,
+      "minimum": 2
+    },
+    {
+      "toolKey": "pick-axe",
+      "description": "Pick axes",
+      "supplierUnit": "No.",
+      "driver": "helpers",
+      "perDriver": 0.75,
+      "fixedQuantity": 0,
+      "minimum": 2
+    },
+    {
+      "toolKey": "hacksaw-frame",
+      "description": "Hack saw frames",
+      "supplierUnit": "No.",
+      "driver": "barbenders",
+      "perDriver": 0.5,
+      "fixedQuantity": 0,
+      "minimum": 1
+    },
+    {
+      "toolKey": "hacksaw-blade",
+      "description": "Hack saw blades",
+      "supplierUnit": "Bdle",
+      "driver": "barbenders",
+      "perDriver": 2.5,
+      "fixedQuantity": 0,
+      "minimum": 2
+    },
+    {
+      "toolKey": "bow-saw-frame",
+      "description": "Bow saw frames",
+      "supplierUnit": "No.",
+      "driver": "carpenters",
+      "perDriver": 0.5,
+      "fixedQuantity": 0,
+      "minimum": 1
+    },
+    {
+      "toolKey": "bow-saw-blade",
+      "description": "Bow saw blades",
+      "supplierUnit": "No.",
+      "driver": "carpenters",
+      "perDriver": 1.5,
+      "fixedQuantity": 0,
+      "minimum": 2
+    },
+    {
+      "toolKey": "panga",
+      "description": "Pangas",
+      "supplierUnit": "No.",
+      "driver": "site",
+      "perDriver": 0,
+      "fixedQuantity": 1,
+      "minimum": 1
+    },
+    {
+      "toolKey": "sledge-hammer",
+      "description": "Sledge hammer",
+      "supplierUnit": "No.",
+      "driver": "site",
+      "perDriver": 0,
+      "fixedQuantity": 1,
+      "minimum": 1
+    },
+    {
+      "toolKey": "string-rope",
+      "description": "Strings and ropes",
+      "supplierUnit": "Rolls",
+      "driver": "site",
+      "perDriver": 0,
+      "fixedQuantity": 2,
+      "minimum": 2
+    },
+    {
+      "toolKey": "water-tank",
+      "description": "Water tank (200 ltr)",
+      "supplierUnit": "No.",
+      "driver": "storeys",
+      "perDriver": 1.0,
+      "fixedQuantity": 1,
+      "minimum": 1
+    }
+  ]
+}


### PR DESCRIPTION
Closes ROADMAP **MATSCHED-9**. The TOOLS section now appears as section A, as it does in the reference schedule.

## Honesty first, because this is the part that could mislead

**There is no published standard for tool quantities.** NRM2 puts tools and plant in **Preliminaries**, priced as a lump or a percentage; no measurement standard publishes a wheelbarrows-per-mason ratio, and I searched for one before writing any of this.

What ships is East African contractor practice in an editable table, calibrated against the PATMAC reference schedule. The JSON note, the class header, the test class and a **warning banner on every export** all say so. A fabricated number wearing the costume of a calculation is worse than no number.

## The chain

`measured work → trade-days → gang → tools`

Gangs come from work ÷ output rate ÷ **the fraction of the programme that trade actually occupies** — walling doesn't run for the whole job, so dividing by full duration would understate the crew. Every step is measured or declared; nothing is a constant buried in code.

## Two deliberate refusals

**No programme duration → no tools at all.** Duration is the denominator of every gang size. The builder produces nothing and explains why, rather than defaulting to a programme nobody stated.

**A trade with no measured work orders no tools for it.** No steel on site, no hacksaws.

## Inputs

| input | source |
|---|---|
| duration | `PRJ_DURATION_DAYS` on Project Information, else a dialog (6 mo / 12 mo / skip), asked once before the build |
| storeys | counted from the model's **Levels**, excluding anything below the project base so stray datum levels and basements don't inflate the water-tank count |
| measured work | read back from the commodities the schedule already produced — tools follow the same quantities as the bill, not a second take-off that could drift |

## Calibration against the reference kit

| tool | model | PATMAC |
|---|---|---|
| spade | **8** | 8 |
| pick-axe | **5** | 5 |
| hoe | **2** | 2 |
| sledge / ropes | **1 / 2** | 1 / 2 |
| jerrycan | 9 | 10 |
| water-tank | 2 | 3 |
| wheelbarrow | 2 | **4** |
| saw frames | 1 / 1 | **2 / 2** |

Five exact, two within one. Wheelbarrows and saw frames come out at about half — that reads like a real habit the ratios don't capture (a spare barrow because a punctured wheel stops a pour). **The ratios are left honest rather than bent to fit one project**, and the calibration test allows a band instead of pretending to an exactness nobody can justify.

Priced against the shipped rates the kit comes to **UGX 1,198,000** versus the sample's **1,800,000**, the gap being almost entirely those two lines. Every tool is priced; none orphaned.

## Rates

The reference schedule's own figures — wheelbarrow 150,000, spade 15,000, water tank 75,000 — marked in the CSV as indicative Kampala mid-2026, to be re-priced before tender.

## One invariant broadened, not weakened

Tools are priced but never unit-converted, so they would have failed *"every rate needs a supplier-unit rule"*. The invariant is now **"every rate is reachable by something"** and spans both libraries — an unreachable rate still fails the build.

## Verification

- `dotnet build` → **0 errors, 0 warnings**
- `StingTools.Boq.Tests` → **351 passing**

Thirteen new tests cover gang derivation, the two refusals, per-driver / shared / fixed / storey-driven / minimum rules, and the calibration band. One caught a real error: my storey test asserted 2 tanks for a single-storey building, contradicting its own comment — the **test** was wrong and was corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
