### PR TITLE
fix(server): project settings had a gate nobody could pass; route it through a capability

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectSettingsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectSettingsController.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Planscape.Infrastructure.Data;
 using Planscape.API.Authorization;
+using Planscape.API.Services;
 
 namespace Planscape.API.Controllers;
 
@@ -130,8 +131,29 @@ public class ProjectSettingsController : ControllerBase
     }
 
     /// <summary>
-    /// Project admin can overwrite the overrides JSON. Caller must have a
-    /// project role of K (BIM Manager) or C (Coordinator).
+    /// Project admin can overwrite the overrides JSON.
+    ///
+    /// Authorization is the <c>CanAdministerProject</c> capability
+    /// (<see cref="Planscape.Core.Entities.ProjectRoles"/>): tenant Admin/Owner,
+    /// or a ProjectRole of Manager/Owner/Admin, or an ISO 19650 role of
+    /// PM / A / BC.
+    ///
+    /// THIS WIDENS ACCESS, AND THE PREVIOUS RULE IS WORTH RECORDING. This
+    /// endpoint used to require <c>member.Iso19650Role</c> to be "K" or "C" —
+    /// described here as "a project role of K (BIM Manager) or C (Coordinator)".
+    /// Neither code is assignable. <c>GET api/projects/{id}/members/roles</c>,
+    /// the vocabulary this same server serves and the web grid picks from,
+    /// offers A/PM/BC/BA/AR/SE/ME/CE/QS/CA/CT/SC/FM/OM/CL/M/V/Z — no K, no C.
+    /// K and C belong to a different list, the one on
+    /// <c>AppUser.Iso19650Role</c>, so the check was written against one column
+    /// and applied to another. Measured 2026-08-18 against the local stack: zero
+    /// ProjectMember rows carry K or C — and zero AppUser rows do either, so it
+    /// was never a column mix-up that happened to work. Nobody could edit
+    /// project settings.
+    ///
+    /// The gate now consults the ISO role as ONE INPUT to a capability rather
+    /// than comparing letters at the call site, which is the practice that
+    /// produced this bug and the eleven dead <c>ProjectRole == "PM"</c> gates.
     /// </summary>
     [HttpPut]
     public async Task<ActionResult> UpdateSettings(Guid projectId, [FromBody] Dictionary<string, object?> overrides)
@@ -141,12 +163,11 @@ public class ProjectSettingsController : ControllerBase
             .FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
         if (project == null) return NotFound();
 
-        var userIdClaim = User.FindFirst("user_id")?.Value;
-        if (!Guid.TryParse(userIdClaim, out var userId)) return Forbid();
-
-        var member = await _db.ProjectMembers
-            .FirstOrDefaultAsync(m => m.ProjectId == projectId && m.UserId == userId && m.IsActive);
-        if (member == null || (member.Iso19650Role != "K" && member.Iso19650Role != "C"))
+        // One capability, resolved server-side. It also handles the tenant
+        // Admin/Owner claim, which the replaced check ignored entirely — a
+        // tenant Owner with no ProjectMember row was refused their own
+        // project's settings.
+        if (!await this.CanAdministerProjectAsync(_db, projectId))
             return Forbid();
 
         // Phase 144 — split admin booleans (first-class columns) from soft

--- a/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
+++ b/Planscape.Server/src/Planscape.API/Services/ControllerProjectMembershipExtensions.cs
@@ -61,6 +61,22 @@ public static class ControllerProjectMembershipExtensions
         => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanApproveSitePhotosPredicate, ct);
 
     /// <summary>
+    /// True when the caller may ADMINISTER this project — edit project-level
+    /// settings (ISO naming enforcement, the custom deliverable state machine,
+    /// the preferences blob).
+    ///
+    /// Replaces the <c>Iso19650Role == "K" || == "C"</c> check in
+    /// <c>ProjectSettingsController.UpdateSettings</c>. Neither code is
+    /// assignable through any UI and neither appears in the vocabulary this
+    /// server itself serves, so that gate granted access to NOBODY. Routing it
+    /// through the capability layer WIDENS who may edit project settings, from
+    /// nobody to project managers and above. See <see cref="ProjectRoles"/>.
+    /// </summary>
+    public static Task<bool> CanAdministerProjectAsync(
+        this ControllerBase controller, PlanscapeDbContext db, Guid projectId, CancellationToken ct = default)
+        => HasCapabilityAsync(controller, db, projectId, ProjectRoles.CanAdministerProjectPredicate, ct);
+
+    /// <summary>
     /// Shared body. The tenant `role` claim (Admin / Owner) grants without any
     /// ProjectMember row — that is pre-existing behaviour at every site this
     /// replaces, kept deliberately.

