### PR TITLE
fix: the element map described the documents, not the model

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -58,13 +58,25 @@ public class ModelsController : ControllerBase
 
     // ── List / metadata ────────────────────────────────────────────────
 
+    /// <summary>
+    /// Models in the project. Live only by default.
+    ///
+    /// <para><paramref name="deleted"/> returns the soft-deleted ones instead, which is
+    /// what makes the 30-day grace in <c>ModelPurgeJob</c> reachable. Without a way to
+    /// SEE a deleted model there is no way to restore it, and the grace period protects
+    /// nobody — it just delays the bytes leaving.</para>
+    /// </summary>
     [HttpGet]
-    public async Task<ActionResult> List(Guid projectId, CancellationToken ct)
+    public async Task<ActionResult> List(Guid projectId, CancellationToken ct, [FromQuery] bool deleted = false)
     {
         if (!await ProjectInTenant(projectId, ct)) return Forbid();
-        var rows = await _db.ProjectModels.AsNoTracking()
-            .Where(m => m.ProjectId == projectId && m.DeletedAt == null)
-            .OrderByDescending(m => m.UploadedAt)
+        var q = _db.ProjectModels.AsNoTracking()
+            .Where(m => m.ProjectId == projectId);
+        q = deleted ? q.Where(m => m.DeletedAt != null) : q.Where(m => m.DeletedAt == null);
+        var rows = await q
+            // Deleted models sort by when they were deleted — the useful order when the
+            // question is "what did I just remove", not "what was uploaded when".
+            .OrderByDescending(m => deleted ? m.DeletedAt : m.UploadedAt)
             .Select(m => ToMetaDto(m))
             .ToListAsync(ct);
         return Ok(rows);
@@ -587,6 +599,54 @@ public class ModelsController : ControllerBase
         return NoContent();
     }
 
+    // ── Restore ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Undo a delete, within the purge grace.
+    ///
+    /// <para>The delete is a SOFT delete with a 30-day window before
+    /// <c>ModelPurgeJob</c> removes the bytes and the row — but nothing could reach that
+    /// window, so it protected no one. Existence of the row IS the check: the purge job
+    /// deletes it outright, so anything still here is still restorable and a 404 is the
+    /// honest answer for anything past the grace.</para>
+    ///
+    /// <para>Restores the scene chunks that <see cref="Delete"/> retired alongside the
+    /// model — and only those, matched on the same <c>SourceModelId</c>. Restoring the
+    /// model without them brings back a row that renders nothing, which reads as a
+    /// corrupted model rather than a half-finished undo.</para>
+    ///
+    /// <para>Same roles as delete. Anyone who can remove a model can put it back; a
+    /// narrower rule would create a state a Coordinator can enter and not leave.</para>
+    /// </summary>
+    [HttpPost("{modelId:guid}/restore")]
+    [Authorize(Roles = "Admin,Owner,Coordinator")]
+    public async Task<IActionResult> Restore(Guid projectId, Guid modelId, CancellationToken ct)
+    {
+        if (!await ProjectInTenant(projectId, ct)) return Forbid();
+        var row = await _db.ProjectModels
+            .FirstOrDefaultAsync(m => m.Id == modelId && m.ProjectId == projectId && m.DeletedAt != null, ct);
+        if (row == null) return NotFound();
+
+        var deletedAt = row.DeletedAt;
+        row.DeletedAt = null;
+
+        // Only the chunks retired BY THIS DELETE. Matching on SourceModelId alone would
+        // also revive chunks retired by an earlier, unrelated delete of the same model,
+        // so the timestamp is part of the match.
+        var chunks = await _db.SceneNodes
+            .Where(n => n.SourceModelId == modelId && n.DeletedAt == deletedAt)
+            .ToListAsync(ct);
+        foreach (var chunk in chunks) chunk.DeletedAt = null;
+
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Model {ModelId} restored (was deleted {DeletedAt:u}): {Chunks} scene chunk(s) brought back.",
+            modelId, deletedAt, chunks.Count);
+
+        return NoContent();
+    }
+
     // ── Compliance heatmap ─────────────────────────────────────────────
     /// <summary>
     /// Returns STING tag completeness per element GUID for the project so
@@ -732,7 +792,8 @@ public class ModelsController : ControllerBase
         // C7 - appended rather than inserted: this is a POSITIONAL record, so
         // adding a parameter mid-list silently re-maps every argument after it.
         ConversionStatus: m.ConversionStatus,
-        ConversionError: m.ConversionError);
+        ConversionError: m.ConversionError,
+        DeletedAt: m.DeletedAt);
 
     private static ModelFormat InferFormat(string fileName)
     {
@@ -988,4 +1049,13 @@ public record ModelMetaDto(
     DateTime? StorageMissingAt,
     /// <summary>C7 - Pending | Converting | Done | Failed, or null when no conversion was needed.</summary>
     string? ConversionStatus = null,
-    string? ConversionError = null);
+    string? ConversionError = null,
+    /// <summary>
+    /// When this model was soft-deleted, or null while it is live. Appended, not
+    /// inserted — see the note at the ToMetaDto call site: this is a POSITIONAL record
+    /// and a parameter added mid-list silently re-maps every argument after it.
+    ///
+    /// <para>Present so the UI can show how long is left of the 30-day restore window
+    /// rather than making the user guess when the bytes go.</para>
+    /// </summary>
+    DateTime? DeletedAt = null);

--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -42,6 +42,24 @@ public class ModelsController : ControllerBase
     // an uncompressed IFC or a federated model that should be split.
     private const long MaxModelSizeBytes = 500L * 1024 * 1024;
 
+    /// <summary>
+    /// Cap on the element-map sidecar. Raised from 5 MB.
+    ///
+    /// <para>5 MB is roughly 19,000 elements at the ~265 bytes/element a real map costs,
+    /// which a federated site passes easily. It was also being hit for the wrong reason —
+    /// the plugin was describing every element in the source documents rather than the
+    /// ones in the GLB, so a 1,407-element model shipped a 12.28 MB map of mostly legend
+    /// and detail lines. That is fixed on the plugin side; this raises the ceiling so the
+    /// limit binds on genuinely large models instead of on a bug.</para>
+    ///
+    /// <para>Not larger, deliberately: <c>DownloadElementMap</c> reads the whole map into
+    /// a string to merge the cost sidecar, and the free-tier instance has 512 MB of RAM.
+    /// The durable fix is to store it gzipped — measured 31× on a real map (12.28 MB →
+    /// 0.40 MB) — which needs the serve path and the cost merge to decompress. Logged
+    /// rather than done here.</para>
+    /// </summary>
+    private const long MaxElementMapBytes = 25L * 1024 * 1024;
+
     public ModelsController(
         PlanscapeDbContext db,
         IFileStorageService storage,
@@ -204,8 +222,8 @@ public class ModelsController : ControllerBase
             }
             if (req.ElementMap != null && req.ElementMap.Length > 0)
             {
-                if (req.ElementMap.Length > 5 * 1024 * 1024)
-                    return BadRequest(new { error = "element_map_too_large", maxMb = 5 });
+                if (req.ElementMap.Length > MaxElementMapBytes)
+                    return BadRequest(TooLargeBody(req.ElementMap.Length));
                 using var s = req.ElementMap.OpenReadStream();
                 existing.ElementMapPath = await _storage.SaveAsync(
                     tenantSlug, $"{projectCode}/models", req.ElementMap.FileName, s, ct);
@@ -256,8 +274,8 @@ public class ModelsController : ControllerBase
         string? mapPath = null;
         if (req.ElementMap != null && req.ElementMap.Length > 0)
         {
-            if (req.ElementMap.Length > 5 * 1024 * 1024)
-                return BadRequest(new { error = "element_map_too_large", maxMb = 5 });
+            if (req.ElementMap.Length > MaxElementMapBytes)
+                return BadRequest(TooLargeBody(req.ElementMap.Length));
             using var s = req.ElementMap.OpenReadStream();
             mapPath = await _storage.SaveAsync(tenantSlug, $"{projectCode}/models", req.ElementMap.FileName, s, ct);
         }
@@ -794,6 +812,26 @@ public class ModelsController : ControllerBase
         ConversionStatus: m.ConversionStatus,
         ConversionError: m.ConversionError,
         DeletedAt: m.DeletedAt);
