### PR TITLE
fix: publishing a federated model published the container, not the model

### DIFF
--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -421,6 +421,14 @@ namespace StingTools.BIMManager
 
         private static string? PromptForModelFileOrExport(Document doc)
         {
+            // Reset per publish. This is static state, so without it a run that picks an
+            // existing file would inherit the ANSWER FROM THE PREVIOUS RUN and build an
+            // element map that disagrees with the geometry — the same
+            // meshes-without-properties symptom, arriving by a different route and only
+            // on the second publish of a session, which is the worst kind to reproduce.
+            // Only ExportActiveView, which actually asks, may set it true.
+            _includeLinksThisRun = false;
+
             var dlg = new TaskDialog("Publish Model")
             {
                 MainInstruction = "How do you want to provide the 3D geometry?",
@@ -467,8 +475,21 @@ namespace StingTools.BIMManager
                 bool wantTextures =
                     string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_TEXTURES"), "1", StringComparison.OrdinalIgnoreCase)
                     || RevitGltfExporter.ExportTextures;
-                var result = RevitGltfExporter.Export(doc, v3d, outPath, exportTextures: wantTextures);
+                _includeLinksThisRun = AskIncludeLinks(doc, v3d);
+                var result = RevitGltfExporter.Export(doc, v3d, outPath,
+                                                      exportTextures: wantTextures,
+                                                      includeLinks: _includeLinksThisRun);
                 StingLog.Info($"Planscape: GLB exported ({result.ElementCount} elements, {result.FileSizeBytes:N0} bytes) → {outPath}");
+
+                // Say it out loud. The whole reason this option exists is that links were
+                // being dropped SILENTLY, and a deliberate default is not a licence to
+                // reproduce that — a user who publishes a federated site and gets an empty
+                // container must be told why, at the moment it happens.
+                if (result.SkippedLinkCount > 0)
+                    TaskDialog.Show("Publish Model",
+                        $"Published the host model only — {result.SkippedLinkCount} linked model(s) were not included.\n\n"
+                      + "If you expected the buildings or site to appear, publish again and choose "
+                      + "\"Include linked models\".");
                 return outPath;
             }
             catch (Exception ex)
@@ -498,6 +519,76 @@ namespace StingTools.BIMManager
         }
 
         // ── Federation support ─────────────────────────────────────────
+
+        /// <summary>
+        /// Whether THIS publish includes linked models. Set by <see cref="AskIncludeLinks"/>
+        /// immediately before the geometry export and read by <c>BuildElementMap</c>, so
+        /// the GLB and the element map can never disagree about what was published — a
+        /// disagreement shows as meshes with no properties, or tree rows with no mesh.
+        /// </summary>
+        private static bool _includeLinksThisRun;
+
+        /// <summary>
+        /// Ask once per publish, and only when it matters.
+        ///
+        /// <para>No links in the view means no question — a dialog whose answer cannot
+        /// change anything is noise. When links ARE present the choice is explicit,
+        /// because both answers are reasonable: a discipline publish wants the host alone
+        /// (smaller, faster, and the viewer federates published models anyway), while a
+        /// site or coordination publish wants one artefact containing everything.</para>
+        ///
+        /// <para><c>PLANSCAPE_EXPORT_LINKS=1</c> skips the prompt for scripted runs.</para>
+        /// </summary>
+        private static bool AskIncludeLinks(Document doc, View view)
+        {
+            int linkCount;
+            try
+            {
+                var lc = view is View3D
+                    ? new FilteredElementCollector(doc, view.Id)
+                    : new FilteredElementCollector(doc);
+                linkCount = lc.OfClass(typeof(RevitLinkInstance)).GetElementCount();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Publish: could not count links — {ex.Message}");
+                linkCount = 0;
+            }
+
+            if (linkCount == 0) return false;
+
+            if (string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_LINKS"), "1",
+                              StringComparison.OrdinalIgnoreCase)
+                || RevitGltfExporter.IncludeLinks)
+            {
+                StingLog.Info($"Publish: including {linkCount} linked model(s) (set by environment/static override).");
+                return true;
+            }
+
+            var dlg = new TaskDialog("Publish Model")
+            {
+                MainInstruction = $"This view contains {linkCount} linked model(s). Include them?",
+                MainContent = "Linked models are the buildings, site or discipline models attached to this file.",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+            };
+            dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                "Host model only  (default)",
+                "Publishes just this file. Smaller and faster, and you can publish each linked "
+              + "model separately — the viewer federates them and gives you per-model visibility.");
+            dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
+                "Include linked models",
+                "Publishes everything visible in this view as one model — the right choice for a "
+              + "federated site or a coordination snapshot. Larger file and a slower export.");
+            var r = dlg.Show();
+            if (r == TaskDialogResult.CommandLink2)
+            {
+                StingLog.Info($"Publish: including {linkCount} linked model(s) by user choice.");
+                return true;
+            }
+            StingLog.Info($"Publish: EXCLUDING {linkCount} linked model(s) by user choice (host model only).");
+            return false;
+        }
+
 
         /// <summary>One element to publish, with the document it came from, the transform
         /// into host coordinates, and the key it shares with its GLB mesh node.</summary>
