### PR TITLE
fix: connect, invite and sync — three blockers between the plugin and the live server

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/AuthController.cs
@@ -935,13 +935,22 @@ public class AuthController : ControllerBase
         // not a developer "POST /api/…" instruction. SendPasswordResetEmailAsync
         // builds {PublicBaseUrl}/reset-password?token=…&email=… which the
         // reset-password.html page consumes.
+        //
+        // Through EmailDispatch, because a throwing provider DEFEATS THIS ENDPOINT'S
+        // ONLY SECURITY PROPERTY. An unknown address returns above without sending, so
+        // it always answered 200; a real one reached the send, and when Resend rejected
+        // the recipient the unhandled exception answered 500. Two different answers for
+        // "unknown" and "real" is exactly the enumeration this endpoint exists to
+        // prevent — demonstrated against production on 2026-08-20. The reset token is
+        // already committed by this point, so failing the request would also be a lie
+        // about what happened.
         var emailService = HttpContext.RequestServices.GetService<Planscape.Core.Interfaces.IEmailService>();
-        if (emailService != null)
-        {
-            await emailService.SendPasswordResetEmailAsync(
-                user.Email, resetToken, Planscape.API.PublicUrl.Resolve(_config, Request));
-        }
+        await Planscape.Infrastructure.Services.EmailDispatch.TrySendAsync(
+            emailService, _logger, "password-reset", user.Email,
+            () => emailService!.SendPasswordResetEmailAsync(
+                user.Email, resetToken, Planscape.API.PublicUrl.Resolve(_config, Request)));
 
+        // Same body either way, whatever happened above — see the note on the send.
         return Ok(new { message = "If that email exists, a reset link has been sent." });
     }
 

--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -374,10 +374,16 @@ public class ProjectMembersController : ControllerBase
             // Send invite email with the one-click deep link (token + email +
             // project). baseUrl uses Planscape:PublicBaseUrl when set, so the
             // link a remote guest receives is reachable — never internal localhost.
-            await _emailService.SendInviteEmailAsync(
-                user.Email, user.DisplayName, GetCurrentUserName(),
-                project.Name, baseUrl, rawInviteToken, projectId);
-            emailDispatched = _emailService.IsConfigured;
+            // Through EmailDispatch: the rows above are ALREADY COMMITTED, and the
+            // ProjectMember row is added further down, so letting the provider throw
+            // here half-creates the invitation and then reports failure. Measured
+            // against production 2026-08-20: 500, empty body, because Resend answered
+            // 422 for the recipient domain.
+            emailDispatched = await Planscape.Infrastructure.Services.EmailDispatch.TrySendAsync(
+                _emailService, _logger, "invite", user.Email,
+                () => _emailService.SendInviteEmailAsync(
+                    user.Email, user.DisplayName, GetCurrentUserName(),
+                    project.Name, baseUrl, rawInviteToken, projectId));
         }
         else if (!user.IsActive)
         {
@@ -390,10 +396,11 @@ public class ProjectMembersController : ControllerBase
             rawInviteToken = MintInviteToken(user);
             await _db.SaveChangesAsync();
 
-            await _emailService.SendInviteEmailAsync(
-                user.Email, user.DisplayName, GetCurrentUserName(),
-                project.Name, baseUrl, rawInviteToken, projectId);
-            emailDispatched = _emailService.IsConfigured;
+            emailDispatched = await Planscape.Infrastructure.Services.EmailDispatch.TrySendAsync(
+                _emailService, _logger, "invite (reissued)", user.Email,
+                () => _emailService.SendInviteEmailAsync(
+                    user.Email, user.DisplayName, GetCurrentUserName(),
+                    project.Name, baseUrl, rawInviteToken, projectId));
             _logger.LogInformation("[invite] reissued token for {Email} on project {ProjectId}", user.Email, projectId);
         }
 
@@ -442,8 +449,12 @@ public class ProjectMembersController : ControllerBase
 
         await _db.SaveChangesAsync();
 