+
+    /// <summary>
+    /// The refusal, with the numbers and a next step.
+    ///
+    /// <para>The previous body was <c>{"error":"element_map_too_large","maxMb":5}</c> —
+    /// true, and unusable: it did not say how large the map WAS, so there was no way to
+    /// tell "slightly over" from "twenty times over", and no hint that the usual cause is
+    /// a map describing far more than the model contains. <c>actualMb</c> and <c>hint</c>
+    /// are additive; <c>error</c> and <c>maxMb</c> keep their names for anything already
+    /// matching on them.</para>
+    /// </summary>
+    private static object TooLargeBody(long actualBytes) => new
+    {
+        error = "element_map_too_large",
+        maxMb = MaxElementMapBytes / (1024 * 1024),
+        actualMb = Math.Round(actualBytes / 1024d / 1024d, 2),
+        hint = "The element map should describe the elements in the published geometry. "
+             + "A map far larger than the model usually means it also covers annotation, "
+             + "legend or detail content. Update the plugin, or publish fewer linked models.",
+    };
 
     private static ModelFormat InferFormat(string fileName)
     {

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -421,6 +421,14 @@ namespace StingTools.BIMManager
 
         private static string? PromptForModelFileOrExport(Document doc)
         {
+            // Reset per publish. This is static state, so without it a run that picks an
+            // existing file would inherit the ANSWER FROM THE PREVIOUS RUN and build an
+            // element map that disagrees with the geometry — the same
+            // meshes-without-properties symptom, arriving by a different route and only
+            // on the second publish of a session, which is the worst kind to reproduce.
+            // Only ExportActiveView, which actually asks, may set it true.
+            _includeLinksThisRun = false;
+
             var dlg = new TaskDialog("Publish Model")
             {
                 MainInstruction = "How do you want to provide the 3D geometry?",
@@ -467,8 +475,21 @@ namespace StingTools.BIMManager
                 bool wantTextures =
                     string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_TEXTURES"), "1", StringComparison.OrdinalIgnoreCase)
                     || RevitGltfExporter.ExportTextures;
-                var result = RevitGltfExporter.Export(doc, v3d, outPath, exportTextures: wantTextures);
+                _includeLinksThisRun = AskIncludeLinks(doc, v3d);
+                var result = RevitGltfExporter.Export(doc, v3d, outPath,
+                                                      exportTextures: wantTextures,
+                                                      includeLinks: _includeLinksThisRun);
                 StingLog.Info($"Planscape: GLB exported ({result.ElementCount} elements, {result.FileSizeBytes:N0} bytes) → {outPath}");
+
+                // Say it out loud. The whole reason this option exists is that links were
+                // being dropped SILENTLY, and a deliberate default is not a licence to
+                // reproduce that — a user who publishes a federated site and gets an empty
+                // container must be told why, at the moment it happens.
+                if (result.SkippedLinkCount > 0)
+                    TaskDialog.Show("Publish Model",
+                        $"Published the host model only — {result.SkippedLinkCount} linked model(s) were not included.\n\n"
+                      + "If you expected the buildings or site to appear, publish again and choose "
+                      + "\"Include linked models\".");
                 return outPath;
             }
             catch (Exception ex)
@@ -498,6 +519,76 @@ namespace StingTools.BIMManager
         }
 
         // ── Federation support ─────────────────────────────────────────
+
+        /// <summary>
+        /// Whether THIS publish includes linked models. Set by <see cref="AskIncludeLinks"/>
+        /// immediately before the geometry export and read by <c>BuildElementMap</c>, so
+        /// the GLB and the element map can never disagree about what was published — a
+        /// disagreement shows as meshes with no properties, or tree rows with no mesh.
+        /// </summary>
+        private static bool _includeLinksThisRun;
+
+        /// <summary>
+        /// Ask once per publish, and only when it matters.
+        ///
+        /// <para>No links in the view means no question — a dialog whose answer cannot
+        /// change anything is noise. When links ARE present the choice is explicit,
+        /// because both answers are reasonable: a discipline publish wants the host alone
+        /// (smaller, faster, and the viewer federates published models anyway), while a
+        /// site or coordination publish wants one artefact containing everything.</para>
+        ///
+        /// <para><c>PLANSCAPE_EXPORT_LINKS=1</c> skips the prompt for scripted runs.</para>
+        /// </summary>
+        private static bool AskIncludeLinks(Document doc, View view)
+        {
+            int linkCount;
+            try
+            {
+                var lc = view is View3D
+                    ? new FilteredElementCollector(doc, view.Id)
+                    : new FilteredElementCollector(doc);
+                linkCount = lc.OfClass(typeof(RevitLinkInstance)).GetElementCount();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Publish: could not count links — {ex.Message}");
+                linkCount = 0;
+            }
+
+            if (linkCount == 0) return false;
+
+            if (string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_LINKS"), "1",
+                              StringComparison.OrdinalIgnoreCase)
+                || RevitGltfExporter.IncludeLinks)
+            {
+                StingLog.Info($"Publish: including {linkCount} linked model(s) (set by environment/static override).");
+                return true;
+            }
+
+            var dlg = new TaskDialog("Publish Model")
+            {
+                MainInstruction = $"This view contains {linkCount} linked model(s). Include them?",
+                MainContent = "Linked models are the buildings, site or discipline models attached to this file.",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+            };
+            dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink1,
+                "Host model only  (default)",
+                "Publishes just this file. Smaller and faster, and you can publish each linked "
+              + "model separately — the viewer federates them and gives you per-model visibility.");
+            dlg.AddCommandLink(TaskDialogCommandLinkId.CommandLink2,
+                "Include linked models",
+                "Publishes everything visible in this view as one model — the right choice for a "
+              + "federated site or a coordination snapshot. Larger file and a slower export.");
+            var r = dlg.Show();
+            if (r == TaskDialogResult.CommandLink2)
+            {
+                StingLog.Info($"Publish: including {linkCount} linked model(s) by user choice.");
+                return true;
+            }
+            StingLog.Info($"Publish: EXCLUDING {linkCount} linked model(s) by user choice (host model only).");
+            return false;
+        }
+
 
         /// <summary>One element to publish, with the document it came from, the transform
         /// into host coordinates, and the key it shares with its GLB mesh node.</summary>
@@ -685,7 +776,10 @@ namespace StingTools.BIMManager
             // fault in its own way (see RevitGltfExporter's document stack); fixing one
             // without the other gives you either geometry with no properties or
             // properties with no geometry.
-            elements.AddRange(CollectLinkedElements(doc, activeView));
+            if (_includeLinksThisRun)
+                elements.AddRange(CollectLinkedElements(doc, activeView));
+            else
+                StingLog.Info("Publish: element map covers the host model only (links excluded for this publish).");
 
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -497,6 +497,165 @@ namespace StingTools.BIMManager
             return ok == true ? dlg.FileName : null;
         }
 