@@ -685,7 +776,10 @@ namespace StingTools.BIMManager
             // fault in its own way (see RevitGltfExporter's document stack); fixing one
             // without the other gives you either geometry with no properties or
             // properties with no geometry.
-            elements.AddRange(CollectLinkedElements(doc, activeView));
+            if (_includeLinksThisRun)
+                elements.AddRange(CollectLinkedElements(doc, activeView));
+            else
+                StingLog.Info("Publish: element map covers the host model only (links excluded for this publish).");
 
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -497,6 +497,165 @@ namespace StingTools.BIMManager
             return ok == true ? dlg.FileName : null;
         }
 
+        // ── Federation support ─────────────────────────────────────────
+
+        /// <summary>One element to publish, with the document it came from, the transform
+        /// into host coordinates, and the key it shares with its GLB mesh node.</summary>
+        private readonly struct MapItem
+        {
+            public MapItem(Document doc, Element el, Transform xf, string key)
+            { Doc = doc; El = el; Xf = xf; Key = key; }
+            public Document Doc { get; }
+            public Element El { get; }
+            public Transform Xf { get; }
+            public string Key { get; }
+        }
+
+        /// <summary>
+        /// Every element inside every loaded Revit link, paired with its document and
+        /// placement transform.
+        ///
+        /// <para><b>Scope note, stated plainly:</b> this returns model elements with
+        /// geometry from each link, NOT "elements visible in the host's active view".
+        /// A view id belongs to the host document, so it cannot filter a linked
+        /// document's collector, and per-element visibility across a link is not
+        /// something the API answers cheaply. The GLB — which Revit's own view traversal
+        /// produces — remains the authority on what is drawn. The practical effect is
+        /// that the map can list a few elements the geometry does not show; a tree row
+        /// with no mesh is a far smaller problem than the mesh with no properties this
+        /// replaces.</para>
+        ///
+        /// <para>Links that are unloaded, or that fail to resolve, are skipped with a
+        /// warning rather than failing the publish — a partial federation is still worth
+        /// publishing, and the log says which link was missing.</para>
+        /// </summary>
+        private static IEnumerable<MapItem> CollectLinkedElements(Document host, View activeView)
+        {
+            var results = new List<MapItem>();
+            // Keyed by document identity so a cycle (A links B links A) terminates, and
+            // so the same file linked twice is not collected twice into one map.
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                RevitGltfExporter.LinkScope(host)
+            };
+            CollectLinksRecursive(host, activeView, Transform.Identity, visited, results, depth: 0);
+            return results;
+        }
+
+        /// <summary>
+        /// Walks links, then links inside those links.
+        ///
+        /// <para>Revit's own view traversal descends nested links, so the GLB contains
+        /// them. A one-level metadata walk would therefore reproduce the exact bug this
+        /// change fixes, one level down — geometry present, properties missing — which is
+        /// the failure mode hardest to notice because the model looks right.</para>
+        ///
+        /// <para>Depth is capped and documents are visited once. A cycle is legal in
+        /// Revit and would otherwise recurse until the stack gives out.</para>
+        /// </summary>
+        private static void CollectLinksRecursive(
+            Document parent, View activeView, Transform parentXf,
+            HashSet<string> visited, List<MapItem> results, int depth)
+        {
+            const int MaxDepth = 8;
+            if (depth >= MaxDepth)
+            {
+                StingLog.Warn($"Publish: link nesting deeper than {MaxDepth} in '{parent.Title}' — not descending further.");
+                return;
+            }
+
+            List<RevitLinkInstance> links;
+            try
+            {
+                // At the top level, filter by the active view so links hidden in THIS view
+                // are not published — the link INSTANCE is a host element, so unlike
+                // per-element visibility this is a question the host view can answer.
+                // Deeper down there is no equivalent view, so take them all.
+                var lc = (depth == 0 && activeView is View3D)
+                    ? new FilteredElementCollector(parent, activeView.Id)
+                    : new FilteredElementCollector(parent);
+                links = lc.OfClass(typeof(RevitLinkInstance))
+                          .Cast<RevitLinkInstance>()
+                          .ToList();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Publish: could not enumerate links in '{parent.Title}' — {ex.Message}");
+                return;
+            }
+
+            foreach (var link in links)
+            {
+                Document ldoc = null;
+                try { ldoc = link.GetLinkDocument(); }
+                catch (Exception ex) { StingLog.Warn($"Publish: link '{link.Name}' — {ex.Message}"); }
+
+                if (ldoc == null)
+                {
+                    // Unloaded link. Named explicitly: silently publishing a federation
+                    // minus one building is exactly the failure this whole change fixes.
+                    StingLog.Warn($"Publish: link '{link.Name}' is not loaded — its elements are NOT in this publish.");
+                    continue;
+                }
+
+                Transform xf;
+                try { xf = parentXf.Multiply(link.GetTotalTransform() ?? Transform.Identity); }
+                catch { xf = parentXf; }
+
+                string scope = RevitGltfExporter.LinkScope(ldoc);
+                if (!visited.Add(scope))
+                {
+                    StingLog.Info($"Publish: link '{ldoc.Title}' already collected — skipping duplicate/cyclic reference.");
+                    continue;
+                }
+                int n = 0;
+                try
+                {
+                    foreach (var e in new FilteredElementCollector(ldoc)
+                                          .WhereElementIsNotElementType()
+                                          .Where(e => e.Category != null
+                                                      && e.Category.CategoryType == CategoryType.Model
+                                                      && e.get_Geometry(new Options()) != null))
+                    {
+                        results.Add(new MapItem(ldoc, e, xf, scope + "|" + e.UniqueId));
+                        n++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"Publish: collecting from link '{link.Name}' failed — {ex.Message}");
+                }
+                StingLog.Info($"Publish: link '{ldoc.Title}' contributed {n} element(s).");
+
+                // Descend. The transform accumulates, so a building nested two links deep
+                // still lands in host coordinates.
+                CollectLinksRecursive(ldoc, activeView, xf, visited, results, depth + 1);
+            }
+        }
+
+        /// <summary>
+        /// The eight transformed corners of a bounding box.
+        ///
+        /// <para>All eight, not Min and Max. Under rotation the transformed Min is not
+        /// the minimum of the transformed box — taking the two corners gives an AABB that
+        /// can be smaller than the geometry it is meant to contain, and a link placed at
+        /// an angle is the normal case, not an exotic one.</para>
+        /// </summary>
+        private static IEnumerable<XYZ> Corners(BoundingBoxXYZ b, Transform xf)
+        {
+            var t = xf ?? Transform.Identity;
+            // A BoundingBoxXYZ carries its own Transform; fold it in so a box expressed
+            // in a non-identity local frame is read correctly before the link transform.
+            var local = b.Transform ?? Transform.Identity;
+            for (int i = 0; i < 8; i++)
+            {
+                var p = new XYZ((i & 1) == 0 ? b.Min.X : b.Max.X,
+                                (i & 2) == 0 ? b.Min.Y : b.Max.Y,
+                                (i & 4) == 0 ? b.Min.Z : b.Max.Z);
+                yield return t.OfPoint(local.OfPoint(p));
+            }
+        }
+
         // ── Element map generator ──────────────────────────────────────
 
         private static void BuildElementMap(
@@ -508,10 +667,25 @@ namespace StingTools.BIMManager
                 ? new FilteredElementCollector(doc, activeView.Id)
                 : new FilteredElementCollector(doc);
 
+            // Host elements first, each paired with the document it belongs to and the
+            // transform that puts it in host coordinates (identity, by definition).
             var elements = collector
                 .WhereElementIsNotElementType()
                 .Where(e => e.Category != null && e.get_Geometry(new Options()) != null)
+                .Select(e => new MapItem(doc, e, Transform.Identity,
+                                         RevitGltfExporter.ElementKey(doc, doc, e)))
                 .ToList();
+
+            // …then everything inside the loaded links.
+            //
+            // Without this the map described the HOST FILE ONLY. On a federated model —
+            // where the host is a container and every building is a link — that is a
+            // handful of link instances and nothing else, which is why the viewer
+            // reported "8 ELEMENTS / 0% TAGGED" for a whole site. The GLB had the same
+            // fault in its own way (see RevitGltfExporter's document stack); fixing one
+            // without the other gives you either geometry with no properties or
+            // properties with no geometry.
+            elements.AddRange(CollectLinkedElements(doc, activeView));
 
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),
@@ -523,9 +697,13 @@ namespace StingTools.BIMManager
             var sysHist = new Dictionary<string, int>();
             var sysUnresolvedCats = new Dictionary<string, int>();
 
