### PR TITLE
feat(documents): serve the CDE state machine, and delete mobile's copy of it

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/DocumentsController.cs
@@ -72,6 +72,37 @@ public class DocumentsController : ControllerBase
         "PUBLISHED->SUPERSEDED" // Superseding a published document also requires approval
     };
 
+    /// <summary>
+    /// #633 — the state machine's answer for one document, attached to the response.
+    ///
+    /// Computed from the two dictionaries directly above, which are the same ones
+    /// TransitionState, TransitionStateMobile, RequestApproval and SyncFromPlugin
+    /// all enforce against. One source, so a client cannot hold a stale copy.
+    ///
+    /// Deliberately excludes TransitionRoleRequirements and the per-folder ACL:
+    /// those are per-caller, and answering them here would make a list projection
+    /// do a per-row authorization pass while implying the result is a permission
+    /// grant. It is affordance. The server still gates every transition, and a
+    /// client that shows a button from this list must still handle a refusal.
+    ///
+    /// An unknown current state yields an EMPTY list, not null — the state machine
+    /// was consulted and had nothing to offer. Null is reserved for "not computed",
+    /// which is a different statement and the one clients read as unknown.
+    /// </summary>
+    private static IReadOnlyList<CdeTransitionOption> AllowedTransitionsFor(string cdeStatus)
+        => (ValidTransitions.TryGetValue(cdeStatus, out var targets) ? targets : Array.Empty<string>())
+            .Select(t => new CdeTransitionOption(
+                t, ApprovalRequiredTransitions.Contains($"{cdeStatus}->{t}")))
+            .ToArray();
+
+    /// <summary>Fills <see cref="DocumentRecord.AllowedTransitions"/> in place and
+    /// returns the same instance, so a projection reads as one expression.</summary>
+    private static DocumentRecord WithAllowedTransitions(DocumentRecord doc)
+    {
+        doc.AllowedTransitions = AllowedTransitionsFor(doc.CdeStatus);
+        return doc;
+    }
+
     private readonly IFileStorageService _storage;
     private readonly IGeofenceValidationService _geofence;
     private readonly IThumbnailService _thumbnails;
@@ -271,6 +302,9 @@ public class DocumentsController : ControllerBase
         var total = await query.CountAsync();
         var docs = await query.OrderByDescending(d => d.UploadedAt)
             .Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        // #633 — additive. Every existing field is untouched; clients that do not
+        // read allowedTransitions are unaffected.
+        foreach (var d in docs) WithAllowedTransitions(d);
         return Ok(new { items = docs, total, page, pageSize });
     }
 

--- a/Planscape.Server/src/Planscape.Core/Entities/CdeTransitionOption.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/CdeTransitionOption.cs
@@ -1,0 +1,36 @@
+namespace Planscape.Core.Entities;
+
+/// <summary>
+/// One CDE state a document may move to next, and whether that move needs an
+/// approval record first.
+///
+/// WHY THIS IS SERVED RATHER THAN RE-DERIVED
+/// -----------------------------------------
+/// The ISO 19650-2 state machine lives in <c>DocumentsController</c> as two
+/// dictionaries — <c>ValidTransitions</c> and <c>ApprovalRequiredTransitions</c>
+/// — and the server enforces both on every transition. Mobile kept its own copy
+/// of each, and both had drifted, in opposite directions:
+///
+///   VALID: mobile said PUBLISHED -> [ARCHIVE]. The server also allows
+///          SUPERSEDED and WITHDRAWN, and SHARED -> WITHDRAWN. Three legal
+///          transitions the user could not see.
+///
+///   APPROVAL: mobile said {WIP->SHARED, SHARED->PUBLISHED}. The server says
+///          {SHARED->PUBLISHED, PUBLISHED->SUPERSEDED}. So WIP->SHARED was
+///          routed through the approval workflow the server does not require,
+///          and PUBLISHED->SUPERSEDED was sent straight at the transition
+///          endpoint, which refuses it for want of an approval record.
+///
+/// Every one of those is a client guessing at a rule the server already knows.
+/// This type is the answer, sent with the document.
+///
+/// AFFORDANCE, NOT AUTHORITY
+/// -------------------------
+/// Computed from the two state-machine dictionaries ONLY. It deliberately does
+/// not fold in the per-folder ACL or <c>TransitionRoleRequirements</c>: those
+/// are per-caller and per-document-slice, and answering them here would turn a
+/// cheap projection into a per-row authorization pass while implying the list
+/// is a permission grant. The server still gates every transition. This says
+/// what the STATE MACHINE permits, so a client stops inventing that part.
+/// </summary>
+public sealed record CdeTransitionOption(string To, bool RequiresApproval);

