### PR TITLE
Fix the six defects the second real material-schedule export exposed

### DIFF
--- a/StingTools.Boq.Tests/ExclusionProtectionTests.cs
+++ b/StingTools.Boq.Tests/ExclusionProtectionTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — the second real export dropped ONE Windows row as
+    /// not-a-material while keeping twelve others. A description pattern written
+    /// for Generic Models voids ("opening") matched a real window type.
+    ///
+    /// A door or a window is always bought, whatever it is called, so the
+    /// category outranks the pattern.
+    /// </summary>
+    public class ExclusionProtectionTests
+    {
+        private static AggregatorInputs Inputs(params ConstituentInput[] rows)
+        {
+            var a = new AggregatorInputs
+            {
+                Constituents = rows.ToList(),
+                DefaultStageId = "superstructure",
+                StageDefs = new List<StageDefinition>
+                {
+                    new StageDefinition { StageId = "superstructure", Title = "SUPERSTRUCTURE", Order = 2,
+                        Categories = { "Walls", "Generic Models" } },
+                    new StageDefinition { StageId = "doors-windows", Title = "DOORS AND WINDOWS", Order = 4,
+                        Categories = { "Doors", "Windows" } },
+                },
+                ExcludedDescriptionPatterns = new List<string> { "opening" },
+                ExclusionProtectedCategories = new List<string> { "Doors", "Windows" },
+            };
+            return a;
+        }
+
+        [Fact]
+        public void A_Protected_Category_Survives_A_Matching_Pattern()
+        {
+            var doc = CommodityAggregator.Build(Inputs(new ConstituentInput
+            {
+                Category = "Windows", TypeName = "M_Window-Awning OpeningLight 600x750",
+                Description = "Awning window", Unit = "nr", Quantity = 4
+            }));
+
+            Assert.Equal(0, doc.ExcludedRowCount);
+            Assert.Contains(doc.Stages.SelectMany(s => s.Commodities), c => c.Description == "Awning window");
+        }
+
+        [Fact]
+        public void An_Unprotected_Category_Is_Still_Excluded_By_The_Same_Pattern()
+        {
+            // The pattern exists because a Generic Models OPENING was sold 1,187
+            // times. Protecting doors and windows must not disarm it.
+            var doc = CommodityAggregator.Build(Inputs(new ConstituentInput
+            {
+                Category = "Generic Models", TypeName = "M_GM_OpeningWall_Instance",
+                Description = "Opening", Unit = "nr", Quantity = 1187
+            }));
+
+            Assert.Equal(1, doc.ExcludedRowCount);
+            Assert.Empty(doc.Stages.SelectMany(s => s.Commodities));
+        }
+
+        [Fact]
+        public void The_Aggregator_Marks_Intermediates_End_To_End()
+        {
+            var input = Inputs(
+                new ConstituentInput { ConstituentKind = "blockwork", Category = "Walls",
+                    Description = "Blockwork wall", Unit = "m2", Quantity = 174.6 },
+                new ConstituentInput { ConstituentKind = "block_units", Category = "Walls",
+                    Description = "Blocks", Unit = "nr", Quantity = 2182.53 });
+            input.Units = new SupplierUnitTable
+            {
+                Rules =
+                {
+                    new SupplierUnitRule { CommodityKey = "block", Description = "Hollow blocks 8\"",
+                        SupplierUnit = "No.", SourceUnit = "nr", SourceUnitsPerSupplierUnit = 1,
+                        RoundUpToWhole = true, DefaultWastagePct = 5, MatchKinds = { "block_units" } }
+                }
+            };
+            input.IntermediateMeasures = new List<IntermediateMeasureRule>
+            {
+                new IntermediateMeasureRule { Kind = "blockwork", Children = { "block_units" } }
+            };
+
+            var doc = CommodityAggregator.Build(input);
+            var all = doc.Stages.SelectMany(s => s.Commodities).ToList();
+
+            Assert.True(all.Single(c => c.Description == "Blockwork wall").IsMemorandum);
+            Assert.False(all.Single(c => c.CommodityKey == "block").IsMemorandum);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/IntermediateMeasureTests.cs
+++ b/StingTools.Boq.Tests/IntermediateMeasureTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — the second real export listed the intermediate measure AND
+    /// the things bought from it, side by side, each with an empty rate cell and
+    /// an R3 saying "has no rate. It will total zero in a priced schedule":
+    ///
+    ///     Blockwork wall     175 m2   (no rate)
+    ///     Hollow blocks 8"   2,292 No. @ 2,500
+    ///
+    /// 175 m2 x any rate is the same wall, paid for twice. These pin the marking
+    /// that makes the second payment unrepresentable rather than discouraged.
+    /// </summary>
+    public class IntermediateMeasureTests
+    {
+        private static readonly List<IntermediateMeasureRule> Rules = new List<IntermediateMeasureRule>
+        {
+            new IntermediateMeasureRule { Kind = "blockwork", Children = { "block_units" }, Note = "bought as blocks" },
+            new IntermediateMeasureRule { Kind = "mortar", Children = { "mortar_cement", "mortar_sand" } },
+        };
+
+        private static MaterialScheduleDocument Doc(params MaterialCommodity[] rows)
+        {
+            var d = new MaterialScheduleDocument();
+            d.Stages.Add(new StageSection { StageId = "superstructure", Title = "SUPERSTRUCTURE" });
+            d.Stages[0].Commodities.AddRange(rows);
+            return d;
+        }
+
+        [Fact]
+        public void An_Intermediate_Whose_Children_Are_Present_Is_Marked()
+        {
+            var doc = Doc(
+                new MaterialCommodity { CommodityKey = "Blockwork wall", SourceKind = "blockwork", OrderQuantity = 174.6 },
+                new MaterialCommodity { CommodityKey = "block", SourceKind = "block_units", OrderQuantity = 2292, RateUGX = 2500 });
+
+            IntermediateMeasureMarker.Apply(doc, Rules);
+
+            Assert.True(doc.Stages[0].Commodities[0].IsMemorandum);
+            Assert.False(doc.Stages[0].Commodities[1].IsMemorandum);
+        }
+
+        [Fact]
+        public void A_Marked_Row_Can_Never_Carry_Money()
+        {
+            var doc = Doc(
+                new MaterialCommodity { CommodityKey = "Blockwork wall", SourceKind = "blockwork", OrderQuantity = 174.6 },
+                new MaterialCommodity { CommodityKey = "block", SourceKind = "block_units", OrderQuantity = 2292, RateUGX = 2500 });
+            IntermediateMeasureMarker.Apply(doc, Rules);
+
+            // Even if something later resolves a rate onto it — a project rate
+            // card keyed by description would — the amount stays zero.
+            doc.Stages[0].Commodities[0].RateUGX = 35000;
+
+            Assert.Equal(0, doc.Stages[0].Commodities[0].AmountUGX);
+            Assert.Equal(5730000, doc.Stages[0].SubTotalUGX);
+        }
+
+        [Fact]
+        public void An_Intermediate_With_No_Children_Present_Stays_Priceable()
+        {
+            // A project whose data yields no block count must keep its blockwork
+            // area priceable. Turning a double-count into an OMISSION is worse:
+            // a duplicated line is arguable, a missing one is invisible.
+            var doc = Doc(new MaterialCommodity
+            {
+                CommodityKey = "Blockwork wall", SourceKind = "blockwork", OrderQuantity = 174.6
+            });
+
+            IntermediateMeasureMarker.Apply(doc, Rules);
+
+            Assert.False(doc.Stages[0].Commodities[0].IsMemorandum);
+        }
+
+        [Fact]
+        public void Children_Count_Document_Wide_Not_Section_Wide()
+        {
+            // A wall's plaster routes to FINISHES while its blockwork stays in
+            // the frame, so a per-section check would leave half the
+            // intermediates priceable.
+            var doc = new MaterialScheduleDocument();
+            doc.Stages.Add(new StageSection { StageId = "superstructure" });
+            doc.Stages.Add(new StageSection { StageId = "finishes" });
+            doc.Stages[0].Commodities.Add(new MaterialCommodity { SourceKind = "mortar", OrderQuantity = 11.66 });
+            doc.Stages[1].Commodities.Add(new MaterialCommodity { SourceKind = "mortar_cement", OrderQuantity = 93 });
+
+            IntermediateMeasureMarker.Apply(doc, Rules);
+
+            Assert.True(doc.Stages[0].Commodities[0].IsMemorandum);
+        }
+
+        [Fact]
+        public void R3_Does_Not_Flag_A_Memorandum_Row()
+        {
+            // R3 is what invited the double-count: it told the reader the row was
+            // missing a rate. A memorandum row is unpriced by design.
+            var doc = Doc(
+                new MaterialCommodity { CommodityKey = "Blockwork wall", SourceKind = "blockwork", OrderQuantity = 174.6 },
+                new MaterialCommodity { CommodityKey = "block", SourceKind = "block_units", OrderQuantity = 2292, RateUGX = 2500 });
+            IntermediateMeasureMarker.Apply(doc, Rules);
+
+            var rec = Reconciler.Check(doc);
+
+            Assert.DoesNotContain(rec.Issues, i => i.Code == "R3" && i.CommodityKey == "Blockwork wall");
+        }
+
+        [Fact]
+        public void R3_Still_Flags_A_Genuinely_Unpriced_Row()
+        {
+            var doc = Doc(new MaterialCommodity { CommodityKey = "roof-sheet", OrderQuantity = 610 });
+
+            var rec = Reconciler.Check(doc);
+
+            Assert.Contains(rec.Issues, i => i.Code == "R3" && i.CommodityKey == "roof-sheet");
+        }
+    }
+}

--- a/StingTools.Boq.Tests/OrderQuantityRoundingTests.cs
+++ b/StingTools.Boq.Tests/OrderQuantityRoundingTests.cs
@@ -11,8 +11,12 @@ namespace StingTools.Boq.Tests
     /// amount is computed from, so raw binary floats leak into the money column
     /// as fractions of a shilling.
     ///
-    /// Countable units still round UP — you cannot buy 2.08 truck trips. Divisible
-    /// units round to 2 dp, which is as precise as a delivery note gets.
+    /// Countable units round UP — you cannot buy 2.08 truck trips. Divisible
+    /// units round UP to 2 dp, which is as precise as a delivery note gets.
+    ///
+    /// Both directions round UP because an order must never sit below the
+    /// measured net. Half-up rounding was used here first, and the second real
+    /// export caught it: 174.6044 m2 of blockwork ordered as 174.60.
     /// </summary>
     public class OrderQuantityRoundingTests
     {
@@ -38,10 +42,12 @@ namespace StingTools.Boq.Tests
         [Fact]
         public void A_Divisible_Unit_Rounds_To_Two_Decimals()
         {
-            // 156.6490... + 5% = 164.48145 → 164.48
+            // 156.6490... + 5% = 164.48145 → 164.49, NOT 164.48. Rounding to
+            // nearest would put the order 0.00145 m3 under what was measured.
             var r = SupplierUnitConverter.Convert(Divisible(), 156.649);
 
-            Assert.Equal(164.48, r.OrderQuantity, 6);
+            Assert.Equal(164.49, r.OrderQuantity, 6);
+            Assert.True(r.OrderQuantity >= r.NetQuantity * 1.05 - 1e-9);
         }
 
         [Fact]
@@ -73,7 +79,8 @@ namespace StingTools.Boq.Tests
             // so "610.614588311426 m²" reached the sheet.
             var r = SupplierUnitConverter.Convert(null, 610.614588311426);
 
-            Assert.Equal(610.61, r.OrderQuantity, 6);
+            Assert.Equal(610.62, r.OrderQuantity, 6);
+            Assert.True(r.OrderQuantity >= r.NetQuantity);
         }
 
         [Fact]
@@ -89,16 +96,20 @@ namespace StingTools.Boq.Tests
         [Fact]
         public void Rounding_Never_Drops_Below_The_Net_Measured_Quantity()
         {
-            // Rounding DOWN below what was measured would under-order. Half-up
-            // could do that on a divisible unit with no wastage, so the converter
-            // must not produce an order under the net.
+            // This test USED TO PASS while the bug was live, because it compared
+            // the order against Math.Round(net, 2) — the very rounding under
+            // test. A gate that checks a value against its own transformation
+            // cannot fail. Compare against the RAW net, which is the contract.
+            //
+            // 174.6044 is the blockwork figure from the second real export, the
+            // row that made rule R4 fire.
             var rule = Divisible();
             rule.DefaultWastagePct = 0;
 
-            foreach (double q in new[] { 1.001, 2.004, 10.0049, 99.999 })
+            foreach (double q in new[] { 1.001, 2.004, 10.0049, 99.999, 174.6044, 610.614588311426 })
             {
                 var r = SupplierUnitConverter.Convert(rule, q);
-                Assert.True(r.OrderQuantity >= System.Math.Round(r.NetQuantity, 2) - 1e-9,
+                Assert.True(r.OrderQuantity >= r.NetQuantity,
                     $"{q}: order {r.OrderQuantity} fell below net {r.NetQuantity}");
             }
         }

--- a/StingTools.Boq.Tests/StageTypePatternTests.cs
+++ b/StingTools.Boq.Tests/StageTypePatternTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED — an element's CATEGORY often says nothing about the work it
+    /// belongs to. The second real export filed
+    /// `2022_RoofCap_Eagle_HighProfileTiles` and `gate_16438` under
+    /// SUPERSTRUCTURE, because that is where their categories point.
+    ///
+    /// A constituent kind must still win: a roof-shaped NAME must not drag real
+    /// concrete out of the frame.
+    /// </summary>
+    public class StageTypePatternTests
+    {
+        private static List<StageDefinition> Defs() => new List<StageDefinition>
+        {
+            new StageDefinition { StageId = "superstructure", Order = 2,
+                ConstituentKinds = { "concrete", "blockwork" }, Categories = { "Walls", "Generic Models" } },
+            new StageDefinition { StageId = "roof", Order = 3,
+                Categories = { "Roofs" }, TypePatterns = { "roofcap", "roofing" } },
+            new StageDefinition { StageId = "external", Order = 8,
+                TypePatterns = { "gate", "fence" } },
+        };
+
+        [Fact]
+        public void A_Type_Pattern_Beats_The_Category()
+        {
+            var ix = StageIndex.Build(Defs(), "superstructure");
+
+            Assert.Equal("roof", ix.Resolve("", "Generic Models", "", "2022_RoofCap_Eagle_HighProfileTiles"));
+            Assert.Equal("external", ix.Resolve("", "Generic Models", "", "gate_16438 gate"));
+        }
+
+        [Fact]
+        public void A_Constituent_Kind_Still_Beats_A_Type_Pattern()
+        {
+            // A concrete roof slab carries kind "concrete" and belongs to the
+            // frame however its type is named.
+            var ix = StageIndex.Build(Defs(), "superstructure");
+
+            Assert.Equal("superstructure", ix.Resolve("concrete", "Roofs", "", "Roofing slab RC 225"));
+        }
+
+        [Fact]
+        public void No_Type_Text_Behaves_Exactly_As_Before()
+        {
+            var ix = StageIndex.Build(Defs(), "superstructure");
+
+            Assert.Equal(ix.Resolve("", "Roofs", ""), ix.Resolve("", "Roofs", "", null));
+            Assert.Equal("superstructure", ix.Resolve("", "Generic Models", "", null));
+        }
+
+        [Fact]
+        public void A_Blank_Pattern_Is_Inert_Not_A_Wildcard()
+        {
+            var defs = Defs();
+            defs[2].TypePatterns.Add("   ");
+            var ix = StageIndex.Build(defs, "superstructure");
+
+            Assert.Equal("superstructure", ix.Resolve("", "Walls", "", "anything at all"));
+        }
+
+        // ── shipped data ──────────────────────────────────────────────────
+
+        private static StageLibrary Stages() =>
+            JsonConvert.DeserializeObject<StageLibrary>(
+                File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Data", "STING_MATERIAL_STAGES.json")));
+
+        [Fact]
+        public void Shipped_Intermediates_Name_Kinds_That_Differ_From_Their_Children()
+        {
+            var lib = Stages();
+            Assert.NotEmpty(lib.IntermediateMeasures);
+
+            foreach (var r in lib.IntermediateMeasures)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(r.Kind));
+                Assert.NotEmpty(r.Children);
+                Assert.DoesNotContain(r.Children, c =>
+                    string.Equals(c, r.Kind, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        [Fact]
+        public void A_Protected_Category_Is_Never_Also_An_Excluded_One()
+        {
+            // Otherwise the protection is decorative: the category check runs
+            // first and drops the row before any pattern is consulted.
+            var lib = Stages();
+            Assert.NotEmpty(lib.ExclusionProtectedCategories);
+
+            foreach (string c in lib.ExclusionProtectedCategories)
+                Assert.DoesNotContain(lib.ExcludedCategories,
+                    x => string.Equals(x, c, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void No_Stage_Routes_A_Category_That_Is_Excluded_Outright()
+        {
+            // ELEMENT 08 listed "Site" and "Parking", both of which are in
+            // excludedCategories and are dropped before routing — so the stage
+            // advertised coverage it could never deliver. Same class as the
+            // unreachable supplier rules removed in MATSCHED-3b.
+            var lib = Stages();
+            var excluded = new HashSet<string>(lib.ExcludedCategories, StringComparer.OrdinalIgnoreCase);
+
+            var dead = lib.Stages
+                .SelectMany(s => (s.Categories ?? new List<string>()).Select(c => $"{s.StageId}:{c}"))
+                .Where(pair => excluded.Contains(pair.Split(':')[1]))
+                .ToList();
+
+            Assert.True(dead.Count == 0, "stages route categories that are excluded outright: " + string.Join(", ", dead));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\Reconciler.cs" Link="MaterialSchedule\Reconciler.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ManualRowPlacer.cs" Link="MaterialSchedule\ManualRowPlacer.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\SiteToolsCalculator.cs" Link="MaterialSchedule\SiteToolsCalculator.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\IntermediateMeasures.cs" Link="MaterialSchedule\IntermediateMeasures.cs" />
     <Compile Include="..\StingTools\Core\ExportRouteMerge.cs" Link="ExportRouteMerge.cs" />
   </ItemGroup>
 

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -55,6 +55,8 @@ namespace StingTools.BOQ.MaterialSchedule
             inputs.DefaultStageId = lib.DefaultStageId;
             inputs.ExcludedCategories = lib.ExcludedCategories;
             inputs.ExcludedDescriptionPatterns = lib.ExcludedDescriptionPatterns;
+            inputs.ExclusionProtectedCategories = lib.ExclusionProtectedCategories;
+            inputs.IntermediateMeasures = lib.IntermediateMeasures;
             inputs.Rates = LoadRates(doc);
 
             foreach (var item in boq.AllItems.Where(i => i.Source == BOQRowSource.Model))

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
@@ -72,24 +72,38 @@ namespace StingTools.BOQ.MaterialSchedule
                 int item = 1;
                 foreach (var c in stage.Commodities)
                 {
-                    ws.Cell(row, 1).Value = item++;
-                    ws.Cell(row, 2).Value = string.IsNullOrWhiteSpace(c.Spec)
+                    string desc = string.IsNullOrWhiteSpace(c.Spec)
                         ? c.Description : $"{c.Description} — {c.Spec}";
-                    ws.Cell(row, 3).Value = c.SupplierUnit;
+                    if (c.IsMemorandum) desc += $"   [memo — {c.MemorandumNote}]";
+
+                    ws.Cell(row, 1).Value = item++;
+                    ws.Cell(row, 2).Value = desc;
+                    ws.Cell(row, 3).Value = DisplayUnit(c.SupplierUnit);
                     ws.Cell(row, 4).Value = Math.Round(c.NetQuantity, 2);
                     ws.Cell(row, 5).Value = c.WastagePct;
                     ws.Cell(row, 6).Value = c.OrderQuantity;
                     if (priced)
                     {
-                        ws.Cell(row, 7).Value = c.RateUGX;
-                        // Live formula, not a baked number — the workbook stays
-                        // arithmetically honest if a QS edits a rate downstream.
-                        // No leading '=' — that is the convention every other
-                        // FormulaA1 site in BOQExportCommand already uses.
-                        ws.Cell(row, 8).FormulaA1 = $"F{row}*G{row}";
-                        BoqXlsxStyle.MoneyFormat(ws.Range(row, 7, row, 8));
-                        if (c.IsUnpriced)
-                            ws.Range(row, 1, row, cols.Length).Style.Fill.BackgroundColor = BoqXlsxStyle.ManualRow;
+                        // A memorandum row gets NO rate cell and NO formula. Its
+                        // constituents carry the money; leaving an empty rate
+                        // cell here is what invited pricing the same wall twice.
+                        if (c.IsMemorandum)
+                        {
+                            ws.Cell(row, 8).Value = "—";
+                            ws.Range(row, 1, row, cols.Length).Style.Font.Italic = true;
+                        }
+                        else
+                        {
+                            ws.Cell(row, 7).Value = c.RateUGX;
+                            // Live formula, not a baked number — the workbook stays
+                            // arithmetically honest if a QS edits a rate downstream.
+                            // No leading '=' — that is the convention every other
+                            // FormulaA1 site in BOQExportCommand already uses.
+                            ws.Cell(row, 8).FormulaA1 = $"F{row}*G{row}";
+                            BoqXlsxStyle.MoneyFormat(ws.Range(row, 7, row, 8));
+                            if (c.IsUnpriced)
+                                ws.Range(row, 1, row, cols.Length).Style.Fill.BackgroundColor = BoqXlsxStyle.ManualRow;
+                        }
                     }
                     row++;
                 }
@@ -159,7 +173,7 @@ namespace StingTools.BOQ.MaterialSchedule
                 foreach (var g in rolled)
                 {
                     ws.Cell(row, 1).Value = g.First().Description;
-                    ws.Cell(row, 2).Value = g.Key.SupplierUnit;
+                    ws.Cell(row, 2).Value = DisplayUnit(g.Key.SupplierUnit);
                     ws.Cell(row, 3).Value = g.Sum(c => c.OrderQuantity);
                     row++;
                 }
@@ -200,5 +214,22 @@ namespace StingTools.BOQ.MaterialSchedule
             ws.Column(4).Width = 90;
             foreach (var c in ws.Columns(1, 3)) c.AdjustToContents();
         }
+
+        /// <summary>
+        /// Superscript the cubic/square metre for display. A converted row shows
+        /// the rule's supplier unit and an unconverted one shows the BOQ's raw
+        /// token, so one export printed "m3" against bedding mortar and "m³"
+        /// against in-situ concrete two rows apart. Display only — nothing
+        /// downstream parses these cells.
+        /// </summary>
+        internal static string DisplayUnit(string unit)
+        {
+            if (string.IsNullOrWhiteSpace(unit)) return unit;
+            string u = unit.Trim();
+            if (string.Equals(u, "m2", StringComparison.OrdinalIgnoreCase)) return "m²";
+            if (string.Equals(u, "m3", StringComparison.OrdinalIgnoreCase)) return "m³";
+            return unit;
+        }
+
     }
 }

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -94,6 +94,18 @@ namespace StingTools.BOQ.Takeoff
                     return BuildWall(doc, el, csvRates);
                 if (cat.IndexOf("Floor", StringComparison.OrdinalIgnoreCase) >= 0)
                     return BuildRcSlab(doc, el, csvRates);
+                // A concrete roof slab is a slab. Until now Roofs decomposed into
+                // nothing, so 856 m2 of 225mm roof reached one export as three
+                // unpriced area rows: the supplier table could not convert them
+                // (they are not sheets or tiles) and the take-off never offered
+                // concrete, rebar or formwork to price instead.
+                //
+                // requireExplicitConcrete, unlike the Floors path: a floor with no
+                // material assigned is almost always a slab, whereas an unassigned
+                // ROOF is just as likely to be sheeting, and calling that concrete
+                // would invent 137 m3 that does not exist.
+                if (cat.IndexOf("Roof", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return BuildRcSlab(doc, el, csvRates, requireExplicitConcrete: true);
                 if (cat.IndexOf("Structural Framing", StringComparison.OrdinalIgnoreCase) >= 0
                     || cat.IndexOf("Beam", StringComparison.OrdinalIgnoreCase) >= 0)
                     return BuildRcBeam(doc, el, csvRates);
@@ -188,10 +200,14 @@ namespace StingTools.BOQ.Takeoff
 
         // ── RC slab (concrete net + rebar + formwork) ───────────────────────
         private static List<BOQLineItem> BuildRcSlab(Document doc, Element el,
-            Dictionary<string, (double rate, string unit)> csvRates)
+            Dictionary<string, (double rate, string unit)> csvRates,
+            bool requireExplicitConcrete = false)
         {
             string material = (GetPrimaryMaterialName(doc, el) ?? "").ToLowerInvariant();
-            if (!(material.Contains("concrete") || material.Contains("rc") || material.Length == 0))
+            bool isConcrete = material.Contains("concrete") || material.Contains("rc");
+            // Blank material reads as concrete for a FLOOR and as unknown for a
+            // roof — see the Roofs branch in TryBuild.
+            if (!isConcrete && (requireExplicitConcrete || material.Length != 0))
                 return null;   // non-RC floor (timber deck etc.) → composite fallback
 
             double grossM3 = ReadVolumeM3(el);

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -34,6 +34,10 @@ namespace StingTools.Core.MaterialSchedule
         public List<string> ExcludedCategories = new List<string>();
         /// <summary>Description/type substrings that are never materials.</summary>
         public List<string> ExcludedDescriptionPatterns = new List<string>();
+        /// <summary>Categories no description pattern may exclude — see StageLibrary.</summary>
+        public List<string> ExclusionProtectedCategories = new List<string>();
+        /// <summary>Intermediate measures and their purchasable constituents.</summary>
+        public List<IntermediateMeasureRule> IntermediateMeasures = new List<IntermediateMeasureRule>();
         public CommodityRateResolver Rates;
         public MaterialScheduleOptions Options = new MaterialScheduleOptions();
     }
@@ -59,6 +63,9 @@ namespace StingTools.Core.MaterialSchedule
             var excluded = new HashSet<string>(
                 input.ExcludedCategories ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
 
+            var protectedCats = new HashSet<string>(
+                input.ExclusionProtectedCategories ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+
             foreach (var row in input.Constituents ?? new List<ConstituentInput>())
             {
                 if (row == null) continue;
@@ -77,7 +84,8 @@ namespace StingTools.Core.MaterialSchedule
                 // Not a material despite a legitimate category — an opening, a
                 // muntin pattern, a trim. Blank patterns are skipped: "".IndexOf
                 // returns 0 and would exclude the entire model.
-                if (patterns.Count > 0)
+                if (patterns.Count > 0
+                    && !(!string.IsNullOrWhiteSpace(row.Category) && protectedCats.Contains(row.Category.Trim())))
                 {
                     string hay = (row.Description ?? "") + " " + (row.TypeName ?? "");
                     bool hit = false;
@@ -103,7 +111,8 @@ namespace StingTools.Core.MaterialSchedule
                 // wall paint under the frame, because "Walls" routes there.
                 string stageId = !string.IsNullOrWhiteSpace(rule?.StageId)
                     ? rule.StageId
-                    : stageIndex.Resolve(row.ConstituentKind, row.Category, row.LevelCode);
+                    : stageIndex.Resolve(row.ConstituentKind, row.Category, row.LevelCode,
+                                         ((row.TypeName ?? "") + " " + (row.Description ?? "")).Trim());
 
                 // No rule → the row still appears, keyed by its own description and
                 // carrying its measured unit. Silently dropping it would lose real
@@ -119,7 +128,8 @@ namespace StingTools.Core.MaterialSchedule
                         Rule = rule,
                         Description = rule?.Description ?? row.Description ?? commodityKey,
                         Spec = rule?.Spec ?? "",
-                        FallbackUnit = row.Unit ?? ""
+                        FallbackUnit = row.Unit ?? "",
+                        SourceKind = row.ConstituentKind ?? ""
                     };
                     acc[k] = a;
                 }
@@ -193,6 +203,7 @@ namespace StingTools.Core.MaterialSchedule
                         RateUGX = rate.RateUGX,
                         RateSource = rate.Source,
                         TraceRefs = a.TraceRefs,
+                        SourceKind = a.SourceKind,
                         ConversionBlocked = a.ConversionBlocked,
                         ConversionNote = a.ConversionNote
                     });
@@ -202,6 +213,11 @@ namespace StingTools.Core.MaterialSchedule
             }
 
             StageMapper.AssignLetters(doc.Stages);
+
+            // AFTER assembly: a row is only an intermediate if the things bought
+            // in its place actually reached the document, which cannot be known
+            // while the rows are still being accumulated.
+            IntermediateMeasureMarker.Apply(doc, input.IntermediateMeasures);
             return doc;
         }
 
@@ -225,6 +241,7 @@ namespace StingTools.Core.MaterialSchedule
             public string Description = "";
             public string Spec = "";
             public string FallbackUnit = "";
+            public string SourceKind = "";
             public double SourceQuantity;
             public bool ConversionBlocked;
             public string ConversionNote = "";

--- a/StingTools/Core/MaterialSchedule/IntermediateMeasures.cs
+++ b/StingTools/Core/MaterialSchedule/IntermediateMeasures.cs
@@ -1,0 +1,75 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  IntermediateMeasures.cs — MAT-SCHED memorandum-row marking.
+//
+//  A compound take-off emits both the intermediate measure and the things you
+//  actually buy from it: 390 m2 of brickwork AND the 23,377 bricks derived
+//  from it, 11.66 m3 of mortar AND its cement and sand. Both belong in the
+//  document — the area is how a QS checks the count — but only one of them is
+//  purchasable, and the first real export offered rate cells on all of them.
+//
+//  Marking is CONDITIONAL on the children actually being present. A project
+//  whose data produces no block count must keep its blockwork area priceable,
+//  or the fix to a double-count becomes an omission — which is worse, because
+//  a missing line is invisible and a duplicated one is at least arguable.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    /// <summary>One intermediate kind and the kinds bought in its place.</summary>
+    public sealed class IntermediateMeasureRule
+    {
+        public string Kind = "";
+        public List<string> Children = new List<string>();
+        /// <summary>Shown against the row so the reader knows why it has no rate.</summary>
+        public string Note = "";
+    }
+
+    public static class IntermediateMeasureMarker
+    {
+        /// <summary>
+        /// Mark every commodity whose SourceKind names an intermediate AND at
+        /// least one of whose children is present ANYWHERE in the document.
+        ///
+        /// Document-wide, not stage-wide, on purpose: a wall's blockwork routes
+        /// to a storey stage while its plaster cement routes to Finishes, so a
+        /// per-section check would leave half the intermediates priceable.
+        /// </summary>
+        public static int Apply(MaterialScheduleDocument doc,
+                                IReadOnlyList<IntermediateMeasureRule> rules)
+        {
+            if (doc == null || rules == null || rules.Count == 0) return 0;
+
+            var present = new HashSet<string>(
+                doc.Stages.SelectMany(s => s.Commodities)
+                          .Select(c => c?.SourceKind ?? "")
+                          .Where(k => !string.IsNullOrWhiteSpace(k)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var byKind = new Dictionary<string, IntermediateMeasureRule>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in rules)
+                if (r != null && !string.IsNullOrWhiteSpace(r.Kind) && !byKind.ContainsKey(r.Kind.Trim()))
+                    byKind[r.Kind.Trim()] = r;
+
+            int marked = 0;
+            foreach (var c in doc.Stages.SelectMany(s => s.Commodities))
+            {
+                if (c == null || string.IsNullOrWhiteSpace(c.SourceKind)) continue;
+                if (!byKind.TryGetValue(c.SourceKind.Trim(), out var rule)) continue;
+
+                bool anyChild = (rule.Children ?? new List<string>())
+                    .Any(k => !string.IsNullOrWhiteSpace(k) && present.Contains(k.Trim()));
+                if (!anyChild) continue;   // nothing replaces it — leave it priceable
+
+                c.IsMemorandum = true;
+                c.MemorandumNote = string.IsNullOrWhiteSpace(rule.Note)
+                    ? "measured quantity shown for checking; bought as its constituents"
+                    : rule.Note;
+                marked++;
+            }
+            return marked;
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
+++ b/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
@@ -37,8 +37,31 @@ namespace StingTools.Core.MaterialSchedule
         public bool ConversionBlocked;
         public string ConversionNote = "";
 
+        /// <summary>The constituent kind this row came from, or "" for a row that
+        /// carried none. Used to decide whether the row is an intermediate.</summary>
+        public string SourceKind = "";
+
+        /// <summary>
+        /// True when this row is an INTERMEDIATE MEASURE whose purchasable
+        /// constituents are separately listed in the same document — blockwork
+        /// area against the block count derived from it, mortar volume against
+        /// its cement and sand.
+        ///
+        /// The first real export listed all four alongside their own children
+        /// and flagged each with R3 ("has no rate. It will total zero"), which
+        /// reads as an instruction to price them. Rating 175 m2 of blockwork
+        /// next to 2,292 blocks pays for the same wall twice.
+        ///
+        /// A memorandum row keeps its quantity — it is the audit trail that
+        /// makes the derived counts checkable — but it can never carry money:
+        /// AmountUGX is hard-zero, so the double-count is unrepresentable
+        /// rather than merely discouraged.
+        /// </summary>
+        public bool IsMemorandum;
+        public string MemorandumNote = "";
+
         /// <summary>Derived — see the file header. Rounded to whole UGX.</summary>
-        public double AmountUGX => Math.Round(OrderQuantity * RateUGX, 0);
+        public double AmountUGX => IsMemorandum ? 0 : Math.Round(OrderQuantity * RateUGX, 0);
 
         /// <summary>True when no rate could be resolved for this commodity.</summary>
         public bool IsUnpriced => RateUGX <= 0;

--- a/StingTools/Core/MaterialSchedule/Reconciler.cs
+++ b/StingTools/Core/MaterialSchedule/Reconciler.cs
@@ -96,14 +96,24 @@ namespace StingTools.Core.MaterialSchedule
             if (doc.Options == null || !doc.Options.ShowPrices) return;
 
             foreach (var stage in doc.Stages)
-                foreach (var c in stage.Commodities.Where(x => x.IsUnpriced))
+                // A memorandum row is unpriced BY DESIGN — its constituents carry
+                // the money. Flagging it as missing a rate is what invited the
+                // double-count this marking exists to prevent.
+                foreach (var c in stage.Commodities.Where(x => x.IsUnpriced && !x.IsMemorandum))
                     rec.Issues.Add(new ReconciliationIssue
                     {
                         Code = "R3",
                         StageId = stage.StageId,
                         CommodityKey = c.CommodityKey,
+                        // Name the key and the file. 47 door and window rows came
+                        // back unpriced in one export; "has no rate" alone leaves
+                        // the reader to work out WHERE a rate goes, and the key is
+                        // a 70-character Revit type name nobody will retype from
+                        // memory.
                         Message = $"'{c.Description}' ({c.OrderQuantity:N0} {c.SupplierUnit}) in "
-                                + $"{stage.Title} has no rate. It will total zero in a priced schedule."
+                                + $"{stage.Title} has no rate. It will total zero in a priced schedule. "
+                                + $"Add a row keyed '{c.CommodityKey}' to "
+                                + "_BIM_COORD/commodity_rates.csv to price it."
                     });
         }
 
@@ -124,7 +134,8 @@ namespace StingTools.Core.MaterialSchedule
                         CommodityKey = c.CommodityKey,
                         Message = $"'{c.Description}' stayed in measured units ({c.SupplierUnit}) — "
                                 + c.ConversionNote
-                                + ". Extend the rule's type patterns to convert it, or price it as measured."
+                                + ". Add the type name to that rule's matchTypePatterns in "
+                                + "_BIM_COORD/supplier_units.json to convert it, or price it as measured."
                     });
         }
 
@@ -140,8 +151,12 @@ namespace StingTools.Core.MaterialSchedule
                             Code = "R4",
                             StageId = stage.StageId,
                             CommodityKey = c.CommodityKey,
-                            Message = $"'{c.Description}': order quantity {c.OrderQuantity:N2} is below the "
-                                    + $"net measured {c.NetQuantity:N2}. Wastage can only add."
+                            // 4 dp, not 2: at 2 dp this printed "order quantity
+                            // 174.60 is below the net measured 174.60", which
+                            // reads as a false alarm and buried a real (if tiny)
+                            // under-order behind its own rounding.
+                            Message = $"'{c.Description}': order quantity {c.OrderQuantity:N4} is below the "
+                                    + $"net measured {c.NetQuantity:N4}. Wastage can only add."
                         });
 
                     if (c.WastagePct < 0)

--- a/StingTools/Core/MaterialSchedule/StageMapper.cs
+++ b/StingTools/Core/MaterialSchedule/StageMapper.cs
@@ -24,6 +24,18 @@ namespace StingTools.Core.MaterialSchedule
         public List<string> ConstituentKinds = new List<string>();
         /// <summary>Revit category display names routed here.</summary>
         public List<string> Categories = new List<string>();
+
+        /// <summary>
+        /// Type-name / description substrings routed here, checked AFTER the
+        /// constituent kind and BEFORE the category.
+        ///
+        /// Category alone routes the element, and an element's category often
+        /// says nothing about the work it belongs to: the first real export put
+        /// `2022_RoofCap_Eagle_HighProfileTiles` and a gate in SUPERSTRUCTURE
+        /// because that is where their categories point. A kind still wins —
+        /// a roof-shaped name must not drag real concrete out of the frame.
+        /// </summary>
+        public List<string> TypePatterns = new List<string>();
         /// <summary>When set, only rows on these level codes route here.</summary>
         public List<string> LevelCodes = new List<string>();
     }
@@ -56,6 +68,21 @@ namespace StingTools.Core.MaterialSchedule
         /// A blank pattern is inert, never a wildcard.
         /// </summary>
         public List<string> ExcludedDescriptionPatterns = new List<string>();
+
+        /// <summary>
+        /// Categories a description pattern may NEVER exclude. The first real
+        /// export dropped one Windows row as not-a-material while keeping twelve
+        /// others: some pattern written for Generic Models voids matched a real
+        /// window type. A door or a window is always bought, whatever it is
+        /// called, so the category outranks the pattern.
+        /// </summary>
+        public List<string> ExclusionProtectedCategories = new List<string>();
+
+        /// <summary>
+        /// Intermediate measures and the constituents bought in their place.
+        /// See <see cref="IntermediateMeasureMarker"/>.
+        /// </summary>
+        public List<IntermediateMeasureRule> IntermediateMeasures = new List<IntermediateMeasureRule>();
     }
 
     /// <summary>
@@ -77,6 +104,10 @@ namespace StingTools.Core.MaterialSchedule
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, string> _byLevel =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Ordered, not a dictionary: these are substring tests, and first-wins
+        // in stage Order is the same precedence every other lookup here uses.
+        private readonly List<KeyValuePair<string, string>> _byTypePattern =
+            new List<KeyValuePair<string, string>>();
         private readonly string _default;
 
         private StageIndex(string defaultStageId) { _default = defaultStageId ?? ""; }
@@ -95,6 +126,9 @@ namespace StingTools.Core.MaterialSchedule
                 Seed(ix._byKind, d.ConstituentKinds, d.StageId);
                 Seed(ix._byCategory, d.Categories, d.StageId);
                 Seed(ix._byLevel, d.LevelCodes, d.StageId);
+                foreach (string p in d.TypePatterns ?? new List<string>())
+                    if (!string.IsNullOrWhiteSpace(p))
+                        ix._byTypePattern.Add(new KeyValuePair<string, string>(p.Trim(), d.StageId));
             }
             return ix;
         }