-            foreach (var el in elements)
+            foreach (var item in elements)
             {
-                var guid = el.UniqueId;
+                var el   = item.El;
+                // The element's OWN document. Level lookup, quantities and materials all
+                // read from it, and for a linked element the host knows none of them.
+                var edoc = item.Doc;
+                var guid = item.Key;
                 var tag = ParameterHelpers.GetString(el, ParamRegistry.TAG1);
 
                 // Track bounds from EVERY element with a bounding box, not just
@@ -536,12 +714,16 @@ namespace StingTools.BIMManager
                 var eb = el.get_BoundingBox(null);
                 if (eb != null)
                 {
-                    bb.Min = new XYZ(Math.Min(bb.Min.X, eb.Min.X),
-                                     Math.Min(bb.Min.Y, eb.Min.Y),
-                                     Math.Min(bb.Min.Z, eb.Min.Z));
-                    bb.Max = new XYZ(Math.Max(bb.Max.X, eb.Max.X),
-                                     Math.Max(bb.Max.Y, eb.Max.Y),
-                                     Math.Max(bb.Max.Z, eb.Max.Z));
+                    // A linked element's bounding box is in ITS OWN coordinates. Folded
+                    // into the host AABB untransformed, a link with any offset drags the
+                    // published bounds out to enclose empty space, and the viewer opens
+                    // zoomed to nothing. Transform all eight corners — transforming only
+                    // Min/Max is wrong as soon as the link is rotated.
+                    foreach (var c in Corners(eb, item.Xf))
+                    {
+                        bb.Min = new XYZ(Math.Min(bb.Min.X, c.X), Math.Min(bb.Min.Y, c.Y), Math.Min(bb.Min.Z, c.Z));
+                        bb.Max = new XYZ(Math.Max(bb.Max.X, c.X), Math.Max(bb.Max.Y, c.Y), Math.Max(bb.Max.Z, c.Z));
+                    }
                     boundsContributors++;
                 }
 
@@ -576,7 +758,7 @@ namespace StingTools.BIMManager
                     // untagged ones still get name + category + level + elementId
                     // which is what the right-panel Properties tab needs.
                     string lvlOnly = "";
-                    try { lvlOnly = ParameterHelpers.GetLevelCode(doc, el) ?? ""; } catch { }
+                    try { lvlOnly = ParameterHelpers.GetLevelCode(edoc, el) ?? ""; } catch { }
                     var untaggedEntry = new JObject
                     {
                         ["name"]      = el.Name ?? "",
@@ -593,7 +775,7 @@ namespace StingTools.BIMManager
                         ["elementId"] = el.Id.Value,
                     };
                     AddCost(el, untaggedEntry);   // M3 — per-element cost (rate × measured qty)
-                    AddQuantitiesAndMaterials(doc, el, untaggedEntry);   // E4 — area/volume/length + materials
+                    AddQuantitiesAndMaterials(edoc, el, untaggedEntry);   // E4 — area/volume/length + materials
                     map[guid] = untaggedEntry;
                     count++;
                     continue;
@@ -631,7 +813,7 @@ namespace StingTools.BIMManager
                     ["elementId"]  = el.Id.Value,
                 };
                 AddCost(el, taggedEntry);     // M3 — per-element cost
