### PR TITLE
fix(email): stop writing password-reset tokens to the log, and make the dev send path real

### DIFF
--- a/Planscape.Server/docker/.env.template
+++ b/Planscape.Server/docker/.env.template
@@ -70,11 +70,26 @@ APS_CLIENT_SECRET=
 #   NOT your normal password). SMTP_FROM should match the Gmail address.
 # SECURITY: this .env is gitignored — never commit a populated one; the app
 # password lives only here, typed locally.
-SMTP_HOST=
-SMTP_PORT=587
+#
+# DEFAULT = mailpit, the SMTP sink this compose file already starts. It is on by
+# default deliberately: with SMTP_HOST blank the stack selects NullEmailService,
+# so the MailKit transport, the rendered HTML and every outward link go
+# unexercised on every developer machine — the send path is only ever run for the
+# first time in production. Measured 2026-08-20: mailpit had been running in this
+# stack with 0 messages ever captured.
+# Read what was sent at http://localhost:8025 (no credentials, nothing leaves the box).
+#
+# Change HOST and PORT together — 1025 is mailpit's, not a general default.
+#   GMAIL:       SMTP_HOST=smtp.gmail.com  SMTP_PORT=587  SMTP_USER=you@gmail.com
+#                SMTP_PASS=<16-char App Password> (Google account → Security → App
+#                passwords; NOT your normal password). SMTP_FROM must match SMTP_USER.
+#   Resend-SMTP: SMTP_HOST=smtp.resend.com  SMTP_PORT=465  SMTP_USE_SSL=true
+#   No email:    SMTP_HOST=  (blank) ⇒ NullEmailService, loud warning, nothing sent
+SMTP_HOST=mailpit
+SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
-SMTP_FROM=
+SMTP_FROM=no-reply@planscape.local
 SMTP_FROM_NAME=Planscape
 
 # ── Push notifications (Firebase / FCM + APNs) ──────────────────────────

--- a/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
+++ b/Planscape.Server/src/Planscape.Infrastructure/Services/SmtpEmailService.cs
@@ -112,12 +112,28 @@ public class NullEmailService : IEmailService
         return Task.CompletedTask;
     }
 
+    // NEVER log the reset token VALUE. It is a single-use credential that grants
+    // a password change on the named account, so writing it here hands anyone with
+    // log access the ability to take over any account that ever requested a reset.
+    //
+    // NullEmailService is selected whenever NO provider is configured — which on a
+    // production host means email is broken AND every reset token is being written
+    // to the platform's log store. That is the same class of defect as #711, where
+    // a secret-shaped EMAIL_FROM was interpolated into Cloudflare's Function logs.
+    //
+    // The invite path immediately above already had this right (hasToken={HasToken});
+    // this one printed the value. Reporting presence is what makes the log line
+    // actionable — "a reset was requested and nothing was sent" — and the value adds
+    // nothing to that. To actually receive the link in development, point the stack
+    // at the mailpit sink the compose file already runs (SMTP_HOST=mailpit,
+    // SMTP_PORT=1025) and read the real email at http://localhost:8025.
     public Task SendPasswordResetEmailAsync(
         string toEmail, string resetToken, string serverUrl, CancellationToken ct = default)
     {
         _logger.LogWarning(
-            "[NullEmail] ⚠ PASSWORD-RESET NOT SENT (no provider) to={ToEmail}, token={Token}, url={Url}",
-            toEmail, resetToken, serverUrl);
+            "[NullEmail] ⚠ PASSWORD-RESET NOT SENT (no provider) to={ToEmail}, hasToken={HasToken}, url={Url} "
+          + "— the token is deliberately NOT logged; use the mailpit sink (SMTP_HOST=mailpit) to receive the link.",
+            toEmail, !string.IsNullOrWhiteSpace(resetToken), serverUrl);
         return Task.CompletedTask;
     }
 