-        // Item 8 — report whether mail ACTUALLY went out (not merely whether SMTP
-        // is configured) so the plugin shows "emailed" vs "copy the link" honestly.
+        // Report whether mail ACTUALLY went out (not merely whether a provider is
+        // configured) so the plugin shows "emailed" vs "copy the link" honestly. This
+        // comment described the intent long before the code could deliver it:
+        // emailDispatched was assigned `_emailService.IsConfigured`, which says a
+        // provider EXISTS, not that it accepted the message — and the only path where
+        // those differ threw before reaching here.
         // Deep link — return the one-click accept URL so the plugin can show + log
         // it and copy it as the fallback when mail wasn't sent.
         bool emailSent = emailDispatched;

--- a/Planscape.Server/src/Planscape.API/Controllers/StatusController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/StatusController.cs
@@ -143,10 +143,18 @@ public class StatusController : ControllerBase
     ///   ownersSeeded            allow-listed Owner rows present in the platform tenant
     ///   ownersLoginable         …of those, how many are active (can sign in)
     ///   ready                   platform tenant present AND ≥1 loginable owner
+    ///   emailProvider           which IEmailService is registered
+    ///   emailConfigured         it has the credentials it needs to send
     /// </summary>
     [HttpGet("bootstrap")]
     public async Task<ActionResult> Bootstrap([FromServices] IConfiguration config, CancellationToken ct)
     {
+        // GetService, not [FromServices]: an unregistered service makes the latter throw
+        // during model binding, and a DIAGNOSTIC endpoint that 500s when something is
+        // missing reports nothing about the very condition it exists to report. One
+        // provider is always registered today; this survives the day one is not.
+        var email = HttpContext.RequestServices.GetService<Planscape.Core.Interfaces.IEmailService>();
+
         // Read across the tenant query filter (no HTTP tenant context here).
         _db.BypassTenantFilter = true;
 
@@ -178,7 +186,33 @@ public class StatusController : ControllerBase
             ownersSeeded            = seeded,
             ownersLoginable         = loginable,
             ready                   = tenant != null && loginable >= 1,
+
+            // Whether invites and password resets can actually be delivered. Added
+            // because an email misconfiguration was undiagnosable from outside: the
+            // only symptom was an invite answering 500 with an EMPTY BODY, which reads
+            // as "the endpoint is broken" rather than "the provider rejected the
+            // recipient". Answering that needed Render's logs.
+            //
+            // The provider TYPE, never its credentials — this endpoint is anonymous.
+            // "configured" is the provider's own IsConfigured, so it means "has what it
+            // needs to try", not "the last send succeeded"; a valid key can still be
+            // refused per-recipient. That is why the send sites log their reason.
+            emailProvider           = email?.GetType().Name ?? "(none registered)",
+            emailConfigured         = EmailConfiguredSafely(email),
+
             checkedUtc              = DateTime.UtcNow,
         });
