### PR TITLE
fix: the element map described the documents, not the model

### DIFF
--- a/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
+++ b/Planscape.Server/src/Planscape.API/Controllers/ModelsController.cs
@@ -42,6 +42,24 @@ public class ModelsController : ControllerBase
     // an uncompressed IFC or a federated model that should be split.
     private const long MaxModelSizeBytes = 500L * 1024 * 1024;
 
+    /// <summary>
+    /// Cap on the element-map sidecar. Raised from 5 MB.
+    ///
+    /// <para>5 MB is roughly 19,000 elements at the ~265 bytes/element a real map costs,
+    /// which a federated site passes easily. It was also being hit for the wrong reason —
+    /// the plugin was describing every element in the source documents rather than the
+    /// ones in the GLB, so a 1,407-element model shipped a 12.28 MB map of mostly legend
+    /// and detail lines. That is fixed on the plugin side; this raises the ceiling so the
+    /// limit binds on genuinely large models instead of on a bug.</para>
+    ///
+    /// <para>Not larger, deliberately: <c>DownloadElementMap</c> reads the whole map into
+    /// a string to merge the cost sidecar, and the free-tier instance has 512 MB of RAM.
+    /// The durable fix is to store it gzipped — measured 31× on a real map (12.28 MB →
+    /// 0.40 MB) — which needs the serve path and the cost merge to decompress. Logged
+    /// rather than done here.</para>
+    /// </summary>
+    private const long MaxElementMapBytes = 25L * 1024 * 1024;
+
     public ModelsController(
         PlanscapeDbContext db,
         IFileStorageService storage,
@@ -204,8 +222,8 @@ public class ModelsController : ControllerBase
             }
             if (req.ElementMap != null && req.ElementMap.Length > 0)
             {
-                if (req.ElementMap.Length > 5 * 1024 * 1024)
-                    return BadRequest(new { error = "element_map_too_large", maxMb = 5 });
+                if (req.ElementMap.Length > MaxElementMapBytes)
+                    return BadRequest(TooLargeBody(req.ElementMap.Length));
                 using var s = req.ElementMap.OpenReadStream();
                 existing.ElementMapPath = await _storage.SaveAsync(
                     tenantSlug, $"{projectCode}/models", req.ElementMap.FileName, s, ct);
@@ -256,8 +274,8 @@ public class ModelsController : ControllerBase
         string? mapPath = null;
         if (req.ElementMap != null && req.ElementMap.Length > 0)
         {
-            if (req.ElementMap.Length > 5 * 1024 * 1024)
-                return BadRequest(new { error = "element_map_too_large", maxMb = 5 });
+            if (req.ElementMap.Length > MaxElementMapBytes)
+                return BadRequest(TooLargeBody(req.ElementMap.Length));
             using var s = req.ElementMap.OpenReadStream();
             mapPath = await _storage.SaveAsync(tenantSlug, $"{projectCode}/models", req.ElementMap.FileName, s, ct);
         }
@@ -794,6 +812,26 @@ public class ModelsController : ControllerBase
         ConversionStatus: m.ConversionStatus,
         ConversionError: m.ConversionError,
         DeletedAt: m.DeletedAt);
