### PR TITLE
feat(capabilities): expose canAdministerProject, and stop the fourth client-side copy of the rule

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ProjectMembersController.cs
@@ -184,6 +184,18 @@ public class ProjectMembersController : ControllerBase
             userId,
             canCurateProject     = await this.CanCurateProjectAsync(_db, projectId, ct),
             canApproveSitePhotos = await this.CanApproveSitePhotosAsync(_db, projectId, ct),
+            // The third capability, proposed in #666 and approved before being
+            // written — which is the step the comment above asks for, honoured
+            // rather than asserted. It is additive: a client that does not read
+            // the field is unaffected, and one that does stops re-deriving the
+            // rule from projectRole by hand.
+            //
+            // The mobile project-settings screen kept its own copy —
+            // {'Admin','Owner','PM','BIM_Manager','BIMManager'} tested against
+            // projectRole — of which 'PM', 'BIM_Manager' and 'BIMManager' are not
+            // ProjectRoles at all. That is the fourth client-side re-derivation of
+            // a server rule in this codebase, and the drift is the same every time.
+            canAdministerProject = await this.CanAdministerProjectAsync(_db, projectId, ct),
         });
     }
 

--- a/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/ProjectCapabilitiesEndpointTests.cs
@@ -178,7 +178,7 @@ public class ProjectCapabilitiesEndpointTests
         };
     }
 
-    private static (bool curate, bool approve, Guid projectId, Guid userId) Read(ActionResult result)
+    private static (bool curate, bool approve, bool administer, Guid projectId, Guid userId) Read(ActionResult result)
     {
         var ok = Assert.IsType<OkObjectResult>(result);
         var v = ok.Value!;
@@ -186,6 +186,7 @@ public class ProjectCapabilitiesEndpointTests
         return (
             (bool)t.GetProperty("canCurateProject")!.GetValue(v)!,
             (bool)t.GetProperty("canApproveSitePhotos")!.GetValue(v)!,
+            (bool)t.GetProperty("canAdministerProject")!.GetValue(v)!,
             (Guid)t.GetProperty("projectId")!.GetValue(v)!,
             (Guid)t.GetProperty("userId")!.GetValue(v)!);
     }
@@ -232,23 +233,60 @@ public class ProjectCapabilitiesEndpointTests
     // ── Capability resolution per role ────────────────────────────────────────
 
     [Theory]
