### PR TITLE
Measure tiling from the finish layer (MATSCHED-3)

### DIFF
--- a/StingTools.Boq.Tests/TilingTakeoffTests.cs
+++ b/StingTools.Boq.Tests/TilingTakeoffTests.cs
@@ -1,0 +1,219 @@
+using System.Linq;
+using StingTools.BOQ.Takeoff;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED-3 — tiling.
+    ///
+    /// The first attempt matched a whole ELEMENT from the unit table and priced
+    /// entire floors as tiling; it was withdrawn. Tiling is measured from the
+    /// host's own finish LAYER instead, so a floor that carries no tiled layer
+    /// produces no tiling at all rather than a confident wrong number.
+    ///
+    /// These pin the engine half. The layer READ is Revit-side and cannot run
+    /// here — see MATSCHED-3's remaining note.
+    /// </summary>
+    public class TilingTakeoffTests
+    {
+        private static TiledFinishInput Floor(double area) => new TiledFinishInput
+        {
+            AreaM2 = area, IsWall = false, TileLabel = "Ceramic Tile",
+            AdhesiveKgPerM2 = 4.5, GroutKgPerM2 = 0.5
+        };
+
+        [Fact]
+        public void Tiling_Emits_Tile_Adhesive_And_Grout()
+        {
+            var lines = CompoundTakeoff.TiledFinish(Floor(100));
+
+            Assert.Equal(100, lines.Single(l => l.Kind == "floor_tile").Quantity);
+            Assert.Equal(450, lines.Single(l => l.Kind == "tile_adhesive").Quantity);
+            Assert.Equal(50, lines.Single(l => l.Kind == "tile_grout").Quantity);
+        }
+
+        [Fact]
+        public void Wall_And_Floor_Tiling_Are_Different_Commodities()
+        {
+            // Different products at different rates, bought in different box
+            // sizes — merging them would average two prices into one wrong one.
+            var f = Floor(10);
+            var w = Floor(10); w.IsWall = true;
+
+            Assert.Contains(CompoundTakeoff.TiledFinish(f), l => l.Kind == "floor_tile");
+            Assert.Contains(CompoundTakeoff.TiledFinish(w), l => l.Kind == "wall_tile");
+        }
+
+        [Fact]
+        public void No_Area_Means_No_Tiling()
+        {
+            Assert.Empty(CompoundTakeoff.TiledFinish(Floor(0)));
+            Assert.Empty(CompoundTakeoff.TiledFinish(Floor(-5)));
+        }
+
+        [Fact]
+        public void Quantities_Are_Net_Of_Wastage()
+        {
+            // Tiles carry the largest allowance in the schedule (cuts at every
+            // edge and penetration), which is exactly why it belongs to the
+            // supplier-unit rule where it is visible and arguable — not baked in
+            // here, where it would be applied twice as it was for blocks.
+            var lines = CompoundTakeoff.TiledFinish(Floor(100));
+
+            Assert.Equal(100, lines.Single(l => l.Kind == "floor_tile").Quantity);
+        }
+
+        [Fact]
+        public void Missing_Coverage_Figures_Emit_Tiles_But_No_Consumables()
+        {
+            // A material with no row in MATERIAL_LOOKUP must not silently invent
+            // adhesive from a zero rate.
+            var t = Floor(50); t.AdhesiveKgPerM2 = 0; t.GroutKgPerM2 = 0;
+
+            var lines = CompoundTakeoff.TiledFinish(t);
+
+            Assert.Single(lines);
+            Assert.Equal("floor_tile", lines[0].Kind);
+        }
+
+        // ── the paint interaction ────────────────────────────────────────
+
+        private static MasonryWallInput Wall(int plasterFaces, int tiledFaces) => new MasonryWallInput
+        {
+            FaceAreaM2 = 100, PlasterFaces = plasterFaces, TiledFaces = tiledFaces,
+            PlasterThicknessM = 0.012, IsExteriorWall = false
+        };
+
+        [Fact]
+        public void A_Tiled_Face_Is_Not_Painted()
+        {
+            // Plastered both sides, tiled one: 100 m2 of paint, not 200.
+            var lines = CompoundTakeoff.MasonryWall(Wall(2, 1));
+
+            Assert.Equal(100, lines.Single(l => l.Kind == "paint_interior").Quantity);
+            // The backing plaster still covers BOTH faces — a tiled wall is
+            // plastered before it is tiled.
+            Assert.Equal(200, lines.Single(l => l.Kind == "plaster").Quantity);
+        }
+
+        [Fact]
+        public void A_Fully_Tiled_Wall_Emits_No_Paint_Row_At_All()
+        {
+            var lines = CompoundTakeoff.MasonryWall(Wall(2, 2));
+
+            Assert.DoesNotContain(lines, l => l.Kind == "paint_interior" || l.Kind == "paint_exterior");
+        }
+
+        [Fact]
+        public void More_Tiled_Faces_Than_Plastered_Never_Yields_Negative_Paint()
+        {
+            var lines = CompoundTakeoff.MasonryWall(Wall(1, 2));
+
+            Assert.DoesNotContain(lines, l => l.Kind.StartsWith("paint"));
+            Assert.All(lines, l => Assert.True(l.Quantity >= 0));
+        }
+
+        [Fact]
+        public void An_Untiled_Wall_Paints_Exactly_As_Before()
+        {
+            var lines = CompoundTakeoff.MasonryWall(Wall(2, 0));
+
+            Assert.Equal(200, lines.Single(l => l.Kind == "paint_interior").Quantity);
+        }
+    }
+
+    /// <summary>
+    /// MAT-SCHED-3 — the seam between the tiling code and the three data files
+    /// it depends on. Each is valid on its own; only a comparison catches a key
+    /// the builder composes one way and the CSV spells another, which fails
+    /// silently at runtime as a zero coverage and no adhesive row.
+    /// </summary>
+    public class TilingShippedDataTests
+    {
+        private static string DataFile(string name) =>
+            System.IO.Path.Combine(System.AppContext.BaseDirectory, "Data", name);
+
+        private static System.Collections.Generic.Dictionary<string, StingTools.UI.MaterialLookupRow> Lookup() =>
+            StingTools.UI.MaterialLookupParser.Parse(System.IO.File.ReadAllLines(DataFile("MATERIAL_LOOKUP.csv")));
+
+        [Theory]
+        [InlineData("TILE CERAMIC")]
+        [InlineData("TILE PORCELAIN")]
+        [InlineData("TILE STONE")]
+        [InlineData("TILE TERRAZZO")]
+        [InlineData("TILE MOSAIC")]
+        [InlineData("TILE DEFAULT")]
+        public void Every_Tile_Key_The_Builder_Composes_Resolves_To_Real_Coverages(string key)
+        {
+            // The builder asks for exactly these keys — "TILE " + TileKeyFor(material).
+            // A typo here is not a compile error and not a load error; it is a
+            // zero, and a zero silently drops the adhesive and grout rows.
+            var row = Lookup()[key];
+
+            Assert.True(row.Properties["ADHESIVE_KG_PER_M2"] > 0, key + " has no adhesive rate");
+            Assert.True(row.Properties["GROUT_KG_PER_M2"] > 0, key + " has no grout rate");
+        }
+
+        [Fact]
+        public void Adhesive_Coverage_Stays_In_A_Believable_Band()
+        {
+            // 2-10 kg/m2 spans a 4mm notch for mosaic to a 10mm notch for large
+            // format. A figure outside it is a data-entry slip, not a product.
+            foreach (var key in new[] { "TILE CERAMIC", "TILE PORCELAIN", "TILE STONE", "TILE TERRAZZO", "TILE MOSAIC", "TILE DEFAULT" })
+            {
+                double kg = Lookup()[key].Properties["ADHESIVE_KG_PER_M2"];
+                Assert.InRange(kg, 2.0, 10.0);
+            }
+        }
+
+        [Fact]
+        public void Every_Tiling_Kind_Routes_To_A_Finishes_Stage()
+        {
+            // Tiling is a finish. The regression this guards is real and shipped
+            // once: category-matched finish rules inherited the ELEMENT's stage
+            // and filed wall paint under SUPERSTRUCTURE.
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<StingTools.Core.MaterialSchedule.StageLibrary>(
+                System.IO.File.ReadAllText(DataFile("STING_MATERIAL_STAGES.json")));
+            var ix = StingTools.Core.MaterialSchedule.StageIndex.Build(lib.Stages, lib.DefaultStageId);
+
+            foreach (string kind in new[] { "floor_tile", "wall_tile", "tile_adhesive", "tile_grout" })
+                Assert.Equal("finishes", ix.Resolve(kind, "Floors", ""));
+        }
+
+        [Fact]
+        public void Every_Tiling_Kind_Has_A_Supplier_Rule_And_A_Rate()
+        {
+            var units = Newtonsoft.Json.JsonConvert.DeserializeObject<StingTools.Core.MaterialSchedule.SupplierUnitTable>(
+                System.IO.File.ReadAllText(DataFile("STING_SUPPLIER_UNITS.json")));
+            var rates = StingTools.Core.MaterialSchedule.CommodityRateResolver.ParseCsv(
+                System.IO.File.ReadAllLines(DataFile("STING_COMMODITY_RATES.csv")), out _);
+            var resolver = new StingTools.Core.MaterialSchedule.CommodityRateResolver(rates, null);
+
+            foreach (string kind in new[] { "floor_tile", "wall_tile", "tile_adhesive", "tile_grout" })
+            {
+                var rule = units.ResolveByKind(kind);
+                Assert.True(rule != null, "no supplier-unit rule matches kind " + kind);
+                Assert.True(resolver.Resolve(rule.CommodityKey).RateUGX > 0,
+                    "commodity " + rule.CommodityKey + " has no baseline rate");
+            }
+        }
+
+        [Fact]
+        public void A_Tile_Rule_Buys_By_The_Unit_It_Is_Measured_In()
+        {
+            // The unit guard added in MATSCHED-10 REFUSES to convert when a
+            // rule's sourceUnit disagrees with the measured unit — so a tile
+            // rule declaring anything but m2 would silently stop converting and
+            // print bare square metres instead of boxes.
+            var units = Newtonsoft.Json.JsonConvert.DeserializeObject<StingTools.Core.MaterialSchedule.SupplierUnitTable>(
+                System.IO.File.ReadAllText(DataFile("STING_SUPPLIER_UNITS.json")));
+
+            Assert.Equal("m2", units.ResolveByKind("floor_tile").SourceUnit);
+            Assert.Equal("m2", units.ResolveByKind("wall_tile").SourceUnit);
+            Assert.Equal("kg", units.ResolveByKind("tile_adhesive").SourceUnit);
+            Assert.Equal("kg", units.ResolveByKind("tile_grout").SourceUnit);
+        }
+    }
+
+}

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -24,7 +24,8 @@ namespace StingTools.BOQ.Takeoff
         public string Kind;         // "blockwork" | "brickwork" | "units" | "mortar" |
                                     // "mortar_cement" | "mortar_sand" | "plaster" |
                                     // "plaster_cement" | "plaster_sand" | "concrete" |