+
+    /// <summary>
+    /// The refusal, with the numbers and a next step.
+    ///
+    /// <para>The previous body was <c>{"error":"element_map_too_large","maxMb":5}</c> —
+    /// true, and unusable: it did not say how large the map WAS, so there was no way to
+    /// tell "slightly over" from "twenty times over", and no hint that the usual cause is
+    /// a map describing far more than the model contains. <c>actualMb</c> and <c>hint</c>
+    /// are additive; <c>error</c> and <c>maxMb</c> keep their names for anything already
+    /// matching on them.</para>
+    /// </summary>
+    private static object TooLargeBody(long actualBytes) => new
+    {
+        error = "element_map_too_large",
+        maxMb = MaxElementMapBytes / (1024 * 1024),
+        actualMb = Math.Round(actualBytes / 1024d / 1024d, 2),
+        hint = "The element map should describe the elements in the published geometry. "
+             + "A map far larger than the model usually means it also covers annotation, "
+             + "legend or detail content. Update the plugin, or publish fewer linked models.",
+    };
 
     private static ModelFormat InferFormat(string fileName)
     {

--- a/StingTools/BIMManager/PublishModelCommand.cs
+++ b/StingTools/BIMManager/PublishModelCommand.cs
@@ -428,6 +428,7 @@ namespace StingTools.BIMManager
             // on the second publish of a session, which is the worst kind to reproduce.
             // Only ExportActiveView, which actually asks, may set it true.
             _includeLinksThisRun = false;
+            _exportedKeysThisRun = null;
 
             var dlg = new TaskDialog("Publish Model")
             {
@@ -479,6 +480,7 @@ namespace StingTools.BIMManager
                 var result = RevitGltfExporter.Export(doc, v3d, outPath,
                                                       exportTextures: wantTextures,
                                                       includeLinks: _includeLinksThisRun);
+                _exportedKeysThisRun = result.ElementKeys;
                 StingLog.Info($"Planscape: GLB exported ({result.ElementCount} elements, {result.FileSizeBytes:N0} bytes) → {outPath}");
 
                 // Say it out loud. The whole reason this option exists is that links were
@@ -527,6 +529,23 @@ namespace StingTools.BIMManager
         /// disagreement shows as meshes with no properties, or tree rows with no mesh.
         /// </summary>
         private static bool _includeLinksThisRun;
+
+        /// <summary>
+        /// Keys the GLB export actually wrote, or null when this publish did not run the
+        /// exporter (the user picked an existing .glb/.ifc, so we cannot know what is in
+        /// it and must not pretend to).
+        ///
+        /// <para>The map exists to annotate the geometry, so it should describe THE FILE,
+        /// not the documents the file came from. Measured on a real federated site: 1,407
+        /// elements in the GLB, 37,110 in an independently-built map — 29,521 of them
+        /// <c>Lines</c> and 5,706 <c>Legend Components</c> living in the links' legend and
+        /// detail views. 12.28 MB of mostly annotation for 1,407 meshes, which is what hit
+        /// the server's element-map limit.</para>
+        ///
+        /// <para>Filtering by Revit category cannot solve this — <c>OST_Lines</c> is a
+        /// model category. Only the exporter knows what was drawn.</para>
+        /// </summary>
+        private static HashSet<string>? _exportedKeysThisRun;
 
         /// <summary>
         /// Ask once per publish, and only when it matters.
@@ -781,6 +800,21 @@ namespace StingTools.BIMManager
             else
                 StingLog.Info("Publish: element map covers the host model only (links excluded for this publish).");
 
+            // Describe the FILE, not the documents. Anything that produced no mesh is not
+            // in the GLB, so an entry for it is a tree row the viewer can never select and
+            // bytes the upload has to carry — 95% of the payload on a real federated site.
+            //
+            // Only when we ran the exporter. A user-picked .glb/.ifc leaves this null and
+            // the map keeps its full scope, because guessing which elements a file we did
+            // not produce contains would drop real ones.
+            if (_exportedKeysThisRun != null && _exportedKeysThisRun.Count > 0)
+            {
+                int before = elements.Count;
+                elements = elements.Where(i => _exportedKeysThisRun.Contains(i.Key)).ToList();
+                StingLog.Info($"Publish: element map narrowed to the {elements.Count} element(s) " +
+                              $"actually in the GLB (from {before} with geometry in the documents).");
+            }
+
             var map = new JObject();
             var bb = new BoundingBoxXYZ { Min = new XYZ(double.MaxValue, double.MaxValue, double.MaxValue),
                                           Max = new XYZ(double.MinValue, double.MinValue, double.MinValue) };
@@ -948,7 +982,10 @@ namespace StingTools.BIMManager
                 : new[] { 0d, 0d, 0d, 0d, 0d, 0d };
             elementCount = count;
 
-            File.WriteAllText(outputPath, map.ToString(Newtonsoft.Json.Formatting.Indented), Encoding.UTF8);
+            // None, not Indented. Measured 12.28 MB pretty vs 9.70 MB compact on a real
+            // model: a 21% saving on a machine-read sidecar that no one opens by hand, and
+            // it counts against an upload limit.
+            File.WriteAllText(outputPath, map.ToString(Newtonsoft.Json.Formatting.None), Encoding.UTF8);
         }
 
         /// <summary>

--- a/StingTools/BIMManager/RevitGltfExporter.cs
+++ b/StingTools/BIMManager/RevitGltfExporter.cs
@@ -86,6 +86,11 @@ namespace StingTools.BIMManager
 
         /// <summary>Links encountered and skipped, so the caller can say so out loud.</summary>
         public int SkippedLinkCount { get; private set; }
+
+        /// <summary>Keys of the elements that produced at least one mesh. Populated in
+        /// <see cref="OnElementEnd"/> under the SAME condition that keeps the node, so
+        /// the two can never disagree about what is in the file.</summary>
+        public HashSet<string> WrittenKeys { get; } = new(StringComparer.Ordinal);
         // Per-material appearance cache (Revit material ElementId.Value → resolved def),
         // so the version-sensitive appearance read runs once per material, not per face.
         private readonly Dictionary<string, MaterialDef?> _appearanceCache = new();
@@ -143,6 +148,7 @@ namespace StingTools.BIMManager
                     exporter.Export(view);
                     var result = ctx.WriteGlb(outputGlbPath);
                     result.SkippedLinkCount = ctx.SkippedLinkCount;
+                    result.ElementKeys = ctx.WrittenKeys;
                     if (ctx.SkippedLinkCount > 0)
                         StingLog.Info($"Planscape: GLB excluded {ctx.SkippedLinkCount} linked model instance(s) " +
                                       "(links off — set PLANSCAPE_EXPORT_LINKS=1 or choose 'include links' to add them).");
@@ -193,7 +199,11 @@ namespace StingTools.BIMManager
 
         public void OnElementEnd(ElementId id)
         {
-            if (_current != null && _current.Positions.Count > 0) _nodes.Add(_current);
+            if (_current != null && _current.Positions.Count > 0)
+            {
+                _nodes.Add(_current);
+                WrittenKeys.Add(_current.UniqueId);
+            }
             _current = null;
             _currentUniqueId = null;
             _currentName = null;
@@ -1130,6 +1140,22 @@ namespace StingTools.BIMManager
             /// file is the host model only — say so to the user rather than letting a
             /// federated model arrive as an empty container.</summary>
             public int SkippedLinkCount;
+
+            /// <summary>
+            /// The key of every element that actually produced geometry, so the element
+            /// map can describe THIS FILE rather than the document it came from.
+            ///
+            /// <para>Measured on a real federated site: the GLB held 1,407 elements while
+            /// a map built independently from the same documents held 37,110 — 29,521
+            /// <c>Lines</c> and 5,706 <c>Legend Components</c>, i.e. legend and detail
+            /// content that is not in the 3D model at all. That is 12.28 MB of mostly
+            /// annotation describing 1,407 meshes, and it broke the upload.</para>
+            ///
+            /// <para>A Revit category test cannot fix that: <c>OST_Lines</c> IS a model
+            /// category. Only the exporter knows what got drawn, so it is the exporter
+            /// that must say.</para>
+            /// </summary>
+            public HashSet<string> ElementKeys = new();
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 242 — the element map described the documents, not the model)
+
+The federation fix worked — the GLB went from 13 elements to **1,407**, six links
+contributing ~7,000 elements each. The upload then failed:
+
+```
+Upload failed: HTTP 400: {"error":"element_map_too_large","maxMb":5}
+```
+
+**The map was 12.28 MB describing 1,407 meshes.** Measured on the generated file: 37,110
+entries, of which **29,521 were `Lines` and 5,706 `Legend Components`** — legend and detail
+content living inside the linked files' non-3D views. Real building elements numbered a few
+hundred: 181 walls, 133 pipes, 130 furniture, 106 columns, 87 windows, 67 doors, 57
+toposolids. **95% of the payload was annotation the viewer can never select.**
+
+A category filter cannot fix this — `OST_Lines` *is* a model category, and the entries
+come from views that are not the 3D view. Only the exporter knows what was drawn, so the
+exporter now says: it records the key of every element that produced at least one mesh,
+under the same condition that keeps the node, and the map is narrowed to that set.
+**37,110 → ~1,407.**
+
+Only when this publish ran the exporter. A user-picked `.glb`/`.ifc` leaves the set null
+and the map keeps its full scope, because guessing what a file we did not produce contains
+would drop real elements. Logged as ROADMAP PUB-2.
+
+**Also.** The map is written compact rather than indented — measured 12.28 MB → 9.70 MB, a
+21% saving on a machine-read sidecar nobody opens by hand. And ~2.40 MB of the original was
+pure repetition of the absolute link path in every key, an artefact of the Phase 240
+namespacing; narrowing the set removes most of it.
+
+**Server.** The cap moves 5 MB → 25 MB, into one named constant instead of two magic
+numbers that had to agree. 5 MB is ~19,000 elements at the ~265 bytes/element a real map
+costs — a federated site passes that easily, so the limit was binding on ordinary models,
+not just on this bug. Not raised further on purpose: `DownloadElementMap` reads the whole
+map into a string to merge the cost sidecar, on a 512 MB instance. Storing it gzipped is
+the durable answer — **31× on this file, 12.28 MB → 0.40 MB** — and is logged as PUB-1
+rather than bolted on here, because it needs the serve path and the cost merge to
+decompress.
+
+The refusal now carries `actualMb` and a `hint`. `{"maxMb":5}` alone was true and unusable:
+it never said how large the map *was*, so "slightly over" and "twenty times over" looked
+identical, and nothing pointed at the real cause.
+
 #### Completed (Phase 241 — a model could be published but never removed)
 
 The Models page offered Upload and View and nothing else. A model published by mistake —

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,6 +29,14 @@ Open automation gaps, future-enhancement tables, and deep-review findings for th
 | LIC-5 | **Merging licensing changes ships nothing** | Tracked as #651. `marketing-site` has no git-connected Pages build, so `/licences` and every Function change reach production only when a human runs `npm run deploy`. Compounded by the deploy-time binding behaviour corrected in #674: a secret that `wrangler pages secret list` shows is stored, not bound. |
 | LIC-6 | **Preview and production share one D1** | Tracked as #652 (#644 closed as its duplicate). A preview deployment can issue, revoke and stamp rows in the production `licenses` table — now the billing artefact, since #626 made D1 the sole owner of seat entitlement. |
 
+## Model publishing — after the federation pass (2026-08-22)
+
+| ID | Item | Detail |
+|---|---|---|
+| PUB-1 | **Store the element map gzipped** | Measured on a real federated site: 12.28 MB of JSON gzips to **0.40 MB — 31×**. The cap is 25 MB and cannot go much higher because `ModelsController.DownloadElementMap` reads the whole map into a string to merge the cost sidecar, on a 512 MB free-tier instance. Compressing at rest removes the ceiling problem entirely, but needs the serve path AND the cost merge to decompress, plus a magic-byte check so plugins still sending plain JSON keep working. |
+| PUB-2 | **The map can still over-collect on a user-picked file** | When the publish exports the GLB itself, the map is narrowed to the keys the exporter actually wrote — which took a real model from 37,110 entries to ~1,407. When the user picks an existing `.glb`/`.ifc` we cannot know its contents, so the map keeps its full document scope and the old bloat returns. Reading the element list back out of a picked GLB would close it. |
+| PUB-3 | **Nested-link metadata is collected, its visibility is not filtered** | `CollectLinksRecursive` filters top-level link INSTANCES by the active view, because that is a host element the view can answer for. Deeper links, and per-element visibility inside any link, cannot be filtered by a host view id. The PUB-2 narrowing hides the consequence today; it would reappear on the picked-file path. |
+
 ## Planscape hosting — after the connect pass (2026-08-20)
 
 | ID | Item | Detail |


### PR DESCRIPTION
Replaces #763, which was cut from the delete/restore branch and went `CONFLICTING` once
that was squash-merged as #760. Same change, cherry-picked onto current `main`.

---

The federation fix (#754) worked — the GLB went from **13 elements to 1,407**, six links
contributing ~7,000 each. Then the upload failed:

```
Upload failed: HTTP 400: {"error":"element_map_too_large","maxMb":5}
```

## The map was 12.28 MB describing 1,407 meshes

Measured on the generated file, not guessed:

| | |
|---|---|
| entries | **37,110** |
| `Lines` | **29,521** |
| `Legend Components` | **5,706** |
| Walls / Pipes / Furniture / Columns / Windows / Doors / Toposolid | 181 / 133 / 130 / 106 / 87 / 67 / 57 |

**95% of the payload was legend and detail content** from inside the linked files' non-3D
views — annotation the viewer can never select.

**A category filter cannot fix this.** `OST_Lines` *is* a model category; these come from
views that are not the 3D view. Only the exporter knows what was drawn, so it now records
the key of every element that produced at least one mesh — **under the same condition that
keeps the node**, so the two can never disagree about what is in the file. The map is
narrowed to that set: **37,110 → ~1,407**.

Only when the publish ran the exporter. A user-picked `.glb`/`.ifc` leaves the set null and
the map keeps its full scope, because guessing what a file we did not produce contains
would drop real elements. Logged as **PUB-2**.

## Two smaller wins, both measured

- **Compact instead of indented**: 12.28 MB → 9.70 MB — 21% off a machine-read sidecar
  nobody opens by hand, which counts against an upload limit.
- ~**2.40 MB** of the original was the absolute link path repeated in every key, an
  artefact of #754's namespacing. Narrowing removes most of it.

## Server: the cap was binding on ordinary models

5 MB → **25 MB**, in one named constant instead of two magic numbers that had to agree.

At the ~265 bytes/element a real map costs, 5 MB is about **19,000 elements** — a federated
site passes that easily, so the limit was catching ordinary work and not just this bug.

**Deliberately not higher.** `DownloadElementMap` reads the whole map into a string to
merge the cost sidecar, on a **512 MB** free-tier instance. Gzip at rest is the durable
answer — **31× measured, 12.28 MB → 0.40 MB** — and is logged as **PUB-1** rather than
bolted on, since it needs the serve path *and* the cost merge to decompress, plus a
magic-byte check so plugins still sending plain JSON keep working.

## The error message

`{"error":"element_map_too_large","maxMb":5}` was true and unusable: it never said how
large the map *was*, so "slightly over" and "twenty times over" looked identical, and
nothing pointed at the cause. It now carries `actualMb` and a `hint`; `error` and `maxMb`
keep their names for anything already matching on them.

## Verification

- Plugin **0 errors, 0 warnings**; server **0 errors**; suite **842 passing, 0 failing**.
- #754's federation work is present via `main` (document stack, recursive link walk) —
  checked after the cherry-pick rather than assumed.
- Deployed, and the change confirmed in the shipped DLL by scanning **both byte
  alignments** with a must-find *and* a must-miss control. A single-alignment scan reported
  this exact class of change as missing earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