-                AddQuantitiesAndMaterials(doc, el, taggedEntry);   // E4 — area/volume/length + materials
+                AddQuantitiesAndMaterials(edoc, el, taggedEntry);   // E4 — area/volume/length + materials
                 map[guid] = taggedEntry;
                 count++;
             }

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -62,6 +62,30 @@ namespace StingTools.BIMManager
         // ("PlanscapeExportTextures" export option).
         public static bool ExportTextures { get; set; } = false;
         private readonly bool _exportTextures;
+
+        /// <summary>
+        /// Whether linked models are included. <b>Default false — the host model only.</b>
+        ///
+        /// <para>Two publishes serve different purposes and want opposite answers. A
+        /// discipline publish ("here is MY model") wants the host alone: smaller file,
+        /// faster, and the platform federates published models on the viewer side anyway.
+        /// A site or coordination publish wants everything in one artefact.</para>
+        ///
+        /// <para>Off by default because that is the smaller, faster, more predictable
+        /// result and matches what most publishes are for. <b>The obligation that comes
+        /// with the default is that exclusion must be VISIBLE</b> — a federated model
+        /// silently arriving as an empty container is precisely the failure this option
+        /// grew out of, and a default is not an excuse to reproduce it quietly. Callers
+        /// must report how many links were left out.</para>
+        ///
+        /// <para>Set via <c>PLANSCAPE_EXPORT_LINKS=1</c>, this static, or the
+        /// <c>includeLinks</c> parameter on <see cref="Export"/>.</para>
+        /// </summary>
+        public static bool IncludeLinks { get; set; } = false;
+        private readonly bool _includeLinks;
+
+        /// <summary>Links encountered and skipped, so the caller can say so out loud.</summary>
+        public int SkippedLinkCount { get; private set; }
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
         private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
@@ -86,24 +110,29 @@ namespace StingTools.BIMManager
         // its millimetre survey figures from RevitGeoref, which reads metres.)
         private const double FeetToMetres = 0.3048;
 
-        public RevitGltfExporter(Document doc, bool exportTextures = false)
+        public RevitGltfExporter(Document doc, bool exportTextures = false, bool includeLinks = false)
         {
             _doc = doc;
             _exportTextures = exportTextures;
+            _includeLinks = includeLinks;
             _xformStack.Push(Transform.Identity);
             _docStack.Push(doc);
         }
 