-    [InlineData("manager",                       true,  true)]
-    [InlineData("coordinator",                   true,  false)] // curates, cannot release imagery
-    [InlineData("contributor-who-is-the-iso-PM", true,  true)]  // authority via Iso19650Role
-    [InlineData("plain-contributor",             false, false)]
-    [InlineData("viewer",                        false, false)]
-    public async Task Capabilities_match_the_role(string label, bool expectCurate, bool expectApprove)
+    //                                           curate approve administer
+    [InlineData("manager",                       true,  true,   true)]
+    [InlineData("coordinator",                   true,  false,  false)] // curates; neither releases imagery nor administers
+    [InlineData("contributor-who-is-the-iso-PM", true,  true,   true)]  // authority via Iso19650Role
+    [InlineData("plain-contributor",             false, false,  false)]
+    [InlineData("viewer",                        false, false,  false)]
+    public async Task Capabilities_match_the_role(
+        string label, bool expectCurate, bool expectApprove, bool expectAdminister)
     {
         using var f = NewDb();
         var userId = f.User(label);
 
-        var (curate, approve, pid, uid) = Read(
+        var (curate, approve, administer, pid, uid) = Read(
             await NewController(f, userId).GetMyCapabilities(f.ProjectId));
 
         Assert.Equal(expectCurate, curate);
         Assert.Equal(expectApprove, approve);
+        Assert.Equal(expectAdminister, administer);
         Assert.Equal(f.ProjectId, pid);
         Assert.Equal(userId, uid);
+    }
+
+    [Fact]
+    public async Task Coordinator_curates_but_cannot_administer()
+    {
+        // The second place the predicates diverge, and the one that matters to the
+        // mobile screen: a Coordinator may organise albums and checklists, and may
+        // NOT change ISO naming enforcement or the deliverable state machine.
+        // The role set this replaces on that screen — {Admin, Owner, PM,
+        // BIM_Manager, BIMManager} — got this right by accident and got Manager
+        // wrong, since "Manager" was not in it.
+        using var f = NewDb();
+
+        var (curate, _, administer, _, _) = Read(
+            await NewController(f, f.User("coordinator")).GetMyCapabilities(f.ProjectId));
+
+        Assert.True(curate);
+        Assert.False(administer);
+    }
+
+    [Fact]
+    public async Task A_project_Manager_can_administer_which_the_replaced_client_gate_denied()
+    {
+        // Regression-in-reverse: project-settings/index.tsx tested projectRole
+        // against {'Admin','Owner','PM','BIM_Manager','BIMManager'}. A plain
+        // project MANAGER — the most common administrator — was not in that set,
+        // so the screen greyed the toggles out for exactly the person meant to use
+        // them, while the server (pre-#737) refused everyone anyway.
+        using var f = NewDb();
+
+        var (_, _, administer, _, _) = Read(
+            await NewController(f, f.User("manager")).GetMyCapabilities(f.ProjectId));
+
+        Assert.True(administer);
     }
 
     [Fact]
@@ -259,7 +297,7 @@ public class ProjectCapabilitiesEndpointTests
         // this is the test that fails.
         using var f = NewDb();
 
-        var (curate, approve, _, _) = Read(
+        var (curate, approve, _, _, _) = Read(
             await NewController(f, f.User("coordinator")).GetMyCapabilities(f.ProjectId));
 
         Assert.True(curate);
@@ -277,21 +315,27 @@ public class ProjectCapabilitiesEndpointTests
         Assert.False(f.Db.ProjectMembers.Any(m => m.UserId == admin),
             "Fixture must NOT give the admin a member row, or this proves nothing.");
 
-        var (curate, approve, _, _) = Read(
+        var (curate, approve, administer, _, _) = Read(
             await NewController(f, admin, tenantRole: "Admin").GetMyCapabilities(f.ProjectId));
 
         Assert.True(curate);
         Assert.True(approve);
+        Assert.True(administer);
     }
 
     // ── Response shape ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Response_carries_exactly_four_fields()
+    public async Task Response_carries_exactly_five_fields()
     {
-        // Two booleans, matching the two predicates that exist. A third
+        // Three booleans, matching the three predicates that exist. A fourth
         // capability goes through propose-first review, so an inline addition
         // should fail here rather than ship unnoticed.
+        //
+        // This guard DID fire when canAdministerProject was added, which is the
+        // point of it. That capability was proposed in #666 and approved before it
+        // was written, so the expectation moves with it — deliberately, in the same
+        // change, rather than the guard being weakened to stop complaining.
         using var f = NewDb();
 
         var ok = Assert.IsType<OkObjectResult>(
@@ -299,7 +343,7 @@ public class ProjectCapabilitiesEndpointTests
 
         var names = ok.Value!.GetType().GetProperties().Select(p => p.Name).OrderBy(n => n).ToArray();
         Assert.Equal(
-            new[] { "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
+            new[] { "canAdministerProject", "canApproveSitePhotos", "canCurateProject", "projectId", "userId" },
             names);
     }
 }

--- a/Planscape/app/project-settings/index.tsx
+++ b/Planscape/app/project-settings/index.tsx
@@ -24,16 +24,20 @@ import { theme } from '@/utils/theme';
 import {
   getProjectSettings,
   updateProjectSettings,
-  getMyProjectAccess,
 } from '@/api/endpoints';
+import { getProjectCapabilities } from '@/api/capabilities';
 import type { ProjectSettings } from '@/types/api';
 import { CAPABILITY_COPY, alertFailure } from '@/utils/forbidden';
 import { useProjectStore } from '@/stores/projectStore';
 
-// Only BIM Managers (K) and tenant-level Admins / Owners can change project
-// admin settings. Coordinators (C) and field roles see the switches greyed
-// out with an explanatory note so they understand why they can't toggle them.
-const ADMIN_EDIT_ROLES = new Set(['Admin', 'Owner', 'PM', 'BIM_Manager', 'BIMManager']);
+// The role set that stood here — {'Admin','Owner','PM','BIM_Manager','BIMManager'}
+// tested against projectRole — is gone. Only 'Admin' and 'Owner' are ProjectRoles
+// at all; 'PM' lives in Iso19650Role, and 'BIM_Manager'/'BIMManager' are in no
+// vocabulary this server has ever served. It was the fourth client-side copy of a
+// server rule in this codebase, and it had drifted exactly like the other three.
+//
+// Authority now comes from GET .../members/capabilities (#666, approved before
+// being written). The server decides; this screen only decides what to OFFER.
 
 export default function ProjectSettingsScreen() {
   const router = useRouter();
@@ -50,21 +54,24 @@ export default function ProjectSettingsScreen() {
     if (!projectId) return;
     try {
       setError(null);
-      const [s, access] = await Promise.all([
+      const [s, caps] = await Promise.all([
         getProjectSettings(projectId),
-        getMyProjectAccess(projectId).catch(() => null),
+        // Never throws: every failure mode yields 'unknown', and a 404 — the one
+        // status that IS authoritative-false — yields 'denied'.
+        getProjectCapabilities(projectId),
       ]);
       setSettings(s);
-      if (access) {
-        const role = access.projectRole ?? '';
-        setCanEdit(access.bypassesAcl || ADMIN_EDIT_ROLES.has(role));
-      } else {
-        // Unknown, not denied: allow UI interaction and let the server
-        // answer. This screen already had the three-state behaviour #558
-        // asks for — site-photos/review.tsx did the opposite and is
-        // corrected in this change to match.
-        setCanEdit(true);
-      }
+
+      // #634's three states, mapped onto this screen's two-and-a-half:
+      //   'allowed' -> offer the toggles
+      //   'denied'  -> disable them and name the capability
+      //   'unknown' -> LEAVE THEM ENABLED and let the attempt report
+      //
+      // Unknown must not render as denied. A dropped connection says nothing
+      // about permissions, and failing closed on a phone locks a legitimate
+      // administrator out of the screen while telling them it is a permissions
+      // problem — which is both wrong and unactionable.
+      setCanEdit(caps.administerProject === 'denied' ? false : true);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load settings');
     } finally {

--- a/Planscape/src/api/__typetests__/capabilities.typetest.ts
+++ b/Planscape/src/api/__typetests__/capabilities.typetest.ts
@@ -47,34 +47,40 @@ void noFourthState;
 
 // Captured from GET /api/projects/{id}/members/capabilities — the anonymous
 // object ProjectMembersController.GetMyCapabilities returns, serialized by
-// ASP.NET Core's default camelCase policy. Only the two booleans are read.
+// ASP.NET Core's default camelCase policy. Only the booleans are read.
 const SERVER_SAMPLE = {
   projectId: '11111111-1111-4111-8111-111111111111',
   userId: '22222222-2222-4222-8222-222222222222',
   canCurateProject: true,
   canApproveSitePhotos: false,
+  canAdministerProject: true,
 };
 
-// Both flags must be booleans on the wire. `flag()` deliberately treats
+// Every flag must be a boolean on the wire. `flag()` deliberately treats
 // anything else as 'unknown' rather than coercing it, so this assertion is
 // what catches the server changing them to strings.
 const curate: boolean = SERVER_SAMPLE.canCurateProject;
 const approve: boolean = SERVER_SAMPLE.canApproveSitePhotos;
+const administer: boolean = SERVER_SAMPLE.canAdministerProject;
 void curate;
 void approve;
+void administer;
 
-// The parsed result carries exactly the two capabilities the server has
-// predicates for. A third does not get added client-side — it goes through
-// the same propose-first step on the server that these two did.
+// The parsed result carries exactly the capabilities the server has predicates
+// for — now three. A fourth does not get added client-side: it goes through the
+// same propose-first step on the server that these did. administerProject was
+// proposed in #666 and approved before it was written.
 const PARSED: ProjectCapabilities = {
   curateProject: 'allowed',
   approveSitePhotos: 'unknown',
+  administerProject: 'denied',
 };
 void PARSED;
 
 const INVENTED: ProjectCapabilities = {
   curateProject: 'allowed',
   approveSitePhotos: 'denied',
+  administerProject: 'allowed',
   // @ts-expect-error — no inventing capabilities the server does not serve.
   canDeleteEverything: 'allowed',
 };

--- a/Planscape/src/api/capabilities.ts
+++ b/Planscape/src/api/capabilities.ts
@@ -36,16 +36,29 @@ export interface ProjectCapabilities {
   curateProject: CapabilityState;
   /** Photo approve / reject, share-link issuance, photo policy. */
   approveSitePhotos: CapabilityState;
+  /**
+   * Project-level settings — ISO naming enforcement, the deliverable state
+   * machine, the preferences blob. Proposed in #666 before being written, the
+   * same propose-first step the first two took.
+   *
+   * Replaces a fourth client-side copy of the rule: project-settings/index.tsx
+   * tested projectRole against {Admin, Owner, PM, BIM_Manager, BIMManager}, of
+   * which only Admin and Owner are ProjectRoles. Its own gate had drifted the
+   * same way the two this module already documents had.
+   */
+  administerProject: CapabilityState;
 }
 
 export const UNKNOWN_CAPABILITIES: ProjectCapabilities = {
   curateProject: 'unknown',
   approveSitePhotos: 'unknown',
+  administerProject: 'unknown',
 };
 
 const ALL_DENIED: ProjectCapabilities = {
   curateProject: 'denied',
   approveSitePhotos: 'denied',
+  administerProject: 'denied',
 };
 
 /**
@@ -72,6 +85,10 @@ export async function getProjectCapabilities(projectId: string): Promise<Project
     return {
       curateProject: flag(raw?.canCurateProject),
       approveSitePhotos: flag(raw?.canApproveSitePhotos),
+      // A server that predates the field returns undefined here, which flag()
+      // reads as 'unknown' — NOT denied. That is the correct answer during a
+      // rollout: the old server has not refused, it was never asked.
+      administerProject: flag(raw?.canAdministerProject),
     };
   } catch (e) {
     // The caller cannot see this project at all — nothing is possible on it.


### PR DESCRIPTION
> ## ⚠ STACKED ON #737 — base is `claude/one-authz-model`, not `main`
>
> #737 supplies `ProjectRoles.CanAdministerProject` and `CanAdministerProjectAsync`. **Neither exists on `main`** — verified with `git grep CanAdministerProject origin/main`, which returns nothing. This cannot branch from `main` today.
>
> #737 is itself **blocked on one production number** (`SELECT count(*) FROM "ProjectMembers" WHERE "Iso19650Role" IN ('K','C')`).
>
> **Merge order: #737 first, then rebase this onto `main`.** Declaring the stack rather than hiding it, because an undeclared stale base is precisely the trap that cost four PR rescues today — see the queue read on #556. This base is fresh and actively moving, so it is a stack, not a stale base; it becomes one if #737 sits.

Part 4c. Proposed in #666 and **approved before being written**, which is the propose-first step `GetMyCapabilities`' own docstring asks for:

```csharp
/// A third does not get added inline — it goes through the same
/// propose-first step these two did.
```

## Server — one additive field

`canAdministerProject` joins `canCurateProject` and `canApproveSitePhotos` on `GET .../members/capabilities`. Additive: a client that does not read the field is unaffected.

## Mobile — the fourth re-derivation of a server rule, deleted

`Planscape/app/project-settings/index.tsx` decided authority itself:

```ts
const ADMIN_EDIT_ROLES = new Set(['Admin', 'Owner', 'PM', 'BIM_Manager', 'BIMManager']);
setCanEdit(access.bypassesAcl || ADMIN_EDIT_ROLES.has(access.projectRole ?? ''));
```

Only `Admin` and `Owner` are ProjectRoles at all. `'PM'` lives in `Iso19650Role`; `'BIM_Manager'` and `'BIMManager'` appear in **no** vocabulary this server has ever served.

This is worse than untidy — it had drifted exactly the way `capabilities.ts` already documents for the two screens it replaced:

> mobile's copy had already drifted: `APPROVER_ROLES` is `{PM, Admin, Owner}`, but "PM" is not a ProjectRole at all

**A plain project Manager — the most common administrator — was not in that set.** So the screen greyed the toggles out for exactly the person meant to use them, while the server (pre-#737) refused everyone anyway. **Both halves were wrong and they cancelled out**, which is why the screen looked like it worked: the affordance said no to the right people for the wrong reason, and the gate behind it said no to everyone.

Authority now comes from the capability. New test:

```
A_project_Manager_can_administer_which_the_replaced_client_gate_denied
```

## The client contract — #634's three states, unchanged

| Capability | Screen |
|---|---|
| `allowed` | offer the toggles |
| `denied` (server said false, **or 404**) | disable, name the capability |
| `unknown` (transport failure, timeout, 5xx, unparseable) | **leave enabled**, let the attempt report |

```ts
setCanEdit(caps.administerProject === 'denied' ? false : true);
```

Unknown is not rendered as denied. A dropped connection says nothing about permissions, and failing closed on a phone locks a legitimate administrator out while telling them it is a permissions problem — wrong *and* unactionable.

**A server predating this field** returns `undefined`, which `flag()` reads as `'unknown'` — not denied. That is the correct answer during a rollout: the old server has not refused, it was never asked. No fallback data is invented for it.

Refusals keep the #558 treatment #645 landed — `CAPABILITY_COPY.projectAdmin` through `alertFailure`. **No second treatment invented.**

## Tests

**The response-shape guard fired, and that is the point of it.** `Response_carries_exactly_four_fields` existed to make an inline fourth capability fail loudly. It failed. The expectation moves with the approved addition, **in the same change**, rather than the guard being weakened to stop complaining — and the comment now records that it did its job.

Per-role expectations extended to three columns:

| Seeded member | curate | approve | **administer** |
|---|---|---|---|
| manager | ✔ | ✔ | **✔** |
| coordinator | ✔ | ✘ | **✘** |
| contributor whose `Iso19650Role` is PM | ✔ | ✔ | **✔** |
| plain contributor | ✘ | ✘ | **✘** |
| viewer | ✘ | ✘ | **✘** |

Plus two cases pinning the divergences: a Coordinator curates but cannot administer, and the Manager case above.

Mobile's capabilities type test pins the three-field wire shape and still `@ts-expect-error`s an invented fourth.

```
Server:  809 passed, 0 failed, 15 skipped
Mobile:  tsc --noEmit 0 errors · forbidden-states 8/8 · geofence 11/11
```

## One flaky run, measured rather than waved away

The **first** full run failed `LastAdministratorGuardTests.The_last_administrator_cannot_be_demoted`. Rather than assert it was unrelated, I measured:

- passes **in isolation** with this change ✔
- passes on the **unmodified base** ✔
- passes on a **second full run** (809 / 0) ✔

**Proven mechanism:** that class takes `IClassFixture<PlanscapeWebApplicationFactory>` — the shared, process-wide store this suite already documents as a source of non-deterministic cross-class failures — and it *mutates the seeded administrator and restores it*, so any interleaving class that authenticates during that window sees a tenant with no administrator.

**Hypothesised trigger:** this change adds one DB round trip to the capabilities endpoint, shifting interleaving. **That is a hypothesis, not a finding** — I did not isolate it further. Recorded so the next person to see it starts from the measurement instead of a fresh diagnosis.

Refs #666, #737, #634, #558, #645