--- a/Planscape.Server/tests/Planscape.Tests/NullEmailLoggingTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/NullEmailLoggingTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using Planscape.Infrastructure.Services;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// Pins the rule that a credential never reaches the log, even on the failure path.
+///
+/// <para><see cref="NullEmailService"/> is selected whenever no email provider is
+/// configured. On a production host that means two things at once: email is broken,
+/// AND — until this change — every password-reset token was being written verbatim
+/// into the platform's log store at Warning level, which is above the
+/// <c>Serilog__MinimumLevel__Default=Warning</c> floor render.yaml sets, so it was
+/// retained rather than dropped.</para>
+///
+/// <para>A single-use reset token grants a password change on the named account, so a
+/// log line carrying both the address and the token is a complete account takeover for
+/// anyone who can read logs. This is the same defect class as #711, where a
+/// secret-shaped <c>EMAIL_FROM</c> was interpolated into Cloudflare's Function logs on
+/// every failed send.</para>
+///
+/// <para>The invite path in the same class already reported presence rather than value
+/// (<c>hasToken={HasToken}</c>), which is the evidence this was an oversight rather
+/// than a deliberate development affordance.</para>
+/// </summary>
+public class NullEmailLoggingTests
+{
+    private const string Token = "PLNS-RESET-3f9a1c7e5b2d48a6b0c1d2e3f4a5b6c7";
+
+    [Fact]
+    public async Task A_password_reset_token_is_never_written_to_the_log()
+    {
+        var log = new CapturingLogger<NullEmailService>();
+        var svc = new NullEmailService(log);
+
+        await svc.SendPasswordResetEmailAsync(
+            "victim@example.com", Token, "https://app.planscape.build");
+
+        // Assert on the WHOLE rendered line plus every structured argument: the token
+        // must not survive in either, because a Serilog sink writes both.
+        Assert.NotEmpty(log.Entries);                       // it really did log — an empty
+                                                            // log would pass this test
+                                                            // vacuously and hide a
+                                                            // silent no-op.
+        Assert.DoesNotContain(Token, log.Everything);
+    }
+
+    [Fact]
+    public async Task The_reset_line_still_names_the_account_and_that_nothing_was_sent()
+    {
+        // Redaction must not become silence. The operator still has to be able to tell
+        // "a reset was requested for this address and no mail left the building" —
+        // otherwise the fix trades a credential leak for the invisibility that let the
+        // #711 outage run unnoticed.
+        var log = new CapturingLogger<NullEmailService>();
+        var svc = new NullEmailService(log);
+
+        await svc.SendPasswordResetEmailAsync(
+            "victim@example.com", Token, "https://app.planscape.build");
+
+        var line = log.Entries.Single(e => e.Level == LogLevel.Warning
+                                        && e.Rendered.Contains("PASSWORD-RESET"));
+        Assert.Contains("victim@example.com", line.Rendered);
+        Assert.Contains("NOT SENT", line.Rendered);
+        Assert.True(line.Level >= LogLevel.Warning,
+            "must clear the production Serilog floor (Warning) or it is invisible where it matters");
+    }
+
+    [Fact]
+    public async Task An_invite_token_is_not_logged_either()
+    {
+        // Guards the path that was already correct, so a later edit cannot regress it
+        // back to printing the value.
+        var log = new CapturingLogger<NullEmailService>();
+        var svc = new NullEmailService(log);
+
+        await svc.SendInviteEmailAsync(
+            "invitee@example.com", "Invitee", "Inviter", "Project X",
+            "https://app.planscape.build", Token, Guid.NewGuid());
+
+        Assert.NotEmpty(log.Entries);
+        Assert.DoesNotContain(Token, log.Everything);
+    }
+
+    // ── capture ──────────────────────────────────────────────────────────────
+
+    private sealed record Entry(LogLevel Level, string Rendered, string State);
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public readonly List<Entry> Entries = new();
+
+        /// <summary>Rendered message AND raw structured state, concatenated — a secret
+        /// that escapes only as a structured property is still in the sink.</summary>
+        public string Everything => string.Join("\n",
+            Entries.Select(e => e.Rendered + "\n" + e.State));
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add(new Entry(logLevel, formatter(state, exception), state?.ToString() ?? ""));
+    }
+}


### PR DESCRIPTION
Measured the whole email surface rather than starting from the mail code, as asked. The headline of #711 turned out to be **already fixed** — this is what the measurement found that it did not cover.

## What was measured

There are **two independent email stacks**, and #711 only ever examined one.

| Stack | Transport | Senders | State |
|---|---|---|---|
| `marketing-site/functions` (Cloudflare Pages) | Resend HTTP | signup verification, resend-verify, password reset, welcome, team invitation, contact | **Fixed** — `f22f50de0` on main: sender value no longer logged, `email_log` records one row per attempt. Full suite passes here (0 fail). |
| `Planscape.Server` (.NET) | MailKit SMTP / Resend HTTP / Null | invite, password reset, meeting invite, photo digest, dunning, trial reminders, FW renewals, outbox | Transports are **loud** (log + throw). Call sites were fixed on main **today** (`EmailDispatch.TrySendAsync`). Two defects remained. |

