### PR TITLE
fix(server): validate the ISO 19650 vocabulary on write, and say the strays out loud

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -194,6 +194,20 @@ public class ProjectMembersController : ControllerBase
     {
         if (!await IsManagerOrAboveAsync(projectId)) return Forbid();
 
+        // Reject an ISO 19650 role outside the served vocabulary. Same shape as
+        // invalid_project_role below, so a client parses one error, not two.
+        //
+        // Only an EXPLICITLY SUPPLIED value is checked: `req.Iso19650Role == null`
+        // falls through to the profile default or "M" exactly as before. That
+        // matters because two rows in the wild already hold values outside this
+        // list, and someone editing such a member's ProjectRole must not be blocked
+        // by a code they did not write. See Iso19650Roles for why tolerance here is
+        // deliberate, and Program.cs for the boot report that keeps it from becoming
+        // amnesia.
+        if (req.Iso19650Role != null && !Iso19650Roles.IsCanonical(req.Iso19650Role))
+            return BadRequest(new { error = "invalid_iso19650_role", allowed = Iso19650Roles.All });
+
+
         var tenantId = GetTenantId();
         var project = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
         if (project == null) return NotFound("Project not found");
@@ -290,6 +304,19 @@ public class ProjectMembersController : ControllerBase
                 message = $"You don't have permission to invite members to this project ({auth.reason})."
             });
         }
+
+        // Reject an ISO 19650 role outside the served vocabulary. Same shape as
+        // invalid_project_role below, so a client parses one error, not two.
+        //
+        // Only an EXPLICITLY SUPPLIED value is checked: `req.Iso19650Role == null`
+        // falls through to the profile default or "M" exactly as before. That
+        // matters because two rows in the wild already hold values outside this
+        // list, and someone editing such a member's ProjectRole must not be blocked
+        // by a code they did not write. See Iso19650Roles for why tolerance here is
+        // deliberate, and Program.cs for the boot report that keeps it from becoming
+        // amnesia.
+        if (req.Iso19650Role != null && !Iso19650Roles.IsCanonical(req.Iso19650Role))
+            return BadRequest(new { error = "invalid_iso19650_role", allowed = Iso19650Roles.All });
 
         var tenantId = GetTenantId();
         var project  = await _db.Projects.FirstOrDefaultAsync(p => p.Id == projectId && p.TenantId == tenantId);
@@ -514,11 +541,17 @@ public class ProjectMembersController : ControllerBase
         // anything outside the canonical set; same error shape as invalid_kind
         // in DistributionGroupsController.
         //
-        // Iso19650Role is deliberately NOT validated in this pass — its
-        // vocabulary lives in GetRoles() below and constraining it is a
-        // separate, wider change.
+        // Iso19650Role IS now validated — this is the "separate, wider change"
+        // the comment that stood here was waiting for. Its vocabulary moved out of
+        // GetRoles() and into Iso19650Roles, so the list clients are offered and the
+        // list writes are checked against are one list.
         if (req.ProjectRole != null && !ProjectRoles.IsCanonical(req.ProjectRole))
             return BadRequest(new { error = "invalid_project_role", allowed = ProjectRoles.All });
+
+        // Explicitly-supplied only: omitting the field leaves an existing stray
+        // untouched and the edit succeeds. See the note on AddMember above.
+        if (req.Iso19650Role != null && !Iso19650Roles.IsCanonical(req.Iso19650Role))
+            return BadRequest(new { error = "invalid_iso19650_role", allowed = Iso19650Roles.All });
 
         if (req.ProjectRole  != null) member.ProjectRole  = req.ProjectRole;
         if (req.Iso19650Role != null) member.Iso19650Role = req.Iso19650Role;
@@ -651,27 +684,11 @@ public class ProjectMembersController : ControllerBase
     // ── ISO 19650 roles lookup ─────────────────────────────────────────────────
 
     [HttpGet("roles")]
-    public ActionResult GetRoles() => Ok(new[]
-    {
-        new { Code = "A",  Label = "Appointing Party" },
-        new { Code = "PM", Label = "Project Manager" },
-        new { Code = "BC", Label = "BIM Coordinator" },
-        new { Code = "BA", Label = "BIM Author" },
-        new { Code = "AR", Label = "Architect" },
-        new { Code = "SE", Label = "Structural Engineer" },
-        new { Code = "ME", Label = "MEP Engineer" },
-        new { Code = "CE", Label = "Civil Engineer" },
-        new { Code = "QS", Label = "Quantity Surveyor" },
-        new { Code = "CA", Label = "Contract Administrator" },
-        new { Code = "CT", Label = "Main Contractor" },
-        new { Code = "SC", Label = "Subcontractor" },
-        new { Code = "FM", Label = "Facilities Manager" },
-        new { Code = "OM", Label = "Operations Manager" },
-        new { Code = "CL", Label = "Client Representative" },
-        new { Code = "M",  Label = "Model Author" },
-        new { Code = "V",  Label = "Viewer" },
-        new { Code = "Z",  Label = "Unassigned" }
-    });
+    // Served from Iso19650Roles.Catalogue, not a literal, so the list offered to
+    // clients and the list writes are validated against cannot drift apart. The
+    // response shape is unchanged: [{ code, label }, ...] in the same order.
+    public ActionResult GetRoles() => Ok(
+        Iso19650Roles.Catalogue.Select(r => new { Code = r.Code, Label = r.Label }));
 
     // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/Planscape.Server/src/Planscape.API/Program.cs