+        // ── Federation support ─────────────────────────────────────────
+
+        /// <summary>One element to publish, with the document it came from, the transform
+        /// into host coordinates, and the key it shares with its GLB mesh node.</summary>
+        private readonly struct MapItem
+        {
+            public MapItem(Document doc, Element el, Transform xf, string key)
+            { Doc = doc; El = el; Xf = xf; Key = key; }
+            public Document Doc { get; }
+            public Element El { get; }
+            public Transform Xf { get; }
+            public string Key { get; }
+        }
+
+        /// <summary>
+        /// Every element inside every loaded Revit link, paired with its document and
+        /// placement transform.
+        ///
+        /// <para><b>Scope note, stated plainly:</b> this returns model elements with
+        /// geometry from each link, NOT "elements visible in the host's active view".
+        /// A view id belongs to the host document, so it cannot filter a linked
+        /// document's collector, and per-element visibility across a link is not
+        /// something the API answers cheaply. The GLB — which Revit's own view traversal
+        /// produces — remains the authority on what is drawn. The practical effect is
+        /// that the map can list a few elements the geometry does not show; a tree row
+        /// with no mesh is a far smaller problem than the mesh with no properties this
+        /// replaces.</para>
+        ///
+        /// <para>Links that are unloaded, or that fail to resolve, are skipped with a
+        /// warning rather than failing the publish — a partial federation is still worth
+        /// publishing, and the log says which link was missing.</para>
+        /// </summary>
+        private static IEnumerable<MapItem> CollectLinkedElements(Document host, View activeView)
+        {
+            var results = new List<MapItem>();
+            // Keyed by document identity so a cycle (A links B links A) terminates, and
+            // so the same file linked twice is not collected twice into one map.
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                RevitGltfExporter.LinkScope(host)
+            };
+            CollectLinksRecursive(host, activeView, Transform.Identity, visited, results, depth: 0);
+            return results;
+        }
+
+        /// <summary>
+        /// Walks links, then links inside those links.
+        ///
+        /// <para>Revit's own view traversal descends nested links, so the GLB contains
+        /// them. A one-level metadata walk would therefore reproduce the exact bug this
+        /// change fixes, one level down — geometry present, properties missing — which is
+        /// the failure mode hardest to notice because the model looks right.</para>
+        ///
+        /// <para>Depth is capped and documents are visited once. A cycle is legal in
+        /// Revit and would otherwise recurse until the stack gives out.</para>
+        /// </summary>
+        private static void CollectLinksRecursive(
+            Document parent, View activeView, Transform parentXf,
+            HashSet<string> visited, List<MapItem> results, int depth)
+        {
+            const int MaxDepth = 8;
+            if (depth >= MaxDepth)
+            {
+                StingLog.Warn($"Publish: link nesting deeper than {MaxDepth} in '{parent.Title}' — not descending further.");
+                return;
+            }
+
+            List<RevitLinkInstance> links;
+            try
+            {
+                // At the top level, filter by the active view so links hidden in THIS view
+                // are not published — the link INSTANCE is a host element, so unlike
+                // per-element visibility this is a question the host view can answer.
+                // Deeper down there is no equivalent view, so take them all.
+                var lc = (depth == 0 && activeView is View3D)
+                    ? new FilteredElementCollector(parent, activeView.Id)
+                    : new FilteredElementCollector(parent);
+                links = lc.OfClass(typeof(RevitLinkInstance))
+                          .Cast<RevitLinkInstance>()
+                          .ToList();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Publish: could not enumerate links in '{parent.Title}' — {ex.Message}");
+                return;
+            }
+
+            foreach (var link in links)
+            {
+                Document ldoc = null;
+                try { ldoc = link.GetLinkDocument(); }
+                catch (Exception ex) { StingLog.Warn($"Publish: link '{link.Name}' — {ex.Message}"); }
+
+                if (ldoc == null)
+                {
+                    // Unloaded link. Named explicitly: silently publishing a federation
+                    // minus one building is exactly the failure this whole change fixes.
+                    StingLog.Warn($"Publish: link '{link.Name}' is not loaded — its elements are NOT in this publish.");
+                    continue;
+                }
+
+                Transform xf;
+                try { xf = parentXf.Multiply(link.GetTotalTransform() ?? Transform.Identity); }
+                catch { xf = parentXf; }
+
+                string scope = RevitGltfExporter.LinkScope(ldoc);
+                if (!visited.Add(scope))
+                {
+                    StingLog.Info($"Publish: link '{ldoc.Title}' already collected — skipping duplicate/cyclic reference.");
+                    continue;
+                }
+                int n = 0;
+                try
+                {
+                    foreach (var e in new FilteredElementCollector(ldoc)
+                                          .WhereElementIsNotElementType()
+                                          .Where(e => e.Category != null
+                                                      && e.Category.CategoryType == CategoryType.Model
+                                                      && e.get_Geometry(new Options()) != null))
+                    {
+                        results.Add(new MapItem(ldoc, e, xf, scope + "|" + e.UniqueId));
+                        n++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"Publish: collecting from link '{link.Name}' failed — {ex.Message}");
+                }
+                StingLog.Info($"Publish: link '{ldoc.Title}' contributed {n} element(s).");
+
+                // Descend. The transform accumulates, so a building nested two links deep
+                // still lands in host coordinates.
+                CollectLinksRecursive(ldoc, activeView, xf, visited, results, depth + 1);
+            }
+        }
+
+        /// <summary>
+        /// The eight transformed corners of a bounding box.
+        ///
+        /// <para>All eight, not Min and Max. Under rotation the transformed Min is not
+        /// the minimum of the transformed box — taking the two corners gives an AABB that
+        /// can be smaller than the geometry it is meant to contain, and a link placed at
+        /// an angle is the normal case, not an exotic one.</para>
+        /// </summary>
+        private static IEnumerable<XYZ> Corners(BoundingBoxXYZ b, Transform xf)
+        {
+            var t = xf ?? Transform.Identity;
+            // A BoundingBoxXYZ carries its own Transform; fold it in so a box expressed
+            // in a non-identity local frame is read correctly before the link transform.
+            var local = b.Transform ?? Transform.Identity;
+            for (int i = 0; i < 8; i++)
+            {
+                var p = new XYZ((i & 1) == 0 ? b.Min.X : b.Max.X,
+                                (i & 2) == 0 ? b.Min.Y : b.Max.Y,
+                                (i & 4) == 0 ? b.Min.Z : b.Max.Z);
+                yield return t.OfPoint(local.OfPoint(p));
+            }
+        }
+
         // ── Element map generator ──────────────────────────────────────
 
         private static void BuildElementMap(
@@ -508,10 +667,25 @@ namespace StingTools.BIMManager
                 ? new FilteredElementCollector(doc, activeView.Id)
                 : new FilteredElementCollector(doc);
 
+            // Host elements first, each paired with the document it belongs to and the
+            // transform that puts it in host coordinates (identity, by definition).
             var elements = collector
                 .WhereElementIsNotElementType()
                 .Where(e => e.Category != null && e.get_Geometry(new Options()) != null)
+                .Select(e => new MapItem(doc, e, Transform.Identity,
+                                         RevitGltfExporter.ElementKey(doc, doc, e)))
                 .ToList();
+
+            // …then everything inside the loaded links.
+            //
+            // Without this the map described the HOST FILE ONLY. On a federated model —
+            // where the host is a container and every building is a link — that is a
+            // handful of link instances and nothing else, which is why the viewer
+            // reported "8 ELEMENTS / 0% TAGGED" for a whole site. The GLB had the same
+            // fault in its own way (see RevitGltfExporter's document stack); fixing one
+            // without the other gives you either geometry with no properties or
+            // properties with no geometry.
+            elements.AddRange(CollectLinkedElements(doc, activeView));
 
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),
@@ -523,9 +697,13 @@ namespace StingTools.BIMManager
             var sysHist = new Dictionary<string, int>();
             var sysUnresolvedCats = new Dictionary<string, int>();
 
-            foreach (var el in elements)
+            foreach (var item in elements)
             {
-                var guid = el.UniqueId;
+                var el   = item.El;
+                // The element's OWN document. Level lookup, quantities and materials all
+                // read from it, and for a linked element the host knows none of them.
+                var edoc = item.Doc;
+                var guid = item.Key;
                 var tag = ParameterHelpers.GetString(el, ParamRegistry.TAG1);
 
                 // Track bounds from EVERY element with a bounding box, not just
@@ -536,12 +714,16 @@ namespace StingTools.BIMManager
                 var eb = el.get_BoundingBox(null);
                 if (eb != null)
                 {
-                    bb.Min = new XYZ(Math.Min(bb.Min.X, eb.Min.X),
-                                     Math.Min(bb.Min.Y, eb.Min.Y),
-                                     Math.Min(bb.Min.Z, eb.Min.Z));
-                    bb.Max = new XYZ(Math.Max(bb.Max.X, eb.Max.X),
-                                     Math.Max(bb.Max.Y, eb.Max.Y),
-                                     Math.Max(bb.Max.Z, eb.Max.Z));
+                    // A linked element's bounding box is in ITS OWN coordinates. Folded
+                    // into the host AABB untransformed, a link with any offset drags the
+                    // published bounds out to enclose empty space, and the viewer opens
+                    // zoomed to nothing. Transform all eight corners — transforming only
+                    // Min/Max is wrong as soon as the link is rotated.
+                    foreach (var c in Corners(eb, item.Xf))
+                    {
+                        bb.Min = new XYZ(Math.Min(bb.Min.X, c.X), Math.Min(bb.Min.Y, c.Y), Math.Min(bb.Min.Z, c.Z));
+                        bb.Max = new XYZ(Math.Max(bb.Max.X, c.X), Math.Max(bb.Max.Y, c.Y), Math.Max(bb.Max.Z, c.Z));
+                    }
                     boundsContributors++;
                 }
 
@@ -576,7 +758,7 @@ namespace StingTools.BIMManager
                     // untagged ones still get name + category + level + elementId
                     // which is what the right-panel Properties tab needs.
                     string lvlOnly = "";
-                    try { lvlOnly = ParameterHelpers.GetLevelCode(doc, el) ?? ""; } catch { }
+                    try { lvlOnly = ParameterHelpers.GetLevelCode(edoc, el) ?? ""; } catch { }
                     var untaggedEntry = new JObject
                     {
                         ["name"]      = el.Name ?? "",
@@ -593,7 +775,7 @@ namespace StingTools.BIMManager
                         ["elementId"] = el.Id.Value,
                     };
                     AddCost(el, untaggedEntry);   // M3 — per-element cost (rate × measured qty)
-                    AddQuantitiesAndMaterials(doc, el, untaggedEntry);   // E4 — area/volume/length + materials
+                    AddQuantitiesAndMaterials(edoc, el, untaggedEntry);   // E4 — area/volume/length + materials
                     map[guid] = untaggedEntry;
                     count++;
                     continue;
@@ -631,7 +813,7 @@ namespace StingTools.BIMManager
                     ["elementId"]  = el.Id.Value,
                 };
                 AddCost(el, taggedEntry);     // M3 — per-element cost
-                AddQuantitiesAndMaterials(doc, el, taggedEntry);   // E4 — area/volume/length + materials
+                AddQuantitiesAndMaterials(edoc, el, taggedEntry);   // E4 — area/volume/length + materials
                 map[guid] = taggedEntry;
                 count++;
             }

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -428,6 +428,7 @@ namespace StingTools.BIMManager
             // on the second publish of a session, which is the worst kind to reproduce.
             // Only ExportActiveView, which actually asks, may set it true.
             _includeLinksThisRun = false;