**Signup verification is not affected.** It lives only in the Cloudflare stack, and that path is fixed and verified. The .NET server has no signup-verification sender at all.

**Where it failed** was not one mechanism but three different ones, and naming them separately matters:

- *Cloudflare* — credentials rejected. `EMAIL_FROM` held a 44-character base64 value, so Resend 422'd every send. Fixed by deleting the secret.
- *.NET call sites* — exception propagated. Providers throw by contract; controllers called them bare, so `POST /members/invite` 500'd after committing the invitee, and `forgot-password` 500'd for a real address but 200'd for an unknown one — an enumeration oracle. Fixed on main today.
- *.NET dev stack* — **never exercised at all**, which is what this PR addresses.

## 1. `NullEmailService` wrote the raw password-reset token to the log

```
[NullEmail] ⚠ PASSWORD-RESET NOT SENT (no provider) to={ToEmail}, token={Token}, url={Url}
```

`NullEmailService` is selected whenever no provider is configured. On a production host that means two things at once: email is broken, **and** every reset token is written to the platform's log store — at `Warning`, so *above* the `Serilog__MinimumLevel__Default=Warning` floor `render.yaml` sets, and therefore retained rather than dropped. Address + single-use reset token is a complete account takeover for anyone who can read logs.

This is the same defect class as #711 itself, where a secret-shaped `EMAIL_FROM` was interpolated into Cloudflare's Function logs on every failed send.

The invite path in the same class already had it right — `hasToken={HasToken}`. That in-file precedent is the evidence this was an oversight rather than a deliberate development affordance. The reset line now matches it and still names the address and says nothing was sent, so **redaction does not become silence** — the operator can still tell "a reset was requested here and no mail left the building", which is the property #665 paid for.

Whether production is currently running `NullEmailService` I cannot say without querying it: `render.yaml` declares `Email__Provider` / `Resend__ApiKey` / `Smtp__Host` as `sync: false`, and per #717 the blueprint does not govern the live service anyway. If it is, this has been leaking; if it is not, this is a latent trap. Either way the line should not print the value.

## 2. The compose stack runs mailpit and nothing has ever sent to it

Measured today:

```
docker-mailpit-1   Up 15 minutes (healthy)   0.0.0.0:1025->1025, 0.0.0.0:8025->8025
GET :8025/api/v1/messages  ->  {"total":0, ... "messages":[]}
docker exec docker-api-1 env | grep Smtp__Host   ->  Smtp__Host=
docker logs docker-api-1 | grep NullEmail
  [WRN] [NullEmail] ⚠ NO EMAIL PROVIDER CONFIGURED — emails ... will NOT be delivered
```

`.env.template` ships `SMTP_HOST=` blank, so every fresh developer checkout selects `NullEmailService`. The MailKit transport, the rendered HTML and every outward link are therefore first exercised **in production**. The compose file's own comment says mailpit exists so the send path "can be PROVEN without real creds" — as shipped, it could not be.

`.env.template` now defaults to the sink that is already running (`mailpit:1025`), with host and port documented as a pair since 1025 is mailpit's port and not a general default.

**Only the template changes.** `docker-compose.yml` keeps its blank default deliberately: a self-hosted run with no `.env` still gets the loud "no provider configured" warning rather than a confusing connection error against a host that does not exist outside this compose network. Trading a clear diagnosis for an obscure one is the failure mode this whole issue is about.

## Tests — 3 new, proven RED before GREEN

Reverting change 1 and re-running:

```
Planscape.Tests.NullEmailLoggingTests.A_password_reset_token_is_never_written_to_the_log [FAIL]
Failed! - Failed: 1, Passed: 2
```

Restoring it:

```
Passed! - Failed: 0, Passed: 12   (3 new + 9 existing email tests)
```

The tests assert on the rendered line **and** the raw structured state, because a secret that escapes only as a structured property is still in the sink. Each asserts the log is non-empty *first*, so a silent no-op cannot pass them vacuously.

## Not fixed here — filed separately

The measurement also found the weekly compliance digest and SLA alert senders are **dead code**: they depend on `Planscape.API.Services.IEmailService`, which has **zero DI registrations**, and neither job is registered or scheduled. They have never sent anything and have never logged that they did not, because they never run. Wiring them up would start sending mail to real users, which is a product decision, not a bug fix — filed rather than fixed.

Refs #711