-                                    // "rebar" | "formwork"
+                                    // "rebar" | "formwork" | "floor_tile" |
+                                    // "wall_tile" | "tile_adhesive" | "tile_grout"
         public string Description;
         public string Unit;         // "m2" | "m3" | "nr" | "kg" | "bag"
         public double Quantity;
@@ -56,6 +57,36 @@ namespace StingTools.BOQ.Takeoff
         /// different products at different prices, so they are separate
         /// commodities. Read from WallType.Function by the Revit-side builder.</summary>
         public bool IsExteriorWall;
+
+        /// <summary>
+        /// Faces carrying a TILED finish (0-2), read from the wall type's
+        /// compound structure. Those faces are plastered as a backing but NOT
+        /// painted — you do not paint a tiled wall — so they are deducted from
+        /// the painted area. Without this the same face is finished twice.
+        /// </summary>
+        public int TiledFaces;
+    }
+
+    /// <summary>
+    /// MAT-SCHED — tiling, measured from the host's own finish LAYER.
+    ///
+    /// A floor's tiled area is not its slab area and cannot be inferred from
+    /// one: the RC-slab path knows only concrete, rebar and formwork, and has
+    /// no way to say whether a floor is tiled at all. An earlier attempt to
+    /// convert whole ELEMENTS to tiles from a unit table was withdrawn for
+    /// exactly that reason — it priced entire floors as tiling.
+    ///
+    /// The compound structure answers it directly: a Finish1/Finish2 layer whose
+    /// material reads as tile IS the tiled area, and its absence means the
+    /// surface is not tiled.
+    /// </summary>
+    public struct TiledFinishInput
+    {
+        public double AreaM2;            // net tiled area — one face, not the element
+        public bool IsWall;              // wall tiling and floor tiling are different products
+        public string TileLabel;         // material name, for the description
+        public double AdhesiveKgPerM2;   // manufacturer spreading rate
+        public double GroutKgPerM2;      // joint width / tile size dependent
     }
 
     public struct RcElementInput