+            _exportedKeysThisRun = null;
 
             var dlg = new TaskDialog("Publish Model")
             {
@@ -479,6 +480,7 @@ namespace StingTools.BIMManager
                 var result = RevitGltfExporter.Export(doc, v3d, outPath,
                                                       exportTextures: wantTextures,
                                                       includeLinks: _includeLinksThisRun);
+                _exportedKeysThisRun = result.ElementKeys;
                 StingLog.Info($"Planscape: GLB exported ({result.ElementCount} elements, {result.FileSizeBytes:N0} bytes) → {outPath}");
 
                 // Say it out loud. The whole reason this option exists is that links were
@@ -527,6 +529,23 @@ namespace StingTools.BIMManager
         /// disagreement shows as meshes with no properties, or tree rows with no mesh.
         /// </summary>
         private static bool _includeLinksThisRun;
+
+        /// <summary>
+        /// Keys the GLB export actually wrote, or null when this publish did not run the
+        /// exporter (the user picked an existing .glb/.ifc, so we cannot know what is in
+        /// it and must not pretend to).
+        ///
+        /// <para>The map exists to annotate the geometry, so it should describe THE FILE,
+        /// not the documents the file came from. Measured on a real federated site: 1,407
+        /// elements in the GLB, 37,110 in an independently-built map — 29,521 of them
+        /// <c>Lines</c> and 5,706 <c>Legend Components</c> living in the links' legend and
+        /// detail views. 12.28 MB of mostly annotation for 1,407 meshes, which is what hit
+        /// the server's element-map limit.</para>
+        ///
+        /// <para>Filtering by Revit category cannot solve this — <c>OST_Lines</c> is a
+        /// model category. Only the exporter knows what was drawn.</para>
+        /// </summary>
+        private static HashSet<string>? _exportedKeysThisRun;
 
         /// <summary>
         /// Ask once per publish, and only when it matters.
@@ -781,6 +800,21 @@ namespace StingTools.BIMManager
             else
                 StingLog.Info("Publish: element map covers the host model only (links excluded for this publish).");
 
+            // Describe the FILE, not the documents. Anything that produced no mesh is not
+            // in the GLB, so an entry for it is a tree row the viewer can never select and
+            // bytes the upload has to carry — 95% of the payload on a real federated site.
+            //
+            // Only when we ran the exporter. A user-picked .glb/.ifc leaves this null and
+            // the map keeps its full scope, because guessing which elements a file we did
+            // not produce contains would drop real ones.
+            if (_exportedKeysThisRun != null && _exportedKeysThisRun.Count > 0)
+            {
+                int before = elements.Count;
+                elements = elements.Where(i => _exportedKeysThisRun.Contains(i.Key)).ToList();
+                StingLog.Info($"Publish: element map narrowed to the {elements.Count} element(s) " +
+                              $"actually in the GLB (from {before} with geometry in the documents).");
+            }
+
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),
                                           Max = new XYZ(double.MinValue, double.MinValue, double.MinValue) };
@@ -948,7 +982,10 @@ namespace StingTools.BIMManager
                 : new[] { 0d, 0d, 0d, 0d, 0d, 0d };
             elementCount = count;
 
-            File.WriteAllText(outputPath, map.ToString(Newtonsoft.Json.Formatting.Indented), Encoding.UTF8);
+            // None, not Indented. Measured 12.28 MB pretty vs 9.70 MB compact on a real
+            // model: a 21% saving on a machine-read sidecar that no one opens by hand, and
+            // it counts against an upload limit.
+            File.WriteAllText(outputPath, map.ToString(Newtonsoft.Json.Formatting.None), Encoding.UTF8);
         }
 
         /// <summary>

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -62,6 +62,30 @@ namespace StingTools.BIMManager
         // ("PlanscapeExportTextures" export option).
         public static bool ExportTextures { get; set; } = false;
         private readonly bool _exportTextures;
+
+        /// <summary>
+        /// Whether linked models are included. <b>Default false — the host model only.</b>
+        ///
+        /// <para>Two publishes serve different purposes and want opposite answers. A
+        /// discipline publish ("here is MY model") wants the host alone: smaller file,
+        /// faster, and the platform federates published models on the viewer side anyway.
+        /// A site or coordination publish wants everything in one artefact.</para>
+        ///
+        /// <para>Off by default because that is the smaller, faster, more predictable
+        /// result and matches what most publishes are for. <b>The obligation that comes
+        /// with the default is that exclusion must be VISIBLE</b> — a federated model
+        /// silently arriving as an empty container is precisely the failure this option
+        /// grew out of, and a default is not an excuse to reproduce it quietly. Callers
+        /// must report how many links were left out.</para>
+        ///
+        /// <para>Set via <c>PLANSCAPE_EXPORT_LINKS=1</c>, this static, or the
+        /// <c>includeLinks</c> parameter on <see cref="Export"/>.</para>
+        /// </summary>
+        public static bool IncludeLinks { get; set; } = false;
+        private readonly bool _includeLinks;
+
+        /// <summary>Links encountered and skipped, so the caller can say so out loud.</summary>
+        public int SkippedLinkCount { get; private set; }
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
         private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
@@ -86,24 +110,29 @@ namespace StingTools.BIMManager
         // its millimetre survey figures from RevitGeoref, which reads metres.)
         private const double FeetToMetres = 0.3048;
 
-        public RevitGltfExporter(Document doc, bool exportTextures = false)
+        public RevitGltfExporter(Document doc, bool exportTextures = false, bool includeLinks = false)
         {
             _doc = doc;
             _exportTextures = exportTextures;
+            _includeLinks = includeLinks;
             _xformStack.Push(Transform.Identity);
             _docStack.Push(doc);
         }
 
-        public static ExportResult Export(Document doc, View3D view, string outputGlbPath, bool? exportTextures = null)
+        public static ExportResult Export(Document doc, View3D view, string outputGlbPath,
+                                          bool? exportTextures = null, bool? includeLinks = null)
         {
             bool textures = exportTextures ?? ExportTextures;
+            bool links = includeLinks
+                ?? (string.Equals(Environment.GetEnvironmentVariable("PLANSCAPE_EXPORT_LINKS"), "1", StringComparison.OrdinalIgnoreCase)
+                    || IncludeLinks);
             // S8.2.2 — span around the whole export so telemetry-on users see
             // p99 export latency vs scene size in their dashboards.
             return StingTools.Core.PluginTelemetry.Run(
                 "RevitGltfExporter.export",
                 () =>
                 {
-                    var ctx = new RevitGltfExporter(doc, textures);
+                    var ctx = new RevitGltfExporter(doc, textures, links);
                     var exporter = new CustomExporter(doc, ctx)
                     {
                         IncludeGeometricObjects = false,
@@ -113,6 +142,10 @@ namespace StingTools.BIMManager
                     };
                     exporter.Export(view);
                     var result = ctx.WriteGlb(outputGlbPath);
+                    result.SkippedLinkCount = ctx.SkippedLinkCount;
+                    if (ctx.SkippedLinkCount > 0)
+                        StingLog.Info($"Planscape: GLB excluded {ctx.SkippedLinkCount} linked model instance(s) " +
+                                      "(links off — set PLANSCAPE_EXPORT_LINKS=1 or choose 'include links' to add them).");
                     // Gap J — write coordinate sidecar alongside the GLB so the
                     // server can populate IfcAlignmentReport without re-parsing IFC.
                     ExportCoordinateSidecar(doc, outputGlbPath);
@@ -181,6 +214,15 @@ namespace StingTools.BIMManager
 
         public RenderNodeAction OnLinkBegin(LinkNode node)
         {
+            if (!_includeLinks)
+            {
+                // Skip means Revit does NOT call OnLinkEnd for this node, so nothing is
+                // pushed here — pushing and never popping would leave every element after
+                // the first link resolving against the wrong document and transform.
+                SkippedLinkCount++;
+                return RenderNodeAction.Skip;
+            }
+
             var t = _xformStack.Peek().Multiply(node.GetTransform());
             _xformStack.Push(t);
 
@@ -1084,6 +1126,10 @@ namespace StingTools.BIMManager
             public int ElementCount;
             public double[] BoundsMm = Array.Empty<double>();
             public long FileSizeBytes;
+            /// <summary>Linked model instances NOT in this export. Non-zero means the
+            /// file is the host model only — say so to the user rather than letting a
+            /// federated model arrive as an empty container.</summary>
+            public int SkippedLinkCount;
         }
     }
 }

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -86,6 +86,11 @@ namespace StingTools.BIMManager
 
         /// <summary>Links encountered and skipped, so the caller can say so out loud.</summary>
         public int SkippedLinkCount { get; private set; }
+
+        /// <summary>Keys of the elements that produced at least one mesh. Populated in
+        /// <see cref="OnElementEnd"/> under the SAME condition that keeps the node, so
+        /// the two can never disagree about what is in the file.</summary>
+        public HashSet<string> WrittenKeys { get; } = new(StringComparer.Ordinal);
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
         private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
@@ -143,6 +148,7 @@ namespace StingTools.BIMManager
                     exporter.Export(view);
                     var result = ctx.WriteGlb(outputGlbPath);
                     result.SkippedLinkCount = ctx.SkippedLinkCount;
+                    result.ElementKeys = ctx.WrittenKeys;
                     if (ctx.SkippedLinkCount > 0)
                         StingLog.Info($"Planscape: GLB excluded {ctx.SkippedLinkCount} linked model instance(s) " +
                                       "(links off — set PLANSCAPE_EXPORT_LINKS=1 or choose 'include links' to add them).");
@@ -193,7 +199,11 @@ namespace StingTools.BIMManager
 
         public void OnElementEnd(ElementId id)
         {
-            if (_current != null && _current.Positions.Count > 0) _nodes.Add(_current);
+            if (_current != null && _current.Positions.Count > 0)
+            {
+                _nodes.Add(_current);
+                WrittenKeys.Add(_current.UniqueId);
+            }
             _current = null;
             _currentUniqueId = null;
             _currentName = null;
@@ -1130,6 +1140,22 @@ namespace StingTools.BIMManager
             /// file is the host model only — say so to the user rather than letting a
             /// federated model arrive as an empty container.</summary>
             public int SkippedLinkCount;
+
+            /// <summary>
+            /// The key of every element that actually produced geometry, so the element
+            /// map can describe THIS FILE rather than the document it came from.
+            ///
+            /// <para>Measured on a real federated site: the GLB held 1,407 elements while
+            /// a map built independently from the same documents held 37,110 — 29,521
+            /// <c>Lines</c> and 5,706 <c>Legend Components</c>, i.e. legend and detail
+            /// content that is not in the 3D model at all. That is 12.28 MB of mostly
+            /// annotation describing 1,407 meshes, and it broke the upload.</para>
+            ///
+            /// <para>A Revit category test cannot fix that: <c>OST_Lines</c> IS a model
+            /// category. Only the exporter knows what got drawn, so it is the exporter
+            /// that must say.</para>
+            /// </summary>
+            public HashSet<string> ElementKeys = new();
         }
     }
 }

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -29,6 +29,27 @@ namespace StingTools.BIMManager
         private readonly List<MeshNode> _nodes = new();
         private readonly Stack<Transform> _xformStack = new();
 