-        public static ExportResult Export(Document doc, View3D view, string outputGlbPath, bool? exportTextures = null)
+        public static ExportResult Export(Document doc, View3D view, string outputGlbPath,
+                                          bool? exportTextures = null, bool? includeLinks = null)
         {
             bool textures = exportTextures ?? ExportTextures;
+            bool links = includeLinks
+                ?? (string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_LINKS"), "1", StringComparison.OrdinalIgnoreCase)
+                    || IncludeLinks);
             // S8.2.2 — span around the whole export so telemetry-on users see
             // p99 export latency vs scene size in their dashboards.
             return StingTools.Core.PluginTelemetry.Run(
                 "RevitGltfExporter.export",
                 () =>
                 {
-                    var ctx = new RevitGltfExporter(doc, textures);
+                    var ctx = new RevitGltfExporter(doc, textures, links);
                     var exporter = new CustomExporter(doc, ctx)
                     {
                         IncludeGeometricObjects = false,
@@ -113,6 +142,10 @@ namespace StingTools.BIMManager
                     };
                     exporter.Export(view);
                     var result = ctx.WriteGlb(outputGlbPath);
+                    result.SkippedLinkCount = ctx.SkippedLinkCount;
+                    if (ctx.SkippedLinkCount > 0)
+                        StingLog.Info($"Planscape: GLB excluded {ctx.SkippedLinkCount} linked model instance(s) " +
+                                      "(links off — set PLANSCAPE_EXPORT_LINKS=1 or choose 'include links' to add them).");
                     // Gap J — write coordinate sidecar alongside the GLB so the
                     // server can populate IfcAlignmentReport without re-parsing IFC.
                     ExportCoordinateSidecar(doc, outputGlbPath);
@@ -181,6 +214,15 @@ namespace StingTools.BIMManager
 
         public RenderNodeAction OnLinkBegin(LinkNode node)
         {
+            if (!_includeLinks)
+            {
+                // Skip means Revit does NOT call OnLinkEnd for this node, so nothing is
+                // pushed here — pushing and never popping would leave every element after
+                // the first link resolving against the wrong document and transform.
+                SkippedLinkCount++;
+                return RenderNodeAction.Skip;
+            }
+
             var t = _xformStack.Peek().Multiply(node.GetTransform());
             _xformStack.Push(t);
 
@@ -1084,6 +1126,10 @@ namespace StingTools.BIMManager
             public int ElementCount;
             public double[] BoundsMm = Array.Empty<double>();
             public long FileSizeBytes;
+            /// <summary>Linked model instances NOT in this export. Non-zero means the
+            /// file is the host model only — say so to the user rather than letting a
+            /// federated model arrive as an empty container.</summary>
+            public int SkippedLinkCount;
         }
     }
 }

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -29,6 +29,27 @@ namespace StingTools.BIMManager
         private readonly List<MeshNode> _nodes = new();
         private readonly Stack<Transform> _xformStack = new();
 
+        /// <summary>
+        /// The document each <see cref="ElementId"/> should be resolved against, tracked
+        /// in step with <see cref="_xformStack"/>.
+        ///
+        /// <para><b>Element ids are document-local.</b> Inside a link, the id handed to
+        /// <see cref="OnElementBegin"/> belongs to the LINKED document, so resolving it
+        /// against the host is not a near-miss — it is a lookup in the wrong table. It
+        /// returned null and the element was skipped, which is why a federated model
+        /// published as a bare site with no buildings. When the id happened to exist in
+        /// the host it was worse: geometry was emitted carrying another element's name,
+        /// category, colour and UniqueId — and UniqueId is the key the viewer joins the
+        /// element map on.</para>
+        ///
+        /// <para>Same approach as <c>Clash/ClashExportContext</c>, which has always done
+        /// this correctly. This exporter simply never did.</para>
+        /// </summary>
+        private readonly Stack<Document> _docStack = new();
+
+        /// <summary>The document currently being traversed — host, or a link.</summary>
+        private Document CurrentDoc => _docStack.Count > 0 ? _docStack.Peek() : _doc;
+
         private MeshNode? _current;
         private string? _currentUniqueId;
         private string? _currentName;
@@ -43,7 +64,7 @@ namespace StingTools.BIMManager
         private readonly bool _exportTextures;
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
-        private readonly Dictionary<long, MaterialDef?> _appearanceCache = new();
+        private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
         // Phase 2 — resolved texture-path cache (by lowercased filename) so the library
         // filesystem scan runs at most once per filename per export session.
         private static readonly Dictionary<string, string?> _texPathCache = new();
@@ -70,6 +91,7 @@ namespace StingTools.BIMManager
             _doc = doc;
             _exportTextures = exportTextures;
             _xformStack.Push(Transform.Identity);
+            _docStack.Push(doc);
         }
 
         public static ExportResult Export(Document doc, View3D view, string outputGlbPath, bool? exportTextures = null)