@@ -186,10 +217,15 @@ namespace StingTools.BOQ.Takeoff
                 // over-application), exactly as it does for plaster.
                 // An unplastered wall is not painted: this whole branch is
                 // guarded by PlasterFaces > 0.
-                lines.Add(new CompoundLine(
-                    m.IsExteriorWall ? "paint_exterior" : "paint_interior",
-                    m.IsExteriorWall ? "Paint — exterior (weather-guard)" : "Paint — interior",
-                    "m2", plasterArea, SecPlaster));
+                // A tiled face is plastered as backing but never painted, so it
+                // comes off the painted area. Clamped at 0: a wall tiled on more
+                // faces than it is plastered on must not emit NEGATIVE paint.
+                int paintedFaces = Math.Max(0, m.PlasterFaces - Math.Max(0, m.TiledFaces));
+                if (paintedFaces > 0)
+                    lines.Add(new CompoundLine(
+                        m.IsExteriorWall ? "paint_exterior" : "paint_interior",
+                        m.IsExteriorWall ? "Paint — exterior (weather-guard)" : "Paint — interior",
+                        "m2", area * paintedFaces, SecPlaster));
             }
 
             // 5. Formwork for an RC wall (both faces).
@@ -333,6 +369,39 @@ namespace StingTools.BOQ.Takeoff
                 RebarBandKgPerM3 = f.IsBlinding ? 0 : f.RebarBandKgPerM3,
                 FormworkM2 = formwork
             });