+        /// <summary>
+        /// The document each <see cref="ElementId"/> should be resolved against, tracked
+        /// in step with <see cref="_xformStack"/>.
+        ///
+        /// <para><b>Element ids are document-local.</b> Inside a link, the id handed to
+        /// <see cref="OnElementBegin"/> belongs to the LINKED document, so resolving it
+        /// against the host is not a near-miss — it is a lookup in the wrong table. It
+        /// returned null and the element was skipped, which is why a federated model
+        /// published as a bare site with no buildings. When the id happened to exist in
+        /// the host it was worse: geometry was emitted carrying another element's name,
+        /// category, colour and UniqueId — and UniqueId is the key the viewer joins the
+        /// element map on.</para>
+        ///
+        /// <para>Same approach as <c>Clash/ClashExportContext</c>, which has always done
+        /// this correctly. This exporter simply never did.</para>
+        /// </summary>
+        private readonly Stack<Document> _docStack = new();
+
+        /// <summary>The document currently being traversed — host, or a link.</summary>
+        private Document CurrentDoc => _docStack.Count > 0 ? _docStack.Peek() : _doc;
+
         private MeshNode? _current;
         private string? _currentUniqueId;
         private string? _currentName;
@@ -43,7 +64,7 @@ namespace StingTools.BIMManager
         private readonly bool _exportTextures;
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
-        private readonly Dictionary<long, MaterialDef?> _appearanceCache = new();
+        private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
         // Phase 2 — resolved texture-path cache (by lowercased filename) so the library
         // filesystem scan runs at most once per filename per export session.
         private static readonly Dictionary<string, string?> _texPathCache = new();
@@ -70,6 +91,7 @@ namespace StingTools.BIMManager
             _doc = doc;
             _exportTextures = exportTextures;
             _xformStack.Push(Transform.Identity);
+            _docStack.Push(doc);
         }
 
         public static ExportResult Export(Document doc, View3D view, string outputGlbPath, bool? exportTextures = null)