@@ -113,9 +135,16 @@ namespace StingTools.BIMManager
 
         public RenderNodeAction OnElementBegin(ElementId id)
         {
-            var el = _doc.GetElement(id);
+            var doc = CurrentDoc;
+            var el = doc.GetElement(id);
             if (el == null) return RenderNodeAction.Skip;
-            _currentUniqueId = el.UniqueId;
+            // Namespaced for linked elements. UniqueId is unique WITHIN a document, not
+            // across them, and in practice buildings are routinely Saved-As from one
+            // another — so template-derived elements in two different links can carry
+            // identical UniqueIds. Left bare for host elements so nothing already
+            // published changes key. PublishModelCommand.BuildElementMap computes the
+            // same key through the same helper; if one side changes, both must.
+            _currentUniqueId = ElementKey(doc, _doc, el);
             _currentName = el.Name ?? "";
             _currentCategory = el.Category?.Name ?? "";
             _currentRgb = ResolveCategoryColour(el);
@@ -154,12 +183,69 @@ namespace StingTools.BIMManager
         {
             var t = _xformStack.Peek().Multiply(node.GetTransform());
             _xformStack.Push(t);
+
+            // Push the LINKED document so OnElementBegin resolves ids against it.
+            // Falls back to the current document rather than skipping: a link whose
+            // document cannot be resolved (unloaded mid-export) should still contribute
+            // its geometry, mislabelled, rather than vanish silently.
+            Document linkDoc = null;
+            try { linkDoc = node.GetDocument(); }
+            catch (Exception ex) { StingLog.Warn($"RevitGltfExporter.OnLinkBegin: {ex.Message}"); }
+            _docStack.Push(linkDoc ?? CurrentDoc);
             return RenderNodeAction.Proceed;
         }
 
         public void OnLinkEnd(LinkNode node)
         {
             if (_xformStack.Count > 1) _xformStack.Pop();
+            // Popped unconditionally against the same guard as the transform stack —
+            // the two are pushed together in OnLinkBegin and must unwind together, or
+            // every element after a link resolves against the wrong document.
+            if (_docStack.Count > 1) _docStack.Pop();
+        }
+
+        /// <summary>
+        /// The key a mesh node and its element-map entry share.
+        ///
+        /// <para>Host elements keep their bare <c>UniqueId</c> so previously published
+        /// models keep working. Linked elements are prefixed with the link's identity,
+        /// because <c>UniqueId</c> is unique within a document only.</para>
+        ///
+        /// <para><b>Must stay byte-identical to
+        /// <c>PublishModelCommand.LinkedElementKey</c>.</b> The viewer joins geometry to
+        /// metadata on this string; a mismatch shows an element with no properties, and
+        /// nothing errors.</para>
+        /// </summary>
+        internal static string ElementKey(Document elementDoc, Document hostDoc, Element el)
+        {
+            if (elementDoc == null || hostDoc == null || ReferenceEquals(elementDoc, hostDoc))
+                return el.UniqueId;
+            return LinkScope(elementDoc) + "|" + el.UniqueId;
+        }
+
+        /// <summary>
+        /// Stable identity for a linked document, computable from BOTH
+        /// <c>LinkNode.GetDocument()</c> (the exporter) and
+        /// <c>RevitLinkInstance.GetLinkDocument()</c> (the element map).
+        ///
+        /// <para>PathName first because two links can share a file name in different
+        /// folders; Title as the fallback for cloud models, whose PathName is empty.
+        /// Note this does NOT distinguish two INSTANCES of the same file — both resolve
+        /// to one metadata entry. That is deliberate: the two instances are the same
+        /// source element placed twice, so their name, category, level and quantities
+        /// are identical. Only their position differs, and position lives in the
+        /// geometry, which is emitted per instance.</para>
+        /// </summary>
+        internal static string LinkScope(Document linkDoc)
+        {
+            try
+            {
+                var p = linkDoc.PathName;
+                if (!string.IsNullOrWhiteSpace(p)) return p;
+            }
+            catch (Exception ex) { StingLog.Warn($"RevitGltfExporter.LinkScope: {ex.Message}"); }
+            try { return linkDoc.Title ?? "link"; }
+            catch { return "link"; }
         }
 
         public void OnRPC(RPCNode node) { }
@@ -203,21 +289,30 @@ namespace StingTools.BIMManager
             ElementId matId;
             try { matId = node.MaterialId; } catch { return null; }
             if (matId == null || matId == ElementId.InvalidElementId) return null;
+            // Same document rule as OnElementBegin: a MaterialId inside a link belongs to
+            // the LINKED document. Resolving it against the host yields null (unnamed
+            // material) or, on a numeric collision, a different material entirely.
+            var matDoc = CurrentDoc;
+
+            // Cache key includes the document. Keyed on matId alone, a link's material 12
+            // and the host's material 12 shared one entry, so whichever was seen first
+            // decided the name and texture for both.
             long key = matId.Value;
-            if (_appearanceCache.TryGetValue(key, out var cached)) return cached;
+            string cacheKey = (ReferenceEquals(matDoc, _doc) ? "" : LinkScope(matDoc) + "|") + key;
+            if (_appearanceCache.TryGetValue(cacheKey, out var cached)) return cached;
 
             var def = new MaterialDef();
             try
             {
-                var mat = _doc.GetElement(matId) as Material;
+                var mat = matDoc.GetElement(matId) as Material;
                 def.MatName = mat?.Name ?? ("material " + key);
                 try { var c = node.Color; if (c != null) def.DiffuseRgb = new[] { (int)c.Red, (int)c.Green, (int)c.Blue }; } catch { }
                 try { def.Alpha = 1.0 - Clamp01(node.Transparency); } catch { }
 
-                var assetElem = mat != null ? _doc.GetElement(mat.AppearanceAssetId) as AppearanceAssetElement : null;
+                var assetElem = mat != null ? matDoc.GetElement(mat.AppearanceAssetId) as AppearanceAssetElement : null;
                 var asset = assetElem?.GetRenderingAsset();
                 def.HadAsset = asset != null;
-                if (asset == null) { def.Reason = "no-appearance-asset"; def.ComputeKey(); _appearanceCache[key] = def; return def; }
+                if (asset == null) { def.Reason = "no-appearance-asset"; def.ComputeKey(); _appearanceCache[cacheKey] = def; return def; }
 
                 var dc = ReadColor(asset, "generic_diffuse") ?? ReadColor(asset, "diffuse");
                 if (dc != null) def.DiffuseRgb = dc;
@@ -252,7 +347,7 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex) { def.Reason = "exception: " + ex.Message; StingLog.Warn($"[tex] appearance resolve failed for {def.MatName}: {ex.Message}"); }
 
-            _appearanceCache[key] = def;
+            _appearanceCache[cacheKey] = def;
             return def;
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 240 — publishing a federated model published the container, not the model)
+
+A federated site — host container, every building and the site itself a Revit link, all
+visible in `{3D}` — published as a bare toposolid with no buildings, and the viewer
+reported **8 ELEMENTS / 0% TAGGED** for the whole project.
+
+Two independent faults, either of which alone would have produced a broken publish.
+
+**1. The glTF exporter resolved every element against the host document.**
+`RevitGltfExporter.OnElementBegin` did `_doc.GetElement(id)` where `_doc` is fixed to the
+host. `OnLinkBegin` was implemented and pushed the transform, so Revit *was* traversing
+the links — but element ids are **document-local**, so an id from inside a link looked up
+in the host is not a near-miss, it is a lookup in the wrong table. It returned null and
+`RenderNodeAction.Skip` dropped the geometry. Where the id happened to exist in the host,
+worse: geometry was written carrying another element's name, category, colour and
+`UniqueId` — the key the viewer joins metadata on.
+
+`Clash/ClashExportContext` has always done this correctly, with a document stack and
+`LinkNode.GetDocument()`. This exporter simply never did. It now keeps the same stack, and
+`OnLinkEnd` pops it under the same guard as the transform stack — the two are pushed
+together and must unwind together, or every element after a link resolves against the
+wrong document.
+
+The same bug sat in material resolution (`_doc.GetElement(matId)`), and the appearance
+cache was keyed on the raw `ElementId` value, so a link's material 12 and the host's
+material 12 shared one entry and whichever was seen first decided the name and texture for
+both.
+
+**2. The element map never looked at links at all.** `BuildElementMap` collected from
+`new FilteredElementCollector(doc, activeView.Id)` — host only. On a federated model that
+is a handful of link instances and nothing else, which is the "8 ELEMENTS" exactly. Fixing
+the geometry alone would have given properties-free meshes; fixing the map alone,
+propertied nothing.
+
+It now walks links **recursively**, because Revit's view traversal descends nested links
+and a one-level walk would reproduce the same bug one level down — geometry present,
+properties missing, which is the variant hardest to notice because the model looks right.
+Documents are visited once (a cycle is legal in Revit) and depth is capped.
+
+**Keys.** Host elements keep their bare `UniqueId`, so nothing already published changes.
+Linked elements are namespaced by the link's path, because `UniqueId` is unique *within* a
+document and buildings are routinely Saved-As from one another — two links can genuinely
+carry the same id. Both producers compute the key through one helper; they must, since a
+mismatch renders an element with no properties and errors nowhere.
+
+**Bounds.** A linked element's bounding box is in its own coordinates. All eight corners
+are transformed, not Min/Max — under rotation the transformed Min is not the minimum, and
+a link placed at an angle is the normal case.
+
+**Honest scope limit:** the map collects model elements with geometry from each link, not
+"elements visible in the host's active view" — a view id cannot filter another document's
+collector. The GLB, produced by Revit's own view traversal, remains the authority on what
+is drawn, so the map may list a few elements the geometry does not show. A tree row with
+no mesh is a much smaller problem than the mesh with no properties it replaces. Unloaded
+links are named in the log rather than skipped silently.
+
 #### Completed (Phase 239 — Connect could not survive a cold start)
 
 Phase 237 pointed the plugin at a host that answers. The first real sign-in still failed:


