### PR TITLE
fix: the invite note named a cause that was not the cause

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -475,9 +475,22 @@ public class ProjectMembersController : ControllerBase
             emailSent,
             inviteLink = inviteUrl,
             linkWarning,
+            // Three outcomes, not two. "Not sent" used to always read "Email is not
+            // configured on the server", which sends the reader to check env vars when
+            // the actual cause may be this ONE recipient — a rejected domain, a
+            // suppression, a bounce. Verified on the live server 2026-08-20: a rejected
+            // address produced exactly that message while Resend was configured and
+            // working. A message that names the wrong cause is worse than a vague one,
+            // because it is actionable in the wrong direction.
             note       = !user.IsActive
-                ? (emailSent ? "An invitation email has been sent with instructions to set a password."
-                             : "Email is not configured on the server — copy the invitation link to the invitee instead.")
+                ? emailSent
+                    ? "An invitation email has been sent with instructions to set a password."
+                    : _emailService.IsConfigured
+                        ? "The invitation was recorded, but the email could not be delivered to this "
+                          + "address — copy the invitation link to the invitee instead. Check the "
+                          + "address, then the server log for the provider's reason."
+                        : "Email is not configured on the server — copy the invitation link to the "
+                          + "invitee instead."
                 : null
         });
     }

--- a/StingTools/UI/BIMCoordinationCenter.cs
+++ b/StingTools/UI/BIMCoordinationCenter.cs
@@ -4827,8 +4827,11 @@ namespace StingTools.UI
                             // This is NOT the unreachable path.
                             try { System.Windows.Clipboard.SetText(string.IsNullOrEmpty(deepLink) ? invite : deepLink); }
                             catch (Exception cex) { StingLog.Warn($"Suppressed: {cex.Message}"); }
-                            ShowStatus(result.Note ?? "Invite recorded - email not configured on the server; link copied.");
-                            string body = (result.Note ?? "Email is not configured on the server — copy the invitation link to the invitee.")
+                            // The server's note names the actual cause (no provider vs
+                            // this recipient rejected); only guess when it sent none, and
+                            // then say nothing we cannot stand behind.
+                            ShowStatus(result.Note ?? "Invite recorded - no email went out; link copied.");
+                            string body = (result.Note ?? "No invitation email went out — copy the invitation link to the invitee.")
                                         + (string.IsNullOrEmpty(deepLink) ? "" : $"\n\nOne-click invite link (copied to clipboard):\n{deepLink}")
                                         + warnSuffix;
                             TaskDialog.Show("Planscape Invite", body);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 238 — the invite note named the wrong cause)
+
+Follow-on to Phase 237, found by verifying that fix against the live server rather than
+stopping at "it returns 200 now".
+
+The invite response has two outcomes in its `note`: sent, or *"Email is not configured on
+the server."* Once a failing send stopped throwing, a **third** outcome became reachable
+and fell into the second bucket. Measured 2026-08-20: inviting an address Resend rejects
+returned `emailSent: false` with that note, while `/api/status/bootstrap` reported
+`emailProvider: ResendEmailService, emailConfigured: true` — the message named a cause
+that was demonstrably false and pointed the reader at env vars when the problem was one
+recipient.
+
+A wrong-but-actionable message costs more than a vague one: it is specific enough to act
+on and sends you the wrong way. The note now distinguishes "no provider configured" from
+"configured, but this address could not be delivered to", the latter naming the address
+and pointing at the server log for the provider's reason. The BCC's own fallback strings —
+used only when the server sends no note — dropped their "not configured" claim for
+something they can stand behind.
+
+Also confirmed on the live server that the Phase 237 fixes did what they claimed:
+`forgot-password` now answers **200 for both** a real user and an unknown one (the real
+one was 500 — the enumeration oracle), and an invite to a rejected recipient returns 200
+with a working link **and the `ProjectMember` row present**, where the throw previously
+left the invitee half-created.
+
 #### Completed (Phase 237 — connect, invite, sync: three blockers between the plugin and the live server)
 
 Started from a plain request — *"I want to be able to log in, invite a member, and that


### PR DESCRIPTION
Follow-on to #741, found by verifying that fix **against the live server** rather than
stopping at "it returns 200 now".

## What was wrong

The invite response's `note` had two outcomes: sent, or *"Email is not configured on the
server — copy the invitation link to the invitee instead."*

Once a failing send stopped throwing (#741), a **third** outcome became reachable and fell
into the second bucket. Measured on the live API, 2026-08-20:

```
POST /api/projects/{id}/members/invite   -> 200
  emailSent : false
  note      : "Email is not configured on the server ..."

GET /api/status/bootstrap                -> 200
  emailProvider   : "ResendEmailService"
  emailConfigured : true
```

The message named a cause that was **demonstrably false**, and pointed the reader at
environment variables when the problem was a single recipient.

A wrong-but-actionable message costs more than a vague one: it is specific enough to act
on, and it sends you the wrong way. That is the same failure mode as an empty list
standing in for an error — a confident answer where there wasn't one.

## The fix

`note` now distinguishes three states:

| | |
|---|---|
| sent | unchanged |
| **configured, this address failed** | *"the email could not be delivered to this address — copy the link. Check the address, then the server log for the provider's reason."* |
| no provider configured | unchanged |

The BCC's own fallback strings — used only when the server sends no note at all — dropped
their "not configured" claim for something they can stand behind.

## Also verified: #741 did what it claimed

Not asserted from the diff — re-run against the live server after the deploy landed
(~5.5 min after merge):

- **The enumeration oracle is closed.** `forgot-password` answers **200 for both** a real
  user and an unknown one. The real user previously returned **500**, which is what made
  the two distinguishable.
- **The invitation is whole.** An invite to a rejected recipient returns 200 with a
  working one-click link, and `GET /members` shows the `ProjectMember` row — where the
  throw previously left the invitee created but unattached, and reported failure.

## Verification

- `dotnet test` → **813 passing, 0 failing**, 15 skipped (Postgres-gated).
- `Planscape.sln` → 0 errors. `StingTools.csproj` → 0 errors, **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