+    }
+
+    /// <summary>
+    /// <c>IsConfigured</c> reads provider configuration, so a malformed value could
+    /// throw — and this endpoint must answer even then. false means "cannot confirm it
+    /// can send", which is the honest reading of a provider that cannot describe itself.
+    /// </summary>
+    private static bool EmailConfiguredSafely(Planscape.Core.Interfaces.IEmailService? email)
+    {
+        if (email == null) return false;
+        try { return email.IsConfigured; }
+        catch { return false; }
     }
 }

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/EmailDispatch.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/EmailDispatch.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Logging;
+using Planscape.Core.Interfaces;
+
+namespace Planscape.Infrastructure.Services;
+
+/// <summary>
+/// Sends a NOTIFICATION without letting its failure fail the operation that
+/// triggered it.
+///
+/// <para><b>Why this exists.</b> Providers throw on a hard failure by contract —
+/// <c>ResendEmailService</c> throws on a missing key, an unreachable API and any
+/// non-2xx from Resend. Controllers called them bare, so a rejected recipient took
+/// down an entire request that had ALREADY COMMITTED its database work. Measured
+/// against production on 2026-08-20: <c>POST /api/projects/{id}/members/invite</c>
+/// answered <b>500 with an empty body</b> because Resend returned 422 for the
+/// recipient domain — after the invitee's <c>AppUser</c> row and its invite token
+/// were saved, and before the <c>ProjectMember</c> row was added. The invitation was
+/// half-created and the caller was told it had failed.</para>
+///
+/// <para>The same throw defeated <c>ForgotPassword</c>'s entire purpose. That
+/// endpoint returns an identical 200 for every address specifically "to prevent
+/// email enumeration" — but an unknown address returns before sending, so it 200s,
+/// while a REAL one reaches the send and 500d. Two different answers is an
+/// enumeration oracle, and it was demonstrated against production.</para>
+///
+/// <para><b>This is not a silent catch.</b> The failure is logged with its reason
+/// and returned to the caller as <c>false</c>, so the response can say
+/// <c>emailSent: false</c> and hand back a copyable link — which is precisely what
+/// the invite endpoint already promised to do and could not reach. A caller that
+/// treats the email as the operation itself (a "resend verification" button, the
+/// <c>/notifications/test-email</c> diagnostic) must NOT use this — there, a failure
+/// is the answer the user asked for.</para>
+/// </summary>
+public static class EmailDispatch
+{
+    /// <summary>
+    /// Runs <paramref name="send"/> and reports whether mail actually went out.
+    ///
+    /// <para>Returns false — never throws — when the provider is unconfigured or the
+    /// send fails. <paramref name="what"/> and <paramref name="toEmail"/> go in the
+    /// log line so an operator can tell which message was lost and to whom, which is
+    /// the thing that was impossible while the failure surfaced as a bare 500.</para>
+    /// </summary>
+    public static async Task<bool> TrySendAsync(
+        IEmailService? email, ILogger logger, string what, string toEmail, Func<Task> send)
+    {
+        if (email == null)
+        {
+            logger.LogWarning("[email] {What} to {To} not sent — no email service registered.", what, toEmail);
+            return false;
+        }
+
+        // Asked before sending, not after: a provider that no-ops when unconfigured
+        // (SmtpEmailService with no Host, NullEmailService) would otherwise report
+        // success for a message that never left the building.
+        if (!email.IsConfigured)
+        {
+            logger.LogWarning(
+                "[email] {What} to {To} NOT SENT — no email provider configured. "
+              + "Set Email__Provider=resend + RESEND_API_KEY, or Smtp__Host.", what, toEmail);
+            return false;
+        }
+
+        try
+        {
+            await send().ConfigureAwait(false);
+            logger.LogInformation("[email] {What} sent to {To}.", what, toEmail);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Deliberately broad. Every provider failure mode belongs here — a bad key,
+            // a rejected recipient, a rate limit, a network drop — and none of them is a
+            // reason to fail the caller's actual operation. The reason is logged rather
+            // than swallowed; that distinction is the whole point.
+            logger.LogError(ex,
+                "[email] {What} to {To} FAILED — the operation continued. Reason: {Reason}",
+                what, toEmail, ex.Message);
+            return false;
+        }
+    }
+}