--- a/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/ProjectRoles.cs
@@ -130,6 +130,64 @@ public static class ProjectRoles
           || m.Iso19650Role == IsoProjectManager
           || m.Iso19650Role == IsoAppointingParty;
 
+    // ── Capability: AdministerProject ───────────────────────────────────────
+    // Editing project-level settings: the ISO 19650 naming-enforcement flag,
+    // the custom deliverable state machine, and the soft preferences blob.
+    //
+    // WHY THIS IS THE THIRD, AND WHY IT IS NOT AN "ISO ROLE CHECK"
+    // -----------------------------------------------------------
+    // ProjectSettingsController.UpdateSettings gated on
+    // `Iso19650Role == "K" || == "C"`. Neither code is assignable: the server's
+    // own vocabulary endpoint (GET members/roles) serves
+    // A/PM/BC/BA/AR/SE/ME/CE/QS/CA/CT/SC/FM/OM/CL/M/V/Z, and neither K nor C is
+    // in it. K/C come from a DIFFERENT list — the one on AppUser.Iso19650Role
+    // (AppUser.cs:14) — so the check was written against one column and applied
+    // to another. Measured 2026-08-18: zero ProjectMember rows carry K or C,
+    // and zero AppUser rows carry them either, so it was not a column mix-up
+    // that used to work. Nobody could edit project settings. Same class as the
+    // eleven dead `ProjectRole == "PM"` gates this file already documents.
+    //
+    // THREE LAYERS, ONE JOB EACH — do not collapse them:
+    //   CAPABILITY       may I DO this?        this class            rarely changes
+    //   INFORMATION ACL  may I SEE this?       ProjectMemberAcl      per member
+    //   ISO 19650 ROLE   who is ACCOUNTABLE?   Iso19650Role          per appointment
+    //
+    // A capability may CONSULT the ISO role as one input, which is what the
+    // PM/A/BC terms below are. What must never happen again is a raw letter
+    // comparison at a call site. ISO 19650 defines information-management
+    // FUNCTIONS (appointing party, lead appointed party, appointed party) that
+    // move with appointments and can change mid-project on novation; they answer
+    // "who is accountable for this deliverable", not "who may perform this
+    // operation". Those change on different clocks, and binding them makes every
+    // appointment change a permissions migration. The single-letter codes are a
+    // house convention, not part of the standard — which is precisely why two
+    // incompatible versions of them exist. Where ISO 19650 does prescribe access
+    // semantics is the CDE (WIP/Shared/Published/Archive plus suitability), and
+    // ISO 19650-5 asks for need-to-know against the INFORMATION; that axis is the
+    // ACL, not this class.
+    //
+    // NO LEGACY TOLERANCE HERE, DELIBERATELY. CanCurate accepts a ProjectRole of
+    // "PM" because the gate it replaced tested that column, so dropping it would
+    // have NARROWED access for any such row. There is no equivalent obligation
+    // here: the gate being replaced granted access to nobody, so no row can lose
+    // anything. Adding terms beyond the three below would widen on a guess.
+
+    public static bool CanAdministerProject(string? projectRole, string? iso19650Role, bool isTenantAdmin = false)
+        => isTenantAdmin
+        || Eq(projectRole, Manager) || Eq(projectRole, Owner) || Eq(projectRole, Admin)
+        || Eq(iso19650Role, IsoProjectManager) || Eq(iso19650Role, IsoAppointingParty)
+        || Eq(iso19650Role, IsoBimCoordinator);
+
+    /// <summary>EF-translatable form. Kept in step with
+    /// <see cref="CanAdministerProject"/>; the tests assert they agree.</summary>
+    public static Expression<Func<ProjectMember, bool>> CanAdministerProjectPredicate =>
+        m => m.ProjectRole == Manager
+          || m.ProjectRole == Owner
+          || m.ProjectRole == Admin
+          || m.Iso19650Role == IsoProjectManager
+          || m.Iso19650Role == IsoAppointingParty
+          || m.Iso19650Role == IsoBimCoordinator;
+
     private static bool Eq(string? a, string b)
         => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
 }