+        }
+
+        /// <summary>
+        /// MAT-SCHED — tiling constituents for ONE tiled face or floor.
+        ///
+        /// Quantities are NET of wastage; the supplier-unit rule owns the
+        /// allowance, as it does for every other constituent. Tiles carry the
+        /// largest allowance of anything in the schedule (cuts at every edge and
+        /// every penetration), which is precisely why it belongs in one visible,
+        /// arguable place rather than baked in here.
+        ///
+        /// Skirting is NOT measured: it runs to a room's PERIMETER, which a
+        /// floor's area cannot yield. Deriving it from area would be a guess.
+        /// </summary>
+        public static List<CompoundLine> TiledFinish(TiledFinishInput t)
+        {
+            var lines = new List<CompoundLine>();
+            double area = Math.Max(0, t.AreaM2);
+            if (area <= 0) return lines;
+
+            string label = string.IsNullOrWhiteSpace(t.TileLabel) ? "tiling" : t.TileLabel.Trim();
+            lines.Add(new CompoundLine(t.IsWall ? "wall_tile" : "floor_tile",
+                t.IsWall ? $"Wall tiling — {label}" : $"Floor tiling — {label}",
+                "m2", area, SecPlaster));
+
+            if (t.AdhesiveKgPerM2 > 0)
+                lines.Add(new CompoundLine("tile_adhesive", "Tile adhesive", "kg",
+                    area * t.AdhesiveKgPerM2, SecPlaster));
+            if (t.GroutKgPerM2 > 0)
+                lines.Add(new CompoundLine("tile_grout", "Tile grout", "kg",
+                    area * t.GroutKgPerM2, SecPlaster));
+
+            return lines;
         }
 
         public static List<CompoundLine> RcElement(RcElementInput r)

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -191,9 +191,15 @@ namespace StingTools.BOQ.Takeoff
                 PlasterCementBagsPerM3 = plasterCement,
                 PlasterSandRatio = plasterSand,
                 IsRcWall = isRc,