--- a/Planscape.Server/tests/Planscape.Tests/EmailDispatchTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/EmailDispatchTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Pins the rule that a NOTIFICATION failure must not fail the operation that
+/// triggered it.
+///
+/// <para>Measured against production on 2026-08-20:
+/// <c>POST /api/projects/{id}/members/invite</c> answered <b>500 with an empty
+/// body</b> because Resend returned 422 for the recipient domain — after the
+/// invitee's user row and invite token were committed and before the
+/// <c>ProjectMember</c> row was added. And <c>POST /api/auth/forgot-password</c>
+/// answered 200 for an unknown address but 500 for a real one, which is the
+/// enumeration oracle that endpoint exists to prevent.</para>
+///
+/// <para>Both came from the same shape: providers throw on hard failure by contract,
+/// and controllers called them bare.</para>
+/// </summary>
+public class EmailDispatchTests
+{
+    // ── A failing provider is reported, not propagated ───────────────────────
+
+    [Fact]
+    public async Task A_throwing_provider_does_not_propagate()
+    {
+        // The exact production failure: Resend rejects the recipient and the provider
+        // throws by contract. Nothing above it should ever see this exception.
+        var email = new StubEmail(configured: true,
+            onSend: () => throw new InvalidOperationException(
+                "Resend send failed (422): Invalid `to` field."));
+
+        var sent = await EmailDispatch.TrySendAsync(
+            email, NullLogger.Instance, "invite", "x@example.com", email.SendAsync);
+
+        Assert.False(sent);
+        Assert.Equal(1, email.Attempts);   // it really did try
+    }
+
+    [Theory]
+    [InlineData(typeof(TimeoutException))]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(OperationCanceledException))]
+    public async Task Every_transport_failure_mode_is_contained(Type exceptionType)
+    {
+        // Enumerated rather than listing one: a bad key, a rate limit and a dropped
+        // connection are all "the message did not go out", and none of them is a reason
+        // to fail the caller's actual operation.
+        var email = new StubEmail(configured: true,
+            onSend: () => throw (Exception)Activator.CreateInstance(exceptionType)!);
+
+        Assert.False(await EmailDispatch.TrySendAsync(
+            email, NullLogger.Instance, "invite", "x@example.com", email.SendAsync));
+    }
+
+    // ── "Configured" is asked BEFORE sending ─────────────────────────────────
+
+    [Fact]
+    public async Task An_unconfigured_provider_reports_false_without_sending()
+    {
+        // SmtpEmailService with no Host and NullEmailService both no-op and return
+        // normally. Reporting that as success would tell the plugin "emailed" for a
+        // message that never left the building — and the plugin would then NOT copy
+        // the invite link, which is the fallback the user needs.
+        var email = new StubEmail(configured: false);
+
+        Assert.False(await EmailDispatch.TrySendAsync(
+            email, NullLogger.Instance, "invite", "x@example.com", email.SendAsync));
+        Assert.Equal(0, email.Attempts);
+    }
+
+    [Fact]
+    public async Task A_missing_service_is_not_a_crash()
+    {
+        // ForgotPassword resolves IEmailService with GetService, which returns null
+        // when nothing is registered.
+        Assert.False(await EmailDispatch.TrySendAsync(
+            null, NullLogger.Instance, "password-reset", "x@example.com",
+            () => Task.CompletedTask));
+    }
+
+    // ── Success still reports success ────────────────────────────────────────
+
+    [Fact]
+    public async Task A_successful_send_reports_true()
+    {
+        // The guard must not become "always false" — the invite response says
+        // "emailed" vs "copy the link" based on this, and getting it wrong in the
+        // safe-looking direction tells a user to chase a link that was already sent.
+        var email = new StubEmail(configured: true);
+
+        Assert.True(await EmailDispatch.TrySendAsync(
+            email, NullLogger.Instance, "invite", "x@example.com", email.SendAsync));
+        Assert.Equal(1, email.Attempts);
+    }
+
+    /// <summary>Minimal IEmailService that records attempts and can be told to throw.</summary>
+    private sealed class StubEmail : IEmailService
+    {
+        private readonly Action? _onSend;
+        public StubEmail(bool configured, Action? onSend = null)
+        {
+            IsConfigured = configured;
+            _onSend = onSend;
+        }
+
+        public bool IsConfigured { get; }
+        public int Attempts { get; private set; }
+
+        public Task SendAsync()
+        {
+            Attempts++;
+            _onSend?.Invoke();
+            return Task.CompletedTask;
+        }
+
+        public Task SendInviteEmailAsync(string toEmail, string displayName, string inviterName,
+            string projectName, string serverUrl, string? resetToken = null,
+            Guid projectId = default, CancellationToken ct = default) => SendAsync();
+
+        public Task SendPasswordResetEmailAsync(string toEmail, string resetToken,
+            string serverUrl, CancellationToken ct = default) => SendAsync();
+
+        public Task SendNotificationAsync(string toEmail, string subject, string htmlBody,
+            CancellationToken ct = default) => SendAsync();
+
+        public Task SendAsync(string toEmail, string subject, string htmlBody,
+            CancellationToken ct = default) => SendAsync();
+    }
+}

--- a/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Settings.cs
@@ -35,9 +35,35 @@ public sealed partial class PlanscapeServerClient
     /// <summary>
     /// Corporate default API base. Used only when neither the
     /// <c>STING_PLANSCAPE_URL</c> env var nor the machine settings file
