### PR TITLE
fix: Connect could not survive a cold start, and blamed the wrong thing

### DIFF
--- a/StingTools/BIMManager/PlanscapeServerClient.Connectivity.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.Connectivity.cs
@@ -103,7 +103,19 @@ public sealed partial class PlanscapeServerClient
         }
 
         if (ex is TaskCanceledException || ex is OperationCanceledException)
-            return $"Login failed: request to {serverUrl} timed out before the server responded.";
+            // Name the likely cause. "Timed out before the server responded" is true
+            // and useless: it reads as "the server is broken", so the natural next
+            // move is to re-check the password — which cannot help. On a free-tier
+            // host this is almost always an idled instance waking up; measured
+            // 2026-08-20, the first request after an idle period did not answer within
+            // 180s and the next took 66.6s. Waiting and retrying is the fix, and the
+            // message should say so.
+            return $"Login failed: {serverUrl} did not respond in time.\n\n"
+                 + "The server may have been idle and is waking up. On the free tier the "
+                 + "first request after a quiet period can take a couple of minutes. Wait a "
+                 + "moment and press Connect again — the second attempt usually succeeds.\n\n"
+                 + "If it keeps failing, check the Server URL and that this machine can "
+                 + "reach it.";
 
         // FIX 1 — TLS / scheme-mismatch / proxy classification.
         //

--- a/StingTools/BIMManager/PlanscapeServerClient.cs
+++ b/StingTools/BIMManager/PlanscapeServerClient.cs
@@ -187,6 +187,17 @@ public sealed partial class PlanscapeServerClient : IDisposable
             _serverUrl = NormalizeServerUrl(serverUrl);
             EnsureHttpClient(_serverUrl);
 
+            // Absorb a cold start HERE, on a cheap anonymous request, rather than
+            // letting the credentialed login pay it and fail.
+            //
+            // Free-tier hosts idle out and take a long time on the first request
+            // back. Measured on the live host 2026-08-20: the first hit did not
+            // answer within 180s at all; the next took 66.6s. Login carried a 60s
+            // ceiling, so it reported "timed out before the server responded" — true,
+            // and useless: it reads as "the server is broken" when the server is
+            // merely asleep, and re-entering the password does not help.
+            await WakeServerAsync(_serverUrl).ConfigureAwait(false);
+
             // ConfigureAwait(false) prevents the continuation from being
             // posted back to a captured SynchronizationContext (e.g. the
             // WPF dispatcher when this is called via .GetResult() from
@@ -1819,6 +1830,49 @@ public sealed partial class PlanscapeServerClient : IDisposable
     //  Private helpers
     // ────────────────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Give a sleeping server time to wake, on an anonymous request, before anything
