### PR TITLE
fix(visibility): temporary hide reverses; stop the blocker spam

### DIFF
--- a/StingTools/Core/Visibility/VisibilityEngine.cs
+++ b/StingTools/Core/Visibility/VisibilityEngine.cs
@@ -228,15 +228,30 @@ namespace StingTools.Core.Visibility
                 var id = new ElementId((BuiltInCategory)catId);
                 if (catId > 0) id = new ElementId((long)catId);   // import categories are document-created
 
-                // CanCategoryBeHidden is the honest gate: a category the view cannot control
-                // must be reported, not silently skipped.
+                // ORDER MATTERS. Ask "is a change even needed?" BEFORE "is a change allowed?".
+                // Reversed, every ticked category the view cannot control produced a blocker on
+                // every apply — 25 of them in one dialog, most reading '-2001000' because the
+                // restore path passes no name. A category already in the state the user wants
+                // is a no-op, not a problem worth a line in a dialog.
+                if (view.GetCategoryHidden(id) == !visible) return false;
+
                 if (!view.CanCategoryBeHidden(id))
                 {
-                    result?.Blockers.Add($"'{name ?? id.ToString()}' cannot be hidden in this view " +
-                                         "(the view template or Revit itself controls it).");
+                    // Only now is it worth reporting: a change WAS wanted and cannot be made.
+                    // Resolve the display name so the message names the category rather than a
+                    // raw BuiltInCategory id.
+                    string label = name;
+                    if (string.IsNullOrWhiteSpace(label))
+                    {
+                        try { label = Category.GetCategory(view.Document, (BuiltInCategory)catId)?.Name; }
+                        catch { /* optional read */ }
+                    }
+                    result?.Blockers.Add($"'{label ?? id.ToString()}' cannot be " +
+                                         (visible ? "shown" : "hidden") +
+                                         " in this view (the view template or Revit itself controls it).");
                     return false;
                 }
-                if (view.GetCategoryHidden(id) == !visible) return false;   // already right
+
                 view.SetCategoryHidden(id, !visible);
                 return true;
             }
@@ -245,6 +260,23 @@ namespace StingTools.Core.Visibility
                 StingLog.Warn($"SetCategoryVisible({name ?? catId.ToString()}, visible={visible}): {ex.Message}");
                 result?.Blockers.Add($"Could not change visibility of '{name ?? catId.ToString()}': {ex.Message}");
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Drop any active temporary hide/isolate so the next call can state the whole set.
+        /// Requires an open transaction, like the rest of the temporary API.
+        /// </summary>
+        private static void ClearTemporary(View view)
+        {
+            try
+            {
+                if (view.IsTemporaryHideIsolateActive())
+                    view.DisableTemporaryViewMode(TemporaryViewMode.TemporaryHideIsolate);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"VisibilityEngine.ClearTemporary({view?.Name}): {ex.Message}");
             }
         }
 
@@ -257,11 +289,34 @@ namespace StingTools.Core.Visibility
             var ids = plan.MatchedIds.Select(id => new ElementId(id)).ToList();
             try
             {
-                bool hasTokenWork = plan.Set?.Rules != null &&
-                                    plan.Set.Rules.Any(r => r != null && r.Kind == VisibilityRuleKind.Token);
-
-                if (plan.IsIsolate) view.IsolateElementsTemporary(ids);
-                else if (hasTokenWork && ids.Count > 0) view.HideElementsTemporary(ids);
+                if (plan.IsIsolate)
+                {
+                    ClearTemporary(view);
+                    view.IsolateElementsTemporary(ids);
+                }
+                else
+                {
+                    // No `hasTokenWork` guard here on purpose. Re-ticking the LAST unticked
+                    // token value produces zero token rules, so a guard would skip the clear
+                    // and leave the previous hide standing — the restore would silently do
+                    // nothing, which is the bug this whole change exists to kill. Declarative
+                    // means always stating the full set, including the empty set.
+                    // DECLARATIVE temporary hide. HideElementsTemporary only ever ADDS to the
+                    // hidden set, which is why re-ticking a row never brought anything back.
+                    // Clearing the mode first and re-hiding exactly the currently-matched set
+                    // makes the same gesture reverse: re-tick a value, it drops out of
+                    // MatchedIds, and it is simply not re-hidden.
+                    //
+                    // Temporary is kept as the mechanism ON PURPOSE — it is the fast, no-dirt
+                    // way to isolate and evaluate a model, and switching categories to
+                    // SetCategoryHidden must not cost the token rows that speed.
+                    //
+                    // The cost, stated plainly: an apply also clears elements hidden by hand
+                    // with Revit's own HH, because Revit exposes no way to tell those apart
+                    // from ours. Re-ticking everything therefore shows everything.
+                    ClearTemporary(view);
+                    if (ids.Count > 0) view.HideElementsTemporary(ids);
+                }
 
                 result.Ok = true;
                 result.ElementsAffected = ids.Count;


### PR DESCRIPTION
One file, `VisibilityEngine.cs`. Both fixes come from using the feature on a real model.

## 1. Temporary hide now reverses — re-ticking restores

Reported: *"I hid the elements (Toposolid) and it hid temporarily, but when I checked the box again it never came back."* The apply reported **"No element matched these rules — nothing was changed."**

`HideElementsTemporary` only ever **adds** to the hidden set; nothing takes elements out. So an apply could hide but never show. Apply now clears the temporary mode first and re-hides exactly the currently-matched set, so re-ticking a value drops it from `MatchedIds` and it is simply not re-hidden.

**Temporary is deliberately kept as the mechanism for token rows**, rather than moved to `SetCategoryHidden` the way categories were in #702. Temporary hide is the fast, no-dirt way to isolate and evaluate a model — that is the point of the feature — and it should not have to lose that to gain reversibility. It never did: the API supports stating a fresh set; we simply were not clearing first.

**No `hasTokenWork` guard on the clear.** Re-ticking the *last* unticked value produces zero rules, so a guard would skip the clear and leave the previous hide standing — silently doing nothing, which is the exact bug being fixed. Declarative means always stating the full set, the empty set included.

**Cost, stated rather than hidden:** an apply also clears elements hidden by hand with Revit's own HH, because Revit exposes no way to tell those apart from ours. Re-ticking everything therefore shows everything. That is the right trade for a tool whose job is quick isolation, but it is a behaviour change worth knowing.

## 2. Blocker spam — 25 lines, most of them raw ids

One apply produced a dialog of 25 blockers, most reading `'-2001000' cannot be hidden in this view`.

`SetCategoryVisible` asked *"is this change allowed?"* before *"is a change even needed?"*, so every ticked category the view cannot control reported a problem on **every** apply — for a state it was already in. Order reversed: a no-op returns silently, and only a change that was wanted and cannot be made is reported. The message now resolves the category's display name instead of printing a raw `BuiltInCategory` id, and says "shown" or "hidden" to match what was attempted.

## Verification

- `dotnet build StingTools/StingTools.csproj -c Release` → **0 errors, 0 warnings**
- `StingTools.Visibility.Tests` → **102 passing, 0 failing**
- `ClearTemporary` confirmed present in the built DLL (UTF-8 `#Strings` heap, negative control absent)

**Not yet run in Revit.** The add-in slot has moved four times in six days across parallel worktrees, and the currently-loaded build is another agent's from `main` — which correctly lacks this fix, since it is unmerged. Merging is what makes the fix reach whichever build is live, rather than depending on who deployed last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
