### PR TITLE
fix(ci): the Render deploy job reported success while deploying nothing

### DIFF
--- a/.github/workflows/planscape-server.yml
+++ b/.github/workflows/planscape-server.yml
@@ -231,11 +231,40 @@ jobs:
       url: https://api.planscape.build
 
     steps:
-      - name: Trigger Render.com deploy
+      # This job reported SUCCESS for months while deploying nothing.
+      #
+      # RENDER_API_KEY and RENDER_SERVICE_ID were never set on the repository, so the
+      # request went to `/v1/services//deploys` with an empty bearer token — and `curl -s`
+      # with no `-f` exits 0 on any HTTP status, so the step went green. Measured
+      # 2026-08-22: #764 merged, this job reported "Deploy to Render.com - success", and
+      # production still served the previous build an hour later.
+      #
+      # A deploy step that cannot work and cannot fail is worse than none: it turns
+      # "did my change ship?" into a question the green tick answers wrongly.
+      - name: Check the deploy credentials exist
+        env:
+          KEY: ${{ secrets.RENDER_API_KEY }}
+          SVC: ${{ secrets.RENDER_SERVICE_ID }}
         run: |
-          curl -s -X POST "https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys" \
-            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d '{"clearCache": false}'
-        # Secrets required: RENDER_API_KEY, RENDER_SERVICE_ID
-        # Add these in GitHub → Settings → Secrets and variables → Actions
+          missing=""
+          [ -z "$KEY" ] && missing="$missing RENDER_API_KEY"
+          [ -z "$SVC" ] && missing="$missing RENDER_SERVICE_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Cannot deploy - missing secret(s):$missing. Add them in GitHub > Settings > Secrets and variables > Actions. RENDER_SERVICE_ID must be the service that actually SERVES (planscape-api-free); render.yaml names planscape-api, which 404s."
+            exit 1
+          fi
+
+      - name: Trigger Render.com deploy
+        env:
+          KEY: ${{ secrets.RENDER_API_KEY }}
+          SVC: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          # Capture the status and fail on non-2xx. Without this, an auth error or a
+          # wrong service id is indistinguishable from a deploy.
+          code=$(curl -s -o render.json -w '%{http_code}'             -X POST "https://api.render.com/v1/services/$SVC/deploys"             -H "Authorization: Bearer $KEY"             -H "Content-Type: application/json"             -d '{"clearCache": false}')
+          echo "Render responded HTTP $code"
+          cat render.json || true
+          case "$code" in
+            2*) echo "Deploy queued." ;;
+            *)  echo "::error::Render refused the deploy request (HTTP $code). Failing rather than reporting a deploy that did not happen."; exit 1 ;;
+          esac


### PR DESCRIPTION
Found while verifying that #764's element-map cap raise had reached production. It hadn't —
an hour after merge, with the deploy job green.

## The job could not work, and could not fail

```yaml
curl -s -X POST "https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys" \
  -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" ...
```

`gh secret list` shows **neither secret is set on this repository**. So the request goes to
`/v1/services//deploys` with an empty bearer token — and `curl -s` without `-f` exits **0
on any HTTP status**. The step goes green having deployed nothing.

Measured 2026-08-22: #764 merged at 07:35Z, "Deploy to Render.com — success", and the API
still refused a 6 MB element map with the old `maxMb: 5` an hour later. Nine consecutive
authenticated probes, with a passing control.

**A deploy step that cannot work and cannot fail is worse than no deploy step.** It turns
"did my change ship?" into a question the green tick answers wrongly — the same class of
failure as `render.yaml` describing services that do not serve (#717), and as my own probe
earlier today that read an empty response body as acceptance.

## The fix

- A pre-flight that fails with the **named** missing secrets, rather than proceeding into a
  request that cannot succeed.
- The request captures the HTTP status, prints Render's response body, and **fails on
  non-2xx**. An auth error and a wrong service id are no longer indistinguishable from a
  deploy.
- The error text names the service that is actually wanted: **`planscape-api-free`**, not
  the `planscape-api` in `render.yaml`, which 404s.

## What this does not do

It does not restore deployment — it makes the absence **visible**. The job will now fail on
`main` until the two secrets are added, which is the honest state.

The live deploy path today is the Render dashboard's Auto-Deploy, which is unfiltered and
outside this repo. Whoever adds the secrets should decide whether to keep both triggers or
turn the dashboard one off; #717 covers that, and having two is how a Revit-plugin commit
ends up rebuilding the .NET API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