-                IsExteriorWall = IsExteriorWall(doc, el)
+                IsExteriorWall = IsExteriorWall(doc, el),
+                // Deducted from the PAINTED area inside the engine — a tiled face
+                // is plastered as backing but never painted.
+                TiledFaces = ReadTiledFinish(doc, el).Faces
             };
             var constituents = CompoundTakeoff.MasonryWall(input);
+            // Up to both faces: unlike a floor, a wall can be tiled on each side,
+            // and the compound structure names one finish layer per side.
+            constituents.AddRange(TilingConstituents(doc, el, areaM2, isWall: true, faces: 2));
             if (constituents.Count == 0) return null;
             return Materialise(doc, el, constituents, csvRates, isRc ? "S" : "A", res);
         }
@@ -207,12 +213,26 @@ namespace StingTools.BOQ.Takeoff
             bool isConcrete = material.Contains("concrete") || material.Contains("rc");
             // Blank material reads as concrete for a FLOOR and as unknown for a
             // roof — see the Roofs branch in TryBuild.
-            if (!isConcrete && (requireExplicitConcrete || material.Length != 0))
-                return null;   // non-RC floor (timber deck etc.) → composite fallback
+            bool isRc = isConcrete || !(requireExplicitConcrete || material.Length != 0);
+
+            double areaM2 = ReadAreaM2(el);
+
+            // Tiling is read from the finish LAYER, so it survives a floor whose
+            // structure this path will not measure: a timber or screeded deck
+            // still has a tiled area, and dropping the element wholesale would
+            // lose it. MAT-SCHED-3.
+            var tiling = TilingConstituents(doc, el, areaM2, isWall: false, faces: 1);
+
+            if (!isRc)
+                return tiling.Count > 0
+                    ? Materialise(doc, el, tiling, csvRates, "A", new Resolution())
+                    : null;   // non-RC, untiled floor → composite fallback
 
             double grossM3 = ReadVolumeM3(el);
-            if (grossM3 <= 0) return null;
-            double areaM2 = ReadAreaM2(el);
+            if (grossM3 <= 0)
+                return tiling.Count > 0
+                    ? Materialise(doc, el, tiling, csvRates, "A", new Resolution())
+                    : null;
 
             // MAT-4 — parameter-driven net-concrete resolution.
             var net = Core.Materials.SlabSystemLoader.ResolveNetConcrete(doc, el, grossM3, areaM2);
@@ -239,6 +259,7 @@ namespace StingTools.BOQ.Takeoff
                     FormworkM2 = net.IsVoid ? 0 : areaM2  // don't take gross soffit for void slabs
                 });
             }
+            constituents.AddRange(tiling);
             if (constituents.Count == 0) return null;
             return Materialise(doc, el, constituents, csvRates, "S", new Resolution());
         }