@@ -113,9 +135,16 @@ namespace StingTools.BIMManager
 
         public RenderNodeAction OnElementBegin(ElementId id)
         {
-            var el = _doc.GetElement(id);
+            var doc = CurrentDoc;
+            var el = doc.GetElement(id);
             if (el == null) return RenderNodeAction.Skip;
-            _currentUniqueId = el.UniqueId;
+            // Namespaced for linked elements. UniqueId is unique WITHIN a document, not
+            // across them, and in practice buildings are routinely Saved-As from one
+            // another — so template-derived elements in two different links can carry
+            // identical UniqueIds. Left bare for host elements so nothing already
+            // published changes key. PublishModelCommand.BuildElementMap computes the
+            // same key through the same helper; if one side changes, both must.
+            _currentUniqueId = ElementKey(doc, _doc, el);
             _currentName = el.Name ?? "";
             _currentCategory = el.Category?.Name ?? "";
             _currentRgb = ResolveCategoryColour(el);
@@ -154,12 +183,69 @@ namespace StingTools.BIMManager
         {
             var t = _xformStack.Peek().Multiply(node.GetTransform());
             _xformStack.Push(t);
+
+            // Push the LINKED document so OnElementBegin resolves ids against it.
+            // Falls back to the current document rather than skipping: a link whose
+            // document cannot be resolved (unloaded mid-export) should still contribute
+            // its geometry, mislabelled, rather than vanish silently.
+            Document linkDoc = null;
+            try { linkDoc = node.GetDocument(); }
+            catch (Exception ex) { StingLog.Warn($"RevitGltfExporter.OnLinkBegin: {ex.Message}"); }
+            _docStack.Push(linkDoc ?? CurrentDoc);
             return RenderNodeAction.Proceed;
         }
 
         public void OnLinkEnd(LinkNode node)
         {
             if (_xformStack.Count > 1) _xformStack.Pop();
+            // Popped unconditionally against the same guard as the transform stack —
+            // the two are pushed together in OnLinkBegin and must unwind together, or
+            // every element after a link resolves against the wrong document.
+            if (_docStack.Count > 1) _docStack.Pop();
+        }
+
+        /// <summary>
+        /// The key a mesh node and its element-map entry share.
+        ///
+        /// <para>Host elements keep their bare <c>UniqueId</c> so previously published
+        /// models keep working. Linked elements are prefixed with the link's identity,
+        /// because <c>UniqueId</c> is unique within a document only.</para>
+        ///
+        /// <para><b>Must stay byte-identical to
+        /// <c>PublishModelCommand.LinkedElementKey</c>.</b> The viewer joins geometry to
+        /// metadata on this string; a mismatch shows an element with no properties, and
+        /// nothing errors.</para>
+        /// </summary>
+        internal static string ElementKey(Document elementDoc, Document hostDoc, Element el)
+        {
+            if (elementDoc == null || hostDoc == null || ReferenceEquals(elementDoc, hostDoc))
+                return el.UniqueId;
+            return LinkScope(elementDoc) + "|" + el.UniqueId;
+        }
+
+        /// <summary>
+        /// Stable identity for a linked document, computable from BOTH
+        /// <c>LinkNode.GetDocument()</c> (the exporter) and
+        /// <c>RevitLinkInstance.GetLinkDocument()</c> (the element map).
+        ///
+        /// <para>PathName first because two links can share a file name in different
+        /// folders; Title as the fallback for cloud models, whose PathName is empty.
+        /// Note this does NOT distinguish two INSTANCES of the same file — both resolve
+        /// to one metadata entry. That is deliberate: the two instances are the same
+        /// source element placed twice, so their name, category, level and quantities
+        /// are identical. Only their position differs, and position lives in the
+        /// geometry, which is emitted per instance.</para>
+        /// </summary>
+        internal static string LinkScope(Document linkDoc)
+        {
+            try
+            {
+                var p = linkDoc.PathName;
+                if (!string.IsNullOrWhiteSpace(p)) return p;
+            }
+            catch (Exception ex) { StingLog.Warn($"RevitGltfExporter.LinkScope: {ex.Message}"); }
+            try { return linkDoc.Title ?? "link"; }
+            catch { return "link"; }
         }
 
         public void OnRPC(RPCNode node) { }
@@ -203,21 +289,30 @@ namespace StingTools.BIMManager
             ElementId matId;
             try { matId = node.MaterialId; } catch { return null; }
             if (matId == null || matId == ElementId.InvalidElementId) return null;
+            // Same document rule as OnElementBegin: a MaterialId inside a link belongs to
+            // the LINKED document. Resolving it against the host yields null (unnamed
+            // material) or, on a numeric collision, a different material entirely.
+            var matDoc = CurrentDoc;
+
+            // Cache key includes the document. Keyed on matId alone, a link's material 12
+            // and the host's material 12 shared one entry, so whichever was seen first
+            // decided the name and texture for both.
             long key = matId.Value;
-            if (_appearanceCache.TryGetValue(key, out var cached)) return cached;
+            string cacheKey = (ReferenceEquals(matDoc, _doc) ? "" : LinkScope(matDoc) + "|") + key;
+            if (_appearanceCache.TryGetValue(cacheKey, out var cached)) return cached;
 
             var def = new MaterialDef();
             try
             {
-                var mat = _doc.GetElement(matId) as Material;
+                var mat = matDoc.GetElement(matId) as Material;
                 def.MatName = mat?.Name ?? ("material " + key);
                 try { var c = node.Color; if (c != null) def.DiffuseRgb = new[] { (int)c.Red, (int)c.Green, (int)c.Blue }; } catch { }
                 try { def.Alpha = 1.0 - Clamp01(node.Transparency); } catch { }
 
-                var assetElem = mat != null ? _doc.GetElement(mat.AppearanceAssetId) as AppearanceAssetElement : null;
+                var assetElem = mat != null ? matDoc.GetElement(mat.AppearanceAssetId) as AppearanceAssetElement : null;
                 var asset = assetElem?.GetRenderingAsset();
                 def.HadAsset = asset != null;
-                if (asset == null) { def.Reason = "no-appearance-asset"; def.ComputeKey(); _appearanceCache[key] = def; return def; }
+                if (asset == null) { def.Reason = "no-appearance-asset"; def.ComputeKey(); _appearanceCache[cacheKey] = def; return def; }
 
                 var dc = ReadColor(asset, "generic_diffuse") ?? ReadColor(asset, "diffuse");
                 if (dc != null) def.DiffuseRgb = dc;
@@ -252,7 +347,7 @@ namespace StingTools.BIMManager
             }
             catch (Exception ex) { def.Reason = "exception: " + ex.Message; StingLog.Warn($"[tex] appearance resolve failed for {def.MatName}: {ex.Message}"); }
 
-            _appearanceCache[key] = def;
+            _appearanceCache[cacheKey] = def;
             return def;
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 241 — a model could be published but never removed)
+
+The Models page offered Upload and View and nothing else. A model published by mistake —
+wrong file, wrong discipline, a superseded revision — stayed in the project permanently,
+counting against the tenant's storage quota.
+
+**The API already had the delete.** `ModelsController.Delete` has existed, soft-deleting
+the row, cascading to the model's scene chunks so retired geometry stops rendering, and
+gated to Admin/Owner/Coordinator. `ModelPurgeJob` then removes the bytes after a 30-day
+grace. None of it was reachable: no button anywhere called it. Same shape as the licence
+`revoked_at` gap — a working capability with no way to invoke it.
+
+**The grace period protected nobody.** A soft delete with a 30-day window is only a safety
+net if something can reach into that window. Nothing could list a deleted model, so the
+30 days were not a chance to change your mind, only a delay before the bytes went. `GET
+/models?deleted=true` and a new `POST /models/{id}/restore` make it real; restore brings
+back the scene chunks retired by *that* delete, matched on the delete timestamp so an
+earlier unrelated delete of the same model is not also revived. Restoring the model
+without its chunks would produce a row that renders nothing, which reads as corruption
+rather than a half-finished undo.
+
+Existence of the row is the whole check: the purge job deletes it outright, so anything
+still present is still restorable and a 404 is the honest answer for anything past the
+grace. The page says so in those words rather than "not found", because a retry cannot fix
+it.
+
+**Restore carries the same roles as delete.** A narrower rule would create a state a
+Coordinator can enter and not leave.
+
+**UI.** Per-row Remove with an inline confirm — inline rather than `window.confirm`
+because a native modal cannot say the action is reversible, which is the one fact that
+should decide whether you click. A "Recently removed" section appears only when something
+is in it, showing days remaining per model. The countdown returns null rather than guessing
+when the server sent no timestamp: an invented number on a delete is worse than none,
+because it is the number the user decides against.
+
+`ModelMetaDto` gained `DeletedAt` **appended**, never inserted — it is a positional record
+and the call site already carried that warning from a previous near-miss.
+
+Two mistakes caught before they shipped, both by checking rather than assuming: the first
+draft passed a `notFound` option to `describeFailure`, which takes `{ forbidden, fallback }`
+only and would have silently ignored it; and it styled the destructive button with
+`bg-danger-hover`, a token that does not exist in `tailwind.config.ts`, so the hover state
+would have done nothing.
+
 #### Completed (Phase 240 — publishing a federated model published the container, not the model)
 
 A federated site — host container, every building and the site itself a Revit link, all

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 240 — publishing a federated model published the container, not the model)
+
+A federated site — host container, every building and the site itself a Revit link, all
+visible in `{3D}` — published as a bare toposolid with no buildings, and the viewer
+reported **8 ELEMENTS / 0% TAGGED** for the whole project.
+
+Two independent faults, either of which alone would have produced a broken publish.
+
+**1. The glTF exporter resolved every element against the host document.**
+`RevitGltfExporter.OnElementBegin` did `_doc.GetElement(id)` where `_doc` is fixed to the
+host. `OnLinkBegin` was implemented and pushed the transform, so Revit *was* traversing
+the links — but element ids are **document-local**, so an id from inside a link looked up
+in the host is not a near-miss, it is a lookup in the wrong table. It returned null and
+`RenderNodeAction.Skip` dropped the geometry. Where the id happened to exist in the host,
+worse: geometry was written carrying another element's name, category, colour and
+`UniqueId` — the key the viewer joins metadata on.
+
+`Clash/ClashExportContext` has always done this correctly, with a document stack and
+`LinkNode.GetDocument()`. This exporter simply never did. It now keeps the same stack, and
+`OnLinkEnd` pops it under the same guard as the transform stack — the two are pushed
+together and must unwind together, or every element after a link resolves against the
+wrong document.
+
+The same bug sat in material resolution (`_doc.GetElement(matId)`), and the appearance
+cache was keyed on the raw `ElementId` value, so a link's material 12 and the host's
+material 12 shared one entry and whichever was seen first decided the name and texture for
+both.
+
+**2. The element map never looked at links at all.** `BuildElementMap` collected from
+`new FilteredElementCollector(doc, activeView.Id)` — host only. On a federated model that
+is a handful of link instances and nothing else, which is the "8 ELEMENTS" exactly. Fixing
+the geometry alone would have given properties-free meshes; fixing the map alone,
+propertied nothing.
+
+It now walks links **recursively**, because Revit's view traversal descends nested links
+and a one-level walk would reproduce the same bug one level down — geometry present,
+properties missing, which is the variant hardest to notice because the model looks right.
+Documents are visited once (a cycle is legal in Revit) and depth is capped.
+
+**Keys.** Host elements keep their bare `UniqueId`, so nothing already published changes.
+Linked elements are namespaced by the link's path, because `UniqueId` is unique *within* a
+document and buildings are routinely Saved-As from one another — two links can genuinely
+carry the same id. Both producers compute the key through one helper; they must, since a
+mismatch renders an element with no properties and errors nowhere.
+
+**Bounds.** A linked element's bounding box is in its own coordinates. All eight corners
+are transformed, not Min/Max — under rotation the transformed Min is not the minimum, and
+a link placed at an angle is the normal case.
+
+**Honest scope limit:** the map collects model elements with geometry from each link, not
+"elements visible in the host's active view" — a view id cannot filter another document's
+collector. The GLB, produced by Revit's own view traversal, remains the authority on what
+is drawn, so the map may list a few elements the geometry does not show. A tree row with
+no mesh is a much smaller problem than the mesh with no properties it replaces. Unloaded
+links are named in the log rather than skipped silently.
+
 #### Completed (Phase 239 — Connect could not survive a cold start)
 
 Phase 237 pointed the plugin at a host that answers. The first real sign-in still failed:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 242 — the element map described the documents, not the model)