-    /// supplies a URL. Points at the production Planscape API.
+    /// supplies a URL.
+    ///
+    /// <para><b>This is the Render hostname, not <c>api.planscape.build</c>, because
+    /// api.planscape.build does not resolve.</b> Measured 2026-08-20: a request to it
+    /// fails at connect (curl exit 6, no HTTP status at all) while
+    /// <c>planscape-api-free.onrender.com/health/live</c> answers 200. The custom
+    /// domain has never been attached to a Render service — see #705 — so every
+    /// out-of-the-box install pointed at an address with no DNS record and every
+    /// "Connect" failed. A default that cannot work for anybody is worse than an
+    /// unlovely hostname.</para>
+    ///
+    /// <para><b>Swap this back the moment #705 is done</b> — attach
+    /// api.planscape.build to the live service, confirm
+    /// <c>curl https://api.planscape.build/health/live</c> answers 200, then change
+    /// this constant and leave the Render URL as a built-in target. The custom domain
+    /// is the right long-term identity; it is simply not a working one today.</para>
+    ///
+    /// <para>Note the SERVICE name is <c>planscape-api-free</c>. <c>planscape-api</c>
+    /// — the name in <c>render.yaml</c> — 404s; the blueprint does not govern what is
+    /// deployed. Do not "correct" this to match the yaml.</para>
     /// </summary>
-    public const string BakedDefaultServerUrl = "https://api.planscape.build";
+    public const string BakedDefaultServerUrl = "https://planscape-api-free.onrender.com";
+
+    /// <summary>
+    /// The intended long-term production identity, offered as a built-in target so it
+    /// can be selected the moment DNS exists (#705). Kept as a named constant rather
+    /// than a literal so there is exactly one place to change when it goes live.
+    /// </summary>
+    public const string IntendedProductionServerUrl = "https://api.planscape.build";
 
     /// <summary>Env var name a deployment can set to override the default
     /// server URL without editing any file.</summary>
@@ -219,7 +245,19 @@ public sealed partial class PlanscapeServerClient
             bool isLocal = host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
                            || host == "127.0.0.1"
                            || host.EndsWith(".local", StringComparison.OrdinalIgnoreCase);