+++ b/Planscape.Server/src/Planscape.API/Program.cs
@@ -1673,6 +1673,66 @@ app.MapHub<Planscape.Infrastructure.SignalR.DocumentSyncHub>("/hubs/document-syn
             app.Logger.LogWarning(ex, "[ACL] Could not read the per-folder ACL population.");
         }
 
+        // Report ProjectMember.Iso19650Role values outside the served vocabulary.
+        //
+        // Until this change the column accepted any string at five write sites, and
+        // it drifted: a local database holds 'S' — a code from the DIFFERENT
+        // vocabulary AppUser.Iso19650Role declares — and 'EL', which is in no
+        // declared vocabulary at all. Neither could have come from a first-party UI.
+        //
+        // The writes are validated now, so the set can only shrink. Tolerating the
+        // rows that already exist is deliberate (see Iso19650Roles): an edit that
+        // omits the field must still succeed, or someone fixing an unrelated field
+        // is blocked by a code they did not write. But tolerating is not the same as
+        // forgetting, and forgetting is how these got here. This says them out loud,
+        // once per boot, so the cleanup issue has a live number rather than a
+        // one-off local measurement.
+        //
+        // Warning in BOTH cases, for the same reason as the ACL block above:
+        // render.yaml pins Serilog to Warning in production, so an Information line
+        // is invisible there — and an absent line cannot be told apart from a check
+        // that never ran.
+        //
+        // Codes and counts only. No user id, no email, no display name: which humans
+        // hold a stray is exactly the question the cleanup issue asks a person to
+        // answer, and it is not one a log line should leak.
+        try
+        {
+            var canonical = Planscape.Core.Entities.Iso19650Roles.All.ToArray();
+
+            var strays = await db.ProjectMembers
+                .IgnoreQueryFilters()
+                .Where(m => m.Iso19650Role != null
+                         && m.Iso19650Role != ""
+                         && !canonical.Contains(m.Iso19650Role))
+                .GroupBy(m => m.Iso19650Role)
+                .Select(g => new { Code = g.Key, Count = g.Count() })
+                .ToListAsync();
+
+            if (strays.Count > 0)
+                app.Logger.LogWarning(
+                    "[ISO-ROLE] {Rows} ProjectMember row(s) carry an Iso19650Role outside the served " +
+                    "vocabulary, across {Distinct} distinct value(s): {Codes}. New writes are now " +
+                    "rejected, so this set can only shrink — but these rows are NOT auto-corrected, " +
+                    "because guessing what they were meant to be would be inventing data. A human who " +
+                    "knows those members decides; see the ISO role cleanup issue.",
+                    strays.Sum(x => x.Count),
+                    strays.Count,
+                    string.Join(", ", strays.OrderByDescending(x => x.Count)
+                                            .Select(x => $"'{x.Code}' x{x.Count}")));
+            else
+                app.Logger.LogWarning(
+                    "[ISO-ROLE] Every ProjectMember.Iso19650Role is inside the served vocabulary " +
+                    "({Count} canonical codes). Nothing to clean up.",
+                    canonical.Length);
+        }
+        catch (Exception ex)
+        {
+            // Same contract as the ACL report: a diagnostic must never stop the boot,
+            // and must never fail quietly either.
+            app.Logger.LogWarning(ex, "[ISO-ROLE] Could not read the Iso19650Role population.");
+        }
+
         // #653 — report tenants still carrying a seat-derived account cap.
         //
         // Tenant.MaxUsers used to be written from BillingPlanLimits.TotalSeats