+
+The federation fix worked — the GLB went from 13 elements to **1,407**, six links
+contributing ~7,000 elements each. The upload then failed:
+
+```
+Upload failed: HTTP 400: {"error":"element_map_too_large","maxMb":5}
+```
+
+**The map was 12.28 MB describing 1,407 meshes.** Measured on the generated file: 37,110
+entries, of which **29,521 were `Lines` and 5,706 `Legend Components`** — legend and detail
+content living inside the linked files' non-3D views. Real building elements numbered a few
+hundred: 181 walls, 133 pipes, 130 furniture, 106 columns, 87 windows, 67 doors, 57
+toposolids. **95% of the payload was annotation the viewer can never select.**
+
+A category filter cannot fix this — `OST_Lines` *is* a model category, and the entries
+come from views that are not the 3D view. Only the exporter knows what was drawn, so the
+exporter now says: it records the key of every element that produced at least one mesh,
+under the same condition that keeps the node, and the map is narrowed to that set.
+**37,110 → ~1,407.**
+
+Only when this publish ran the exporter. A user-picked `.glb`/`.ifc` leaves the set null
+and the map keeps its full scope, because guessing what a file we did not produce contains
+would drop real elements. Logged as ROADMAP PUB-2.
+
+**Also.** The map is written compact rather than indented — measured 12.28 MB → 9.70 MB, a
+21% saving on a machine-read sidecar nobody opens by hand. And ~2.40 MB of the original was
+pure repetition of the absolute link path in every key, an artefact of the Phase 240
+namespacing; narrowing the set removes most of it.
+
+**Server.** The cap moves 5 MB → 25 MB, into one named constant instead of two magic
+numbers that had to agree. 5 MB is ~19,000 elements at the ~265 bytes/element a real map
+costs — a federated site passes that easily, so the limit was binding on ordinary models,
+not just on this bug. Not raised further on purpose: `DownloadElementMap` reads the whole
+map into a string to merge the cost sidecar, on a 512 MB instance. Storing it gzipped is
+the durable answer — **31× on this file, 12.28 MB → 0.40 MB** — and is logged as PUB-1
+rather than bolted on here, because it needs the serve path and the cost merge to
+decompress.
+
+The refusal now carries `actualMb` and a `hint`. `{"maxMb":5}` alone was true and unusable:
+it never said how large the map *was*, so "slightly over" and "twenty times over" looked
+identical, and nothing pointed at the real cause.
+
 #### Completed (Phase 241 — a model could be published but never removed)
 
 The Models page offered Upload and View and nothing else. A model published by mistake —

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,6 +29,14 @@ Open automation gaps, future-enhancement tables, and deep-review findings for th
 | LIC-5 | **Merging licensing changes ships nothing** | Tracked as #651. `marketing-site` has no git-connected Pages build, so `/licences` and every Function change reach production only when a human runs `npm run deploy`. Compounded by the deploy-time binding behaviour corrected in #674: a secret that `wrangler pages secret list` shows is stored, not bound. |
 | LIC-6 | **Preview and production share one D1** | Tracked as #652 (#644 closed as its duplicate). A preview deployment can issue, revoke and stamp rows in the production `licenses` table — now the billing artefact, since #626 made D1 the sole owner of seat entitlement. |
 
+## Model publishing — after the federation pass (2026-08-22)
+
+| ID | Item | Detail |
+|---|---|---|
+| PUB-1 | **Store the element map gzipped** | Measured on a real federated site: 12.28 MB of JSON gzips to **0.40 MB — 31×**. The cap is 25 MB and cannot go much higher because `ModelsController.DownloadElementMap` reads the whole map into a string to merge the cost sidecar, on a 512 MB free-tier instance. Compressing at rest removes the ceiling problem entirely, but needs the serve path AND the cost merge to decompress, plus a magic-byte check so plugins still sending plain JSON keep working. |
+| PUB-2 | **The map can still over-collect on a user-picked file** | When the publish exports the GLB itself, the map is narrowed to the keys the exporter actually wrote — which took a real model from 37,110 entries to ~1,407. When the user picks an existing `.glb`/`.ifc` we cannot know its contents, so the map keeps its full document scope and the old bloat returns. Reading the element list back out of a picked GLB would close it. |
+| PUB-3 | **Nested-link metadata is collected, its visibility is not filtered** | `CollectLinksRecursive` filters top-level link INSTANCES by the active view, because that is a host element the view can answer for. Deeper links, and per-element visibility inside any link, cannot be filtered by a host view id. The PUB-2 narrowing hides the consequence today; it would reappear on the picked-file path. |
+
 ## Planscape hosting — after the connect pass (2026-08-20)
 
 | ID | Item | Detail |

--- a/planscape-web/app/projects/[id]/models/page.tsx
+++ b/planscape-web/app/projects/[id]/models/page.tsx
@@ -1,40 +1,69 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { AppShell } from '@/components/AppShell';
 import { ErrorNote, ForbiddenNote } from '@/components/ui';
-import { describeFailure } from '@/lib/api';
-import { listModels, uploadModel } from '@/lib/data';
+import { ApiError, describeFailure } from '@/lib/api';
+import { deleteModel, listModels, restoreModel, uploadModel } from '@/lib/data';
 import type { ProjectModel } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
 const ACCEPT = '.glb,.gltf';
 