-            if (!isLocal && host.StartsWith("api.", StringComparison.OrdinalIgnoreCase))
+            // The corporate SPA, for API hosts that do not follow the api.<domain>
+            // convention. planscape-api-free.onrender.com is the baked default
+            // (api.planscape.build has no DNS — #705), and without this it would fall
+            // to the same-origin <base>/app/ branch below. That branch answers 200, so
+            // the mistake would not look like one: the button would open the API host's
+            // static copy rather than the coordinator app, and only differing content
+            // would give it away. app.planscape.build IS attached and serving —
+            // verified 2026-08-20 — so the web half needs no workaround, only the API.
+            if (!isLocal && host.Equals("planscape-api-free.onrender.com", StringComparison.OrdinalIgnoreCase))
+            {
+                url = "https://app.planscape.build/";
+            }
+            else if (!isLocal && host.StartsWith("api.", StringComparison.OrdinalIgnoreCase))
             {
                 var b = new UriBuilder(u) { Host = "app." + host.Substring(4), Path = "/" };
                 if ((u.Scheme == Uri.UriSchemeHttps && u.Port == 443) ||

--- a/StingTools/BIMManager/PlanscapeServerTargets.cs
+++ b/StingTools/BIMManager/PlanscapeServerTargets.cs
@@ -102,6 +102,17 @@ public static class PlanscapeServerTargets
         };
         yield return new ServerTarget
         {
+            // Offered so the custom domain can be selected the moment it is attached
+            // (#705). It does NOT resolve today, and ProbeAsync refuses a target it
+            // cannot reach — which is the point: choosing it before DNS exists fails
+            // at the picker, where the reason is visible, rather than later as a
+            // connect error with no explanation.
+            Label = "Production (custom domain — pending DNS)",
+            Url = PlanscapeServerClient.IntendedProductionServerUrl,
+            IsBuiltIn = true,
+        };
+        yield return new ServerTarget
+        {
             // Matches the docker-compose port mapping (5000:8080) in
             // Planscape.Server/docker/docker-compose.yml.
             Label = "Local (docker)",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 237 — connect, invite, sync: three blockers between the plugin and the live server)
+
+Started from a plain request — *"I want to be able to log in, invite a member, and that
+member should see my updates as I sync"* — with the BCC showing **Not connected** against
+`http://127.0.0.1:56519`.
+
+**The chain itself works. It was verified, not assumed.** Against the live API on
+2026-08-20: register a throwaway tenant → create a project → invite → invitee sets a
+password from the emailed token → invitee logs in → owner `POST /api/tagsync/sync`
+(2 created, 100 %, GREEN) → **the invitee reads both elements back**, stamped
+`syncedBy: "Verify Owner"`. Every hop ran on real components; nothing stood in for
+anything.
+
+Three defects stood between that and the user.
+
+**1. The plugin could not reach any live server — the baked default has no DNS.**
+`BakedDefaultServerUrl` was `https://api.planscape.build`, which fails at *connect* — no
+HTTP status at all, because the custom domain has never been attached to a Render service
+(#705). Meanwhile `planscape-api-free.onrender.com/health/live` answers 200. So every
+out-of-the-box install pointed at an address with no DNS record and every "Connect"
+failed. The default is now the hostname that actually serves, with
+`IntendedProductionServerUrl` kept as a named constant and offered as a built-in target
+labelled *pending DNS* — `ProbeAsync` refuses it, which is the point: it fails at the
+picker where the reason is visible. **Swap back when #705 is done.**
+
+`FormatWebAppUrl` needed a matching case. Its rule is `api.<domain>` → `app.<domain>`;
+the Render host matches neither, so "Open Planscape" would have fallen to the
+same-origin `<base>/app/` branch — which **answers 200**, so the mistake would not have
+looked like one. `app.planscape.build` is attached and serving (verified), so only the
+API half needed the workaround.
+
+**2. An email failure took down the whole operation.** Providers throw on hard failure by
+contract; controllers called them bare. `POST /api/projects/{id}/members/invite` answered
+**500 with an empty body** when Resend returned 422 for the recipient — *after* the
+invitee's `AppUser` row and invite token were committed and *before* the `ProjectMember`
+row was added. Half-invited, reported as failed. The endpoint already promised the right
+behaviour — `emailSent: false` plus a copyable link, which the plugin already handles —
+and simply could not reach it.
+
+The same throw defeated `ForgotPassword`'s only security property. That endpoint returns
+an identical 200 for every address *"to prevent email enumeration"*, but an unknown
+address returns before sending (200) while a real one reached the send (500). **A working
+enumeration oracle, demonstrated against production.**
+
+New `EmailDispatch.TrySendAsync` sends, logs the reason, and returns a bool. Not a silent
+catch — the distinction is the whole point. Callers for whom the email *is* the operation
+(`/notifications/test-email`) deliberately still surface failures. `emailDispatched` now
+reports what actually happened rather than `_emailService.IsConfigured`, which says a
+provider *exists*, not that it accepted the message — a comment above that line had
+described the correct intent for some time.
+
+**3. It was undiagnosable from outside.** The only symptom was a 500 with an empty body,
+which reads as "the endpoint is broken", not "the provider rejected the recipient";
+answering it needed Render's logs. `/api/status/bootstrap` now reports `emailProvider`
+and `emailConfigured` — the provider TYPE, never its credentials, since the endpoint is
+anonymous. It resolves the service with `GetService` rather than `[FromServices]` and
+guards `IsConfigured`, because a diagnostic that 500s reports nothing about the condition
+it exists to report.
+
+*The root cause of the original 500s was the `@example.com` addresses in the harness —
+Resend rejects them by design. Email on the live server is correctly configured and does
+send. That makes the defect narrower than it first looked and no less real: any rejected
+recipient, suppression, rate limit or outage reproduces it.*
+
+**Tests.** `EmailDispatchTests` — 7 cases: a throwing provider does not propagate;
+timeout / HTTP / cancellation are enumerated rather than sampled; an unconfigured
+provider reports false **without attempting**; a missing service is not a crash; and
+success still reports true, so the guard cannot quietly become "always false". Suite
+**813 passing, 0 failing**; server and plugin both build 0 errors, plugin 0 warnings.
+
 #### Completed (Phase 236 — one project gate, and the tier D1 was already sending)
 
 Follow-on to #653 (`MaxUsers`). Same shape of defect on the projects axis, but this one


### PR DESCRIPTION
Goal: *log in from the BCC, invite a member, and have that member see updates as I sync.*
The BCC was showing **Not connected** against `http://127.0.0.1:56519`.

## The chain works — verified, not assumed

Against the live API on 2026-08-20, every hop on real components:

| step | result |
|---|---|
| register a throwaway tenant | 201 |
| create a project | 201 |
| invite a member | `emailSent: true`, one-click link returned |
| invitee sets a password from the emailed token | `Password has been reset` |
| invitee logs in | token issued |
| owner `POST /api/tagsync/sync` | `received 2, created 2, compliance 100, GREEN` |
| **invitee reads the elements back** | **both, stamped `syncedBy: "Verify Owner"`** |

Nothing stood in for anything. Three defects stood between that and the user.

## 1. The plugin could not reach any live server

`BakedDefaultServerUrl` was `https://api.planscape.build` — which fails at **connect**, no
HTTP status at all, because the custom domain has never been attached to a Render service
(#705). `planscape-api-free.onrender.com/health/live` answers **200**.

So every out-of-the-box install pointed at an address with no DNS record, and every
"Connect" failed. A default that cannot work for anybody is worse than an unlovely
hostname.

- default → the host that actually serves
- `IntendedProductionServerUrl` keeps the custom domain as a named constant **and** a
  built-in target labelled *pending DNS* — `ProbeAsync` refuses it, which is the point:
  it fails at the picker, where the reason is visible, instead of later as a bare connect
  error
- **swap back when #705 lands** — the constant is the one place to change

`FormatWebAppUrl` needed a matching case. Its rule is `api.<domain>` → `app.<domain>`; the
Render host matches neither, so "Open Planscape" would have fallen to the same-origin
`<base>/app/` branch — **which answers 200**, so the mistake would not have looked like
one. `app.planscape.build` *is* attached and serving (verified), so only the API half
needed a workaround.

> Note the service is `planscape-api-free`. `planscape-api` — the name in `render.yaml` —
> 404s. The blueprint does not govern what is deployed; don't "correct" this to match it.

## 2. An email failure took down the whole operation

Providers throw on hard failure by contract. Controllers called them bare.

`POST /api/projects/{id}/members/invite` answered **500 with an empty body** when Resend
returned 422 for the recipient — **after** the invitee's `AppUser` row and invite token
were committed, and **before** the `ProjectMember` row was added. Half-invited, and the
caller told it failed. The endpoint already promised the right behaviour —
`emailSent: false` plus a copyable link, which the plugin already handles — and simply
could not reach it.

The same throw defeated `ForgotPassword`'s **only** security property. It returns an
identical 200 for every address *"to prevent email enumeration"* — but an unknown address
returns before sending (200) while a real one reached the send (500).

**That is a working enumeration oracle, and it was demonstrated against production.**

`EmailDispatch.TrySendAsync` sends, logs the reason, and returns a bool. **Not a silent
catch** — that distinction is the whole point, and callers for whom the email *is* the
operation (`/notifications/test-email`) deliberately still surface failures.
`emailDispatched` now reports what actually happened instead of `_emailService.IsConfigured`,
which says a provider *exists*, not that it accepted the message — a comment above that
line had described the correct intent for some time.

## 3. It was undiagnosable from outside

The only symptom was a 500 with an empty body, which reads as "the endpoint is broken",
not "the provider rejected the recipient". Answering it needed Render's logs.

`/api/status/bootstrap` now reports `emailProvider` and `emailConfigured` — the provider
**type**, never credentials, since the endpoint is anonymous. It resolves the service with
`GetService` rather than `[FromServices]` and guards `IsConfigured`, because a diagnostic
that 500s reports nothing about the condition it exists to report.

## Worth stating plainly

The original 500s were **triggered by the `@example.com` addresses in my harness**, which
Resend rejects by design. Email on the live server is correctly configured and does send.
That makes the defect narrower than it first looked — and no less real: any rejected
recipient, suppression, rate limit or Resend outage reproduces it, and the enumeration
oracle needs only one of those.

## Verification

- `dotnet test` → **813 passing, 0 failing**, 15 skipped (Postgres-gated).
- `Planscape.sln` → 0 errors. `StingTools.csproj` → **0 errors, 0 warnings**.
- `EmailDispatchTests` — 7 cases. Transport failure modes are **enumerated** (timeout /
  HTTP / cancellation) rather than sampled; an unconfigured provider reports false
  **without attempting**; success still reports true, so the guard cannot quietly become
  "always false" and send everyone chasing a link that was already delivered.

## Follow-up that is not code

**#705** — attach `api.planscape.build` to `planscape-api-free` (DNS + Render dashboard),
then flip `BakedDefaultServerUrl` back. Worth pairing with always-on: a cold start on the
free tier measured **53.6 s**, which reads as a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