+    /// that matters is attempted.
+    ///
+    /// <para><b>The long ceiling costs nothing when the server is awake.</b> A timeout
+    /// bounds how long we are willing to wait, not how long we do wait — a warm
+    /// <c>/health/live</c> answers in well under a second. So this is not "make login
+    /// slow for everyone"; it is "stop failing the one user whose call arrives first
+    /// after an idle period".</para>
+    ///
+    /// <para><c>/health/live</c> and not <c>/health</c>: the latter is the
+    /// authenticated full diagnostic and answers 403 to an anonymous caller, which
+    /// would read as a dead server. Same reasoning as
+    /// <c>PlanscapeServerTargets.ProbeAsync</c>.</para>
+    ///
+    /// <para>Never fails the caller. A 404 means an older server without the endpoint,
+    /// and a timeout here means login is likely to fail too — but login gives the far
+    /// better error, so let it be the one to speak.</para>
+    /// </summary>
+    private static async Task WakeServerAsync(string baseUrl)
+    {
+        try
+        {
+            using var probe = new HttpClient { Timeout = TimeSpan.FromSeconds(240) };
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var resp = await probe.GetAsync(baseUrl.TrimEnd('/') + "/health/live")
+                                  .ConfigureAwait(false);
+            sw.Stop();
+
+            // Worth a line at 5s+ — that is the signature of a cold start, and it is
+            // the explanation for a slow "Connect" that would otherwise look like a
+            // hang. Below that it is noise.
+            if (sw.Elapsed.TotalSeconds >= 5)
+                StingLog.Info($"Planscape: server took {sw.Elapsed.TotalSeconds:F1}s to respond " +
+                              $"(HTTP {(int)resp.StatusCode}) — it had most likely idled out and was waking up.");
+        }
+        catch (Exception ex)
+        {
+            StingLog.Warn($"Planscape: pre-login wake probe of {baseUrl} did not succeed ({ex.Message}). " +
+                          "Continuing to login, which reports the real error.");
+        }
+    }
+
     private HttpClient EnsureHttpClient(string baseUrl)
     {
         lock (_httpSem)
@@ -1828,7 +1882,16 @@ public sealed partial class PlanscapeServerClient : IDisposable
             _http = new HttpClient
             {
                 BaseAddress = new Uri(baseUrl),
-                Timeout     = TimeSpan.FromSeconds(60)
+                // 120s, not 60. Measured against the live free-tier host on
+                // 2026-08-20: a request arriving after the instance had idled took
+                // 66.6s to answer — over the old ceiling, so it failed as a timeout
+                // while the server was working normally. A ceiling is not a wait: a
+                // warm call still returns in well under a second.
+                //
+                // The COLD case is handled separately, by WakeServerAsync before
+                // login, because it can exceed three minutes and no sane per-request
+                // ceiling should cover that.
+                Timeout     = TimeSpan.FromSeconds(120)
             };
             _http.DefaultRequestHeaders.Accept.Add(
                 new MediaTypeWithQualityHeaderValue("application/json"));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 239 — Connect could not survive a cold start)
+
+Phase 237 pointed the plugin at a host that answers. The first real sign-in still failed:
+
+> Login failed: request to https://planscape-api-free.onrender.com timed out before the
+> server responded.
+
+**The server was asleep, not broken.** Free-tier instances idle out. Measured on the live
+host 2026-08-20, roughly two hours after the last traffic: the first request **did not
+answer within 180s at all**, and the next took **66.6s**. The plugin's `HttpClient` carried
+a flat **60s** ceiling, so login could not survive either.
+
+Two things were wrong, and the second is the one that cost time.
+
+**The ceiling was below the measured warm-ish response.** 60s → **120s**. A timeout bounds
+how long we are *willing* to wait, not how long we *do* — a warm call still returns in well
+under a second — so this costs nobody anything and stops failing a request the server is
+answering normally.
+
+**The cold case is not a per-request problem.** Three minutes is not a sane ceiling for
+every sync call, so `WakeServerAsync` now absorbs it *before* login, on a cheap anonymous
+`/health/live` with a 240s budget. `/health/live` and not `/health` — the latter is the
+authenticated diagnostic and answers 403 anonymously, which would read as a dead server
+(same reasoning as `PlanscapeServerTargets.ProbeAsync`). It never fails the caller: a 404
+means an older server, and if it times out, login is about to give a better error anyway.
+A wake taking 5s or more is logged, because that is the explanation for a slow Connect that
+would otherwise look like a hang.
+
+**The message named the wrong cause.** *"Timed out before the server responded"* is true and
+useless — it reads as "the server is broken", so the natural next move is to re-check the
+password, which cannot possibly help. It now says the server may be waking, that the first
+request after a quiet period can take a couple of minutes on the free tier, and that
+pressing Connect again usually succeeds. Same failure mode as Phase 238's invite note: a
+message specific enough to act on, pointing the wrong way.
+
+The durable fix is not in the plugin — it is an always-on instance. Logged in
+[`ROADMAP.md`](ROADMAP.md) against #705, which already wants the custom domain attached.
 #### Completed (Phase 238 — the invite note named the wrong cause)
 
 Follow-on to Phase 237, found by verifying that fix against the live server rather than

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,6 +29,13 @@ Open automation gaps, future-enhancement tables, and deep-review findings for th
 | LIC-5 | **Merging licensing changes ships nothing** | Tracked as #651. `marketing-site` has no git-connected Pages build, so `/licences` and every Function change reach production only when a human runs `npm run deploy`. Compounded by the deploy-time binding behaviour corrected in #674: a secret that `wrangler pages secret list` shows is stored, not bound. |
 | LIC-6 | **Preview and production share one D1** | Tracked as #652 (#644 closed as its duplicate). A preview deployment can issue, revoke and stamp rows in the production `licenses` table — now the billing artefact, since #626 made D1 the sole owner of seat entitlement. |
 
