### PR TITLE
fix(billing): decouple the tenant account ceiling from paid seat totals

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AdminController.cs
@@ -86,8 +86,12 @@ public class AdminController : ControllerBase
         if (tenant == null) return NotFound("Tenant not found");
 
         var userCount = await _db.Users.CountAsync(u => u.TenantId == tenantId && u.IsActive);
-        if (userCount >= tenant.MaxUsers)
-            return BadRequest($"User limit ({tenant.MaxUsers}) reached for {tenant.Tier} tier");
+        // Via AccountCeilingPolicy, not a raw >=: a non-positive cap must read as
+        // unlimited rather than denying the tenant its first user (#616, #653).
+        if (!Planscape.Core.AccountCeilingPolicy.Allows(userCount, tenant))
+            return BadRequest(
+                $"Account limit ({Planscape.Core.AccountCeilingPolicy.Label(tenant.MaxUsers)}) " +
+                "reached for this organisation.");
 
         if (await _db.Users.AnyAsync(u => u.Email == req.Email))
             return Conflict($"Email {req.Email} already exists");

--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -460,7 +460,13 @@ public class AuthController : ControllerBase
             Plan          = BillingPlan.Trial,
             Currency      = currency,
             BillingCycle  = BillingCycle.Monthly,
-            MaxUsers      = planLimits.TotalSeats,
+            // Flat anti-abuse ceiling, NOT planLimits.TotalSeats (#653). The old
+            // derivation read the limits of the plan the caller ASKED for while the
+            // tenant is assigned Trial, so an anonymous signup chose its own cap —
+            // omitted plan gave 20, "Enterprise" gave int.MaxValue. It also charged
+            // free viewers against paid role caps, which the pricing FAQ says we
+            // don't do. Paid entitlement is metered by the D1 licence count.
+            MaxUsers      = BillingPlanLimits.AccountCeiling,
             MaxProjects   = planLimits.MaxProjects,
             MimEnabled    = false,
             TrialExpiresAt = DateTime.UtcNow.AddDays(30)