+/** Matches ModelPurgeJob.PurgeGrace. If that changes, this copy is a lie. */
+const PURGE_GRACE_DAYS = 30;
+
+/**
+ * Days left before ModelPurgeJob removes the bytes for good.
+ *
+ * Returns null rather than guessing when the server sent no timestamp — an
+ * invented countdown on a delete is worse than none, because it is the number a
+ * user decides against.
+ */
+function daysLeft(deletedAt?: string): number | null {
+  if (!deletedAt) return null;
+  const t = Date.parse(deletedAt);
+  if (Number.isNaN(t)) return null;
+  const elapsedDays = (Date.now() - t) / 86_400_000;
+  return Math.max(0, Math.ceil(PURGE_GRACE_DAYS - elapsedDays));
+}
+
 export default function ModelsPage() {
   const params = useParams<{ id: string }>();
   const projectId = params.id;
 
   const [models, setModels] = useState<ProjectModel[]>([]);
+  const [deletedModels, setDeletedModels] = useState<ProjectModel[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [forbidden, setForbidden] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // Which row is asking "are you sure". Inline rather than window.confirm: a native
+  // modal cannot explain that this is reversible, and that is the whole point here.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [rowBusyId, setRowBusyId] = useState<string | null>(null);
 
   const fileRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState('');
   const [discipline, setDiscipline] = useState('');
 
-  function refresh() {
+  const refresh = useCallback(() => {
     listModels(projectId)
       .then(setModels)
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load models'));
-  }
+    // Deleted models are fetched separately and failures are swallowed on purpose:
+    // the restore list is an extra, and losing it must not blank the page that shows
+    // the live models.
+    listModels(projectId, { deleted: true })
+      .then(setDeletedModels)
+      .catch(() => setDeletedModels([]));
+  }, [projectId]);
 
-  useEffect(refresh, [projectId]);
+  useEffect(refresh, [refresh]);
 
   async function onUpload(e: React.FormEvent) {
     e.preventDefault();
@@ -72,6 +101,69 @@ export default function ModelsPage() {
       setForbidden(d.tone === 'forbidden');
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function onDelete(m: ProjectModel) {
+    setRowBusyId(m.id);
+    setError(null);
+    setForbidden(false);
+    setNotice(null);
+    try {
+      await deleteModel(projectId, m.id);
+      setNotice(
+        `"${m.name}" removed. It can be restored below for ${PURGE_GRACE_DAYS} days, ` +
+          'after which the file is deleted permanently.',
+      );
+      setConfirmId(null);
+      refresh();
+    } catch (err) {
+      // Same 403 shape as upload — an empty body would otherwise surface as a bare
+      // status code, which tells the user nothing they can act on.
+      const d = describeFailure(err, {
+        forbidden: 'Only an Admin, Owner or Coordinator can remove a model from this project.',
+        fallback: 'Could not remove the model',
+      });
+      setError(d.message);
+      setForbidden(d.tone === 'forbidden');
+    } finally {
+      setRowBusyId(null);
+    }
+  }
+
+  async function onRestore(m: ProjectModel) {
+    setRowBusyId(m.id);
+    setError(null);
+    setForbidden(false);
+    setNotice(null);
+    try {
+      await restoreModel(projectId, m.id);
+      setNotice(`"${m.name}" restored.`);
+      refresh();
+    } catch (err) {
+      // 404 means ModelPurgeJob already ran: the row and the bytes are gone. That is
+      // not something a retry fixes, and describeFailure has no notFound case — it
+      // takes { forbidden, fallback } only — so it is handled here rather than passed
+      // as an option that would be silently ignored.
+      if (err instanceof ApiError && err.status === 404) {
+        setError(
+          `"${m.name}" is past its ${PURGE_GRACE_DAYS}-day window and has been permanently ` +
+            'deleted. Publish it again to bring it back.',
+        );
+        setForbidden(false);
+      } else {
+        const d = describeFailure(err, {
+          forbidden: 'Only an Admin, Owner or Coordinator can restore a model.',
+          fallback: 'Could not restore the model',
+        });
+        setError(d.message);
+        setForbidden(d.tone === 'forbidden');
+      }
+      // Re-read either way: a 404 means our list is stale, and showing a Restore button
+      // for something that no longer exists invites the same failure again.
+      refresh();
+    } finally {
+      setRowBusyId(null);
     }
   }
 
@@ -141,8 +233,8 @@ export default function ModelsPage() {
       ) : (
         <ul className="divide-y divide-border rounded-lg border border-border bg-surface">
           {models.map((m) => (
-            <li key={m.id} className="flex items-center justify-between px-4 py-3">
-              <div>
+            <li key={m.id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
                 <span className="text-sm font-medium">{m.name}</span>
                 <span className="ml-2 text-xs text-fg-subtle">
                   {m.discipline ? `${m.discipline} · ` : ''}
@@ -150,15 +242,84 @@ export default function ModelsPage() {
                   {m.revision ? ` · ${m.revision}` : ''}
                 </span>
               </div>
-              <Link
-                href={`/projects/${projectId}/viewer?model=${m.id}`}
-                className="text-sm text-accent hover:underline"
-              >
-                View
-              </Link>
+
+              {confirmId === m.id ? (
+                <div className="flex shrink-0 items-center gap-2">
+                  <span className="text-xs text-fg-subtle">
+                    Remove from this project? Restorable for {PURGE_GRACE_DAYS} days.
+                  </span>
+                  <button
+                    onClick={() => onDelete(m)}
+                    disabled={rowBusyId === m.id}
+                    className="rounded bg-danger-subtle px-2 py-1 text-xs font-medium text-danger hover:opacity-80 disabled:opacity-50"
+                  >
+                    {rowBusyId === m.id ? 'Removing…' : 'Remove'}
+                  </button>
+                  <button
+                    onClick={() => setConfirmId(null)}
+                    className="rounded border border-border-strong px-2 py-1 text-xs hover:bg-surface-2"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <div className="flex shrink-0 items-center gap-3">
+                  <Link
+                    href={`/projects/${projectId}/viewer?model=${m.id}`}
+                    className="text-sm text-accent hover:underline"
+                  >
+                    View
+                  </Link>
+                  <button
+                    onClick={() => setConfirmId(m.id)}
+                    className="text-sm text-fg-subtle hover:text-danger hover:underline"
+                  >
+                    Remove
+                  </button>
+                </div>
+              )}
             </li>
           ))}
         </ul>
+      )}
+
+      {/* Recently deleted — the 30-day window made reachable. Hidden when empty so it
+          costs nothing on the common path. */}
+      {deletedModels.length > 0 && (
+        <section className="mt-8">
+          <h2 className="mb-2 text-sm font-medium">Recently removed</h2>
+          <p className="mb-2 text-xs text-fg-subtle">
+            Removed models are kept for {PURGE_GRACE_DAYS} days and can be restored. After that the
+            file is deleted permanently.
+          </p>
+          <ul className="divide-y divide-border rounded-lg border border-border bg-surface">
+            {deletedModels.map((m) => {
+              const left = daysLeft(m.deletedAt);
+              return (
+                <li key={m.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0">
+                    <span className="text-sm text-fg-muted">{m.name}</span>
+                    <span className="ml-2 text-xs text-fg-subtle">
+                      {m.discipline ? `${m.discipline} · ` : ''}
+                      {left === null
+                        ? 'removed'
+                        : left === 0
+                          ? 'deletes today'
+                          : `${left} day${left === 1 ? '' : 's'} left`}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => onRestore(m)}
+                    disabled={rowBusyId === m.id}
+                    className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs hover:bg-surface-2 disabled:opacity-50"
+                  >
+                    {rowBusyId === m.id ? 'Restoring…' : 'Restore'}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
       )}
     </AppShell>
   );

--- a/planscape-web/lib/data.ts
+++ b/planscape-web/lib/data.ts
@@ -167,8 +167,25 @@ export function promoteClashToIssue(projectId: string, clashId: string): Promise
 }
 
 // ── Models / viewer ──
-export function listModels(projectId: string): Promise<ProjectModel[]> {
-  return api<ProjectModel[]>(`/api/projects/${projectId}/models`);
+export function listModels(
+  projectId: string,
+  opts: { deleted?: boolean } = {},
+): Promise<ProjectModel[]> {
+  const q = opts.deleted ? '?deleted=true' : '';
+  return api<ProjectModel[]>(`/api/projects/${projectId}/models${q}`);
+}
+
+/** Soft-delete. The bytes survive for 30 days (ModelPurgeJob), so this is undoable
+ *  via restoreModel until then — say so wherever it is offered, because a Delete the
+ *  user believes is permanent gets avoided, and one they believe is reversible when it
+ *  is not gets trusted. */
+export function deleteModel(projectId: string, modelId: string): Promise<void> {
+  return api<void>(`/api/projects/${projectId}/models/${modelId}`, { method: 'DELETE' });
+}
+
+/** Undo a delete inside the 30-day window. 404 means the model is already purged. */
+export function restoreModel(projectId: string, modelId: string): Promise<void> {
+  return api<void>(`/api/projects/${projectId}/models/${modelId}/restore`, { method: 'POST' });
 }
 
 /** Authenticated GLB URL — the token rides as a query param because the viewer

--- a/planscape-web/lib/types.ts
+++ b/planscape-web/lib/types.ts
@@ -119,6 +119,10 @@ export interface ProjectModel {
   format?: string;
   revision?: string;
   uploadedAt?: string;
+  /** Set only on rows from listModels(projectId, { deleted: true }). The server
+   *  soft-deletes and purges the bytes 30 days later, so this is what the UI counts
+   *  down from — otherwise the restore window is invisible and the user has to guess. */
+  deletedAt?: string;
 }
 
 // Federation — one Draco/GLB chunk per discipline (+level/system), produced by


### PR DESCRIPTION
The federation fix (#754) worked — the GLB went from **13 elements to 1,407**, six links
contributing ~7,000 elements each. Then the upload failed:

```
Upload failed: HTTP 400: {"error":"element_map_too_large","maxMb":5}
```

## The map was 12.28 MB describing 1,407 meshes

Measured on the generated file rather than guessed:

| | |
|---|---|
| entries | **37,110** |
| `Lines` | **29,521** |
| `Legend Components` | **5,706** |
| Walls / Pipes / Furniture / Columns / Windows / Doors / Toposolid | 181 / 133 / 130 / 106 / 87 / 67 / 57 |

**95% of the payload was legend and detail content** living inside the linked files'
non-3D views — annotation the viewer can never select.

**A category filter cannot fix this.** `OST_Lines` *is* a model category; these entries come
from views that are not the 3D view. Only the exporter knows what was actually drawn — so
it now says. It records the key of every element that produced at least one mesh, **under
the same condition that keeps the node**, so the two can never disagree about what is in
the file. The map is narrowed to that set: **37,110 → ~1,407**.

Only when the publish ran the exporter. A user-picked `.glb`/`.ifc` leaves the set null and
the map keeps its full scope — guessing what a file we did not produce contains would drop
real elements. Logged as **PUB-2**.

## Two smaller wins, both measured

- **Compact instead of indented**: 12.28 MB → 9.70 MB. A 21% saving on a machine-read
  sidecar nobody opens by hand, which counts against an upload limit.
- ~**2.40 MB** of the original was pure repetition of the absolute link path in every key —
  an artefact of #754's namespacing. Narrowing the set removes most of it.

## Server: the cap was binding on ordinary models

5 MB → **25 MB**, in one named constant rather than two magic numbers that had to agree.

At the ~265 bytes/element a real map costs, 5 MB is roughly **19,000 elements** — a
federated site passes that easily. So the limit was catching ordinary work, not just this
bug.

**Deliberately not higher.** `DownloadElementMap` reads the whole map into a string to
merge the cost sidecar, on a **512 MB** free-tier instance. Storing it gzipped is the
durable answer — **31× measured on this file, 12.28 MB → 0.40 MB** — and is logged as
**PUB-1** rather than bolted on here, because it needs the serve path *and* the cost merge
to decompress, plus a magic-byte check so plugins still sending plain JSON keep working.

## The error message

`{"error":"element_map_too_large","maxMb":5}` was true and unusable. It never said how
large the map *was*, so "slightly over" and "twenty times over" looked identical, and
nothing pointed at the actual cause. It now carries `actualMb` and a `hint`; `error` and
`maxMb` keep their names for anything already matching on them.

## Verification

- Plugin: **0 errors, 0 warnings**. Deployed, and the fix confirmed present in the shipped
  DLL by scanning **both byte alignments** with a must-find and a must-miss control — a
  single-alignment scan reported this exact class of change as missing earlier in the day.
- Server: 0 errors, **813 passing**.

Not yet re-run against the real model — that is the next thing to do, and the log now
prints the narrowed count so the result is visible without opening the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