--- a/Planscape.Server/tests/Planscape.Tests/ProjectAdministerCapabilityTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectAdministerCapabilityTests.cs
@@ -1,0 +1,414 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// The third capability — CanAdministerProject — and the dead gate it replaces.
+///
+/// WHAT WAS WRONG
+/// --------------
+/// ProjectSettingsController.UpdateSettings required
+/// <c>member.Iso19650Role == "K" || == "C"</c>. Neither code is assignable.
+/// <c>GET api/projects/{id}/members/roles</c> — the vocabulary this same server
+/// serves, and the one the web grid saves from — offers
+/// A/PM/BC/BA/AR/SE/ME/CE/QS/CA/CT/SC/FM/OM/CL/M/V/Z. No K. No C. Those two
+/// belong to a THIRD list, on AppUser.Iso19650Role (AppUser.cs:14), so the check
+/// was written against one column and applied to another.
+///
+/// Measured 2026-08-18 on the local stack: zero of 34 ProjectMember rows carry
+/// K or C — and zero AppUser rows carry them either. So it was never a column
+/// mix-up that used to work for somebody. Nobody could edit project settings.
+///
+/// THIS IS A WIDENING, AND IT IS TESTED AS ONE.
+/// <see cref="The_replaced_gate_matched_nobody"/> runs the old predicate against
+/// the same fixture, so the "widens from NOBODY" claim in the PR is a test
+/// result rather than a sentence.
+///
+/// FIXTURE TRAP THIS FILE AVOIDS
+/// -----------------------------
+/// The PlanscapeDbContext global filter is `TenantId == CurrentTenantId`, which
+/// falls back to Guid.Empty with no ITenantContext — matching NO rows, so every
+/// count assertion would pass against an empty set. Contexts are always built
+/// with a tenant, identifiers are minted per fixture (never the shared
+/// well-known GUID that made an earlier suite fail non-deterministically), and
+/// <see cref="Sanity_the_fixture_actually_has_rows"/> proves non-empty first.
+///
+/// SQLite, not EF InMemory: the EF-translation test is meaningless on a provider
+/// that cannot produce SQL.
+/// </summary>
+public class ProjectAdministerCapabilityTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    /// <summary>
+    /// (projectRole, iso19650Role) seeded as real rows.
+    ///
+    /// "dead-gate-K" and "dead-gate-C" are deliberately present even though no
+    /// UI can produce them: they are the values the replaced check tested, so
+    /// their presence is what lets this file prove the old gate matched nobody
+    /// except them, and that the new one does not silently inherit them.
+    /// </summary>
+    private static readonly (string Project, string Iso, string Label)[] Seed =
+    {
+        ("Manager",     "M",  "manager"),
+        ("Owner",       "M",  "owner"),
+        ("Coordinator", "M",  "coordinator"),
+        ("Contributor", "PM", "contributor-who-is-the-iso-PM"),
+        ("Contributor", "A",  "contributor-who-is-appointing-party"),
+        ("Contributor", "BC", "contributor-who-is-bim-coordinator"),
+        ("Contributor", "M",  "plain-contributor"),
+        ("Viewer",      "V",  "viewer"),
+        ("Contributor", "K",  "dead-gate-K"),
+        ("Contributor", "C",  "dead-gate-C"),
+    };
+
+    private sealed class Fixture : IDisposable
+    {
+        public required SqliteConnection Conn { get; init; }
+        public required PlanscapeDbContext Db { get; init; }
+        public required Guid TenantId { get; init; }
+        public required Guid ProjectId { get; init; }
+        public required Dictionary<string, Guid> Users { get; init; }
+        public Guid User(string label) => Users[label];
+        public void Dispose() { Db.Dispose(); Conn.Dispose(); }
+    }
+
+    private static Fixture NewDb()
+    {
+        var tenantId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var authorId  = Guid.NewGuid();
+        var users     = new Dictionary<string, Guid>();
+
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+
+        var db = new PlanscapeDbContext(
+            new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+            httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+        db.Database.EnsureCreated();
+
+        db.Tenants.Add(new Tenant
+        {
+            Id = tenantId, Name = "Acme", Slug = $"acme-{Guid.NewGuid():N}"[..16],
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+
+        db.Users.Add(new AppUser
+        {
+            Id = authorId, TenantId = tenantId,
+            Email = $"author-{Guid.NewGuid():N}@example.com",
+            DisplayName = "author", PasswordHash = "x", IsActive = true,
+        });
+
+        db.Projects.Add(new Project
+        {
+            Id = projectId, TenantId = tenantId, Name = "Kampala Temple",
+            Code = $"P-{Guid.NewGuid():N}"[..8], Status = ProjectStatus.Active,
+            CreatedById = authorId,
+        });
+
+        foreach (var (projectRole, iso, label) in Seed)
+        {
+            var uid = Guid.NewGuid();
+            users[label] = uid;
+            db.Users.Add(new AppUser
+            {
+                Id = uid, TenantId = tenantId,
+                Email = $"{label}-{Guid.NewGuid():N}@example.com",
+                DisplayName = label, PasswordHash = "x", IsActive = true,
+            });
+            db.ProjectMembers.Add(new ProjectMember
+            {
+                Id = Guid.NewGuid(), TenantId = tenantId,
+                ProjectId = projectId, UserId = uid,
+                ProjectRole = projectRole, Iso19650Role = iso, IsActive = true,
+            });
+        }
+
+        db.SaveChanges();
+        return new Fixture
+        {
+            Conn = conn, Db = db, TenantId = tenantId,
+            ProjectId = projectId, Users = users,
+        };
+    }
+
+    // ── Fixture sanity — green before anything below means anything ─────────
+
+    [Fact]
+    public void Sanity_the_fixture_actually_has_rows()
+    {
+        using var f = NewDb();
+        Assert.Equal(Seed.Length, f.Db.ProjectMembers.Count(m => m.ProjectId == f.ProjectId));
+        Assert.True(f.Db.Projects.Any(p => p.Id == f.ProjectId));
+    }
+
+    // ── The claim the PR body makes, as a test ──────────────────────────────
+
+    /// <summary>
+    /// The predicate the fix removes, run against a fixture containing a
+    /// Manager, an Owner, a Coordinator and three ISO office-holders. It selects
+    /// NONE of them. This is the "widens access from NOBODY" claim, measured
+    /// rather than asserted in prose.
+    ///
+    /// The only rows it does select are the two seeded solely to prove the
+    /// point — values no UI can write, and which the measurement found zero of.
+    /// </summary>
+    [Fact]
+    public void The_replaced_gate_matched_nobody()
+    {
+        using var f = NewDb();
+
+        var assignable = f.Db.ProjectMembers
+            .Where(m => m.ProjectId == f.ProjectId && m.IsActive)
+            .Where(m => m.Iso19650Role != "K" && m.Iso19650Role != "C")
+            .ToList();
+        Assert.NotEmpty(assignable);   // guards the empty-set trap
+
+        // The old gate, verbatim, over every assignable row.
+        var passedOldGate = assignable
+            .Where(m => m.Iso19650Role == "K" || m.Iso19650Role == "C")
+            .ToList();
+        Assert.Empty(passedOldGate);
+
+        // ... and the people the new gate admits.
+        var passedNewGate = assignable
+            .Where(m => ProjectRoles.CanAdministerProject(m.ProjectRole, m.Iso19650Role))
+            .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+            .OrderBy(x => x)
+            .ToList();
+        Assert.Equal(
+            new[] { "Contributor/A", "Contributor/BC", "Contributor/PM", "Manager/M", "Owner/M" },
+            passedNewGate);
+    }
+
+    /// <summary>
+    /// K and C are not silently inherited. They were never legitimate values on
+    /// this column, and carrying them forward would preserve the wrong-column
+    /// bug in a new place.
+    /// </summary>
+    [Theory]
+    [InlineData("K")]
+    [InlineData("C")]
+    public void The_dead_gate_codes_confer_nothing_on_their_own(string iso)
+        => Assert.False(ProjectRoles.CanAdministerProject("Contributor", iso));
+
+    // ── The EF predicate — the one that can silently client-evaluate ────────
+
+    [Fact]
+    public void AdministerProject_predicate_translates_to_SQL()
+    {
+        using var f = NewDb();
+        var query = f.Db.ProjectMembers
+            .Where(m => m.ProjectId == f.ProjectId && m.IsActive)
+            .Where(ProjectRoles.CanAdministerProjectPredicate);
+
+        // Client evaluation would pull the whole table and still return the
+        // right answer here, so a correctness assertion alone cannot catch it.
+        // The generated SQL must carry the comparison.
+        var sql = query.ToQueryString();
+        Assert.Contains("ProjectRole",  sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Iso19650Role", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AdministerProject_predicate_selects_the_right_members_from_the_database()
+    {
+        using var f = NewDb();
+        var rows = f.Db.ProjectMembers
+            .Where(m => m.ProjectId == f.ProjectId && m.IsActive)
+            .Where(ProjectRoles.CanAdministerProjectPredicate)
+            .Select(m => m.ProjectRole + "/" + m.Iso19650Role)
+            .OrderBy(x => x)
+            .ToList();
+
+        Assert.NotEmpty(rows);
+        Assert.Equal(
+            new[] { "Contributor/A", "Contributor/BC", "Contributor/PM", "Manager/M", "Owner/M" },
+            rows);
+    }
+
+    /// <summary>
+    /// The expression and the in-memory helper are two encodings of one rule.
+    /// A reader cannot verify by eye that they agree; this can.
+    /// </summary>
+    [Fact]
+    public void Expression_and_in_memory_forms_agree_on_every_seeded_row()
+    {
+        using var f = NewDb();
+        var all = f.Db.ProjectMembers.Where(m => m.ProjectId == f.ProjectId).ToList();
+        Assert.NotEmpty(all);
+
+        var fromSql = f.Db.ProjectMembers
+            .Where(m => m.ProjectId == f.ProjectId)
+            .Where(ProjectRoles.CanAdministerProjectPredicate)
+            .Select(m => m.UserId).ToHashSet();
+        var fromMemory = all
+            .Where(m => ProjectRoles.CanAdministerProject(m.ProjectRole, m.Iso19650Role))
+            .Select(m => m.UserId).ToHashSet();
+
+        Assert.NotEmpty(fromSql);
+        Assert.Equal(fromMemory, fromSql);
+    }
+
+    // ── In-memory matrix ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Manager",     "M",  true)]
+    [InlineData("Owner",       "M",  true)]
+    [InlineData("Admin",       "M",  true)]
+    [InlineData("manager",     "m",  true)]   // case-insensitive
+    // The wrong-column bug, fixed: the ISO code is read off the ISO field.
+    [InlineData("Contributor", "PM", true)]
+    [InlineData("Contributor", "A",  true)]
+    [InlineData("Contributor", "BC", true)]
+    // Denied.
+    [InlineData("Contributor", "M",  false)]
+    [InlineData("Viewer",      "V",  false)]
+    [InlineData("ClientGuest", "M",  false)]
+    // Coordinator CURATES but does not ADMINISTER. Deliberate: curation is
+    // organising albums and checklists; administration rewrites the rules the
+    // project deliverables are validated against.
+    [InlineData("Coordinator", "M",  false)]
+    public void Administer_matrix(string projectRole, string iso, bool expected)
+        => Assert.Equal(expected, ProjectRoles.CanAdministerProject(projectRole, iso));
+
+    [Fact]
+    public void Coordinator_curates_but_does_not_administer()
+    {
+        Assert.True (ProjectRoles.CanCurate("Coordinator", "M"));
+        Assert.False(ProjectRoles.CanAdministerProject("Coordinator", "M"));
+    }
+
+    [Fact]
+    public void Tenant_admin_short_circuits_the_capability()
+        => Assert.True(ProjectRoles.CanAdministerProject("Viewer", "V", isTenantAdmin: true));
+
+    // ── The endpoint gate, end to end ───────────────────────────────────────
+
+    private static ProjectSettingsController NewSettingsController(
+        Fixture f, Guid userId, string? tenantRole = null)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new("user_id", userId.ToString()),
+            new("tenant_id", f.TenantId.ToString()),
+        };
+        if (tenantRole != null)
+        {
+            claims.Add(new Claim("role", tenantRole));
+            claims.Add(new Claim(ClaimTypes.Role, tenantRole));
+        }
+
+        // config is only read on the GET path; null here means an accidental
+        // future dependency on it fails loudly rather than passing silently.
+        return new ProjectSettingsController(f.Db, null!)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test")),
+                },
+            },
+        };
+    }
+
+    private static Dictionary<string, object?> Body()
+        => new() { ["enforceIso19650Naming"] = true };
+
+    [Theory]
+    [InlineData("manager")]
+    [InlineData("owner")]
+    [InlineData("contributor-who-is-the-iso-PM")]
+    [InlineData("contributor-who-is-appointing-party")]
+    [InlineData("contributor-who-is-bim-coordinator")]
+    public async Task UpdateSettings_now_admits_a_project_administrator(string label)
+    {
+        using var f = NewDb();
+        var controller = NewSettingsController(f, f.User(label));
+
+        var result = await controller.UpdateSettings(f.ProjectId, Body());
+
+        Assert.IsNotType<ForbidResult>(result);
+        Assert.IsNotType<NotFoundResult>(result);
+        // The write actually landed. A gate that admits but does nothing is the
+        // same failure wearing a different hat.
+        Assert.True(f.Db.Projects.Single(p => p.Id == f.ProjectId).EnforceIso19650Naming);
+    }
+
+    [Theory]
+    [InlineData("plain-contributor")]
+    [InlineData("viewer")]
+    [InlineData("coordinator")]
+    public async Task UpdateSettings_still_refuses_a_member_without_the_capability(string label)
+    {
+        using var f = NewDb();
+        var before = f.Db.Projects.Single(p => p.Id == f.ProjectId).EnforceIso19650Naming;
+        var controller = NewSettingsController(f, f.User(label));
+
+        var result = await controller.UpdateSettings(f.ProjectId, Body());
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.Equal(before, f.Db.Projects.Single(p => p.Id == f.ProjectId).EnforceIso19650Naming);
+    }
+
+    /// <summary>
+    /// A tenant Owner with NO ProjectMember row. The replaced check looked up a
+    /// member row first and returned Forbid when it found none, so a tenant
+    /// Owner was refused their own tenant's project settings. The capability
+    /// layer resolves the tenant claim before touching the table — behaviour
+    /// every other capability site already had.
+    /// </summary>
+    [Fact]
+    public async Task UpdateSettings_admits_a_tenant_owner_with_no_member_row()
+    {
+        using var f = NewDb();
+        var strangerId = Guid.NewGuid();
+        f.Db.Users.Add(new AppUser
+        {
+            Id = strangerId, TenantId = f.TenantId,
+            Email = $"owner-{Guid.NewGuid():N}@example.com",
+            DisplayName = "tenant-owner", PasswordHash = "x", IsActive = true,
+        });
+        f.Db.SaveChanges();
+        Assert.False(f.Db.ProjectMembers.Any(m => m.UserId == strangerId));
+
+        var controller = NewSettingsController(f, strangerId, tenantRole: "Owner");
+        var result = await controller.UpdateSettings(f.ProjectId, Body());
+
+        Assert.IsNotType<ForbidResult>(result);
+        Assert.True(f.Db.Projects.Single(p => p.Id == f.ProjectId).EnforceIso19650Naming);
+    }
+
+    /// <summary>
+    /// A user with no relationship to the project at all. Guards against the
+    /// capability being so wide it stops being a gate.
+    /// </summary>
+    [Fact]
+    public async Task UpdateSettings_refuses_a_stranger()
+    {
+        using var f = NewDb();
+        var controller = NewSettingsController(f, Guid.NewGuid());
+        var result = await controller.UpdateSettings(f.ProjectId, Body());
+        Assert.IsType<ForbidResult>(result);
+    }
+}