--- a/Planscape.Server/src/Planscape.Core/Entities/Iso19650Roles.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/Iso19650Roles.cs
@@ -1,0 +1,98 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// The canonical <see cref="ProjectMember.Iso19650Role"/> vocabulary.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// This list already existed — as an anonymous array inlined in
+/// <c>ProjectMembersController.GetRoles()</c>, served to the web members grid and
+/// the mobile picker. Being a response literal rather than a type, nothing could
+/// validate against it, so every write path accepted any string at all:
+///
+///   ProjectMembersController:217  join/update existing member
+///   ProjectMembersController:248  add member
+///   ProjectMembersController:348  invite by email (new user)
+///   ProjectMembersController:430  invite by email (existing user)
+///   ProjectMembersController:524  edit member
+///
+/// The result is measurable. A local database holds two rows outside this
+/// vocabulary: <c>'S'</c>, which is a value from the DIFFERENT list that
+/// <see cref="AppUser.Iso19650Role"/> declares, and <c>'EL'</c>, which is in no
+/// declared vocabulary at all. Neither could have been written by a first-party
+/// UI, and neither was rejected.
+///
+/// The same shape produced the bug <see cref="ProjectRoles"/> documents: eleven
+/// gates testing an ISO code against the ProjectRole column. An unvalidated
+/// column drifts, and a drifted column makes every gate reading it a guess.
+///
+/// The deferral was explicit. <c>ProjectMembersController</c> carried:
+///
+///     // Iso19650Role is deliberately NOT validated in this pass — its
+///     // vocabulary lives in GetRoles() below and constraining it is a
+///     // separate, wider change.
+///
+/// This is that separate change.
+///
+/// TOLERANT BY DESIGN
+/// ------------------
+/// Validation rejects an explicitly-supplied value outside the list. It does NOT
+/// reject a request that omits the field, so an existing row holding a stray stays
+/// editable — someone fixing a member's ProjectRole must not be blocked by a value
+/// they did not write and may not be able to interpret.
+///
+/// That tolerance is deliberate but must not become amnesia: the boot report in
+/// Program.cs names the strays out loud, and the cleanup is tracked as its own
+/// issue so a human who knows what those members were meant to be decides. Guessing
+/// at a mapping table would be inventing data.
+///
+/// NOT THE SAME LIST AS AppUser.Iso19650Role
+/// -----------------------------------------
+/// <see cref="AppUser"/> declares its own, different vocabulary for a column of the
+/// same name (A/M/E/S/H/P/C/I/K/Q/F/W/L/Z). Two vocabularies for one concept is how
+/// 'S' arrived here. Reconciling them is tracked separately; this type governs the
+/// ProjectMember column only, and says so rather than quietly covering both.
+/// </summary>
+public static class Iso19650Roles
+{
+    /// <summary>One ISO 19650 role code and the label the UI shows for it.</summary>
+    public readonly record struct Role(string Code, string Label);
+
+    /// <summary>Every legal ProjectMember.Iso19650Role, in the order the members
+    /// grid and the mobile picker present them. This is the single source served by
+    /// <c>GET api/projects/{id}/members/roles</c> — the endpoint no longer carries
+    /// its own copy, so the list clients are offered and the list writes are checked
+    /// against cannot drift apart.</summary>
+    public static readonly IReadOnlyList<Role> Catalogue = new[]
+    {
+        new Role("A",  "Appointing Party"),
+        new Role("PM", "Project Manager"),
+        new Role("BC", "BIM Coordinator"),
+        new Role("BA", "BIM Author"),
+        new Role("AR", "Architect"),
+        new Role("SE", "Structural Engineer"),
+        new Role("ME", "MEP Engineer"),
+        new Role("CE", "Civil Engineer"),
+        new Role("QS", "Quantity Surveyor"),
+        new Role("CA", "Contract Administrator"),
+        new Role("CT", "Main Contractor"),
+        new Role("SC", "Subcontractor"),
+        new Role("FM", "Facilities Manager"),
+        new Role("OM", "Operations Manager"),
+        new Role("CL", "Client Representative"),
+        new Role("M",  "Model Author"),
+        new Role("V",  "Viewer"),
+        new Role("Z",  "Unassigned"),
+    };
+
+    /// <summary>Just the codes — the shape a validation error reports back, matching
+    /// the <c>allowed</c> field of <c>invalid_project_role</c>.</summary>
+    public static readonly IReadOnlyList<string> All =
+        Catalogue.Select(r => r.Code).ToArray();
+
+    /// <summary>Case-insensitive membership test for write validation. Mirrors
+    /// <see cref="ProjectRoles.IsCanonical"/> so the two columns are validated the
+    /// same way.</summary>
+    public static bool IsCanonical(string? role)
+        => role != null && All.Any(r => string.Equals(r, role, StringComparison.OrdinalIgnoreCase));
+}