--- a/Planscape.Server/src/Planscape.Core/Entities/DocumentRecord.cs
+++ b/Planscape.Server/src/Planscape.Core/Entities/DocumentRecord.cs
@@ -46,6 +46,19 @@ public class DocumentRecord : ITenantScoped
     // auto-transition the document from PUBLISHED to ARCHIVE on this date.
     public DateTime? RetentionExpiresAt { get; set; }
 
+    // #633 — where this document may go next, and whether approval is needed
+    // first. NOT PERSISTED and NOT part of the state machine: it is computed
+    // from DocumentsController's ValidTransitions + ApprovalRequiredTransitions
+    // and attached to the response, so a client stops keeping its own copy of
+    // rules the server already enforces. See CdeTransitionOption.
+    //
+    // NULL means "this response did not compute it" — an older server, or an
+    // endpoint that does not fill it. It does NOT mean "no transitions are
+    // available", and a client must not render it that way: unknown and
+    // none-allowed are different answers, and only one of them is a refusal.
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public IReadOnlyList<CdeTransitionOption>? AllowedTransitions { get; set; }
+
     // Navigation
     public Project? Project { get; set; }
     public CdeContainer? Container { get; set; }

--- a/Planscape.Server/tests/Planscape.Tests/AllowedTransitionsTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/AllowedTransitionsTests.cs
@@ -1,0 +1,185 @@
+using System.Reflection;
+using Planscape.API.Controllers;
+using Planscape.Core.Entities;
+
+namespace Planscape.Tests;
+
+/// <summary>
+/// #633 — the CDE state machine, served with the document instead of re-derived
+/// by every client.
+///
+/// WHAT THIS IS FOR
+/// ----------------
+/// Mobile kept its own copy of both halves and both had drifted, in OPPOSITE
+/// directions, which is why neither showed up as an obvious bug:
+///
+///   VALID: mobile said PUBLISHED -> [ARCHIVE]. The server also allows
+///          SUPERSEDED and WITHDRAWN, and SHARED -> WITHDRAWN. Three legal
+///          transitions the user could not see at all.
+///
+///   APPROVAL: mobile said {WIP->SHARED, SHARED->PUBLISHED}. The server says
+///          {SHARED->PUBLISHED, PUBLISHED->SUPERSEDED}. So WIP->SHARED was
+///          routed through an approval workflow the server does not require,
+///          and PUBLISHED->SUPERSEDED was sent at the transition endpoint,
+///          which refuses it for want of an approval record.
+///
+/// These tests read the controller's OWN dictionaries by reflection rather than
+/// restating them. A test that repeats the table is a fourth copy, and would
+/// happily agree with a wrong one.
+/// </summary>
+public class AllowedTransitionsTests
+{
+    private static readonly MethodInfo Compute =
+        typeof(DocumentsController).GetMethod(
+            "AllowedTransitionsFor", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static IReadOnlyList<CdeTransitionOption> For(string state)
+        => (IReadOnlyList<CdeTransitionOption>)Compute.Invoke(null, new object[] { state })!;
+
+    private static Dictionary<string, string[]> ValidTransitions =>
+        (Dictionary<string, string[]>)typeof(DocumentsController)
+            .GetField("ValidTransitions", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    private static HashSet<string> ApprovalRequired =>
+        (HashSet<string>)typeof(DocumentsController)
+            .GetField("ApprovalRequiredTransitions", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    // ── Sanity — reflection actually found the real tables ───────────────────
+
+    [Fact]
+    public void Sanity_the_controller_tables_were_found_and_are_not_empty()
+    {
+        // Reflection that silently returns nothing would make every assertion
+        // below pass vacuously — the exact failure mode this suite keeps hitting.
+        Assert.NotNull(Compute);
+        Assert.NotEmpty(ValidTransitions);
+        Assert.NotEmpty(ApprovalRequired);
+    }
+
+    // ── The served list IS the controller's table ────────────────────────────
+
+    [Fact]
+    public void Every_state_offers_exactly_what_the_state_machine_allows()
+    {
+        foreach (var (state, targets) in ValidTransitions)
+        {
+            var served = For(state).Select(o => o.To).ToArray();
+            Assert.Equal(targets, served);
+        }
+    }
+
+    [Fact]
+    public void Approval_is_flagged_for_exactly_the_transitions_that_require_it()
+    {
+        foreach (var (state, targets) in ValidTransitions)
+        foreach (var option in For(state))
+            Assert.Equal(
+                ApprovalRequired.Contains($"{state}->{option.To}"),
+                option.RequiresApproval);
+
+        // And the flag is actually used somewhere — an all-false result would
+        // satisfy the loop above if ApprovalRequired never matched anything.
+        Assert.Contains(
+            ValidTransitions.Keys.SelectMany(For),
+            o => o.RequiresApproval);
+    }
+
+    // ── The specific drifts that motivated this ──────────────────────────────
+
+    [Fact]
+    public void PUBLISHED_offers_the_two_transitions_mobile_could_not_see()
+    {
+        var served = For("PUBLISHED").Select(o => o.To).ToArray();
+
+        Assert.Contains("ARCHIVE", served);      // mobile knew this one
+        Assert.Contains("SUPERSEDED", served);   // it did not
+        Assert.Contains("WITHDRAWN", served);    // nor this
+    }
+
+    [Fact]
+    public void SHARED_offers_WITHDRAWN_which_mobile_could_not_see()
+        => Assert.Contains("WITHDRAWN", For("SHARED").Select(o => o.To));
+
+    [Fact]
+    public void WIP_to_SHARED_does_NOT_require_approval()
+    {
+        // Mobile asserted it did, and routed it through the approval workflow —
+        // filing a request for a transition the server would have performed
+        // directly, then telling the user to wait for a decision nobody was
+        // asked to make.
+        var toShared = Assert.Single(For("WIP"), o => o.To == "SHARED");
+        Assert.False(toShared.RequiresApproval);
+    }
+
+    [Fact]
+    public void PUBLISHED_to_SUPERSEDED_DOES_require_approval()
+    {
+        // The other half of the same drift: mobile did not know, so it would
+        // have called the direct endpoint and been refused.
+        var toSuperseded = Assert.Single(For("PUBLISHED"), o => o.To == "SUPERSEDED");
+        Assert.True(toSuperseded.RequiresApproval);
+    }
+
+    // ── Terminal and unknown states ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("ARCHIVE")]
+    [InlineData("SUPERSEDED")]
+    [InlineData("WITHDRAWN")]
+    [InlineData("OBSOLETE")]
+    public void A_terminal_state_serves_an_empty_list_not_null(string state)
+    {
+        // Empty is a real answer: the state machine was consulted and offers
+        // nothing. Null is reserved for "not computed", which clients read as
+        // unknown. Conflating them would make a terminal document look like an
+        // old server, and vice versa.
+        var served = For(state);
+        Assert.NotNull(served);
+        Assert.Empty(served);
+    }
+
+    [Fact]
+    public void An_unrecognised_state_serves_empty_rather_than_throwing()
+    {
+        // A document carrying a state the machine does not know must not take
+        // the whole document list down with it.
+        var served = For("NOT_A_REAL_STATE");
+        Assert.NotNull(served);
+        Assert.Empty(served);
+    }
+
+    // ── Affordance, not authority ────────────────────────────────────────────
+
+    [Fact]
+    public void The_computation_depends_on_nothing_but_the_current_state()
+    {
+        // Deliberately excludes TransitionRoleRequirements and the per-folder
+        // ACL: those are per-caller, and folding them in here would make a list
+        // projection do a per-row authorization pass while implying the result
+        // is a permission grant. If this method ever gains a caller or document
+        // parameter, that decision is being reversed and should be argued.
+        var parameters = Compute.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);
+    }
+
+    // ── The field is additive, not persisted ─────────────────────────────────
+
+    [Fact]
+    public void AllowedTransitions_is_NotMapped_so_no_schema_changes()
+    {
+        var prop = typeof(DocumentRecord).GetProperty(nameof(DocumentRecord.AllowedTransitions))!;
+        Assert.NotNull(prop.GetCustomAttribute<
+            System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute>());
+    }
+
+    [Fact]
+    public void AllowedTransitions_defaults_to_null_meaning_not_computed()
+    {
+        // A freshly-constructed document must not claim "no transitions
+        // available" — that is a statement the state machine has not made.
+        Assert.Null(new DocumentRecord().AllowedTransitions);
+    }
+}

--- a/Planscape/app/(tabs)/documents.tsx
+++ b/Planscape/app/(tabs)/documents.tsx
@@ -21,7 +21,25 @@ import { useAuthStore } from '@/stores/authStore';
 
 const CDE_STATES: CDEStatus[] = ['WIP', 'SHARED', 'PUBLISHED', 'ARCHIVE'];
 
-const VALID_TRANSITIONS: Record<CDEStatus, CDEStatus[]> = {
+/**
+ * #633 — the CDE state machine is SERVED now (doc.allowedTransitions), not
+ * re-derived here. Two local tables used to hold a copy of it and both had
+ * drifted, in opposite directions:
+ *
+ *   VALID_TRANSITIONS said PUBLISHED -> [ARCHIVE]. The server also allows
+ *   SUPERSEDED and WITHDRAWN, and SHARED -> WITHDRAWN. Three legal moves the
+ *   user simply could not see.
+ *
+ *   TRANSITIONS_REQUIRING_APPROVAL said {WIP->SHARED, SHARED->PUBLISHED}. The
+ *   server says {SHARED->PUBLISHED, PUBLISHED->SUPERSEDED}. So WIP->SHARED was
+ *   sent through an approval workflow the server does not require, and
+ *   PUBLISHED->SUPERSEDED went straight at the transition endpoint, which
+ *   refuses it for want of an approval record.
+ *
+ * Both tables are gone. What remains is the FALLBACK for a server that does
+ * not send the field yet — see transitionsFor() below.
+ */
+const LEGACY_FALLBACK_TRANSITIONS: Record<string, CDEStatus[]> = {
   WIP: ['SHARED'],
   SHARED: ['WIP', 'PUBLISHED'],
   PUBLISHED: ['ARCHIVE'],
@@ -29,18 +47,42 @@ const VALID_TRANSITIONS: Record<CDEStatus, CDEStatus[]> = {
 };
 
 /**
- * Phase 96 — ISO 19650-2 §5.6 approval gates. Transitions into SHARED and
- * PUBLISHED state require Task Information Manager / BIM Coordinator sign-off
- * before the document is released on the CDE. Mobile routes these through
- * the approval workflow endpoints instead of directly calling transitionCDE.
+ * The document's transitions, and where they came from.
+ *
+ * THREE STATES, NOT TWO — the same contract capabilities.ts uses (#634).
+ *
+ *   served  the server computed them; trust them completely, including
+ *           requiresApproval, which decides WHICH ENDPOINT the button calls
+ *   legacy  the field is absent — an older server. UNKNOWN, not "none".
+ *           Offer the old local set so the screen still works, but treat
+ *           approval as unknown and let the server answer: it enforces the
+ *           gate either way and says so when it refuses.
+ *
+ * An empty served array is NOT the legacy case. It means the state machine was
+ * consulted and this is a terminal state (ARCHIVE, SUPERSEDED, WITHDRAWN) —
+ * a real answer, and the screen renders "no further transitions" for it.
  */
-const TRANSITIONS_REQUIRING_APPROVAL = new Set<string>([
-  'WIP->SHARED',
-  'SHARED->PUBLISHED',
-]);
-
-function requiresApproval(from: CDEStatus, to: CDEStatus): boolean {
-  return TRANSITIONS_REQUIRING_APPROVAL.has(`${from}->${to}`);
+function transitionsFor(doc: DocumentRecord):
+  { source: 'served' | 'legacy'; options: { to: string; requiresApproval: boolean | null }[] } {
+  if (Array.isArray(doc.allowedTransitions)) {
+    return {
+      source: 'served',
+      options: doc.allowedTransitions.map((t) => ({
+        to: t.to,
+        requiresApproval: t.requiresApproval,
+      })),
+    };
+  }
+  return {
+    source: 'legacy',
+    options: (LEGACY_FALLBACK_TRANSITIONS[doc.cdeStatus] ?? []).map((to) => ({
+      to,
+      // null = we do not know. NOT false — claiming "no approval needed" would
+      // send PUBLISHED->SUPERSEDED at the wrong endpoint, which is exactly the
+      // bug the old hardcoded table caused.
+      requiresApproval: null,
+    })),
+  };
 }
 
 const SUITABILITY_LABELS: Record<string, string> = {
@@ -148,7 +190,17 @@ export default function DocumentsScreen() {
    * (e.g. SHARED→WIP rework, PUBLISHED→ARCHIVE retention) call transitionCDE
    * directly because they don't release new information to the CDE.
    */
-  async function handleTransition(doc: DocumentRecord, newStatus: CDEStatus) {
+  /**
+   * `needsApproval` comes from the server (doc.allowedTransitions) — or is null
+   * when this server does not send the field yet. Null takes the DIRECT path
+   * deliberately: the server enforces the approval gate itself and refuses with
+   * a reason, so an unknown becomes a message the user can act on. Guessing
+   * "yes" instead would file an approval request for a transition that never
+   * needed one, and the user would wait for a decision nobody was asked to make.
+   */
+  async function handleTransition(
+    doc: DocumentRecord, newStatus: CDEStatus, needsApproval: boolean | null,
+  ) {
     if (!activeProject) return;
     setTransitioning(true);
 
@@ -160,7 +212,7 @@ export default function DocumentsScreen() {
     // pending, and the user was told to wait for an approval that would never
     // arrive. Keep the attempts — and the messages — apart.
     try {
-      if (requiresApproval(doc.cdeStatus, newStatus)) {
+      if (needsApproval === true) {
         // Fire the approval request — does NOT actually move the CDE state;
         // the approver's decideDocumentApproval call does that server-side.
         try {
@@ -434,11 +486,11 @@ function DocumentDetailModal({
   doc: DocumentRecord;
   projectId?: string;
   transitioning: boolean;
-  onTransition: (doc: DocumentRecord, status: CDEStatus) => void;
+  onTransition: (doc: DocumentRecord, status: CDEStatus, needsApproval: boolean | null) => void;
   onClose: () => void;
 }) {
   const cdeColor = getCDEColor(doc.cdeStatus);
-  const validNext = VALID_TRANSITIONS[doc.cdeStatus] ?? [];
+  const { source: transitionSource, options: nextOptions } = transitionsFor(doc);
   const suitLabel = doc.suitabilityCode ? SUITABILITY_LABELS[doc.suitabilityCode] : null;
 
   return (
@@ -474,18 +526,22 @@ function DocumentDetailModal({
           </View>
 
           {/* CDE State Machine — Transition Buttons */}
-          {validNext.length > 0 && (
+          {nextOptions.length > 0 && (
             <View style={styles.transitionSection}>
               <Text style={styles.transitionTitle}>CDE Transition</Text>
               <View style={styles.transitionRow}>
-                {validNext.map((next) => {
+                {nextOptions.map((opt) => {
+                  const next = opt.to as CDEStatus;
                   const nextColor = getCDEColor(next);
-                  const gated = requiresApproval(doc.cdeStatus, next);
+                  // true -> approval route. false -> direct. null -> unknown
+                  // (legacy server): label it plainly rather than asserting
+                  // either, and let the server's own refusal decide.
+                  const gated = opt.requiresApproval === true;
                   return (
                     <TouchableOpacity
                       key={next}
                       style={[styles.transitionBtn, { backgroundColor: nextColor }]}
-                      onPress={() => onTransition(doc, next)}
+                      onPress={() => onTransition(doc, next, opt.requiresApproval)}
                       disabled={transitioning}
                     >
                       {transitioning ? (
@@ -500,12 +556,23 @@ function DocumentDetailModal({
                 })}
               </View>
               <Text style={styles.transitionHint}>
-                {doc.cdeStatus} {'\u2192'} {validNext.join(' / ')}
+                {doc.cdeStatus} {'\u2192'} {nextOptions.map((o) => o.to).join(' / ')}
               </Text>
+              {transitionSource === 'legacy' && (
+                // Say that this list is the app's older built-in guess, not the
+                // server's answer. Without it the screen looks equally
+                // authoritative either way, and missing transitions read as
+                // rules rather than as a gap.
+                <Text style={styles.transitionHint}>
+                  This server does not publish its CDE state machine — showing
+                  this app&apos;s built-in list. Some transitions may be missing,
+                  and the server decides whether approval is required.
+                </Text>
+              )}
             </View>
           )}
 
-          {validNext.length === 0 && (
+          {nextOptions.length === 0 && (
             <View style={styles.transitionSection}>
               <Text style={styles.transitionHint}>This document is in its final CDE state.</Text>
             </View>

--- a/Planscape/src/types/api.ts
+++ b/Planscape/src/types/api.ts
@@ -148,6 +148,22 @@ export interface DocumentRecord {
   originator: string;
   createdAt: string;
   updatedAt: string;
+  /**
+   * #633 — where this document may go next, and whether approval is needed
+   * first, computed server-side from the ISO 19650-2 state machine.
+   *
+   * OPTIONAL ON PURPOSE. A server that predates the field omits it, and that
+   * is UNKNOWN, not "no transitions available". The two are different answers
+   * and only one of them is a refusal — see documents.tsx for how the screen
+   * keeps them apart.
+   */
+  allowedTransitions?: CdeTransitionOption[] | null;
+}
+
+/** One legal next CDE state, as served with the document. */
+export interface CdeTransitionOption {
+  to: string;
+  requiresApproval: boolean;
 }
 
 export interface DashboardData {


### PR DESCRIPTION
Part 4e — #633, Shape 1 (approved). Branched from `main`, independent of #737/#751/#752.

## The exact JSON, stated before the reasoning

`GET /api/projects/{projectId}/documents` — each item in `items[]` gains one field. Nothing else changes.

```jsonc
{
  "id": "…", "fileName": "…", "cdeStatus": "PUBLISHED", "suitabilityCode": "S4",
  // …every existing field, untouched…

  "allowedTransitions": [
    { "to": "ARCHIVE",    "requiresApproval": false },
    { "to": "SUPERSEDED", "requiresApproval": true  },
    { "to": "WITHDRAWN",  "requiresApproval": false }
  ]
}
```

Three values are possible and they are **not** interchangeable:

| Value | Means | Client must |
|---|---|---|
| a non-empty array | the state machine's answer | drive the buttons from it |
| `[]` | consulted, and this is a **terminal state** (ARCHIVE / SUPERSEDED / WITHDRAWN / OBSOLETE) | say "no further transitions" |
| `null` / absent | **not computed** — an older server | treat as **unknown**, not as "none" |

## Why — mobile's two copies had drifted in opposite directions

Neither looked like a bug, because each was wrong in a way the other hid.

| | mobile said | server says | consequence |
|---|---|---|---|
| **Valid** | `PUBLISHED → [ARCHIVE]`<br>`SHARED → [WIP, PUBLISHED]` | also `SUPERSEDED`, `WITHDRAWN`<br>also `WITHDRAWN` | **three legal transitions the user could not see** |
| **Approval** | `{WIP→SHARED, SHARED→PUBLISHED}` | `{SHARED→PUBLISHED, PUBLISHED→SUPERSEDED}` | `WIP→SHARED` filed an approval request the server never required — the user waits for a decision **nobody was asked to make**. `PUBLISHED→SUPERSEDED` went at the direct endpoint, which refuses it for want of an approval record. |

## Server

`DocumentRecord.AllowedTransitions` is `[NotMapped]` — **no schema change, nothing persisted**. `AllowedTransitionsFor(state)` reads the two dictionaries directly, which are the same ones `TransitionState`, `TransitionStateMobile`, `RequestApproval` and `SyncFromPlugin` all enforce against. One source; a client cannot hold a stale copy.

**Affordance, not authority.** It deliberately excludes `TransitionRoleRequirements` and the per-folder ACL: those are per-caller, and folding them in would make a list projection do a per-row authorization pass *while implying the result is a permission grant*. The server still gates every transition, and a client showing a button from this list must still handle a refusal. A test pins that decision by asserting the method takes exactly one `string` parameter — if it ever gains a caller or document argument, the decision is being reversed and should be argued.

## Mobile — in the required order

The field is served **first**; only then is the table deleted. Deleting first would have left mobile attempting blindly.

`TRANSITIONS_REQUIRING_APPROVAL` and `requiresApproval()` are gone. The screen reads `doc.allowedTransitions`, and `requiresApproval` decides **which endpoint the button calls**.

**The rollout case is handled honestly.** An older server omits the field:

- the screen falls back to the previous built-in list so it still works,
- it **says so on screen** — *"This server does not publish its CDE state machine — showing this app's built-in list. Some transitions may be missing…"* — rather than looking equally authoritative in both cases,
- and it passes `requiresApproval: null`, not `false`.

Null takes the **direct** path deliberately: the server enforces the approval gate itself and refuses with a reason, so an unknown becomes a message the user can act on. Guessing "approval needed" would recreate precisely the bug being removed. This is the same three-state discipline `capabilities.ts` uses for #634 — unknown is never rendered as a refusal, and no fallback data is invented.

## Tests — 15 cases

They **read the controller's own dictionaries by reflection** rather than restating them. A test that repeats the table is a fourth copy of the state machine and would happily agree with a wrong one. A sanity case asserts reflection found non-empty tables *first*, so nothing below can pass vacuously.

Cases pin the two drifts by name:

```
WIP_to_SHARED_does_NOT_require_approval
PUBLISHED_to_SUPERSEDED_DOES_require_approval
PUBLISHED_offers_the_two_transitions_mobile_could_not_see
SHARED_offers_WITHDRAWN_which_mobile_could_not_see
A_terminal_state_serves_an_empty_list_not_null
AllowedTransitions_defaults_to_null_meaning_not_computed
```

```
Server:  828 passed, 0 failed, 15 skipped
Mobile:  tsc --noEmit 0 errors · forbidden-states 8/8 · geofence 11/11
```

## #628 verified, as asked

The `/approvals` → `/approval-request` fix **is** on `main`:

- `endpoints.ts:1051` posts to `.../documents/{id}/approval-request`
- `DocumentsController:1076` is `[HttpPost("{docId}/approval-request")]`

Unchanged here.

## One thing noticed, unverified, not fixed

`listDocuments` is typed `Promise<DocumentRecord[]>`, but the endpoint returns the envelope `{ items, total, page, pageSize }` and `apiFetch` does not unwrap it — so `setDocuments(docs)` appears to receive an object where an array is expected. I have **not** run the app to confirm, so this is an observation rather than a finding, and it is untouched by this change (the new field rides on each item either way). Worth a look; I did not want to lose it.

Refs #633, #628, #634