+## Planscape hosting — after the connect pass (2026-08-20)
+
+| ID | Item | Detail |
+|---|---|---|
+| HOST-1 | **`api.planscape.build` does not resolve** | Tracked as #705. The plugin's baked default now points at `planscape-api-free.onrender.com` because that is the host that answers; `PlanscapeServerClient.IntendedProductionServerUrl` is the one place to change when the custom domain is attached. Note the service is `planscape-api-free` — `planscape-api`, the name in `render.yaml`, 404s. |
+| HOST-2 | **The API instance sleeps, and waking it takes minutes** | Measured 2026-08-20 after ~2h idle: first request no answer within **180s**, next **66.6s**. The plugin now absorbs this with a pre-login wake probe and says so in the error, but that is mitigation. An always-on plan is the fix, and it pairs naturally with HOST-1 since both are one dashboard visit. Until then, the first Connect of the day is slow and may need a second press. |
+
 ## Entitlement plumbing — after the project-ceiling pass (2026-08-20)
 
 The project cap now resolves in one place (`ProjectCeilingPolicy`): D1's tier grants where


### PR DESCRIPTION
Your sign-in failed with:

> Login failed: request to `https://planscape-api-free.onrender.com` timed out before the
> server responded.

**The server was asleep, not broken.** Everything in the dialog was correct.

## Measured, not inferred

Free-tier instances idle out. On the live host, ~2 h after the last traffic:

```
first request  -> no answer within 180s
second request -> HTTP 200 in 66.6s
```

The plugin's `HttpClient` carried a flat **60 s** ceiling. It could not survive either
number.

## Three fixes

**1. The ceiling was below the measured warm-ish response.** 60 s → **120 s**. A timeout
bounds how long we are *willing* to wait, not how long we *do* — a warm call still returns
in well under a second — so this costs nobody anything and stops failing a request the
server is answering normally.

**2. The cold case is not a per-request problem.** Three minutes is not a sane ceiling for
every sync call, so `WakeServerAsync` absorbs it **before** login, on a cheap anonymous
`/health/live` with a 240 s budget.

- `/health/live`, not `/health` — the latter is the authenticated diagnostic and answers
  403 anonymously, which would read as a dead server (same reasoning as
  `PlanscapeServerTargets.ProbeAsync`).
- It **never fails the caller**: a 404 means an older server, and if it times out, login is
  about to give the better error anyway.
- A wake of ≥5 s is logged, because that is the explanation for a slow Connect that would
  otherwise look like a hang.

**3. The message named the wrong cause.** *"Timed out before the server responded"* is true
and useless — it reads as "the server is broken", so the natural next move is to re-check
the password, which cannot possibly help. It now says the server may be waking, that the
first request after a quiet period can take a couple of minutes on the free tier, and that
pressing Connect again usually works.

That is the same failure mode as the invite note in #742: a message specific enough to act
on, pointing the wrong way. Both were found by *using* the thing rather than reading the
diff.

## What this does not fix

Mitigation, not a cure. The durable fix is an **always-on instance** — the first Connect of
the day is still slow and may need a second press. Recorded as **HOST-1 / HOST-2** in
`ROADMAP.md` against #705, which already wants `api.planscape.build` attached; both are one
dashboard visit.

## Verification

`StingTools.csproj` → **0 errors, 0 warnings**. Server untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