--- a/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/CoreApiTests.cs
@@ -579,11 +579,18 @@ public class CoreApiTests : IClassFixture<PlanscapeWebApplicationFactory>
     {
         var client = await _factory.CreateAuthenticatedClientAsync();
 
+        // projectRole/iso19650Role are the values a first-party client can actually
+        // produce. This used to read projectRole = "Engineer", iso19650Role = "E" —
+        // NEITHER is in its column's vocabulary ("Engineer" is not a ProjectRole,
+        // and "E" belongs to AppUser's separate ISO list, not the one
+        // GET .../members/roles serves). The test passed because both columns
+        // accepted any string, so it asserted the drift rather than the contract.
         var addResp = await client.PostAsJsonAsync($"{_projBase}/members", new
         {
             userId = TestData.MemberUserId,
-            projectRole = "Engineer",
-            iso19650Role = "E"
+            projectRole = "Contributor",
+            iso19650Role = "ME"          // MEP Engineer — the canonical code for what
+                                         // "E" was reaching for
         });
         Assert.Equal(HttpStatusCode.Created, addResp.StatusCode);
 
@@ -607,12 +614,15 @@ public class CoreApiTests : IClassFixture<PlanscapeWebApplicationFactory>
     public async Task Members_InviteByEmail()
     {
         var client = await _factory.CreateAuthenticatedClientAsync();
+        // iso19650Role was "C" — a code from AppUser's vocabulary, and one of the two
+        // letters ProjectSettingsController gated on while matching (essentially)
+        // nobody (#737). "CL" (Client Representative) is the canonical code.
         var response = await client.PostAsJsonAsync($"{_projBase}/members/invite", new
         {
             email = "invited@test.org",
             displayName = "Invited User",
             projectRole = "Viewer",
-            iso19650Role = "C"
+            iso19650Role = "CL"
         });
         // Should succeed — creates pending user and adds as member
         Assert.True(

--- a/Planscape.Server/tests/Planscape.Tests/Iso19650RoleValidationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/Iso19650RoleValidationTests.cs
@@ -1,0 +1,293 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+using Planscape.Core.Interfaces;
+using Planscape.Infrastructure.Data;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// ProjectMember.Iso19650Role is validated on write — the change the controller's
+/// own comment was waiting for:
+///
+///     // Iso19650Role is deliberately NOT validated in this pass — its
+///     // vocabulary lives in GetRoles() below and constraining it is a
+///     // separate, wider change.
+///
+/// THE TWO PROPERTIES THAT MATTER, AND THEY PULL AGAINST EACH OTHER
+/// ----------------------------------------------------------------
+/// 1. A supplied value outside the vocabulary is REJECTED, so the column stops
+///    drifting. An unvalidated column is what made eleven gates read the wrong
+///    field (see <see cref="ProjectRoles"/>).
+/// 2. A row that ALREADY holds a stray stays editable. Two exist locally — 'S'
+///    (a code from AppUser's different vocabulary) and 'EL' (in no vocabulary).
+///    An edit that omits the field must succeed, or someone fixing a member's
+///    ProjectRole is blocked by a code they did not write and cannot interpret.
+///
+/// Property 2 is the one a naive implementation breaks, so it is tested first and
+/// tested hardest.
+///
+/// FIXTURE TRAPS — the same two this suite documents elsewhere
+/// -----------------------------------------------------------
+/// PlanscapeDbContext's global filter is TenantId == CurrentTenantId, falling back
+/// to Guid.Empty without an ITenantContext — matching NO rows, so assertions pass
+/// vacuously. Every context here is built WITH a tenant, and the sanity test proves
+/// the rows are visible before any claim is made. Identifiers are minted per
+/// fixture; a fixed GUID collides with the shared web-factory store and produces
+/// non-deterministic failures in unrelated classes.
+/// </summary>
+public class Iso19650RoleValidationTests
+{
+    private sealed class FixedTenant : ITenantContext
+    {
+        public FixedTenant(Guid id) => TenantId = id;
+        public Guid TenantId { get; }
+        public string TenantSlug => "acme";
+        public LicenseTier Tier => LicenseTier.Professional;
+        public bool MimEnabled => false;
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        public required SqliteConnection Conn { get; init; }
+        public required PlanscapeDbContext Db { get; init; }
+        public required Guid TenantId { get; init; }
+        public required Guid ProjectId { get; init; }
+        public required Guid ManagerUserId { get; init; }
+        public required Guid StrayMemberId { get; init; }
+        public required Guid CleanMemberId { get; init; }
+        public void Dispose() { Db.Dispose(); Conn.Dispose(); }
+    }
+
+    /// <summary>The exact value found in the wild, from AppUser's OTHER vocabulary.</summary>
+    private const string StrayFromTheOtherVocabulary = "S";
+
+    private static Fixture NewDb()
+    {
+        var tenantId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var authorId  = Guid.NewGuid();
+        var mgrId     = Guid.NewGuid();
+        var strayUser = Guid.NewGuid();
+        var cleanUser = Guid.NewGuid();
+
+        var conn = new SqliteConnection("DataSource=:memory:");
+        conn.Open();
+        var db = new PlanscapeDbContext(
+            new DbContextOptionsBuilder<PlanscapeDbContext>().UseSqlite(conn).Options,
+            httpContextAccessor: null!, tenantContext: new FixedTenant(tenantId));
+        db.Database.EnsureCreated();
+
+        db.Tenants.Add(new Tenant
+        {
+            Id = tenantId, Name = "Acme", Slug = "acme-" + Guid.NewGuid().ToString("N").Substring(0, 10),
+            ContactEmail = "a@example.com", Tier = LicenseTier.Professional,
+            Plan = BillingPlan.Studio, MaxUsers = 50, MaxProjects = 50,
+        });
+
+        foreach (var pair in new[]
+                 {
+                     (Id: authorId, Label: "author"), (Id: mgrId, Label: "manager"),
+                     (Id: strayUser, Label: "stray"), (Id: cleanUser, Label: "clean"),
+                 })
+            db.Users.Add(new AppUser
+            {
+                Id = pair.Id, TenantId = tenantId,
+                Email = pair.Label + "-" + Guid.NewGuid().ToString("N") + "@example.com",
+                DisplayName = pair.Label, PasswordHash = "x", IsActive = true,
+            });
+
+        db.Projects.Add(new Project
+        {
+            Id = projectId, TenantId = tenantId, Name = "Kampala Temple",
+            Code = "P-" + Guid.NewGuid().ToString("N").Substring(0, 6),
+            Status = ProjectStatus.Active, CreatedById = authorId, PurgeAfter = null,
+        });
+
+        var strayMember = new ProjectMember
+        {
+            Id = Guid.NewGuid(), TenantId = tenantId, ProjectId = projectId,
+            UserId = strayUser, ProjectRole = "Contributor",
+            // Seeded DIRECTLY, bypassing the controller — which is how the real rows
+            // got here, and the only way to reproduce them now the write path refuses.
+            Iso19650Role = StrayFromTheOtherVocabulary, IsActive = true,
+        };
+        var cleanMember = new ProjectMember
+        {
+            Id = Guid.NewGuid(), TenantId = tenantId, ProjectId = projectId,
+            UserId = cleanUser, ProjectRole = "Contributor",
+            Iso19650Role = "M", IsActive = true,
+        };
+        db.ProjectMembers.Add(strayMember);
+        db.ProjectMembers.Add(cleanMember);
+        db.ProjectMembers.Add(new ProjectMember
+        {
+            Id = Guid.NewGuid(), TenantId = tenantId, ProjectId = projectId,
+            UserId = mgrId, ProjectRole = "Manager", Iso19650Role = "PM", IsActive = true,
+        });
+
+        db.SaveChanges();
+        return new Fixture
+        {
+            Conn = conn, Db = db, TenantId = tenantId, ProjectId = projectId,
+            ManagerUserId = mgrId, StrayMemberId = strayMember.Id, CleanMemberId = cleanMember.Id,
+        };
+    }
+
+    private static ProjectMembersController NewController(Fixture f, Guid userId)
+        => new ProjectMembersController(f.Db, null!, null!, null!, null!)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                        new Claim("sub", userId.ToString()),
+                        new Claim("tenant_id", f.TenantId.ToString()),
+                    }, "test")),
+                },
+            },
+        };
+
+    // ── Sanity — nothing below means anything until this is green ────────────
+
+    [Fact]
+    public void Sanity_the_fixture_has_a_visible_stray_row()
+    {
+        using var f = NewDb();
+        Assert.Equal(3, f.Db.ProjectMembers.Count(m => m.ProjectId == f.ProjectId));
+        var stray = f.Db.ProjectMembers.Single(m => m.Id == f.StrayMemberId);
+        Assert.Equal(StrayFromTheOtherVocabulary, stray.Iso19650Role);
+        Assert.False(Iso19650Roles.IsCanonical(stray.Iso19650Role),
+            "the fixture must actually be outside the vocabulary or the tolerance tests prove nothing");
+    }
+
+    // ── Property 2 — an existing stray stays editable ────────────────────────
+
+    [Fact]
+    public async Task An_edit_that_omits_the_field_leaves_a_stray_row_untouched_and_succeeds()
+    {
+        // The whole point of Option 1. A manager fixing this member's ProjectRole
+        // must not be blocked by an ISO code they did not write.
+        using var f = NewDb();
+        var c = NewController(f, f.ManagerUserId);
+
+        var result = await c.UpdateMember(f.ProjectId, f.StrayMemberId,
+            new UpdateMemberRequest("Coordinator", null, null, null, null, null));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var after = f.Db.ProjectMembers.Single(m => m.Id == f.StrayMemberId);
+        Assert.Equal("Coordinator", after.ProjectRole);                 // the edit landed
+        Assert.Equal(StrayFromTheOtherVocabulary, after.Iso19650Role);  // untouched, not "corrected"
+    }
+
+    [Fact]
+    public async Task A_stray_row_can_be_corrected_to_a_canonical_value()
+    {
+        // Tolerance must not mean the row is frozen — the cleanup has to be possible.
+        using var f = NewDb();
+        var c = NewController(f, f.ManagerUserId);
+
+        var result = await c.UpdateMember(f.ProjectId, f.StrayMemberId,
+            new UpdateMemberRequest(null, "QS", null, null, null, null));
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("QS", f.Db.ProjectMembers.Single(m => m.Id == f.StrayMemberId).Iso19650Role);
+    }
+
+    // ── Property 1 — a supplied stray is rejected ────────────────────────────
+
+    [Theory]
+    [InlineData("S")]    // real: from AppUser's different vocabulary
+    [InlineData("EL")]   // real: in no declared vocabulary at all
+    [InlineData("XX")]
+    [InlineData("")]     // empty string is not "omitted" — it is a supplied non-value
+    public async Task A_supplied_value_outside_the_vocabulary_is_rejected(string bad)
+    {
+        using var f = NewDb();
+        var c = NewController(f, f.ManagerUserId);
+
+        var result = await c.UpdateMember(f.ProjectId, f.CleanMemberId,
+            new UpdateMemberRequest(null, bad, null, null, null, null));
+
+        var br = Assert.IsType<BadRequestObjectResult>(result);
+        var t = br.Value!.GetType();
+        // Error SHAPE must match invalid_project_role exactly, so a client parses
+        // one thing, not two.
+        Assert.Equal("invalid_iso19650_role", t.GetProperty("error")!.GetValue(br.Value));
+        Assert.NotNull(t.GetProperty("allowed"));
+
+        // And it must not have written anything on the way to refusing.
+        Assert.Equal("M", f.Db.ProjectMembers.Single(m => m.Id == f.CleanMemberId).Iso19650Role);
+    }
+
+    [Fact]
+    public async Task Every_canonical_code_is_accepted()
+    {
+        // Enumerated rather than spot-checked: a rejection list that happens to
+        // exclude a legal code is a lockout, and would surface as "I cannot set this
+        // member to Civil Engineer" long after the change shipped.
+        foreach (var code in Iso19650Roles.All)
+        {
+            using var f = NewDb();
+            var c = NewController(f, f.ManagerUserId);
+
+            var result = await c.UpdateMember(f.ProjectId, f.CleanMemberId,
+                new UpdateMemberRequest(null, code, null, null, null, null));
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(code, f.Db.ProjectMembers.Single(m => m.Id == f.CleanMemberId).Iso19650Role);
+        }
+    }
+
+    [Fact]
+    public void Validation_is_case_insensitive_like_ProjectRole()
+    {
+        // Matches ProjectRoles.IsCanonical, so the two columns behave the same way.
+        Assert.True(Iso19650Roles.IsCanonical("pm"));
+        Assert.True(Iso19650Roles.IsCanonical("Pm"));
+        Assert.False(Iso19650Roles.IsCanonical("P M"));
+        Assert.False(Iso19650Roles.IsCanonical(null));
+    }
+
+    // ── The served list and the validated list are one list ──────────────────
+
+    [Fact]
+    public void GetRoles_serves_exactly_the_vocabulary_that_is_validated_against()
+    {
+        // The drift this whole change is about: the list clients are offered used to
+        // be a response literal, and the write path checked nothing. If the two ever
+        // diverge again, a user picks a role from a dropdown and the server rejects it.
+        using var f = NewDb();
+        var ok = Assert.IsType<OkObjectResult>(NewController(f, f.ManagerUserId).GetRoles());
+
+        var served = ((System.Collections.IEnumerable)ok.Value!)
+            .Cast<object>()
+            .Select(o => (string)o.GetType().GetProperty("Code")!.GetValue(o)!)
+            .ToArray();
+
+        Assert.NotEmpty(served);
+        Assert.Equal(Iso19650Roles.All, served);
+        Assert.All(served, code => Assert.True(Iso19650Roles.IsCanonical(code)));
+    }
+
+    [Fact]
+    public void The_vocabulary_still_contains_every_code_it_shipped_with()
+    {
+        // Pins the list against an accidental deletion. Dropping a code silently
+        // makes existing rows carrying it unwritable — the same failure the tolerance
+        // tests above guard from the other direction.
+        foreach (var code in new[] { "A", "PM", "BC", "BA", "AR", "SE", "ME", "CE", "QS",
+                                     "CA", "CT", "SC", "FM", "OM", "CL", "M", "V", "Z" })
+            Assert.Contains(code, Iso19650Roles.All);
+
+        Assert.Equal(18, Iso19650Roles.All.Count);
+    }
+}