@@ -110,9 +144,25 @@ namespace StingTools.Core.MaterialSchedule
         /// <summary>Kind → category → level → the caller's default. An unmatched
         /// row is never dropped; it lands in the default so it stays countable.</summary>
         public string Resolve(string constituentKind, string category, string levelCode)
+            => Resolve(constituentKind, category, levelCode, null);
+
+        /// <summary>
+        /// Kind → type pattern → category → level → the caller's default.
+        /// <paramref name="typeText"/> is the type name and description joined;
+        /// pass null and this behaves exactly as the three-argument overload.
+        /// </summary>
+        public string Resolve(string constituentKind, string category, string levelCode, string typeText)
         {
             if (!string.IsNullOrWhiteSpace(constituentKind)
                 && _byKind.TryGetValue(constituentKind.Trim(), out string s)) return s;
+
+            if (!string.IsNullOrWhiteSpace(typeText) && _byTypePattern.Count > 0)
+            {
+                foreach (var kv in _byTypePattern)
+                    if (typeText.IndexOf(kv.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                        return kv.Value;
+            }
+
             if (!string.IsNullOrWhiteSpace(category)
                 && _byCategory.TryGetValue(category.Trim(), out s)) return s;
             if (!string.IsNullOrWhiteSpace(levelCode)

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -156,11 +156,21 @@ namespace StingTools.Core.MaterialSchedule
     public static class SupplierUnitConverter
     {
         /// <summary>
-        /// 2 dp, away from zero — so a divisible order never rounds DOWN below
-        /// what was measured and quietly under-orders.
+        /// 2 dp, rounded UP.
+        ///
+        /// This used to be Math.Round(v, 2, MidpointRounding.AwayFromZero) with a
+        /// comment claiming a divisible order could never fall below what was
+        /// measured. That was wrong, and the first real export proved it:
+        /// AwayFromZero only decides TIES, so 174.6044 became 174.60 and rule R4
+        /// fired with "order quantity 174.60 is below the net measured 174.60" —
+        /// true, unreadable at 2 dp, and a genuine under-order.
+        ///
+        /// Ceiling makes the documented contract hold for every value, not only
+        /// for ties: order >= net, always. The 1e-9 nudge keeps a value already
+        /// at 2 dp from being pushed a cent higher by binary representation.
         /// </summary>
         private static double RoundDivisible(double v)
-            => Math.Round(v, 2, MidpointRounding.AwayFromZero);
+            => Math.Ceiling(v * 100.0 - 1e-9) / 100.0;
 
         public static SupplierUnitResult Convert(SupplierUnitRule rule, double sourceQuantity)
         {
@@ -180,10 +190,11 @@ namespace StingTools.Core.MaterialSchedule
             double waste = Math.Max(0, rule.DefaultWastagePct);
             double order = net * (1.0 + waste / 100.0);
             // Countable units round UP — you cannot buy 2.08 truck trips.
-            // Divisible units round to 2 dp: order quantity is what someone
+            // Divisible units round UP to 2 dp: order quantity is what someone
             // purchases and what the amount is computed from, so raw binary
             // floats would otherwise print as "164.48145 m³" and drag fractions
-            // of a shilling into the money column.
+            // of a shilling into the money column. Both directions round UP, so
+            // an order can never sit below the measured net.
             order = rule.RoundUpToWhole ? Math.Ceiling(order - 1e-9) : RoundDivisible(order);
 
             return new SupplierUnitResult

--- a/StingTools/Data/STING_MATERIAL_STAGES.json
+++ b/StingTools/Data/STING_MATERIAL_STAGES.json
@@ -48,7 +48,7 @@
     {
       "stageId": "tools",
       "title": "TOOLS AND EQUIPMENT",
-      "preamble": "Site establishment tools and small plant. Manual rows only — no modelled source.",
+      "preamble": "Site establishment tools and small plant. Manual rows only â€” no modelled source.",
       "order": 10,
       "constituentKinds": [],
       "categories": [],
@@ -102,7 +102,16 @@
       "categories": [
         "Roofs"
       ],
-      "levelCodes": []
+      "levelCodes": [],
+      "typePatterns": [
+        "roofcap",
+        "roof cap",
+        "roof-cap",
+        "roofing",
+        "ridge",
+        "barge board",
+        "fascia"
+      ]
     },
     {
       "stageId": "doors-windows",
@@ -167,11 +176,53 @@
       "order": 90,
       "constituentKinds": [],
       "categories": [
-        "Site",
-        "Hardscape",
-        "Parking"
+        "Hardscape"
       ],
-      "levelCodes": []
+      "levelCodes": [],
+      "typePatterns": [
+        "gate",
+        "fence",
+        "bollard",
+        "kerb",
+        "paving",
+        "manhole"
+      ]
+    }
+  ],
+  "exclusionProtectedCategories": [
+    "Doors",
+    "Windows"
+  ],
+  "intermediateMeasures": [
+    {
+      "kind": "blockwork",
+      "children": [
+        "block_units"
+      ],
+      "note": "blockwork area; bought as blocks and mortar below"
+    },
+    {
+      "kind": "brickwork",
+      "children": [
+        "brick_units"
+      ],
+      "note": "brickwork area; bought as bricks and mortar below"
+    },
+    {
+      "kind": "mortar",
+      "children": [
+        "mortar_cement",
+        "mortar_sand"
+      ],
+      "note": "mortar volume; bought as cement and sand below"
+    },
+    {
+      "kind": "plaster",
+      "children": [
+        "plaster_cement",
+        "plaster_sand"
+      ],
+      "note": "plastered area; bought as cement and sand below"
     }
   ]
 }


### PR DESCRIPTION
The export produced materials for the first time. Producing them showed six things wrong — every one invisible until a real model ran.

### 1. R4 was right; my comment was wrong

Three rows reported *"order quantity 174.60 is below the net measured 174.60"*. That reads as a false alarm and is not one — the model held **174.6044**. `MidpointRounding.AwayFromZero` decides only **ties**, yet the comment claimed it meant a divisible order could never round down below what was measured. Ceiling at 2 dp makes the documented contract hold for every value.

The test that should have caught this asserted `order >= Math.Round(net, 2)` — the rounding under test. **A gate compared against its own transformation cannot fail.** It now compares against the raw net, with the 174.6044 case from the export.

### 2. Intermediate measures were priceable — the only defect that could cost money

```
Blockwork wall     175 m²    (no rate)   ← R3: "has no rate. It will total zero"
Hollow blocks 8"   2,292 No. @ 2,500
```

Same wall, two lines, and R3 telling the reader to price the first. Blockwork/brickwork area, mortar and plaster volume are now **memoranda**: quantity kept (it is how the derived count is checked), `AmountUGX` hard-zero, no rate cell, no formula, skipped by R3.

Marking is **conditional on the children actually being present**. A project whose data yields no block count keeps its blockwork priceable — turning a double-count into an omission is worse, because a duplicated line is arguable and a missing one is invisible.

### 3. Roofs decomposed into nothing

856 m² of 225 mm roof arrived as three unpriced area rows: not sheets, not tiles, and no concrete offered to price instead. A concrete roof slab is a slab, and now decomposes like one.

Unlike the Floors path this requires an **explicit** concrete material. An unassigned floor is almost always a slab; an unassigned roof is as likely to be sheeting, and calling that concrete would invent 137 m³ that does not exist.

### 4–6, and the rest

- **Stage type patterns** — a roof cap and a gate were filed under SUPERSTRUCTURE because that is where their categories point. Checked after the constituent kind, so a roof-shaped *name* cannot drag real concrete out of the frame.
- **Doors and windows outrank exclusion patterns** — one Windows row was dropped while twelve were kept; a pattern written for Generic Models voids matched a real window type.
- **R3/R5 name the override file and the exact key** — 47 unpriced rows keyed by 70-character Revit type names.
- `m3`/`m2` render superscripted; one export printed both spellings two rows apart.
- ELEMENT 08 no longer routes `Site` and `Parking`, which `excludedCategories` drops before routing could reach them — dead config, same class as MATSCHED-3b.

### Verification

Tests **351 → 367**, all passing. Plugin builds **0 warnings / 0 errors**.

Confirmed *by* this export and unchanged here: wastage applies exactly once (all eight conversions re-derived by hand), and the block-vs-mortar wall area now reconciles exactly — 174.60 + 389.62 = 564.22 m², plaster 1,128.45 = 2 × 564.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)