### PR DESCRIPTION
A federated site — host container, every building and the site itself a Revit link, **all
visible in `{3D}`** — published as a bare toposolid with no buildings. The viewer reported
**8 ELEMENTS / 0% TAGGED** for an entire project.

Two independent faults. Either alone breaks a federated publish.

## 1. The exporter looked every element up in the wrong document

[RevitGltfExporter.cs:114](StingTools/BIMManager/RevitGltfExporter.cs:114) did
`_doc.GetElement(id)` with `_doc` fixed to the host. `OnLinkBegin` *was* implemented and
pushed the transform, so Revit was traversing the links — but **element ids are
document-local**. An id from inside a link, looked up in the host, is not a near-miss; it
is a lookup in the wrong table:

- `null` → `RenderNodeAction.Skip` → **geometry silently dropped.** The missing buildings.
- id exists in the host → geometry emitted carrying **another element's** name, category,
  colour and `UniqueId` — the key the viewer joins metadata on.

`Clash/ClashExportContext` has always done this correctly, with a document stack and
`LinkNode.GetDocument()`. This exporter never did. It now keeps the same stack, and
`OnLinkEnd` pops under the same guard as the transform stack — they are pushed together
and must unwind together, or every element *after* a link resolves against the wrong
document.

Material resolution had the identical bug, and `_appearanceCache` was keyed on the raw
`ElementId` value — so a link's material 12 and the host's material 12 shared one entry,
and whichever was seen first decided the name and texture for both.