--- a/Planscape/app/project-settings/members.tsx
+++ b/Planscape/app/project-settings/members.tsx
@@ -28,6 +28,8 @@ import {
   type ProjectMemberRow,
   type MyProjectAccess,
   type UpdateProjectMemberArgs,
+  listIso19650Roles,
+  type Iso19650RoleOption,
 } from '@/api/endpoints';
 import { CAPABILITY_COPY, alertFailure } from '@/utils/forbidden';
 import { useProjectStore } from '@/stores/projectStore';
@@ -37,8 +39,17 @@ import { useProjectStore } from '@/stores/projectStore';
 const CDE_STATES = ['WIP', 'SHARED', 'PUBLISHED', 'ARCHIVE'];
 const DISCIPLINES = ['A', 'S', 'M', 'E', 'P', 'FP', 'LV', 'G'];
 const SUITABILITIES = ['S0', 'S1', 'S2', 'S3', 'S4', 'S6', 'S7', 'A1', 'A2', 'A3', 'B1'];
-const PROJECT_ROLES = ['PM', 'Admin', 'Owner', 'Coordinator', 'Member', 'Viewer'];
-const ISO_ROLES = ['K', 'C', 'TI', 'L', 'AP', 'LAP'];
+// The server's canonical ProjectRole vocabulary (Planscape.Core.Entities.ProjectRoles.All).
+// This list used to read ['PM','Admin','Owner','Coordinator','Member','Viewer'], of
+// which 'PM' and 'Member' are NOT canonical — the server has rejected both with
+// invalid_project_role since that guard landed, so two of the six offered options
+// always failed to save. 'PM' is also the value ProjectRoles.cs tolerates for
+// back-compat while noting "no first-party UI writes it there"; this screen did.
+const PROJECT_ROLES = ['Viewer', 'Contributor', 'Coordinator', 'Manager', 'Owner', 'Admin'];
+
+// ISO 19650 roles are FETCHED, not hardcoded — see loadIsoRoles below. The list
+// that stood here, ['K','C','TI','L','AP','LAP'], contained no code the server
+// serves or accepts, so every save wrote a value outside the vocabulary.
 
 const ALLOWED_EDITORS = new Set(['PM', 'Admin', 'Owner']);
 