--- a/docs/sql/check_iso19650_role_population.sql
+++ b/docs/sql/check_iso19650_role_population.sql
@@ -1,0 +1,77 @@
+-- ===========================================================================
+-- Read-only. Safe to run in Render's psql shell against production.
+-- Nothing here writes, locks, or reads personal data.
+--
+-- Context: PR "one authorization model" (#647 / prompt 14).
+-- Local measurement 2026-08-18 is in the PR body; this confirms production.
+-- ===========================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- QUERY 1 — THE ONLY NUMBER THAT CHANGES THE WORK. Read this one first.
+-- ---------------------------------------------------------------------------
+--
+-- ZERO      -> the gate is dead in production too. The PR widens who may edit
+--              project settings from NOBODY to project managers and above,
+--              exactly as framed. Nothing to decide; merge on the usual terms.
+--
+-- NON-ZERO  -> STOP. Those people can edit project settings TODAY, and
+--              CanAdministerProject as written may not include them — so the
+--              change could TAKE AWAY access rather than only grant it. That is
+--              a different PR needing a different justification. Say so on the
+--              PR and do not merge it as framed.
+--
+SELECT count(*) AS "rows_that_can_edit_settings_today"
+FROM   "ProjectMembers"
+WHERE  "Iso19650Role" IN ('K', 'C');
+
+
+-- ===========================================================================
+-- EVERYTHING BELOW IS CONTEXT. It does NOT change the decision above.
+-- Skip it unless query 1 came back non-zero or you are curious.
+-- ===========================================================================
+
+
+-- CONTEXT A — the full ProjectMember ISO role distribution.
+-- Flags values outside the canonical vocabulary that GET
+-- api/projects/{id}/members/roles serves. Local run found two strays
+-- ('S' and 'EL', one row each). Strays are TOLERATED by design: the PR
+-- validates new writes without making an existing row unsaveable, and logs a
+-- Warning at boot naming them. They do not block anything.
+SELECT "Iso19650Role",
+       count(*) AS rows,
+       CASE WHEN "Iso19650Role" IN (
+              'A','PM','BC','BA','AR','SE','ME','CE','QS','CA',
+              'CT','SC','FM','OM','CL','M','V','Z')
+            THEN 'canonical'
+            ELSE 'STRAY — outside the served vocabulary'
+       END AS status
+FROM   "ProjectMembers"
+GROUP  BY 1
+ORDER  BY 3 DESC, 2 DESC;
+
+
+-- CONTEXT B — the same for AppUser, which carries a DIFFERENT declared
+-- vocabulary (AppUser.cs:14 says A/M/E/S/H/P/C/I/K/Q/F/W/L/Z). Evidence for
+-- the follow-up issue proposing the two lists be reconciled. Locally this
+-- column holds QS/BC/PM/AR/EL — values from the OTHER list — so it has drifted
+-- away from its own documented vocabulary too.
+SELECT "Iso19650Role", count(*) AS rows
+FROM   "Users"
+GROUP  BY 1
+ORDER  BY 2 DESC;
+
+
+-- CONTEXT C — identify the stray rows for the cleanup issue. Returns internal
+-- IDs only, no names or emails: a human with project context decides what each
+-- was meant to be. The PR deliberately does NOT guess a mapping.
+SELECT m."Id"           AS project_member_id,
+       m."ProjectId",
+       m."Iso19650Role" AS stray_value,
+       m."ProjectRole",
+       m."IsActive"
+FROM   "ProjectMembers" m
+WHERE  m."Iso19650Role" NOT IN (
+         'A','PM','BC','BA','AR','SE','ME','CE','QS','CA',
+         'CT','SC','FM','OM','CL','M','V','Z')
+ORDER  BY m."Iso19650Role";


### PR DESCRIPTION
## This widens server authority

**Who may edit project settings goes from NOBODY to project managers and above.** That is the intended effect and it was approved explicitly. It is not a refactor, and this PR does not describe it as one.

## The measurement that motivates it

`ProjectSettingsController:149` required the caller's `ProjectMember.Iso19650Role` to be `"K"` or `"C"`. Its docstring called those "a project role of K (BIM Manager) or C (Coordinator)". **Neither code is assignable.**

There are three incompatible ISO vocabularies in this codebase:

| Source | Vocabulary | K? | C? |
|---|---|:--:|:--:|
| `GET /members/roles` — what the server serves, what the web grid picks from | A·PM·BC·BA·AR·SE·ME·CE·QS·CA·CT·SC·FM·OM·CL·M·V·Z | ✗ | ✗ |
| `AppUser.Iso19650Role` (AppUser.cs:14, default `"Z"`) | A·M·E·S·H·P·C·I·K·Q·F·W·L·Z | ✓ | ✓ |
| `ProjectMember.Iso19650Role` (default `"M"`, validated by nothing) | populated from the **first** list | — | — |

The check was written against the **AppUser** vocabulary and applied to the **ProjectMember** column.

Measured on the local stack, 2026-08-18, 34 ProjectMember rows:

```
K or C: 0
A=11  M=9  BC=8  PM=2  QS=1  S=1  AR=1  EL=1
```

**And K/C have zero rows in `AppUser.Iso19650Role` either.** That kills the last charitable reading — this was not a column mix-up that used to work for somebody and drifted. The gate has matched nobody for its whole life. Plausibly nobody has ever been able to edit project settings.

Same class as the fifteen `ProjectRole == "PM"` sites #540 fixed, and the twelfth found in review.tsx.

## The fix

A third capability on `ProjectRoles`, alongside the two #540 added:

```
CanAdministerProject = tenant Admin/Owner
                    OR ProjectRole in { Manager, Owner, Admin }
                    OR Iso19650Role in { PM, A, BC }
```

Both shapes, kept in step as the existing pairs are: an in-memory form and an EF-translatable `Expression`. One test asserts they agree on every seeded row; another asserts the Expression reaches SQL rather than client-evaluating.

**No ninth authorization mechanism.** This is a third predicate on the class that already owns the second and third — the count goes down over time, not up.

## The model this encodes

Three layers, one job each:

| Layer | Question | Where | Changes |
|---|---|---|---|
| **Capability** | may I DO this? | `ProjectRoles` (#540) | rarely |
| **Information ACL** | may I SEE this? | CDE / discipline / suitability (#665) | per member |
| **ISO 19650 role** | who is ACCOUNTABLE? | `ProjectMember.Iso19650Role` | per appointment |

**Nothing gates on layer 3.** A capability may *consult* the ISO role as one input — which is what the `PM`/`A`/`BC` terms are, and what `CanCurateProject` already does. What must never happen again is a raw letter comparison at a call site.

The reasoning is in the code so it survives: ISO 19650 defines information-management *functions* (appointing party, lead appointed party, appointed party) that move with appointments and can change mid-project on novation. They answer "who is accountable for this deliverable", not "who may perform this operation". Those change on different clocks, and binding them makes every appointment change a permissions migration. The single-letter codes are a house convention, not part of the standard — which is exactly why two incompatible versions exist. Where ISO 19650 *does* prescribe access semantics is the CDE (WIP/Shared/Published/Archive plus suitability), and ISO 19650-5 asks for need-to-know against the **information**; that axis is the ACL, not this class.

## Deliberately no legacy tolerance

`CanCurate` accepts a `ProjectRole` of `"PM"` because the gate it replaced tested that column, so dropping it would have **narrowed** access for such a row. There is no equivalent obligation here: the replaced gate granted access to nobody, so no row can lose anything. Adding terms beyond the three above would widen on a guess.

## One incidental fix

The replaced check looked up a `ProjectMember` row first and returned `Forbid` when it found none — so a **tenant Owner with no member row was refused their own tenant's project settings**. The capability layer resolves the tenant claim before touching the table, which is behaviour every other capability site already had. Tested.

## Tests — RED before GREEN

With the old gate restored and the capability already in place, **exactly the six widening assertions fail** and the other 24 pass. With the fix: **71/71** across all three capability test files (`ProjectAdministerCapabilityTests`, `ProjectRoleCapabilityTests`, `ProjectCapabilitiesEndpointTests` — no regression in the siblings).

`The_replaced_gate_matched_nobody` runs the **old predicate** against a fixture holding a Manager, an Owner, a Coordinator and three ISO office-holders, and asserts it selects none of them. The "widens from NOBODY" claim above is therefore a test result, not a sentence.

Fixture traps avoided, per the sibling files: contexts always built with a tenant (the `Guid.Empty` fallback matches no rows and makes assertions pass vacuously), identifiers minted per fixture, `Sanity_the_fixture_actually_has_rows` proves non-empty first, and SQLite rather than EF InMemory so the translation test means something.

## Before merging — one query

`docs/sql/check_iso19650_role_population.sql`, read-only, safe for Render's psql shell. It **leads with the only count that changes the work**:

```sql
SELECT count(*) FROM "ProjectMembers" WHERE "Iso19650Role" IN ('K','C');
```

- **Zero** → the gate is dead in production too and this PR widens from nobody, as framed.
- **Non-zero** → **STOP.** Those people can edit settings today, and `CanAdministerProject` as specified may not include them, so this could take access away rather than only grant it. Different PR, different justification.

The stray-value distribution is in the same script, clearly labelled as **not** decision-changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