## 2. The element map never looked at links at all

[PublishModelCommand.cs:506](StingTools/BIMManager/PublishModelCommand.cs:506) collected
from `new FilteredElementCollector(doc, activeView.Id)` — host only. On a federated model
that is a few link instances and nothing else: the "8 ELEMENTS", exactly. Fixing the
geometry alone gives properties-free meshes; fixing the map alone, propertied nothing.

It now walks links **recursively**, because Revit's view traversal descends nested links
and a one-level walk reproduces this same bug one level down — geometry present,
properties missing, the variant hardest to notice *because the model looks right*.
Documents are visited once (a cycle is legal in Revit) and depth is capped.

## Then: links became a choice, not a behaviour

Including them unconditionally is the wrong default. A discipline publish wants the host
alone — smaller, faster, and the viewer federates published models anyway. A site or
coordination publish wants one artefact. Both are reasonable, so it asks — **only when the
view actually contains links**, since a dialog whose answer cannot change anything is
noise. `PLANSCAPE_EXPORT_LINKS=1` skips it for scripted runs.

**The obligation that comes with defaulting to OFF is that exclusion must be visible.**
Links vanishing silently is the entire reason this option exists, and a deliberate default
is not a licence to reproduce it. The exporter counts skipped links; the publish reports
them in a dialog that names the fix; the log says so too.

`OnLinkBegin` returns `Skip` *without pushing* — Revit does not call `OnLinkEnd` for a
skipped node, so pushing there would leave everything after the first link on the wrong
document and transform.

## Details worth reviewing

- **Keys.** Host elements keep their bare `UniqueId`, so nothing already published changes
  key. Linked elements are namespaced by link path, because `UniqueId` is unique *within* a
  document and buildings are routinely Saved-As from one another — two links can genuinely
  carry the same id. Both producers compute it through one helper; a mismatch renders an
  element with no properties and **errors nowhere**.
- **Bounds.** All eight corners are transformed, not Min/Max — under rotation the
  transformed Min is not the minimum, and an angled link is the normal case, not an exotic
  one. A link's box folded in untransformed drags the published AABB out to enclose empty
  space and the viewer opens zoomed to nothing.
- **The static flag is reset per publish.** Without that, a run that picks an existing file
  inherits the previous run's answer and builds a map that disagrees with the geometry —
  same symptom, arriving only on the *second* publish of a session.
- **Unloaded links are named in the log**, not skipped silently.

## Honest scope limit, stated in the code

The map collects model elements with geometry per link, **not** "elements visible in the
host's active view" — a view id belongs to the host document and cannot filter another
document's collector. The GLB, produced by Revit's own view traversal, remains the
authority on what is drawn. So the map may list a few elements the geometry does not show.
A tree row with no mesh is a much smaller problem than the mesh with no properties it
replaces.

## Verification

`StingTools.csproj` → **0 errors, 0 warnings**. Deployed to the local Revit add-in slot for
testing against the real federated model that surfaced this — the only test that matters
here, since the fault is in Revit API traversal that no headless test exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