@@ -605,6 +626,95 @@ namespace StingTools.BOQ.Takeoff
         private static string GetFamilyName(Document doc, Element el)
         {
             try { return ParameterHelpers.GetFamilyName(el); } catch { return ""; }
+        }
+
+
+        // ── Tiling from the finish layer (MAT-SCHED-3) ──────────────────────
+
+        /// <summary>
+        /// Material names that read as a tiled finish. Deliberately narrow: a
+        /// false positive prices a whole floor as tiling, which is the defect
+        /// the withdrawn unit-table rules produced.
+        /// </summary>
+        private static readonly System.Text.RegularExpressions.Regex TileMaterialPattern =
+            new System.Text.RegularExpressions.Regex(
+                @"tile|ceramic|porcelain|terrazzo|mosaic|vitrified|granite|marble",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase
+                | System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>Tiled finish layers on a host type: how many, and named by the first.</summary>
+        private static (int Faces, string Label) ReadTiledFinish(Document doc, Element el)
+        {
+            try
+            {
+                var hoa = doc?.GetElement(el.GetTypeId()) as HostObjAttributes;
+                var cs = hoa?.GetCompoundStructure();
+                var layers = cs?.GetLayers();
+                if (layers == null) return (0, "");
+
+                int faces = 0; string label = "";
+                foreach (var layer in layers)
+                {
+                    if (layer == null) continue;
+                    // Finish layers only. A tile is never Structure or Substrate,
+                    // and admitting those would count a screed as tiling.
+                    if (layer.Function != MaterialFunctionAssignment.Finish1
+                     && layer.Function != MaterialFunctionAssignment.Finish2) continue;
+                    if (layer.MaterialId == null || layer.MaterialId == ElementId.InvalidElementId) continue;
+                    if (!(doc.GetElement(layer.MaterialId) is Material mat)) continue;
+                    if (string.IsNullOrWhiteSpace(mat.Name)) continue;
+                    if (!TileMaterialPattern.IsMatch(mat.Name)) continue;
+
+                    faces++;
+                    if (label.Length == 0) label = mat.Name.Trim();
+                }
+                return (faces, label);
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("TileFinish", $"ReadTiledFinish {el?.Id}: {ex.Message}");
+                return (0, "");
+            }
+        }
+
+        /// <summary>
+        /// Tiling constituents for a host, or an empty list when it carries no
+        /// tiled finish layer. <paramref name="faces"/> caps how many of the
+        /// detected layers are measured — a floor is tiled on top only, however
+        /// many finish layers its type declares.
+        /// </summary>
+        private static List<CompoundLine> TilingConstituents(Document doc, Element el,
+            double areaM2, bool isWall, int faces)
+        {
+            var empty = new List<CompoundLine>();
+            if (areaM2 <= 0) return empty;
+
+            var found = ReadTiledFinish(doc, el);
+            if (found.Faces <= 0) return empty;
+
+            int measured = Math.Min(found.Faces, Math.Max(0, faces));
+            if (measured <= 0) return empty;
+
+            string key = TileKeyFor(found.Label);
+            return CompoundTakeoff.TiledFinish(new TiledFinishInput
+            {
+                AreaM2 = areaM2 * measured,
+                IsWall = isWall,
+                TileLabel = found.Label,
+                AdhesiveKgPerM2 = Prop($"TILE {key}", "ADHESIVE_KG_PER_M2", "TILE DEFAULT"),
+                GroutKgPerM2 = Prop($"TILE {key}", "GROUT_KG_PER_M2", "TILE DEFAULT")
+            });
+        }
+
+        /// <summary>Material name → MATERIAL_LOOKUP TypeKey. Unmatched falls to DEFAULT.</summary>
+        private static string TileKeyFor(string materialName)
+        {
+            string n = (materialName ?? "").ToLowerInvariant();
+            if (n.Contains("porcelain") || n.Contains("vitrified")) return "PORCELAIN";
+            if (n.Contains("terrazzo")) return "TERRAZZO";
+            if (n.Contains("granite") || n.Contains("marble")) return "STONE";
+            if (n.Contains("mosaic")) return "MOSAIC";
+            return "CERAMIC";
         }
 
         private static double Prop(string key, string property, string fallbackKey)

--- a/StingTools/Data/MATERIAL_LOOKUP.csv
+++ b/StingTools/Data/MATERIAL_LOOKUP.csv
@@ -378,3 +378,20 @@ TIMBER,SOFTWOOD,CARBON_FOSSIL_KG_M3,126,kgCO₂/m³,ICE v3.0 sawn softwood A1-A3
 TIMBER,SOFTWOOD,CARBON_BIOGENIC_KG_M3,-787,kgCO₂/m³,ICE v3.0 sequestration -1.64 kg/kg × 480
 TIMBER,SOFTWOOD,CARBON_KG_PER_M3,-661,kgCO₂/m³,net = fossil + biogenic (Z-25 split)
 TIMBER,SOFTWOOD,DENSITY_KG_M3,480,kg/m³,corrected softwood density (CIBSE 420-550, Z-23)
+# --- TILE: adhesive spreading rate and grout consumption (MAT-SCHED-3) -------
+# Adhesive is manufacturer coverage for a cementitious adhesive at the notch
+# size that tile size needs; bigger tiles need a bigger notch and more adhesive.
+# Grout scales with JOINT LENGTH per m2, which is why mosaic is 3x ceramic.
+# Both are editable: re-price and re-rate per project.
+TILE,CERAMIC,ADHESIVE_KG_PER_M2,4.5,kg/m2,Ceramic 300x300-400x400 at 6mm notch
+TILE,CERAMIC,GROUT_KG_PER_M2,0.5,kg/m2,2-3mm joints
+TILE,PORCELAIN,ADHESIVE_KG_PER_M2,6,kg/m2,Porcelain 600x600+ at 10mm notch
+TILE,PORCELAIN,GROUT_KG_PER_M2,0.4,kg/m2,Fewer joints per m2 on large format
+TILE,STONE,ADHESIVE_KG_PER_M2,6,kg/m2,Granite / marble slabs at 10mm notch
+TILE,STONE,GROUT_KG_PER_M2,0.4,kg/m2,Narrow joints
+TILE,TERRAZZO,ADHESIVE_KG_PER_M2,5,kg/m2,Terrazzo tile at 8mm notch
+TILE,TERRAZZO,GROUT_KG_PER_M2,0.5,kg/m2,2-3mm joints
+TILE,MOSAIC,ADHESIVE_KG_PER_M2,3.5,kg/m2,Mosaic sheet at 4mm notch
+TILE,MOSAIC,GROUT_KG_PER_M2,1.5,kg/m2,Joint length per m2 is several times a 300mm tile
+TILE,DEFAULT,ADHESIVE_KG_PER_M2,4.5,kg/m2,Default: ceramic at 6mm notch
+TILE,DEFAULT,GROUT_KG_PER_M2,0.5,kg/m2,Default: 2-3mm joints

--- a/StingTools/Data/STING_COMMODITY_RATES.csv
+++ b/StingTools/Data/STING_COMMODITY_RATES.csv
@@ -29,3 +29,7 @@ panga,No.,10000,Panga
 sledge-hammer,No.,100000,Sledge hammer
 string-rope,Rolls,10000,Strings and ropes
 water-tank,No.,75000,Water tank 200 litre
+floor-tile,Boxes,55000,Ceramic floor tile 600x600 box of 4 (1.44 m2)
+wall-tile,Boxes,45000,Ceramic wall tile 300x600 box of 8 (1.44 m2)
+tile-adhesive,Bags,35000,Cementitious tile adhesive 20kg bag
+tile-grout,Bags,25000,Tile grout 5kg bag

--- a/StingTools/Data/STING_MATERIAL_STAGES.json
+++ b/StingTools/Data/STING_MATERIAL_STAGES.json
@@ -135,7 +135,11 @@
         "plaster_cement",
         "plaster_sand",
         "paint_interior",
-        "paint_exterior"
+        "paint_exterior",
+        "floor_tile",
+        "wall_tile",
+        "tile_adhesive",
+        "tile_grout"
       ],
       "categories": [
         "Ceilings"

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -184,6 +184,70 @@
       "matchCategories": [],
       "matchTypePatterns": [],
       "stageId": ""
+    },
+    {
+      "commodityKey": "floor-tile",
+      "description": "Floor tiles",
+      "spec": "600x600 (4 pcs = 1.44 m2 per box)",
+      "supplierUnit": "Boxes",
+      "sourceUnit": "m2",
+      "sourceUnitsPerSupplierUnit": 1.44,
+      "roundUpToWhole": true,
+      "defaultWastagePct": 10,
+      "matchKinds": [
+        "floor_tile"
+      ],
+      "matchCategories": [],
+      "matchTypePatterns": [],
+      "stageId": ""
+    },
+    {
+      "commodityKey": "wall-tile",
+      "description": "Wall tiles",
+      "spec": "300x600 (8 pcs = 1.44 m2 per box)",
+      "supplierUnit": "Boxes",
+      "sourceUnit": "m2",
+      "sourceUnitsPerSupplierUnit": 1.44,
+      "roundUpToWhole": true,
+      "defaultWastagePct": 10,
+      "matchKinds": [
+        "wall_tile"
+      ],
+      "matchCategories": [],
+      "matchTypePatterns": [],
+      "stageId": ""
+    },
+    {
+      "commodityKey": "tile-adhesive",
+      "description": "Tile adhesive",
+      "spec": "cementitious, 20 kg bag",
+      "supplierUnit": "Bags",
+      "sourceUnit": "kg",
+      "sourceUnitsPerSupplierUnit": 20.0,
+      "roundUpToWhole": true,
+      "defaultWastagePct": 0,
+      "matchKinds": [
+        "tile_adhesive"
+      ],
+      "matchCategories": [],
+      "matchTypePatterns": [],
+      "stageId": ""
+    },
+    {
+      "commodityKey": "tile-grout",
+      "description": "Tile grout",
+      "spec": "5 kg bag",
+      "supplierUnit": "Bags",
+      "sourceUnit": "kg",
+      "sourceUnitsPerSupplierUnit": 5.0,
+      "roundUpToWhole": true,
+      "defaultWastagePct": 0,
+      "matchKinds": [
+        "tile_grout"
+      ],
+      "matchCategories": [],
+      "matchTypePatterns": [],
+      "stageId": ""
     }
   ]
 }


