### PR TITLE
fix(plugin): say the update-check host does not exist, instead of "No such host is known"

### DIFF
--- a/StingTools/Core/PluginUpdateChecker.cs
+++ b/StingTools/Core/PluginUpdateChecker.cs
@@ -42,9 +42,59 @@ namespace StingTools.Core
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"Plugin update check failed: {ex.Message}");
+                StingLog.Warn($"Plugin update check failed: {Diagnose(serverUrl, ex)}");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Turns a transport exception into something a reader can act on.
+        ///
+        /// <para>The default .NET text for an unresolvable host is
+        /// <c>"No such host is known. (api.planscape.build:443)"</c>, which reads as a
+        /// transient network problem. It is not: as measured on 2026-08-20 against
+        /// Google's resolver (with controls — a host that certainly exists resolved
+        /// normally, and a host that certainly does not returned NXDOMAIN), the
+        /// documented custom domain <c>api.planscape.build</c> has no DNS record at all,
+        /// while <c>app.planscape.build</c> resolves. See #705: the record was never
+        /// attached to the Render service.</para>
+        ///
+        /// <para>Naming the host and separating "this name does not exist" from "this
+        /// name exists and did not answer" is the whole point. Every Revit session logs
+        /// this line at startup, and for as long as it said "No such host is known" the
+        /// honest conclusion — a documented hostname that was never configured — was
+        /// indistinguishable from the reader being offline.</para>
+        ///
+        /// <para>This deliberately does NOT substitute a different hostname. The
+        /// intended address is correct; the DNS record is missing, and that is the
+        /// owner's to add. Papering over it in code would remove the only signal that
+        /// it is still missing.</para>
+        /// </summary>
+        internal static string Diagnose(string serverUrl, Exception ex)
+        {
+            string host;
+            try { host = new Uri(serverUrl).Host; }
+            catch { host = serverUrl; }
+
+            for (Exception? e = ex; e != null; e = e.InnerException)
+            {
+                if (e is System.Net.Sockets.SocketException se
+                    && (se.SocketErrorCode == System.Net.Sockets.SocketError.HostNotFound
+                     || se.SocketErrorCode == System.Net.Sockets.SocketError.NoData))
+                {
+                    return $"'{host}' does not resolve — no DNS record exists for it. "
+                         + "This is a configuration gap, not a network outage: the hostname is "
+                         + "correct but was never pointed at the running service (see issue #705). "
+                         + "Set STING_PLANSCAPE_URL, or the server URL in Coordination Center "
+                         + "settings, to a host that resolves. "
+                         + $"[{ex.GetType().Name}: {ex.Message}]";
+                }
+            }
+
+            if (ex is TaskCanceledException || ex is OperationCanceledException)
+                return $"'{host}' resolved but did not answer in time (timeout). [{ex.Message}]";
+
+            return $"'{host}': {ex.Message}";
         }
 
         public static bool IsNewer(string remote, string local)


### PR DESCRIPTION
Part of the #705 inventory ([full inventory here](https://github.com/beckykyomugisha/STINGTOOLS/issues/705#issuecomment-5360054555)). This is the one item in it that is a code defect rather than a missing DNS record.

## The line

Every Revit session logs this at startup:

```
Plugin update check failed: No such host is known. (api.planscape.build:443)
```

That reads as a transient network problem — the reader concludes they are offline. They are not. The documented custom domain was never attached to the Render service, and until it is, *every* session logs this, forever, saying the wrong thing.

An absent-or-misleading log line cannot distinguish "I am offline" from "this hostname has never existed". Those have completely different fixes, and only one of them is anybody's to act on.

## The measurement

Against Google's resolver, **with controls first**, because a resolver that intercepts every lookup will answer *something* for a host that does not exist and the answer alone would prove nothing:

```
$ nslookup -type=A google.com 8.8.8.8
Name: google.com   Address: 192.178.54.14        <- real host, real address

$ nslookup -type=A definitely-not-a-real-host-xyzzy-9182.planscape.build 8.8.8.8
*** can't find ...: Non-existent domain           <- fake host, NXDOMAIN
```

Both controls behave, so the real answers are interpretable:

```
api.planscape.build   ->  Non-existent domain   (A and CNAME both)
app.planscape.build   ->  216.24.57.15
```

## The change

`PluginUpdateChecker.Diagnose` walks the exception chain for a `SocketException` with `HostNotFound`/`NoData` and, when it finds one, says so:

> `'api.planscape.build' does not resolve — no DNS record exists for it. This is a configuration gap, not a network outage: the hostname is correct but was never pointed at the running service (see issue #705). Set STING_PLANSCAPE_URL, or the server URL in Coordination Center settings, to a host that resolves. [HttpRequestException: No such host is known. (api.planscape.build:443)]`

A timeout is reported separately as "resolved but did not answer in time", because that is a different fault with a different owner. Anything else keeps its original message, prefixed with the host it was talking to — which the old line did not always include.

The original exception text is retained in brackets, so nothing that was diagnosable before is lost.

## What is deliberately not changed

**The hostname.** The intended address is correct; the missing DNS record is the owner's to add. Substituting the onrender hostname here would make the symptom disappear while the cause remained, and would remove the only recurring signal that the record is still missing. That is the same failure family as #651, #674 and #717 — what the repo says drifting from what is serving, with nothing announcing the gap.

This mirrors the treatment `PlanscapeServerClient.Settings.cs` already received today: keep the intended address as a visible named constant (`IntendedProductionServerUrl`) with the measurement written beside it, and connect elsewhere. The intent stays in the code, waiting for the record.

## Scope

Behaviour is unchanged. The check remains fire-and-forget, still returns `null` on failure, still never delays startup, still logs at `Warn`. Only the text changes.

```
dotnet build StingTools/StingTools.csproj -c Debug
Build succeeded. 0 Warning(s) 0 Error(s)
```

Refs #705