@@ -52,6 +63,12 @@ export default function MembersScreen() {
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
 
+  // null = not loaded or the request failed. Deliberately NOT defaulted to [] or to
+  // a hardcoded list: an empty picker would read as "this project has no roles",
+  // and a hardcoded one is what put values the server rejects into the column. The
+  // editor below renders the difference explicitly.
+  const [isoRoles, setIsoRoles] = useState<Iso19650RoleOption[] | null>(null);
+
   const canEdit = useMemo(() => {
     if (!myAccess) return false;
     if (myAccess.bypassesAcl) return true;
@@ -62,12 +79,16 @@ export default function MembersScreen() {
     if (!projectId) return;
     try {
       setError(null);
-      const [m, a] = await Promise.all([
+      const [m, a, roles] = await Promise.all([
         listProjectMembersFull(projectId),
         getMyProjectAccess(projectId).catch(() => null),
+        // Failing to load the vocabulary must not fail the whole screen — the
+        // member list is still useful. null is carried through as "unknown".
+        listIso19650Roles(projectId).catch(() => null),
       ]);
       setMembers(m);
       setMyAccess(a);
+      setIsoRoles(roles && roles.length > 0 ? roles : null);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load members');
     } finally {
@@ -122,6 +143,7 @@ export default function MembersScreen() {
           onSaved={async () => { setEditingId(null); await load(); }}
           onRemoved={async () => { setEditingId(null); await load(); }}
           projectId={projectId}
+          isoRoles={isoRoles}
         />
       ))}
     </ScrollView>
@@ -129,7 +151,7 @@ export default function MembersScreen() {
 }
 
 function MemberCard({
-  member, editing, canEdit, onStartEdit, onCancelEdit, onSaved, onRemoved, projectId,
+  member, editing, canEdit, onStartEdit, onCancelEdit, onSaved, onRemoved, projectId, isoRoles,
 }: {
   member: ProjectMemberRow;
   editing: boolean;
@@ -139,6 +161,8 @@ function MemberCard({
   onSaved: () => Promise<void>;
   onRemoved: () => Promise<void>;
   projectId: string;
+  /** null = the server's vocabulary could not be loaded. Not the same as empty. */
+  isoRoles: Iso19650RoleOption[] | null;
 }) {
   const [projectRole, setProjectRole] = useState(member.projectRole);
   const [isoRole, setIsoRole] = useState(member.iso19650Role);
@@ -162,11 +186,16 @@ function MemberCard({
     setSaving(true);
     const body: UpdateProjectMemberArgs = {
       projectRole,
-      iso19650Role: isoRole,
       allowedCdeStates: cdeStates,
       allowedDisciplines: disciplines,
       allowedSuitabilities: suitabilities,
     };
+    // Send the ISO role ONLY when the user changed it. The server validates
+    // explicitly-supplied values and tolerates existing ones, so omitting an
+    // unchanged value is what lets a member whose row already holds a code
+    // outside the vocabulary still have their other fields edited from here.
+    // Re-sending it unchanged would turn a tolerated row into a 400.
+    if (isoRole !== member.iso19650Role) body.iso19650Role = isoRole;
     try {
       await updateProjectMember(projectId, member.id, body);
       await onSaved();
@@ -242,7 +271,33 @@ function MemberCard({
           <ChipRow options={PROJECT_ROLES} selected={[projectRole]} onToggle={(v) => setProjectRole(v)} singleSelect />
 
           <Text style={styles.fieldLabel}>ISO 19650 role</Text>
-          <ChipRow options={ISO_ROLES} selected={[isoRole]} onToggle={(v) => setIsoRole(v)} singleSelect />
+          {isoRoles ? (
+            <>
+              <ChipRow
+                options={isoRoles.map((r) => r.code)}
+                selected={[isoRole]}
+                onToggle={(v) => setIsoRole(v)}
+                singleSelect
+              />
+              {isoRole && !isoRoles.some((r) => r.code === isoRole) ? (
+                // The member's stored value is outside the vocabulary the server
+                // serves. Say so rather than showing nothing selected, which would
+                // read as "no role set" and invite an accidental overwrite.
+                <Text style={styles.roleNote}>
+                  Currently "{isoRole}", which is not one of the roles above. Leave it
+                  alone to keep it, or pick a role to replace it.
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            // UNKNOWN, not empty and not denied. Showing an empty chip row here
+            // would claim the project has no roles; substituting a hardcoded list
+            // is what put unusable values in this column in the first place.
+            <Text style={styles.roleNote}>
+              Role list unavailable — keeping "{isoRole || '—'}". Pull to refresh to
+              try again. Other fields still save.
+            </Text>
+          )}
 
           <Text style={styles.fieldLabel}>
             Allowed CDE states <Text style={styles.fieldHint}>(empty = all)</Text>
@@ -413,6 +468,14 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   fieldHint: { color: theme.colors.disabled, fontWeight: '400', textTransform: 'none' },
+  // Says what the picker could NOT show — an out-of-vocabulary stored value, or a
+  // vocabulary that failed to load. Neither is rendered as an empty selection.
+  roleNote: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.textSecondary,
+    marginTop: 4,
+    lineHeight: 16,
+  },
   chipRow: { flexDirection: 'row', flexWrap: 'wrap' },
   chip: {
     paddingHorizontal: 10,

--- a/Planscape/src/api/endpoints.ts
+++ b/Planscape/src/api/endpoints.ts
@@ -360,6 +360,20 @@ export function updateProjectMember(
   });
 }
 
+/** The ISO 19650 role vocabulary the SERVER accepts, served from
+ *  Iso19650Roles.Catalogue. Fetch it rather than hardcoding a list: the app
+ *  previously offered ['K','C','TI','L','AP','LAP'], of which the server accepts
+ *  NONE — so every saved value was outside the vocabulary and no gate reading the
+ *  column could interpret it. Writes are validated now, so a hardcoded list is no
+ *  longer merely wrong, it is a 400. */
+export interface Iso19650RoleOption {
+  code: string;
+  label: string;
+}
+export function listIso19650Roles(projectId: string): Promise<Iso19650RoleOption[]> {
+  return apiFetch(`/api/projects/${projectId}/members/roles`);
+}
+
 /** T3-20 — remove a member from the project (server hard-deletes). */
 export function removeProjectMember(projectId: string, memberId: string): Promise<void> {
   return apiFetch(`/api/projects/${projectId}/members/${memberId}`, { method: 'DELETE' });


### PR DESCRIPTION
Part 4a + 4b. Independent of #737 — branched from `main`, no dependency on it.

## The deferral this closes

`ProjectMembersController` carried, in its own words:

```csharp
// Iso19650Role is deliberately NOT validated in this pass — its
// vocabulary lives in GetRoles() below and constraining it is a
// separate, wider change.
```

That comment is the evidence this was scheduled debt rather than an oversight, and it names this change as the one it was waiting for. It has been replaced with what actually happened.

## Validation — Option 1, explicitly-supplied values only

Five write sites, three action entry points, one guard each:

| Site | Method | Writes |
|---|---|---|
| `:217` | `AddMember` | re-activating an existing member |
| `:248` | `AddMember` | new member row |
| `:348` | `InviteByEmail` | `AppUser.Iso19650Role` (see the note below) |
| `:430` | `InviteByEmail` | `ProjectMember.Iso19650Role` |
| `:524` | `UpdateMember` | edit |

Error shape matches the `invalid_project_role` precedent **exactly** — `{ error, allowed }` — so a client parses one thing, not two:

```json
{ "error": "invalid_iso19650_role", "allowed": ["A","PM","BC", ...] }
```

**A request that omits the field is untouched.** It falls through to the profile default or `"M"` exactly as before, so a row already holding a stray stays editable — someone fixing a member's `ProjectRole` must not be blocked by a code they did not write and probably cannot interpret. That property is tested harder than the rejection is, because it is the one a naive implementation breaks.

The vocabulary moved out of the `GetRoles()` response literal into `Core.Entities.Iso19650Roles`, mirroring `ProjectRoles`. `GetRoles` serves from it, so **the list clients are offered and the list writes are validated against are one list**. Response shape unchanged: `[{ code, label }]`, same order.

## Saying the strays out loud (4b)

Tolerating a stray is correct. Forgetting it is how it got here.

`Program.cs` now reports out-of-vocabulary values once per boot, beside the #665 ACL report and for the same stated reason — **Warning in both the zero and non-zero case**, because `render.yaml` pins `Serilog__MinimumLevel__Default=Warning` and an absent Information line cannot be told apart from a check that never ran:

```
[ISO-ROLE] 2 ProjectMember row(s) carry an Iso19650Role outside the served vocabulary,
across 2 distinct value(s): 'S' x1, 'EL' x1. New writes are now rejected, so this set
can only shrink — but these rows are NOT auto-corrected, because guessing what they
were meant to be would be inventing data. …
```

Codes and counts only. Which humans hold a stray is exactly the question the cleanup issue asks a person, and not one a log line should leak.

Local measurement (34 rows): `'S'` — a code from `AppUser`'s **different** vocabulary — and `'EL'`, in no declared vocabulary at all. Filed with both rows identified so someone who knows those appointments decides; `S → SE` and `EL → ME` are readings, not facts, and a mapping table would apply that guess silently and in bulk.

## The client half, which had to ship with it

Shipping validation alone would have knowingly broken a working screen.

`Planscape/app/project-settings/members.tsx:41` hardcoded a **third** vocabulary:

```ts
const ISO_ROLES = ['K', 'C', 'TI', 'L', 'AP', 'LAP'];
```

Not one of those six is served or accepted. Every save from that screen wrote a value no gate could interpret — **except `ProjectSettingsController`, which gates on `"K" or "C"`, the picker's first two entries.** That is where #737's two magic letters come from; addendum posted there.

It now fetches `GET .../members/roles`. It also offered `'PM'` and `'Member'` as ProjectRoles, neither canonical, **both already 400ing on save today** — corrected to the canonical six. Note this falsifies a documented assumption: `ProjectRoles.cs` says `"PM"` is written by *"no first-party UI"*. This screen offered it first in the list, which makes its legacy tolerance better-founded than its own comment claims.

The picker now distinguishes **three** states rather than two:

- vocabulary loaded → chips
- stored value outside it → named explicitly (*"Currently 'S', which is not one of the roles above. Leave it alone to keep it, or pick a role to replace it."*) rather than showing nothing selected, which reads as "no role set" and invites an accidental overwrite
- vocabulary failed to load → said out loud, current value kept, other fields still save

An empty chip row would have claimed the project has no roles. It is not defaulted to `[]` for that reason.

`save()` now sends `iso19650Role` **only when it changed**, which is precisely what lets a member whose row holds a stray still be edited from mobile.

## On site `:348`

That line writes the request's ProjectMember-vocabulary code into `AppUser.Iso19650Role`, which declares a different list. That is the proven mechanism for `QS/BC/PM/AR` appearing in the AppUser column — filed separately, **not changed here**, because altering it changes persisted values on a column a live authorization path reads.

## Tests

`Iso19650RoleValidationTests` — 11 cases. **RED before GREEN**, with the controller guard reverted:

```
A_supplied_value_outside_the_vocabulary_is_rejected(bad: "S")  [FAIL]
A_supplied_value_outside_the_vocabulary_is_rejected(bad: "EL") [FAIL]
A_supplied_value_outside_the_vocabulary_is_rejected(bad: "XX") [FAIL]
A_supplied_value_outside_the_vocabulary_is_rejected(bad: "")   [FAIL]
Failed! - Failed: 4, Passed: 7
```

The **7 that pass in both states are the preserved-behaviour ones** — tolerance, case-insensitivity, the served list. That split is the signal, same framing as #665.

Every canonical code is asserted accepted, enumerated rather than spot-checked: a rejection list that happens to exclude a legal code is a lockout that surfaces months later as "I cannot set this member to Civil Engineer". Fixtures assert non-empty first, and mint identifiers per test — the `Guid.Empty` tenant fallback makes empty-result assertions pass vacuously, and a fixed GUID collides with the shared web-factory store.

### Two existing tests were asserting the drift

`CoreApiTests.Members_AddAndList` and `Members_InviteByEmail` sent `projectRole = "Engineer"` and `iso19650Role = "E"` / `"C"`. **None is in its column's vocabulary.** They passed because both columns accepted any string — so they pinned the drift rather than the contract. Updated to canonical codes, with that written down rather than quietly changed.

```
Full server suite: 824 passed, 0 failed, 15 skipped
Mobile: tsc --noEmit → 0 errors
```

## Filed, not fixed

- `AppUser.Iso19650Role` carries a different vocabulary and has drifted from its own — with the invite-path mechanism measured.
- The two stray rows, both identified, for a human to resolve.
- `BimManagerOrAdminHandler` as a ninth authorization mechanism, argued both ways.

Refs #737