@@ -1079,6 +1085,14 @@ public class AuthController : ControllerBase
                 .FirstOrDefaultAsync(t => t.Slug == slug);
             if (tenant == null)
             {
+                // Network only for MaxProjects/display. The account ceiling is
+                // deliberately not taken from a plan here: this mirror must not make
+                // entitlement decisions (D1 does), and Network's seat total is 20 —
+                // which would have locked out any D1-paid firm larger than that,
+                // the exact failure the comment below promises to avoid. Compounded
+                // by this path defaulting unknown roles DOWN to Viewer, so it is the
+                // path that manufactures the free accounts a seat-derived cap
+                // charged for. See #653.
                 var limits = BillingPlanLimits.For(BillingPlan.Network);
                 tenant = new Tenant
                 {
@@ -1095,7 +1109,7 @@ public class AuthController : ControllerBase
                     Plan           = BillingPlan.Trial,
                     Currency       = "USD",
                     BillingCycle   = BillingCycle.Monthly,
-                    MaxUsers       = limits.TotalSeats,
+                    MaxUsers       = BillingPlanLimits.AccountCeiling,
                     MaxProjects    = limits.MaxProjects,
                     MimEnabled     = false,
                     TrialExpiresAt = DateTime.UtcNow.AddDays(365)

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -329,8 +329,14 @@ public class ProjectMembersController : ControllerBase
             // User doesn't exist in this org — create a pending account
             var tenant = await _db.Tenants.FindAsync(tenantId);
             var userCount = await _db.Users.CountAsync(u => u.TenantId == tenantId && u.IsActive);
-            if (tenant != null && userCount >= tenant.MaxUsers)
-                return BadRequest($"User limit ({tenant.MaxUsers}) reached. Upgrade your plan to add more users.");
+            // Via AccountCeilingPolicy, not a raw >= (#616, #653). This is an
+            // anti-abuse ceiling, not a plan cap — viewers and coordinators are free
+            // — so the message no longer tells the customer to upgrade, which would
+            // be selling them something that does not raise this number.
+            if (!Planscape.Core.AccountCeilingPolicy.Allows(userCount, tenant))
+                return BadRequest(
+                    $"Account limit ({Planscape.Core.AccountCeilingPolicy.Label(tenant!.MaxUsers)}) " +
+                    "reached for this organisation. Contact support if you need it raised.");
 
             user = new AppUser
             {

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1673,6 +1673,63 @@ app.MapHub<Planscape.Infrastructure.SignalR.DocumentSyncHub>("/hubs/document-syn
             app.Logger.LogWarning(ex, "[ACL] Could not read the per-folder ACL population.");
         }
 
+        // #653 — report tenants still carrying a seat-derived account cap.
+        //
+        // Tenant.MaxUsers used to be written from BillingPlanLimits.TotalSeats
+        // (MaxAuthors + MaxCoordinators) at both creation paths. That summed two
+        // PAID ROLE caps to bound total ACCOUNTS, so a free viewer consumed a paid
+        // allowance — the opposite of what the pricing page FAQ promises. New
+        // tenants now get the flat BillingPlanLimits.AccountCeiling instead.
+        //
+        // Rows created BEFORE this change keep the old number, and nothing in the
+        // data distinguishes "derived from a plan" from "an admin deliberately
+        // capped this tenant" — 20 could be either. So this REPORTS rather than
+        // rewrites: a blind UPDATE would silently overwrite a deliberate cap, and
+        // the fix for a handful of rows is one reviewed statement, not a guess
+        // applied on every boot. Same reasoning and same shape as the ACL report
+        // above (#631).
+        //
+        // Warning level for the same reason: production runs at
+        // Serilog__MinimumLevel__Default=Warning, so an Information line would be
+        // invisible and its absence unreadable.
+        try
+        {
+            var seatTotals = Enum.GetValues<Planscape.Core.Entities.BillingPlan>()
+                .Select(pl => Planscape.Core.Entities.BillingPlanLimits.For(pl).TotalSeats)
+                .Where(t => t > 0 && t != int.MaxValue)
+                .Distinct()
+                .ToList();
+
+            var legacyCapped = await db.Tenants
+                .IgnoreQueryFilters()
+                .Where(t => t.IsActive && seatTotals.Contains(t.MaxUsers))
+                .Select(t => new { t.Slug, t.MaxUsers })
+                .ToListAsync();
+
+            if (legacyCapped.Count > 0)
+                app.Logger.LogWarning(
+                    "[SEATS] {Count} active tenant(s) carry a MaxUsers matching a plan seat " +
+                    "total ({Totals}) and so may still refuse free viewers: {Tenants}. New " +
+                    "tenants now get the flat ceiling of {Ceiling}. If these are legacy " +
+                    "derived caps rather than deliberate admin limits, raise each with " +
+                    "UPDATE \"Tenants\" SET \"MaxUsers\" = {Ceiling2} WHERE \"Slug\" = ... — " +
+                    "reviewed per tenant, not in bulk. See #653.",
+                    legacyCapped.Count,
+                    string.Join("/", seatTotals),
+                    string.Join(", ", legacyCapped.Select(t => $"{t.Slug}={t.MaxUsers}")),
+                    Planscape.Core.Entities.BillingPlanLimits.AccountCeiling,
+                    Planscape.Core.Entities.BillingPlanLimits.AccountCeiling);
+            else
+                app.Logger.LogWarning(
+                    "[SEATS] No active tenant carries a legacy seat-derived MaxUsers. " +
+                    "Account ceilings are decoupled from paid role caps. See #653.");
+        }
+        catch (Exception ex)
+        {
+            // Never let a diagnostic stop the boot — but never swallow it either.
+            app.Logger.LogWarning(ex, "[SEATS] Could not read the tenant account-cap population.");
+        }
+
         // Postgres RLS policies (#545). OFF unless Database:RlsEnabled is set —
         // the same key that gates RlsConnectionInterceptor above, so the
         // session variable and the policies that read it turn on together

--- a/Planscape.Server/src/Planscape.Core/AccountCeilingPolicy.cs
+++ b/Planscape.Server/src/Planscape.Core/AccountCeilingPolicy.cs
@@ -1,0 +1,43 @@
+using Planscape.Core.Entities;
+
+namespace Planscape.Core;
+
+/// <summary>
+/// The one place that decides whether a tenant may add another account.
+///
+/// <para>Exists because the two enforcement sites (<c>AdminController.CreateUser</c>
+/// and <c>ProjectMembersController</c>) each open-coded
+/// <c>userCount &gt;= tenant.MaxUsers</c>, and that comparison cannot express
+/// "unlimited": every non-positive value — the <c>-1</c> sentinel this repo already
+/// uses in <see cref="TierLimits"/>, a <c>0</c> from a partially-populated row, or the
+/// <c>-2</c> that a wrapped seat sum produced in #616 — is <c>&gt;=</c> true at zero
+/// users and denies the tenant its FIRST account, reporting a limit that points at
+/// nothing.</para>
+///
+/// <para>So this fails OPEN on a nonsensical cap. That is the deliberate direction:
+/// <see cref="Tenant.MaxUsers"/> is an anti-abuse ceiling, not a billing gate (#653),
+/// and letting a misconfigured tenant over-provision is strictly less harmful than
+/// locking a paying customer out of their own organisation with an unactionable
+/// message.</para>
+/// </summary>
+public static class AccountCeilingPolicy
+{
+    /// <summary>
+    /// True if a tenant currently holding <paramref name="activeUserCount"/> active
+    /// accounts may add one more. A non-positive <paramref name="maxUsers"/> means
+    /// unlimited.
+    /// </summary>
+    public static bool Allows(int activeUserCount, int maxUsers)
+        => maxUsers <= 0 || activeUserCount < maxUsers;
+
+    /// <inheritdoc cref="Allows(int,int)"/>
+    public static bool Allows(int activeUserCount, Tenant? tenant)
+        => tenant == null || Allows(activeUserCount, tenant.MaxUsers);
+
+    /// <summary>
+    /// Human-readable cap for an error message. Never renders a non-positive value,
+    /// which would put "User limit (-2) reached" in front of a customer.
+    /// </summary>
+    public static string Label(int maxUsers)
+        => maxUsers <= 0 ? "unlimited" : maxUsers.ToString();
+}

--- a/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Tenant.cs
@@ -38,7 +38,27 @@ public class Tenant
     public LicenseTier Tier { get; set; } = LicenseTier.Starter;
     public bool MimEnabled { get; set; } // Planscape MIM add-on
     public MimTier MimTier { get; set; } = MimTier.None;
-    public int MaxUsers { get; set; } = 5;
+    /// <summary>
+    /// Abuse ceiling on total active <see cref="AppUser"/> accounts in this tenant.
+    /// Enforced as a count of active rows in <c>AdminController.CreateUser</c> and
+    /// <c>ProjectMembersController</c>.
+    ///
+    /// <para>This is NOT a commercial seat cap and must not be derived from one.
+    /// The commercial position is that author seats are the only paid unit and
+    /// viewers/coordinators are free and unlimited — a promise we make in public on
+    /// the pricing page — so a ceiling that scales with paid role caps refuses free
+    /// accounts we said were free. It was previously
+    /// <c>BillingPlanLimits.Limits.TotalSeats</c>; see #653. Its only job now is to
+    /// stop runaway automated signup, so it is a single flat number
+    /// (<see cref="BillingPlanLimits.AccountCeiling"/>) that no legitimate practice
+    /// reaches.</para>
+    ///
+    /// <para>Non-positive means unlimited, and both enforcement sites read it through
+    /// <see cref="Planscape.Core.AccountCeilingPolicy.Allows"/> rather than comparing
+    /// directly — a raw <c>count &gt;= MaxUsers</c> treats 0 and -1 as "deny everyone",
+    /// which is how #616 denied a tenant its first user.</para>
+    /// </summary>
+    public int MaxUsers { get; set; } = BillingPlanLimits.AccountCeiling;
     public int MaxProjects { get; set; } = 1;
     public long StorageLimitBytes { get; set; } = 500 * 1024 * 1024; // 500 MB
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
@@ -170,24 +190,43 @@ public enum BillingCycle
 /// </summary>
 public static class BillingPlanLimits
 {
+    /// <summary>
+    /// The per-plan quota envelope.
+    ///
+    /// <para><see cref="Limits.MaxAuthors"/> and <see cref="Limits.MaxCoordinators"/>
+    /// are <b>display figures for the pricing table</b> and nothing else. Since #653
+    /// decoupled <see cref="Tenant.MaxUsers"/> from <see cref="Limits.TotalSeats"/>,
+    /// and #626 retired the <c>Authors</c>/<c>Coordinators</c> quota axes, no
+    /// enforcement decision anywhere reads them. Their three consumers are all
+    /// presentation: <c>PricingController.Render</c>, the <c>limits</c> block of the
+    /// signup response in <c>AuthController.Register</c>, and
+    /// <c>TenantAdminController</c>. Do not reintroduce them as a cap without
+    /// reading #653 first — they describe project roles, not accounts.</para>
+    ///
+    /// <para><see cref="Limits.MaxProjects"/> and <see cref="Limits.StorageMb"/> ARE
+    /// enforced, via <c>QuotaGuardService</c> and the surviving
+    /// <c>QuotaAxis.Projects</c>/<c>QuotaAxis.Storage</c> axes.</para>
+    /// </summary>
     public record Limits(int MaxAuthors, int MaxCoordinators, int MaxProjects, long StorageMb, decimal MonthlyUsd)
     {
         /// <summary>
-        /// Total billable headcount — the number <see cref="Tenant.MaxUsers"/> is
-        /// derived from at tenant creation.
+        /// Total headcount the plan is <b>marketed</b> with — the "up to 6 users" on
+        /// the pricing page is this number. <b>Display only.</b>
+        ///
+        /// <para>It used to be the source of <see cref="Tenant.MaxUsers"/> at both
+        /// tenant-creation paths. It is not any more (#653): summing two paid ROLE
+        /// caps to bound total ACCOUNTS charged free viewers against a paid
+        /// allowance, contradicting the pricing page's own FAQ. The account ceiling
+        /// is now <see cref="BillingPlanLimits.AccountCeiling"/>, which is flat and
+        /// independent of these axes. <b>Do not wire this back to a cap.</b></para>
         ///
         /// <para>SATURATES, and must never be rewritten as
         /// <c>MaxAuthors + MaxCoordinators</c>. C# arithmetic is unchecked by
         /// default, so that sum wraps NEGATIVE once either side is
-        /// <c>int.MaxValue</c> — <c>int.MaxValue + int.MaxValue = -2</c>, which
-        /// is what Enterprise produces today. <c>MaxUsers</c> is consumed as
-        /// <c>userCount &gt;= tenant.MaxUsers</c>, so a negative cap is true at
-        /// zero users and denies the tenant its FIRST user, reporting
-        /// "User limit (-2) reached".</para>
-        ///
-        /// <para>Reachable on main now; latent only because both creation paths
-        /// assign <c>BillingPlan.Trial</c> (1 + 0). It goes live the moment any
-        /// plan with an unlimited axis is assigned at creation. Guarded by
+        /// <c>int.MaxValue</c> — <c>int.MaxValue + int.MaxValue = -2</c>, which is
+        /// what Enterprise produces today. A wrapped figure is a bug even for a
+        /// display value, and the saturation is what stops it becoming a live
+        /// lockout again if anyone does rewire it. Guarded by
         /// <c>BillingPlanSeatTotalTests</c>. See #616.</para>
         /// </summary>
         public int TotalSeats =>
@@ -195,6 +234,28 @@ public static class BillingPlanLimits
                 ? int.MaxValue
                 : MaxAuthors + MaxCoordinators;
     }
+
+    /// <summary>
+    /// Flat ceiling on total active accounts per tenant, written to
+    /// <see cref="Tenant.MaxUsers"/> at both tenant-creation paths.
+    ///
+    /// <para>Deliberately NOT per-plan and NOT derived from
+    /// <see cref="Limits.MaxAuthors"/>/<see cref="Limits.MaxCoordinators"/> (#653).
+    /// Since #626 removed the 402 invite gate this is the only thing bounding
+    /// account creation, so it cannot simply be deleted — but it is an
+    /// <b>anti-abuse</b> bound, not a commercial one. Paid entitlement is metered
+    /// by the StingTools licence count in D1
+    /// (<c>marketing-site/functions/api/license/_lib/seats.ts</c>), which counts
+    /// machines; viewers hold no licence, so nothing on that side can bound them
+    /// and nothing on this side should charge for them.</para>
+    ///
+    /// <para>10,000 is far above any legitimate practice — the largest published
+    /// plan is "up to 20 users" plus their unlimited free clients and contractors —
+    /// while still stopping scripted signup. Raise it rather than special-casing a
+    /// tenant; a customer legitimately at this number is a conversation, not a
+    /// config change.</para>
+    /// </summary>
+    public const int AccountCeiling = 10_000;
 
     public static Limits For(BillingPlan plan) => plan switch
     {

--- a/Planscape.Server/tests/Planscape.Tests/AccountCeilingTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/AccountCeilingTests.cs
@@ -1,0 +1,136 @@
+using Planscape.Core;
+using Planscape.Core.Entities;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Covers what replaced the <c>TotalSeats</c> derivation of <c>Tenant.MaxUsers</c>
+/// (#653): a flat <see cref="BillingPlanLimits.AccountCeiling"/> read through
+/// <see cref="AccountCeilingPolicy"/>.
+///
+/// Two properties are being pinned, and they are the two acceptance criteria:
+/// <list type="number">
+/// <item>no configuration can produce a cap that refuses a tenant its FIRST account
+/// — the #616 failure, which the raw <c>count &gt;= MaxUsers</c> at both enforcement
+/// sites would still reproduce for any non-positive value; and</item>
+/// <item>adding a free viewer does not consume a paid-role allowance — i.e. the
+/// ceiling does not move with <c>MaxAuthors</c>/<c>MaxCoordinators</c>, so it cannot
+/// re-acquire a coupling to paid roles by accident.</item>
+/// </list>
+/// </summary>
+public class AccountCeilingTests
+{
+    // ── 1. No cap can deny the first account ─────────────────────────────────
+
+    [Theory]
+    [InlineData(-2)]              // the #616 wrapped sum
+    [InlineData(int.MinValue)]    // 1 + int.MaxValue
+    [InlineData(-1)]              // the repo's own "unlimited" sentinel (TierLimits)
+    [InlineData(0)]               // a partially-populated row
+    public void A_nonsensical_cap_reads_as_unlimited_not_as_deny_everyone(int cap)
+    {
+        Assert.True(AccountCeilingPolicy.Allows(activeUserCount: 0, maxUsers: cap),
+            $"MaxUsers = {cap} denied the tenant its first account. A non-positive cap " +
+            "must fail open; `count >= MaxUsers` is what produced 'User limit (-2) " +
+            "reached' in #616.");
+
+        Assert.DoesNotContain("-", AccountCeilingPolicy.Label(cap));
+    }
+
+    [Fact]
+    public void No_plan_can_produce_a_ceiling_that_denies_the_first_account()
+    {
+        // Enumerated, not listed: a plan added later is covered automatically.
+        foreach (BillingPlan plan in Enum.GetValues<BillingPlan>())
+        {
+            var tenant = NewTenant(plan);
+            Assert.True(AccountCeilingPolicy.Allows(0, tenant),
+                $"a tenant created on {plan} could not add its first account " +
+                $"(MaxUsers = {tenant.MaxUsers}).");
+        }
+    }
+
+    [Fact]
+    public void The_entity_default_also_admits_a_first_account()
+    {
+        // Paths that construct a Tenant without setting MaxUsers must not inherit a
+        // cap tighter than the ceiling; the default used to be 5.
+        Assert.True(AccountCeilingPolicy.Allows(0, new Tenant()));
+        Assert.Equal(BillingPlanLimits.AccountCeiling, new Tenant().MaxUsers);
+    }
+
+    // ── 2. Free accounts do not consume a paid-role allowance ────────────────
+
+    [Fact]
+    public void The_ceiling_does_not_move_with_the_paid_role_axes()
+    {
+        // The defect: Studio is 1 author + 5 coordinators, so a seat-derived cap
+        // refused the firm's 7th account — including a free viewer, which the pricing
+        // page FAQ promises does not count. Assert the ceiling is above every plan's
+        // marketed seat total, so no plan's role caps can bind an account count.
+        foreach (BillingPlan plan in Enum.GetValues<BillingPlan>())
+        {
+            var limits = BillingPlanLimits.For(plan);
+            Assert.Equal(BillingPlanLimits.AccountCeiling, NewTenant(plan).MaxUsers);
+
+            if (limits.TotalSeats == int.MaxValue) continue;   // unlimited by design
+            Assert.True(BillingPlanLimits.AccountCeiling > limits.TotalSeats,
+                $"{plan}'s marketed seat total ({limits.TotalSeats}) reaches the account " +
+                "ceiling, so paid role caps bound free accounts again. See #653.");
+        }
+    }
+
+    [Fact]
+    public void A_studio_firm_can_add_far_more_accounts_than_its_seat_total()
+    {
+        // The concrete case in #653, stated as behaviour rather than as a constant:
+        // the 7th account on Studio (1 + 5 = 6) must be admitted.
+        var studio = NewTenant(BillingPlan.Studio);
+        Assert.True(AccountCeilingPolicy.Allows(
+            activeUserCount: BillingPlanLimits.For(BillingPlan.Studio).TotalSeats, studio));
+    }
+
+    // ── 3. It is still a ceiling ─────────────────────────────────────────────
+
+    [Fact]
+    public void Runaway_signup_is_still_refused()
+    {
+        // Decoupling must not become "no bound at all": since #626 removed the 402
+        // invite gate this is the only thing standing between a tenant and scripted
+        // account creation.
+        var tenant = NewTenant(BillingPlan.Studio);
+        Assert.False(AccountCeilingPolicy.Allows(BillingPlanLimits.AccountCeiling, tenant));
+        Assert.False(AccountCeilingPolicy.Allows(BillingPlanLimits.AccountCeiling + 1, tenant));
+        Assert.True(AccountCeilingPolicy.Allows(BillingPlanLimits.AccountCeiling - 1, tenant));
+    }
+
+    [Fact]
+    public void An_explicit_admin_override_is_still_honoured()
+    {
+        // Positive values still bind — SeedData, DemoSandboxJob and PlatformTenantSeeder
+        // all set MaxUsers deliberately, and SeedDataUserCapTests asserts against it.
+        var tenant = new Tenant { MaxUsers = 50 };
+        Assert.True(AccountCeilingPolicy.Allows(49, tenant));
+        Assert.False(AccountCeilingPolicy.Allows(50, tenant));
+        Assert.Equal("50", AccountCeilingPolicy.Label(50));
+    }
+
+    [Fact]
+    public void A_missing_tenant_does_not_bound_anything()
+    {
+        // ProjectMembersController reaches this with a nullable tenant and previously
+        // skipped the check entirely when it was null. Preserve that.
+        Assert.True(AccountCeilingPolicy.Allows(int.MaxValue, (Tenant?)null));
+    }
+
+    /// <summary>
+    /// Mirrors what the two tenant-creation paths in <c>AuthController</c> write.
+    /// If this drifts from them the tests stop covering production.
+    /// </summary>
+    private static Tenant NewTenant(BillingPlan plan) => new()
+    {
+        Plan        = BillingPlan.Trial,
+        MaxUsers    = BillingPlanLimits.AccountCeiling,
+        MaxProjects = BillingPlanLimits.For(plan).MaxProjects,
+    };
+}

--- a/Planscape.Server/tests/Planscape.Tests/BillingPlanSeatTotalTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/BillingPlanSeatTotalTests.cs
@@ -3,28 +3,27 @@ using Planscape.Core.Entities;
 namespace Planscape.Tests;
 
 /// <summary>
-/// <c>Tenant.MaxUsers</c> is derived from the plan's seat total at tenant
-/// creation, and consumed as <c>userCount &gt;= tenant.MaxUsers</c>
-/// (<c>AdminController</c>, <c>ProjectMembersController</c>). A non-positive
-/// cap is therefore true at <c>userCount = 0</c> — the tenant is refused its
-/// very first user, with a message (<c>User limit (-2) reached</c>) that points
-/// at nothing.
+/// <c>BillingPlanLimits.Limits.TotalSeats</c> is the headcount a plan is MARKETED
+/// with — "up to 6 users" on the pricing page. Since #653 it is <b>display only</b>:
+/// <c>Tenant.MaxUsers</c> is no longer derived from it (see
+/// <c>AccountCeilingTests</c> for what replaced it).
 ///
-/// C# arithmetic is unchecked by default, so <c>MaxAuthors + MaxCoordinators</c>
-/// wraps negative the moment either side is <c>int.MaxValue</c>:
+/// This file survives the decoupling on purpose. The arithmetic is still wrong in a
+/// way that is easy to reintroduce: C# is unchecked by default, so
+/// <c>MaxAuthors + MaxCoordinators</c> wraps NEGATIVE the moment either side is
+/// <c>int.MaxValue</c>:
 ///
 ///     1 + int.MaxValue            = -2,147,483,648
 ///     int.MaxValue + int.MaxValue = -2
 ///
-/// Enterprise is <c>(int.MaxValue, int.MaxValue)</c> today, so this is reachable
-/// on main right now. It is latent only because both tenant-creation paths
-/// (<c>AuthController</c> registration and the D1 handoff) assign
-/// <c>BillingPlan.Trial</c>, which is <c>1 + 0</c>. It goes live the moment any
-/// plan with an unlimited axis is assigned at creation.
+/// Enterprise is <c>(int.MaxValue, int.MaxValue)</c> today. A wrapped figure is a bug
+/// even as a display value, and keeping the saturation pinned means that if anyone
+/// ever rewires this to a cap again it degrades to "unlimited" rather than to the #616
+/// lockout, where a tenant was denied its FIRST user by <c>User limit (-2) reached</c>.
 ///
-/// See #616. The loop enumerates <see cref="BillingPlan"/> rather than listing
-/// plans on purpose: a plan added later is covered without anyone remembering
-/// this file exists.
+/// See #616 and #653. The loop enumerates <see cref="BillingPlan"/> rather than listing
+/// plans on purpose: a plan added later is covered without anyone remembering this file
+/// exists.
 /// </summary>
 public class BillingPlanSeatTotalTests
 {
@@ -36,9 +35,9 @@ public class BillingPlanSeatTotalTests
             var total = BillingPlanLimits.For(plan).TotalSeats;
 
             Assert.True(total > 0,
-                $"{plan} yields TotalSeats = {total}. A non-positive cap is written to " +
-                "Tenant.MaxUsers and compared as `userCount >= MaxUsers`, so it denies " +
-                "the tenant its first user. The sum must saturate, not wrap.");
+                $"{plan} yields TotalSeats = {total}. The sum must saturate, not wrap — " +
+                "a negative headcount is nonsense on the pricing page, and is a lockout " +
+                "for anyone who rewires this to a cap again. See #616.");
         }
     }
 


### PR DESCRIPTION
Closes #653.

`Tenant.MaxUsers` bounds **accounts**. It was derived from
`BillingPlanLimits.TotalSeats` — `MaxAuthors + MaxCoordinators`, two **paid role**
caps. A free viewer therefore consumed a paid allowance, and a Studio firm was
refused its 7th account at `1 + 5 = 6`.

We say the opposite in public. `marketing-site/pricing.html:351`, live on the
pricing FAQ:

> They get role-restricted access to the project you've invited them to (typically
> Viewer or Client role). **They don't count against your coordinator cap** as long
> as their firm doesn't also need to author models.

They did count. And since #626 removed the 402 invite gate, `MaxUsers` is the only
bound on account creation left, so it could not simply be deleted.

## Two further defects, both live on `main`

**The derivation did not use the plan the tenant is assigned.** `AuthController:463`
read the limits of the plan the caller *requested* while assigning
`BillingPlan.Trial`:

| `req.Plan` on an anonymous signup | resulting `MaxUsers` |
|---|---|
| omitted | 20 (Network) |
| `"Studio"` | 6 |
| `"Enterprise"` | `int.MaxValue` |

So a signup chose its own abuse ceiling — precisely what the ceiling exists to
stop. The often-repeated "this is latent because both creation paths assign Trial
(1 + 0)" was **not true of this path**.

**The handoff path contradicted its own comment.** `AuthController:1098` hardcoded
Network → **20**, directly beneath:

> Provision the mirror generously so this side never locks out a customer D1
> considers paid; reconciliation is deliberately out of scope.

20 locks out any D1-paid firm larger than that. Worse, this is the path that maps
unknown roles **down** to `UserRole.Viewer`, so it manufactures the very free
accounts a seat-derived cap charged for.

## What changed

- **`BillingPlanLimits.AccountCeiling`** — flat 10,000, independent of the role
  axes, written at both creation paths and now the entity default (was 5). An
  anti-abuse bound, not a commercial one; paid entitlement is metered by the D1
  licence count, which counts *machines* and so can never bound viewers.
- **`AccountCeilingPolicy`** — one place the cap is read. Both enforcement sites
  open-coded `count >= MaxUsers`, and that comparison **cannot express
  "unlimited"**: every non-positive value — this repo's own `-1` sentinel from
  `TierLimits`, a `0` from a partial row, the `-2` from #616 — is `>=` true at zero
  users and denies the tenant its **first** account. It now fails **open** on a
  nonsensical cap, so the #616 class is closed at the comparison, not just at its
  one source.
- **`MaxAuthors`/`MaxCoordinators` documented as what they have become.** After
  #626 retired the Authors/Coordinators quota axes and this PR removes the sum,
  **no enforcement decision anywhere reads them**. Their three consumers are all
  presentation (`PricingController`, the signup response, `TenantAdminController`).
  That is the answer to "what are these two fields still for": the pricing table.
- **`TotalSeats` kept but marked display-only** — "up to 6 users" on the pricing
  page *is* that number. Its saturation guard and `BillingPlanSeatTotalTests` stay,
  so if anyone rewires it to a cap again it degrades to "unlimited" rather than to
  the #616 lockout.
- **Boot report** for tenants still carrying a seat-derived cap, at Warning (prod
  runs at `MinimumLevel=Warning`, so Information would be invisible and its absence
  unreadable).

## The one judgment call

Existing rows keep their old cap. **Nothing in the data distinguishes "derived from
a plan" from "an admin deliberately capped this tenant"** — `20` could be either —
so a blind `UPDATE` would silently overwrite deliberate limits on every boot. This
reports instead, naming the tenants and printing the per-tenant statement to run,
following the #631 precedent. If you would rather it rewrite, say so and I will
make it a one-shot patcher statement.

## Verification

- `dotnet build` — **0 errors**; warning set byte-identical to `main`
  (12×NU1603, 6×CS0618, 2×CS1587), checked with `-t:Rebuild`.
- `dotnet test` — **788 passed, 0 failed, 15 skipped**. The 15 are the Postgres
  `SkippableFact`s with no `PLANSCAPE_TEST_PG` set. `known-failing-tests.txt` is a
  deliberate zero-failure gate and stays met.
- `AccountCeilingTests` pins both acceptance criteria from the issue: no plan or
  sentinel can refuse a first account, and the ceiling does not move with the paid
  role axes. Both enumerate `BillingPlan` rather than listing plans, so a plan added
  later is covered without anyone remembering the file exists.
- No production consumer of `TotalSeats` remains — `grep -rn TotalSeats src` returns
  the definition and doc references only.

The pricing FAQ quoted above is now true; no `marketing-site` files are touched, so
nothing deploys to production from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