### PR DESCRIPTION
The last gap against the reference sample.

### Why the first attempt was withdrawn, and why this is different

`paint-wall`, `floor-tile` and `paint-ceiling` matched a whole **element** from the unit table and converted it, so a composite wall whose type read "plastered" priced the entire wall area as paint buckets. All three were removed in #710. The reason they could not work stood: **a floor's tiled area is not its slab area**, and the RC-slab path knows only concrete, rebar and formwork — there was no finish-layer concept to say whether a floor was tiled at all.

The compound structure answers it directly. A `Finish1`/`Finish2` layer whose material reads as tile **is** the tiled area, and its absence means the surface is not tiled — so an untiled floor produces **nothing**, not a guess. The same `MaterialFunctionAssignment` idiom `PlasterOffsetResolver` already uses.

### What it emits

`floor_tile` / `wall_tile` in m², plus adhesive and grout in kg, converted to Boxes and Bags by supplier rules carrying the 10% cutting allowance — in the one visible place wastage lives, not baked into the engine where it was applied twice for blocks.

Coverages are keyed by material in `MATERIAL_LOOKUP.csv`: **4.5 kg/m²** adhesive at a 6 mm notch for ceramic, **6** for large-format porcelain, and grout scaling the *other* way because it follows joint **length** per m² — mosaic needs three times a 300 mm tile.

### Wall tiling also corrects the paint

A tiled face is plastered as backing but **never painted**. Tiled faces are deducted from the painted area and clamped at zero. Without it the same face is finished twice — the double-count fixed in #777 wearing different clothes. Backing plaster still covers both faces.

A tiled floor whose structure this path won't measure — a timber or screeded deck — now yields its tiling alone instead of being dropped whole, since the tiled area exists either way.

**Skirting is not measured**: it runs to a room's *perimeter*, which an area cannot yield.

### Verification

Tests **367 → 386**. Plugin builds **0 warnings / 0 errors**.

The data seam is covered because it is the one that fails silently: the builder composes `"TILE " + key`, and a spelling that misses returns **zero, not an error** — dropping the adhesive and grout rows without a word. That gate was pointed at a deliberately wrong key and **confirmed to fail** before being kept.

Layer reading is Revit-side and still unexercised — see MATSCHED-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)