### PR TITLE
Rescue thirteen documents that existed only in one worktree

### DIFF
--- a/docs/BOQ_5D_PHASE2_PROMPT.md
+++ b/docs/BOQ_5D_PHASE2_PROMPT.md
@@ -1,0 +1,302 @@
+# BOQ 5D Cost Manager — Phase 2 Implementation Prompt (the 5 enhanced-rebuild items)
+
+You are a terminal coding agent on the **StingTools** C# Revit plugin. Phase 0
+(dispatch busy-guard / deadlock fix), the full inline-forms sweep, Phase 1
+(schedule unification), and the Schedule-tab interactivity are all landed and
+smoke-tested in Revit. This prompt covers the five remaining enhanced-rebuild
+items. Implement them as **Phases 2A → 2E, in order**, slicing each, compile-
+verifying + committing + pausing for the human to smoke-test per group.
+
+This prompt is **grounded in the real codebase** — the entry points below were
+verified. Reuse them; do not reinvent or fork.
+
+---
+
+## 0. Environment, build, deploy, git — READ FIRST
+
+**Branch & checkout.** All work is on **`claude/placement-centre-review-audit`**
+in the main checkout **`C:\Dev\STINGTOOLS`**. The checkout is **shared with other
+agents** (placement work commits interleave). Verify before editing:
+```bash
+cd /c/Dev/STINGTOOLS && git branch --show-current   # must print claude/placement-centre-review-audit
+```
+Do NOT create a worktree. Do NOT `git reset --hard` / rebase / force anything —
+other agents' commits live here. Commit only the files you touched.
+
+**Build (compile-verify — headless works via Nice3point). MANDATORY before every
+commit:**
+```bash
+dotnet build StingTools/StingTools.csproj -c Release -t:Rebuild --nologo -v minimal   # must say 0 Error(s)
+```
+**Deploy is the human's job** (Revit locks the DLL). After a group of slices,
+STOP and tell the human to close Revit; they deploy + restart + smoke-test, then
+tell you to continue. **Do NOT push or merge.** Log every slice in
+`docs/CHANGELOG.md` with its Revit smoke test.
+
+---
+
+## 1. Inline conventions to REUSE (no popups, no forks) — VERIFIED SIGNATURES
+
+The Cost Manager is a no-popup inline workspace. Every new surface follows this:
+
+- **Inline result pane:** `BOQInlineResults.Sink` (set in `BOQCostManagerPanel`,
+  ~line 301; deregistered on Unload). Build a `StingResultPanel.Builder`, then
+  `if (!BOQInlineResults.Post(rp)) rp.Show();` — inline when the panel hosts,
+  modal fallback for ribbon callers.
+- **Result builder** (`UI/StingResultPanel.cs`): `.SetTitle/.SetSubtitle/.AddSection/
+  .Metric/.Finding/.PassFail/.RAGBar/.Table(headers, rows)/.Action(label, desc,
+  click)/.Show()`. Use `.Table(...)` for diffs/candidate lists, `.Action(...)` for
+  inline buttons (run with `null` Window, try/catch).
+- **Inline input forms:** render a titled form (combos / numeric `TextBox` /
+  `CheckBox`) + Run button into the Actions pane (`ShowInlineForm` / the
+  `TryShowInlineFormFor` interceptor), collect values, set them via
+  `StingCommandHandler.SetExtraParam(key, value)`, dispatch the tag; the command
+  reads `GetExtraParam(key)` and **skips its dialog when present** (keep the modal
+  as the ribbon fallback). `InlineHost=1` is the established gate.
+- **Inline pickers:** `StingListPicker` (modal fallback while a Revit transaction
+  is open — `IsModifiable` guard). **Never** use `DispatcherFrame`/`PushFrame`
+  (that caused the deadlock — permanently banned).
+- **Persistence:** project-scoped JSON under `<project>/_BIM_COORD/` (same as
+  `boq_links.json`, `boq_ui_state.json`, `schedule.json`, `rate_card.json`).
+- **Engines — call, never fork:** `BOQCostManager`, `RateProviderRegistry`,
+  `MeasurementStandardRegistry`, `TakeoffRuleRegistry`, `BoqSnapshotHasher`,
+  `BOQCostManager.CompareSnapshots`, `BoqSyncCoordinator`, `IfcQuantitySetWriter`,
+  `Scheduling4DEngine`, `ScheduleStore`, `StingResultPanel`, `StingListPicker`.
+- **Errors:** `StingLog.Info/Warn/Error` — never silent-catch. `[Transaction]`
+  attributes correct; Revit API reads stay on the API thread.
+
+---
+
+## PHASE 2A — NRM2 rules-based measurement (the accuracy payoff) — DO FIRST
+
+**The gap.** Today take-off is essentially *raw Revit geometry × rate*.
+`BuildLineItemFromElement` (`BOQ/BOQCostManager.cs` ~line 382) resolves a quantity
+via `TakeoffRuleRegistry` and a unit via `IMeasurementStandard.PreferredUnit`, but
+**no NRM2 measurement rules are applied**: no girth, no void/opening deductions,
+no over-measure conventions, no wastage. The hooks already exist but are unused:
+`IMeasurementStandard.ApplyDeductions(BOQLineItem, Element)` (stub in
+`NRM2Standard`) and `TakeoffRule.WastePercent` (reserved, never consumed).
+
+**Build a measurement-rules layer** that turns *modelled geometry* into
+*measured quantity* with an auditable trail.
+
+1. **Implement `NRM2Standard.ApplyDeductions`** (and the CESMM4 stub) properly —
+   per-category NRM2 rules. At minimum:
+   - **Walls:** deduct openings (doors/windows/curtain panels hosted in the wall)
+     over the NRM2 de-minimis threshold; measure area on the correct face; handle
+     girth for linear items. Use the host/insert relationship
+     (`Wall.FindInserts` / `FamilyInstance.Host`) to find openings.
+   - **Floors/ceilings/roofs:** deduct large voids/openings; net area.
+   - **Linear items (skirting, trim, pipe, conduit, beams):** girth / centre-line
+     length with NRM2 measurement points.
+   - Each rule reads thresholds from a new corporate JSON
+     `Data/STING_NRM2_MEASUREMENT_RULES.json` (de-minimis areas, wastage %, over-
+     measure conventions per NRM2 section) with a project override at
+     `<project>/_BIM_COORD/nrm2_measurement_rules.json` (corporate + override merge,
+     same pattern as `TakeoffRuleRegistry`).
+2. **Consume `TakeoffRule.WastePercent`** (and the JSON wastage %) — apply wastage
+   as a distinct, visible step (not folded silently into the rate).
+3. **Make the maths auditable.** Add to `BOQLineItem`: `GrossQuantity`,
+   `DeductionQuantity`, `WastageQuantity`, and `MeasurementNote` (e.g.
+   *"Gross 43.0 m² − openings 5.2 m² + wastage 5% = 39.8 m²"*). `Quantity` stays
+   the **net measured** value used for cost. Keep raw geometry in `GrossQuantity`
+   so nothing is lost.
+4. **Surface it.** In the BOQ row-details / a new optional column set
+   (`Gross` / `Deduct` / `Waste` / `Net`, hidden by default via the existing
+   `_hiddenColumns` mechanism), and in a new inline **"Measurement audit"** action
+   that lists, per line, the gross→net derivation in a `StingResultPanel.Table`.
+5. **Standard-aware.** The active `IMeasurementStandard` (NRM2 / CESMM4 / POMI /
+   ICMS3 / MMHW — switched via the existing Measurement Standard action) drives
+   which rules apply, so CESMM4 vs NRM2 give different nets.
+
+**Acceptance:** a wall with a door+window measures **net of the openings** (not
+gross); wastage is applied and visible; the gross→net derivation is auditable per
+line; switching the measurement standard changes the nets; raw geometry is still
+recoverable in `GrossQuantity`; rules load from JSON with a project override; no
+popups; build 0 errors. **This is multi-commit** — slice by category family
+(walls/openings first, then floors/slabs, then linear items, then wastage +
+audit surface).
+
+---
+
+## PHASE 2B — Live rate feeds inline (BCIS / Planscape)
+
+**The gap.** `BcisHttpRateProvider` is a **real** HTTP client (Bearer auth, hot +
+disk TTL cache, `RequiresNetwork=true`, `Priority=50`) and `RateProviderRegistry`
+already layers providers by priority and exposes
+`ResolveAll(req) → IReadOnlyList<(IRateProvider, RateLookup)>` with
+`Confidence` / `Provenance` / `MatchedKey` on every `RateLookup`. But the Cost
+Manager never surfaces live feeds: there's no config UI, no "fetch live rates"
+action, and the user can't see/choose among candidate rates.
+
+1. **Config form (inline).** A "Rate feeds" action that renders an inline form:
+   BCIS base URL + API key + TTL minutes; Planscape feed on/off (reuse the
+   existing Planscape server client + auth if present). Persist to
+   `<project>/_BIM_COORD/rate_feeds.json` (never commit secrets; the key lives in
+   the project file only). Wire these into `RateProviderRegistry.Get(...)` so the
+   BCIS provider is constructed with real config instead of being inert.
+2. **Fetch + review (inline).** A "Fetch live rates" action that, for the current
+   bill (or the selected lines), calls `RateProviderRegistry.ResolveAll(req)` per
+   line and renders an inline `StingResultPanel.Table`: line ref · description ·
+   current rate (source/confidence) · **candidate rates from each provider**
+   (value · source · confidence · as-of). Provide an **Action** to *accept* the
+   highest-confidence live rate onto the line (write `RateUGX` + `RateSource` +
+   `RateConfidence` + `LastCosted`, mark `RateSource="BCIS"`/`"Planscape"`), with a
+   per-line or bulk apply. Respect the existing override priority (a manual
+   `Override` rate must not be silently clobbered — flag it instead).
+3. **Confidence + freshness visible.** Show each fetched rate's confidence and
+   fetch date; colour low-confidence (<60) amber. Cache hits vs network fetches
+   noted (the provider already disk-caches by TTL).
+4. **Offline-safe.** When `RequiresNetwork` providers are unreachable, degrade
+   gracefully (keep existing rates, surface a "feed unreachable" note) — never
+   throw, never blank a rate.
+
+**Acceptance:** the user configures a BCIS/Planscape feed inline; "Fetch live
+rates" shows per-line candidate rates with source + confidence; accepting applies
+the live rate and re-totals; manual overrides are protected; offline degrades
+cleanly; config persists; no popups; build 0 errors.
+
+---
+
+## PHASE 2C — Auto-reprice / drift alerts
+
+**The gap.** `BOQCostManager.CompareSnapshots(pathA, pathB)` already produces
+`BOQSnapshotDiff` with `SectionDiff`/`CategoryDiff` rows typed by `ChangeType`
+(`RateRevised` / `QtyChanged` / `NewItem` / `ItemRemoved` / `PSAdded` /
+`SourcePromoted`) and net-change metrics; `BoqSnapshotHasher.ComputeChecksum`
+gives a deterministic per-bill hash. But nothing watches for drift or re-prices
+changed lines automatically.
+
+1. **Drift check (inline).** A "Drift check" action that builds the **live** bill,
+   compares it against the **last saved snapshot** (latest `boq_snapshot_*.json` by
+   timestamp) via the existing compare/hash, and renders an inline panel:
+   headline (checksum changed? net Δ cost / Δ carbon / Δ %), then a
+   `StingResultPanel.Table` of changed lines grouped by `ChangeType` (qty moved,
+   new, removed, rate revised), each clickable to select the element(s) in Revit
+   (use the `Finding(text, elementId)` overload).
+2. **Auto-reprice changed lines.** An **Action** on the drift panel:
+   *"Re-price N changed lines"* — for `QtyChanged` + `NewItem` rows, re-run
+   `RateProviderRegistry.Resolve(req)` (incl. live feeds from 2B if configured) and
+   update those lines only; leave manual `Override` rows untouched; re-total. Show
+   the before/after in the result.
+3. **Drift stamp / passive alert.** On `RefreshAsync`, cheaply compare the new
+   live checksum against the last-snapshot checksum and, if changed, show a small
+   non-blocking banner/metric on the dashboard strip ("Bill drifted from last
+   snapshot — N lines changed · Drift check") that deep-links to the Drift check
+   action. No popup, no modal — a dashboard affordance only.
+4. **Persist** the last-seen checksum + drift summary in
+   `<project>/_BIM_COORD/boq_drift.json` so the banner survives reopen until a new
+   snapshot is saved.
+
+**Acceptance:** Drift check lists exactly what changed vs the last snapshot,
+element-linked; "Re-price changed lines" updates only drifted non-override lines
+via the rate chain and re-totals; the dashboard shows a passive drift indicator
+after a model change; manual overrides survive; no popups; build 0 errors.
+
+---
+
+## PHASE 2D — Incremental / background take-off (performance) — HIGHEST RISK, do carefully
+
+**The gap.** `BuildBOQDocument` is **synchronous on the Revit API thread**
+(`RefreshAsync`, `BOQCostManagerPanel` ~line 2793, shows a progress dialog for
+≥1500-element models). A per-link cache exists (`_linkTakeoffCache`, raw items
+keyed by linked file path, grouping applied post-cache). There is **no host-side
+incremental take-off** — every Refresh walks every host element.
+
+**Two independent, safe levers. Do the dirty-set first (lower risk), background
+split second only if profiling still shows jank.**
+
+1. **Dirty-set incremental host take-off.** Register a lightweight `IUpdater`
+   (mirror `StingStaleMarker` in `Core/StingAutoTagger.cs`) that, on
+   geometry/parameter change of cost-relevant categories, records the changed
+   `ElementId`s into a per-document **dirty set**. `RefreshAsync` gains an
+   *incremental* path: when a prior host take-off result is cached and a dirty set
+   exists, only re-run `BuildLineItemFromElement` for dirty elements (+ removed
+   elements drop their lines), then re-aggregate + re-group + re-total — instead of
+   re-walking the whole model. A full rebuild stays available ("Refresh (full)")
+   and runs on first open / when no cache exists / on demand. Cache the host raw
+   items the same way links are cached (raw, pre-aggregate, pre-group) so grouping
+   toggles stay free. Clear on document close (wire into `OnDocumentClosing`).
+2. **Background the heavy compute (only if needed).** If the host walk still janks
+   the UI on large models: read all needed element data into **POCOs on the API
+   thread** (Revit reads MUST stay on the API thread), then do grouping / rate
+   resolution / aggregation / carbon **off-thread**, marshalling the result back
+   for `RefreshDisplay` via the existing `StingProgressDialog`. **Do NOT** touch
+   the Revit API off-thread. If unsure whether it's needed, **skip 2D.2** — the
+   dirty-set already removes most of the per-refresh cost.
+
+**Acceptance:** after the first full build, editing a handful of elements and
+pressing Refresh re-takes-off only those (visibly faster on a large model);
+results are identical to a full rebuild (verify totals match); a full rebuild is
+still available and correct; no Revit API call runs off the API thread; cache
+clears on close; no regressions to linked-model take-off; build 0 errors.
+**Be conservative — correctness over speed. If the incremental result ever
+diverges from a full rebuild, fall back to full.**
+
+---
+
+## PHASE 2E — User-defined WBS/CBS + ERP export
+
+**The gap.** `BoqGroupingMode` already offers WorkSection / Level / Zone /
+LevelThenWorkSection / Location / SourceModel, but there's **no user-defined
+WBS/CBS**. WBS lives on `ScheduleTask.Wbs` (`Core/Schedule/ScheduleModel.cs`), not
+on `BOQLineItem`. Export is rich (8-sheet XLSX, IFC Qto + `Pset_StingCost`,
+QS round-trip) but there's **no ERP-shaped cost export**.
+
+1. **WBS/CBS on the bill.** Add `WbsCode` + `CbsCode` to `BOQLineItem`. Provide a
+   **mapping editor (inline)**: rules that assign WBS/CBS from element attributes
+   (category / discipline / NRM2 section / level / zone / system), persisted to
+   `<project>/_BIM_COORD/boq_wbs_map.json`. Apply during `BuildLineItemFromElement`
+   (or a post-pass). Add a **`Wbs` / `Cbs` grouping mode** to `BoqGroupingMode`
+   + the Group dropdown, so the bill can be filed by the client's cost breakdown
+   structure, not just NRM2.
+2. **5D rollup link.** Where a `BOQLineItem`'s element is in a `ScheduleTask.ElementIds`,
+   inherit that task's `Wbs` (so the 4D programme and the 5D bill share one WBS).
+   Reconcile: WBS map rule wins if set; else inherit from the linked ScheduleTask.
+3. **ERP export.** A new "Export to ERP" action producing a flat, import-ready
+   file in a **standard ERP cost-import shape** — a CSV with columns
+   `WBS, CBS, CostCode/NRM2, Description, Qty, Unit, UnitRate, Total, Currency,
+   Level, Location, Source, ElementId/IfcGuid` (the union most ERP/accounting
+   importers accept: SAP PS / Oracle Primavera Unifier / QuickBooks / Sage). Plus
+   an optional **Primavera P6-style XML** activity-cost export if cheap to add
+   (reuse the Phase 1c P6 XML writer direction). Render the result inline with the
+   **Open file** button (set the CSV path on the builder). Keep the existing 8-sheet
+   XLSX + IFC Qto exports unchanged.
+
+**Acceptance:** lines carry WBS/CBS from a persisted, user-editable map (with
+ScheduleTask inheritance for 5D); the bill can be grouped by WBS/CBS in the
+dropdown; "Export to ERP" writes a flat import-ready CSV (and optional P6 XML)
+with WBS/CBS columns and opens inline; existing exports unchanged; no popups;
+build 0 errors.
+
+---
+
+## Order, slicing, definition of done
+
+**Pacing (UPDATED): Phase 2A is already done, committed, and builds clean. Run
+the rest — 2B → 2C → 2D → 2E — in ONE continuous pass. Do NOT pause between phase
+parts.** The human will smoke-test **once at the very end**, covering 2A→2E
+together. Only stop at the very end.
+
+- **Order:** 2A (done) → 2B (live rates) → 2C (drift, depends on 2B's chain) →
+  2D (performance) → 2E (WBS/ERP). 2E touches `BOQLineItem` (WBS/CBS fields) — its
+  field additions sit alongside 2A's; keep them together to avoid churn.
+- **Keep it bisectable:** one logical slice = one commit; compile-verify
+  (`0 Error(s)`, `-t:Rebuild`) **before each commit**, so if the single end-to-end
+  smoke test finds a problem the human can bisect to the exact commit and revert
+  just that one.
+- **No popups** — every new surface inline per §1. **Reuse engines; no forks.**
+  `StingLog` for errors, `[Transaction]` correct, Revit reads on the API thread,
+  `_BIM_COORD` JSON for persistence, **no secrets committed**.
+- **2D is the highest-risk part — treat conservatively.** Correctness over speed:
+  if an incremental take-off result ever diverges from a full rebuild, fall back
+  to full. Never let 2D change a number that a full rebuild wouldn't.
+- **Do NOT push or merge.** Shared checkout — no `reset --hard`/rebase/force.
+  Log every slice in `docs/CHANGELOG.md`.
+- **At the very end**, run a final full rebuild + a self-check and report it:
+  (1) `BuildBOQDocument` totals are unchanged for non-deducted lines vs a full
+  rebuild (2A/2D regression guard); (2) live-rate fetch, drift check + reprice,
+  and ERP export all produce output and render inline; (3) no Revit API call runs
+  off the API thread (2D); (4) no new popups for data entry. Then **STOP for one
+  comprehensive human smoke test** covering 2A→2E, with a single consolidated
+  smoke-test checklist in `docs/CHANGELOG.md`. Do not start any later phase.

--- a/docs/BOQ_COST_INTEGRATION_AND_FIXES_PROMPT.md
+++ b/docs/BOQ_COST_INTEGRATION_AND_FIXES_PROMPT.md
@@ -1,0 +1,217 @@
+# Implementation Brief — BOQ/Cost: integrate P1–P4 into one stack + fix verified bugs
+
+> **For the implementing agent.** Self-contained. Read fully before acting.
+> This consolidates four already-built phases into one coherent branch and fixes
+> the bugs found in review. Work in two stages with a **hard STOP** between them
+> (Stage A integration → human sanity-check → Stage B fixes).
+
+---
+
+## 0. Background (what exists, verified)
+
+A prior agent delivered the BOQ/Cost upgrade across four branches. P1–P3 are
+cleanly stacked; P4 is **not** — it was branched off the P0 fix, never saw P1's
+model changes, and carries an unrelated stowaway commit.
+
+| Phase | Branch | Tip SHA | Base |
+|---|---|---|---|
+| P0 (button-revive fix) | `claude/revive-cost-buttons` | `fc44e29e0` | pre-existing |
+| P1 takeoff exclusion + aggregation | `claude/boq-p1-aggregation` | `3f7611792` | `main` |
+| P2 location column + grouping + print profiles | `claude/boq-p2-grouping` | `b6aa405fb` | P1 |
+| P3 QS Excel round-trip | `claude/boq-p3-qs-roundtrip` | `9491c06d9` | P2 |
+| P4 valuations/variations/EVM | `claude/boq-p4-cost-control` | `73c3b6efa` | **P0 (not P3)** |
+| ⚠️ stray `.rfa` deletion on P4 | — | `0570d989d` | on top of P4 — **DROP** |
+
+**Verified-good (do not "fix" these — they are correct):**
+- P1 aggregation: `BOQLineItem` has `SimilarCount`, `ConstituentElementIds = new List<long>()`, `AggregationKey`; `Clone()` copies them; exclusion filter is real + data-driven (`ImportInstance` + `OST_DetailComponents`/`OST_FilledRegion` + config key `COST_TAKEOFF_EXCLUDE_CATEGORIES`).
+- P3 round-trip key: `UID:<uniqueId>` for model rows, `MAN:<id>` for manual/QS rows, hidden column, rates persisted as per-element overrides. Stable across rebuilds.
+- P4 EVM math (BCWS from planned %, SPI/CPI/EAC/VAC/TCPI with div-zero guards), cert carry-forward, VAT order, JSON persistence/sequencing — all correct.
+
+**Conventions (read `CLAUDE.md`):** doc acquisition via `ParameterHelpers.GetDoc(commandData)`; `[Transaction]` attributes + named `Transaction`; `StingLog` not silent catches; `TaskDialog` not `MessageBox`; additive model changes with safe defaults (don't break saved snapshots); commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+**Build/verify command (must be 0 errors before every commit):**
+`dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025"`
+**Do NOT touch the `.rfa` tag-family files** — they are unrelated work; leave them out of this branch entirely.
+
+---
+
+## STAGE A — Integrate the four phases into one linear stack
+
+Goal: one branch `main → P1 → P2 → P3 → P0-fix → P4`, **without** the `.rfa`
+deletion commit, building clean.
+
+### A.1 Create the integration branch off the P3 tip
+```
+git checkout -b claude/boq-cost-integrated claude/boq-p3-qs-roundtrip
+```
+This gives you `main + P1 + P2 + P3` as the base.
+
+### A.2 Replay P0 + P4 on top, excluding the `.rfa` commit
+Recommended (cherry-pick the two cost commits in order; the range stops *before*
+the stray `0570d989d`):
+```
+git cherry-pick fc44e29e0^..73c3b6efa
+```
+> Verify first with `git log --oneline fc44e29e0^..73c3b6efa` — it must list
+> exactly two commits: `fc44e29e0` (P0 fix) and `73c3b6efa` (P4). If anything
+> else appears, adjust. **Never** cherry-pick `0570d989d`.
+
+### A.3 Resolve conflicts (expected in these files)
+Conflicts are expected because P4 was built without P1–P3. Resolution principle:
+**keep BOTH the P1–P3 changes and the P4 changes** — do not drop either side.
+- `StingTools/UI/BOQCostManagerPanel.cs` — P2/P3 added the Location column,
+  grouping selector, print profiles, QS round-trip buttons; P4 added the cost-
+  control action buttons/sections. Merge so **all** controls survive.
+- `StingTools/UI/StingCommandHandler.cs` — keep **all** new command-tag `case`
+  entries from both sides (P3 QS tags + P4 cost tags).
+- `StingTools/Commands/Cost/CostCommands.cs` — P0 converted doc-acquisition to
+  `ParameterHelpers.GetDoc`; ensure the final version uses `GetDoc` everywhere
+  **and** keeps P3/P4 additions. No method may revert to
+  `commandData?.Application?.ActiveUIDocument?.Document`.
+- `StingTools/BOQ/BOQModels.cs` — P4 may reference `BOQLineItem`; ensure P1's
+  aggregation fields remain present (`SimilarCount`, `ConstituentElementIds`,
+  `AggregationKey`) and any P4 additions are layered on, not over them.
+- `docs/CHANGELOG.md` — concatenate both phase entries in order.
+
+After P4 lands, confirm P4's cost engines compile against the **post-P1**
+`BOQLineItem`/`BOQDocument` (the aggregation fields and `BOQDocument.Currency`
+must be in scope — they are needed in Stage B).
+
+### A.4 Re-assert the P0 doc-acquisition fix across ALL Cost commands
+The P0 fix (use `ParameterHelpers.GetDoc(commandData)` instead of
+`commandData?.Application?.ActiveUIDocument?.Document`, which is always null when
+dispatched from the dock panel → dead buttons) is **not reliably present** in the
+current tree — several Cost files still carry the broken pattern. The
+cherry-pick may not cover files P4 overwrote. So, after the cherry-pick:
+```
+grep -rn "commandData?.Application?.ActiveUIDocument" StingTools/Commands/Cost/
+```
+This **must return 0**. For every hit, replace the doc/uidoc acquisition with
+`ParameterHelpers.GetDoc(commandData)` (or `GetApp(commandData)?.ActiveUIDocument`
+where the `uidoc` is reused), exactly as P0 did. Check all six files:
+`CostCommands.cs`, `CostPlanCommands.cs`, `PaymentCertCommands.cs`,
+`VariationAndEvmCommands.cs`, `IfcAndIcmsCommands.cs` (the `MeasurementStandard`
+file has no doc dependency). If any button is still wired to a command reading
+`commandData.Application` directly, it stays dead.
+
+### A.5 Build + commit the integration
+- Run the build command. Fix any compile fallout from the merge (e.g. P4 calling
+  a `BOQLineItem` shape that P1 changed). 0 errors required.
+- Commit: `chore(boq): integrate P1–P4 into one linear stack (drop stray .rfa commit)`.
+
+### ⛔ A.6 — HARD STOP. Hand back for human review.
+Post a summary: the cherry-pick result, every file you had a conflict in and how
+you resolved it (one line each), and the clean build output. **Do not start
+Stage B until a human confirms the conflict resolution.** This is the riskiest
+step; a wrong merge here silently drops a feature.
+
+---
+
+## STAGE B — Fix the verified bugs (only after Stage A is approved)
+
+All line numbers are from the P4 code as reviewed; re-locate after the merge.
+
+### B.1 🔴 CRITICAL — Currency is hardcoded "GBP" but values are UGX
+The cert/variation/EVM models stamp `Currency="GBP"` while the numbers come from
+`BOQSection.TotalUGX` / `boq.GrandTotalUGX`. `BOQDocument.Currency` already holds
+the correct project currency (`"UGX"`). **Thread the BOQ currency through; never
+hardcode the literal.**
+
+Sites to fix:
+- `StingTools/Core/PaymentCert/PaymentCertEngine.cs:78` (`CreateDraft` `Currency="GBP"`) — set from the snapshot/BOQ currency. Minimum: at the call site in `PaymentCertCommands.cs` (~`:57`), `cert.Currency = boq.Currency;` immediately after `CreateDraft`. Also fix the stale `// GBP …` comments on `SovLine.ContractValue`/`PreviouslyCertified`.
+- `StingTools/Core/PaymentCert/PaymentCertModels.cs:69, 142` — default `"GBP"` → `"UGX"`.
+- `StingTools/Core/Variation/VariationEngine.cs:65` (`FromDiff`) — add a `string currency` parameter (or read from the diff/BOQ) instead of `"GBP"`; pass `boq.Currency` from all three call sites in `VariationAndEvmCommands.cs`.
+- `StingTools/Core/Variation/VariationModels.cs:171, 208` — defaults `"GBP"` → `"UGX"`; `StarRate.Currency` too.
+- `StingTools/Core/Evm/EvmCalculator.cs:72` — default `"GBP"` → `"UGX"`.
+- `StingTools/Commands/Cost/CostPlanCommands.cs:70-71` — the cost-plan summary prints `GBP {plan.SubtotalLikely}` / `GBP {plan.GrandTotalLikely}`; and the NRM1 benchmark engine (`Core/CostPlan/`) likely carries £/m² rates. Use `boq.Currency` for display, and confirm the NRM1 benchmark CSV (`STING_NRM1_BENCHMARKS.csv`) units match the project currency — if the benchmarks are genuinely £/m² they need a conversion or a UGX benchmark set (flag this in CHANGELOG rather than silently mislabelling).
+- `StingTools/Commands/Cost/VariationAndEvmCommands.cs` — the ~7 hardcoded `"GBP"` star-rate labels (~`:338-344`) and the ACWP display (`:571`) → use `rate.Currency` / `boq.Currency`.
+- `StingTools/Commands/Cost/CostCommands.cs:513` — the ES-migration `Write(el, rate, unit, "GBP", …)` → use the project currency (`BOQCostManager.BuildBOQDocument(doc)?.Currency ?? "UGX"`).
+- `StingTools/Commands/Cost/CostControlCommands.cs` — any cert/AFC XLSX export that prints `Currency` must read the model's currency.
+
+Acceptance: a UGX project shows "UGX" everywhere; grep for `"GBP"` in
+`Core/PaymentCert`, `Core/Variation`, `Core/Evm`, `Commands/Cost` returns **0**
+hardcoded literals (defaults may be `"UGX"`). (Full currency *conversion* is out
+of scope — this is label/consistency correctness only.)
+
+### B.2 🟠 Variations silently drop omissions
+`StingTools/Core/Variation/VariationEngine.cs:70-93` — a `DeletedItem` (removed
+scope) falls through to the default path producing `Qty=0, Rate=0, Total=0`, so
+omissions vanish. `QuantityChanged` records the surviving positive quantity, not
+the reduction. Add explicit handling so omissions/reductions carry the correct
+**negative** value:
+- `DeletedItem` → `Quantity = c.QtyA`, `UnitRate = -c.RateA`, `RateSource="Omission"`.
+- `QuantityChanged` → `Quantity = c.QtyB - c.QtyA` (signed), `UnitRate = c.RateB`.
+Acceptance: a snapshot diff that removes scope mints a VO line with a negative
+`TotalValue`; the VO register net total reflects omissions.
+
+### B.3 🟠 Anticipated Final Cost double-counts
+`StingTools/Commands/Cost/CostControlCommands.cs:283` — `afc = grand + agreedVo +
+pendingVo`, but `grand` (`boq.GrandTotalUGX`) is the *live* BOQ which already
+reflects agreed changes the VOs were minted from → double count, and there is no
+frozen original contract sum. Fix: anchor AFC on a **contract-sum baseline**, not
+the live total. Use the earliest issued payment cert's contract value (sum of
+`Lines[*].ContractValue`) when one exists, else fall back to the current grand
+total, then `afc = contractSum + agreedVo + pendingVo`. Document the assumption
+in a comment. If no baseline exists yet, surface that in the report rather than
+silently using the live total.
+
+### B.4 🟠 Retention has no cumulative cap
+`StingTools/Core/PaymentCert/PaymentCertEngine.cs` (CreateDraft / retention calc)
+— retention is taken per-cert with no ceiling, so cumulative withheld can exceed
+the contractual cap (JCT 2024 §4.10 / NEC4 X16: cap ≈ `RetentionPercent ×
+ContractSum`). Compute headroom = `cap − ledger.Balance` (the ledger already
+tracks cumulative withheld) and cap this cert's retention at
+`min(GrossValuation × rate, headroom)`. Add a `RetentionCap` field if needed.
+Acceptance: across successive certs, total retention never exceeds the cap; once
+reached, per-cert retention is 0.
+
+### B.5 🟠 EVM actuals double-count on re-import
+`StingTools/Commands/Cost/VariationAndEvmCommands.cs:545-575` — re-importing the
+same actuals CSV adds to ACWP again, and the dialog shows the raw CSV sum, not
+the persisted cumulative. Use `EvmCalculator.ImportActualsToDate(report, …)`
+(which reads the persisted store) and display the merged cumulative
+(`report.CurrentPeriod.Acwp`). Guard against importing an already-imported file
+(e.g. dedupe by file hash or period date) and warn instead of silently doubling.
+
+### B.6 🟢 Minor (do if quick; otherwise note in CHANGELOG)
+- `StingTools/BOQ/BOQCostManager.cs` `AssignBoqLineRefs` — the middle index is
+  hardcoded `"1"` (`{section}.1.{n}`). Refs are still unique within a section
+  (rowIndex increments), so this is cosmetic, not a collision. If trivial, make
+  the group index advance per Category group; otherwise leave + note.
+- P3 XLSX import (`BOQQsRoundtripCommands.cs`) — confirm the importer reads the
+  literal **rate** columns (not formula totals) and parses with
+  `double.TryParse(…, NumberStyles.Any, CultureInfo.InvariantCulture, …)`, with
+  blank/non-numeric cells producing a diff-preview warning rather than a silent 0.
+
+### B.7 Build + commit
+- Build clean (0 errors). One commit per fix (B.1…B.5), or grouped logically with
+  a clear message. Update `docs/CHANGELOG.md` and add any residual gaps to
+  `docs/ROADMAP.md`.
+
+---
+
+## STAGE C — Verification gate (report, do not skip)
+The whole stack builds clean but **has never run in Revit**. You cannot click
+buttons in CI, so produce a **Revit manual-test checklist** in the PR/commit body
+covering, against a real UGX model:
+1. Build BOQ → confirm aggregation (similar items collapse, `SimilarCount`/Qty
+   correct) and 2D/CAD noise excluded.
+2. Location column toggle + regroup by Level/Zone + tender print profile.
+3. QS round-trip: export unpriced → edit rates in Excel → import → rates land on
+   correct rows, manual rows survive, diff preview correct.
+4. Cost: issue interim cert (currency shows **UGX**, retention/MOS/previous/VAT/
+   net correct), raise a variation incl. an **omission** (negative line), check
+   revised contract sum + AFC (no double-count), run EVM with imported actuals
+   (no double-count), export S-curve.
+State explicitly what is build-verified vs. what still needs human Revit testing.
+**Do not push or open PRs unless asked.**
+
+---
+
+## Definition of done
+- Single branch `claude/boq-cost-integrated` = `main→P1→P2→P3→P0fix→P4`, no `.rfa`
+  commit, building clean.
+- 0 hardcoded `"GBP"` literals in cost code; UGX shown throughout.
+- B.2–B.5 fixed with correct signs/caps/dedup; verified-good areas untouched.
+- CHANGELOG updated; Revit manual-test checklist provided; honest caveats stated.
+- **Hard stop after Stage A respected** — human approved the conflict resolution
+  before Stage B began.

--- a/docs/BOQ_QS_IMPLEMENTATION_PROMPT_P1-P4.md
+++ b/docs/BOQ_QS_IMPLEMENTATION_PROMPT_P1-P4.md
@@ -1,0 +1,265 @@
+# Implementation Brief — BOQ & Cost Manager, Quantity-Surveyor Upgrade (P1–P4)
+
+> **For the implementing agent.** This is a self-contained spec. Read it fully
+> before touching code. P0 (reviving the dead Cost buttons) is already done and
+> merged on branch `claude/revive-cost-buttons`. This brief covers P1–P4.
+
+---
+
+## 0. Mission & context
+
+STINGTOOLS' **BOQ & Cost Manager** (a WPF dockable panel inside the BIM
+Coordination Center) produces a bill of quantities and runs cost-management
+workflows (cost plans, payment certificates, variations, EVM) from a live Revit
+model. The goal of P1–P4 is to turn it from a *per-element dump* into a
+**real, QS-grade cost platform** that a professional Quantity Surveyor can work
+**with** — not one that tries to replace them.
+
+**Guiding principle:** the model owns *quantities*; the QS owns *rates and
+adjustments*. The model will never measure everything (excavation, formwork,
+scaffolding, prelims, dayworks), so the BOQ must be a **hybrid**: modelled
+quantities + manual QS-measured rows + provisional/PC sums + dayworks, with
+clear provenance and a clean Excel round-trip to whatever tool the QS uses
+(CostX, Cubicost, Candy/CCS, Buildsoft, or plain Excel).
+
+**Domain context:** Uganda-based practice (Planscape). Dual currency UGX/USD
+already supported. Measurement standards: **NRM2** primary (also SMM7/CESMM/ICMS
+scaffolding exists). Respect ISO 19650 naming already used across the codebase.
+
+### Revit-API reality the implementation must respect
+- Revit gives **net geometric** volumes/areas via `BuiltInParameter`
+  (`HOST_VOLUME_COMPUTED`, `HOST_AREA_COMPUTED`). These are **not** measured
+  quantities — NRM2/SMM7 have deduction thresholds, girth rules, laps, waste,
+  contact-area formwork, rebar-by-weight, etc. Treat model quantity as a
+  *starting point* with per-work-section adjustment/waste factors (a
+  `WasteFactor` helper already exists).
+- **2D content is not measurable.** Detail items, filled regions, model/detail
+  lines, text, dimensions, and **imported CAD (`ImportInstance`)** must be
+  excluded from takeoff. They currently leak in (see P1).
+- Quantities are only as good as model **LOD**. Surface low-confidence rows
+  rather than hiding the limitation (`RateConfidence` already exists).
+
+---
+
+## 1. Verified architecture (current state — do not re-discover, but do verify before editing)
+
+| Concern | File | Key symbols |
+|---|---|---|
+| Data model | `StingTools/BOQ/BOQModels.cs` | `BOQLineItem` (fields: `NRM2Section, Category, Discipline, ItemName, FamilyName, TypeName, Quantity, Unit, RateUGX, RateUSD, EmbodiedCarbonKg, LifecycleCostUGX, BOQLineRef, Note, Source(enum BOQRowSource), RevitElementId, UniqueId, Level, Location, RateSource, RateConfidence, SortOrder`), `BOQSection`, `BOQDocument` |
+| Build pipeline | `StingTools/BOQ/BOQCostManager.cs` | `BuildBOQDocument(doc)` → `CollectCandidateElements(doc, knownCats)` (line 1758) → `BuildLineItemFromElement(doc, el, …)` (186) → `GroupIntoSections(items)` (1794, groups by **NRM2§ + Discipline only**) → `AssignBoqLineRefs(boq)` (1856). `DeriveQuantity(el, unit)` (349), `GetLevelName`, `GetLocationName` |
+| Panel UI (pure C#, no XAML) | `StingTools/UI/BOQCostManagerPanel.cs` | `Build()`, `BuildItemGrid()` (columns ~1017–1043: Ref, Item, Qty, Unit, Rate, Total, Src, Conf, CO₂, Note), `BuildSectionCard()` (876), filter pills/search (383–456), `DispatchAction(tag)` (1981), `RefreshAsync` |
+| Dispatch | `StingTools/UI/StingDockPanel.xaml.cs` `DispatchCommand` → `StingTools/UI/StingCommandHandler.cs` `RunCommand<T>` (passes **null** ExternalCommandData → commands must use `ParameterHelpers.GetDoc(commandData)` / `GetApp(commandData)`) |
+| Cost commands | `StingTools/Commands/Cost/*.cs` | CostCommands, CostPlanCommands, PaymentCertCommands, VariationAndEvmCommands, MeasurementStandardCommands, IfcAndIcmsCommands |
+| Cost engines | `StingTools/Core/CostPlan/`, `Core/Evm/`, `Core/PaymentCert/`, `Core/Variation/` | `CostPlanEngine/Registry`, `EvmCalculator`, `PaymentCertEngine`, `VariationEngine` |
+| Export | `StingTools/BOQ/BOQExportCommand.cs` (21-col XLSX, AutoFilter), `BOQProfessionalExportCommand.cs` (QS tender doc), `BOQModels`/`Rates/`/`Takeoff/TakeoffRule.cs` |
+| ES schemas | `StingTools/Core/Storage/` (`StingCostPlanSchema`, `StingPaymentCertSchema`, `StingVariationSchema`, `StingCostRateOverrideSchema`) |
+
+**Mandatory conventions (read `CLAUDE.md`):**
+- Doc acquisition in every command: `var doc = ParameterHelpers.GetDoc(commandData);` (P0 standard).
+- `[Transaction(TransactionMode.Manual)]` for mutating, `ReadOnly` for diagnostics; wrap DB writes in named `Transaction` ("STING …").
+- Use `StingLog.Info/Warn/Error` — no silent catches. `TaskDialog` not `MessageBox`.
+- Reuse UI building blocks: `StingListPicker`, `StingResultPanel`, `StingDataGridDialog`, `StingProgressDialog`, `StingExportDialog`.
+- Data-driven: new behaviour goes in JSON/CSV under `StingTools/Data/` with a project override under `<project>/_BIM_COORD/`. Corporate baseline stays pristine; project edits flip origin (mirror existing registry patterns).
+- **Verify with `dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025"` — must be 0 errors before each commit.**
+- **Do not regress existing saved snapshots** (`deliverables`/snapshot JSON) — additive model fields only, with safe defaults so old JSON still deserialises.
+- **Branch hygiene:** one branch per phase off latest `main` (e.g. `claude/boq-p1-aggregation`). P2 depends on P1, P3 on P1+P2, P4 on P0. Commit logically; do not push or open PRs unless asked. End commit messages with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+
+---
+
+## P1 — Real takeoff: exclude 2D noise + aggregate similar items
+
+**Problem.** `CollectCandidateElements` sweeps every element whose category is in
+`DiscMap` ∩ `AllCategoryEnums`, so imported-CAD detail and annotation leak in
+(e.g. *"Small Power legend.dwg-2 — Detail Filled Region"* appears 275× as
+`Qty 1.000 each`). And **nothing is aggregated** — each element is its own row,
+so 7 identical shower units = 7 rows. A real BOQ shows **Item / Unit / Quantity**
+with one line per distinct item.
+
+### P1.1 — Takeoff exclusion filter
+- In `CollectCandidateElements`, after the category checks, exclude
+  non-measurable categories. At minimum reject: `OST_DetailComponents`,
+  `OST_FilledRegion`, `OST_Lines`/detail & model lines, `OST_GenericAnnotation`,
+  `OST_TextNotes`, `OST_Dimensions`, `OST_RvtLinks`, and any `ImportInstance`
+  (CAD imports). Also skip elements with no derivable quantity/geometry.
+- Make the exclusion list **data-driven**: config key
+  `COST_TAKEOFF_EXCLUDE_CATEGORIES` (CSV of category names/BuiltInCategory),
+  with a sensible hard-coded default so it works out of the box.
+- Keep the existing Rooms/Spaces/Areas skip and `IsPhaseDemolished` logic.
+- Log a one-line summary of how many elements were excluded and why.
+
+### P1.2 — Aggregation layer (the headline change)
+- Extend `BOQLineItem` (additive, defaulted) with:
+  - `int SimilarCount = 1;` — number of constituent elements collapsed into the row.
+  - `List<long> ConstituentElementIds` (or `string` CSV) — all element ids in the group, for back-selection/drill-down. Keep `RevitElementId`/`UniqueId` as the representative element.
+  - `string AggregationKey` — the grouping key used (for debugging/export).
+- Add an `AggregateLineItems(...)` step in `BuildBOQDocument` **after**
+  per-element line items are built and **before** `GroupIntoSections`. Group by a
+  configurable key: default `NRM2Section + Category + FamilyName + TypeName + Unit
+  + spec-defining params` (and, when a spatial grouping mode is active per P2,
+  include `Level`/`Zone`/`Location`). For each group:
+  - `Quantity` = Σ constituent quantities; `SimilarCount` = count;
+    `ConstituentElementIds` = all ids; `EmbodiedCarbonKg` = Σ; `Total` = Qty×Rate.
+  - Rate is per-unit → keep the representative rate; if constituents disagree on
+    rate, surface a warning and take the modal/most-confident. `RateConfidence` =
+    min across the group. `Source` = most-significant (Manual/PS beat Model).
+  - Preserve `Level`/`Location` only when uniform across the group; otherwise set
+    to a "(various)" sentinel (still filterable).
+- **Aggregation must be reversible/inspectable**: the panel needs a drill-down
+  (P2) to list constituent elements and select them in Revit.
+- Make aggregation **toggleable** (config `COST_AGGREGATE_SIMILAR`, default on) so
+  power users can fall back to per-element rows.
+
+### P1 acceptance
+- The 275 filled-region rows disappear (excluded).
+- 7 identical showers become **1 row, Qty 7, each**.
+- `BOQLineRef` numbering still sequential per section; element-level provenance
+  (constituent ids) retained and selectable.
+- Existing snapshots still load; `dotnet build` clean.
+
+---
+
+## P2 — Location column, spatial grouping, and print/column profiles
+
+`BOQLineItem` already carries `Level` and `Location` (populated per element,
+exported as columns, searchable) — this phase is mostly presentation + grouping.
+
+### P2.1 — Location/Level column in the grid
+- In `BOQCostManagerPanel.BuildItemGrid()` add a **Location** column (and
+  optionally **Level**), bound to the corresponding `BOQItemViewModel` fields.
+- Add a **column-visibility toggle** in the toolbar (show/hide Location, Level,
+  CO₂, Conf, Src, Note) — a lightweight checkable menu or pill row.
+
+### P2.2 — Grouping modes
+- Add a **grouping selector** (toolbar dropdown): `By Work Section (NRM2)`
+  (current default), `By Level`, `By Zone`, `By Level → NRM2`, `By Location`.
+- Refactor `GroupIntoSections` to accept a grouping strategy (don't hard-code the
+  `(NRM2, Discipline)` tuple). NRM2 supports both **elemental** and **locational**
+  bills — this delivers the locational bill.
+- Grouping mode should feed the P1 aggregation key (e.g. *By Level* means similar
+  items aggregate **within** a level, not across levels).
+
+### P2.3 — Print / export column profiles
+- Add a **print/export profile** concept: named column sets (e.g. *Tender*
+  = Ref/Item/Unit/Qty/Rate/Amount, no Location/Src/Conf; *Internal* = all
+  columns incl. Location/Conf/CO₂). Store profiles in
+  `<project>/_BIM_COORD/boq_print_profiles.json` with corporate defaults in
+  `StingTools/Data/`.
+- Wire the profile into both the on-screen grid and the exports
+  (`BOQExportCommand` / `BOQProfessionalExportCommand`) so "remove Location when
+  printing" is one click. Keep Excel AutoFilter.
+
+### P2 acceptance
+- User can toggle a Location column on/off, regroup the bill by Level/Zone, and
+  export a tender bill that omits internal columns — all without losing data.
+
+---
+
+## P3 — QS round-trip + hybrid bill (the integration surface)
+
+A QS lives in Excel/their estimating tool, not in Revit. Make the exchange clean.
+
+### P3.1 — First-class manual / PS / daywork rows
+- Promote the "Manual row" path to a proper workflow. `BOQRowSource` already has
+  Model/Manual/ProvisionalSum — ensure rows of each source can be **created,
+  edited, and persisted** in the panel and survive a model re-build (keyed by a
+  stable id, not `RevitElementId`). Add **Dayworks** and **PC Sum** as sources
+  if not present.
+- Manual/PS/daywork rows must **never be overwritten** by a model re-takeoff.
+
+### P3.2 — QS export (priced & unpriced) in trade order
+- Export the bill to XLSX in **NRM2 trade order** with the classic QS layout
+  (Ref / Description / Unit / Qty / Rate / Amount), section collections, and a
+  grand summary (prelims / contingency / OH&P already in `GRAND TOTAL`). Two
+  modes: **unpriced** (blank Rate/Amount for the QS to price) and **priced**
+  (current rates). Reuse/extend `BOQProfessionalExportCommand`.
+- Each row carries a stable hidden key (`BOQLineRef` + `UniqueId`/aggregation key)
+  so re-import can match.
+
+### P3.3 — QS import (rates + rows back) with diff
+- Re-import the QS's priced XLSX: match rows by the hidden key, **update
+  `RateUGX`/`RateUSD` and `RateSource="QS"`**, and import any **QS-added rows**
+  (manual measured items the model can't carry) as Manual rows.
+- Show a **diff preview** (`StingDataGridDialog`): rate changes, new rows,
+  unmatched rows, quantity drift (model vs QS-measured). Let the user accept/reject.
+- Quantities remain **model-owned** by default; flag any row where the QS changed
+  the quantity for review rather than silently overwriting.
+
+### P3.4 — Rate library
+- Support a project **rate library** (CSV/JSON) the QS maintains, layered through
+  the existing `RateProviderRegistry` pipeline (BCIS → project rate card →
+  material library → manual override). Add a "QS rate card" provider sourced from
+  the imported XLSX / `_BIM_COORD/boq_rate_card.json`.
+
+### P3 acceptance
+- Round-trip: export unpriced → (QS prices in Excel) → import → rates land on the
+  right rows, QS-added rows appear, model quantities preserved, diff shown.
+- Manual/PS/daywork rows survive a model rebuild.
+
+---
+
+## P4 — Make valuations, variations & EVM usable end-to-end
+
+P0 revived the buttons; the engines exist but need to be wired into complete,
+correct workflows. Investigate the engines (`PaymentCertEngine`,
+`VariationEngine`, `EvmCalculator`, `CostPlanEngine`) before extending — confirm
+their current capability, then close the gaps below.
+
+### P4.1 — Interim valuations / payment certificates (JCT/NEC/FIDIC)
+- A valuation needs, per BOQ item or per section: **% complete (or
+  measured-to-date qty)**, **previously certified**, **this period**, **materials
+  on site (MOS)**, **retention** (% with limit/release), **VAT**, **net due this
+  certificate**. Support a `% complete` input per row (or import from progress).
+- Generate a numbered interim certificate (use the template engine / `MiniWord`
+  if available, else XLSX) and persist a cert record (`StingPaymentCertSchema`),
+  so the next valuation knows "previously certified".
+- `PayCert_Approve`/`Sign` should advance status (Draft → Issued → Approved).
+
+### P4.2 — Variations / change orders
+- Variation workflow: instruction ref + status (**Anticipated → Instructed →
+  Quoted → Agreed**), **omission + addition** lines, effect on contract sum and
+  (optionally) completion date. `Variation_FromDiff` (snapshot diff) already
+  scaffolds auto-mint — finish it.
+- **Star-rate build-up** (first principles: labour + plant + material + OH&P) for
+  items with no BOQ rate — `Star Rate Build-Up` button. Persist build-ups.
+- Maintain a **VO register** (already a button) showing cumulative variation value
+  and revised contract sum.
+
+### P4.3 — EVM end-to-end
+- `Calculate EVM` should compute **PV/BCWS, EV/BCWP, AC/ACWP, SPI, CPI, EAC, ETC,
+  VAC, TCPI** from: a **baseline** (cost plan or a saved BOQ snapshot mapped to a
+  programme) + **actuals** (`Import Actuals` CSV) + **% complete**. `Export S-Curve`
+  emits the cumulative PV/EV/AC curve (XLSX/HTML).
+- Persist EVM snapshots; link periods so trends work.
+
+### P4.4 — Cost reporting & final account
+- A **cost report / anticipated final cost** view: contract sum + agreed
+  variations + pending variations + provisional-sum reconciliation + dayworks →
+  anticipated final cost vs budget. Reuse the `GRAND TOTAL` machinery.
+- **Final account reconciliation**: provisional/PC sums reconciled against
+  outturn (a `BOQReconcileProvisionals` path already exists — extend).
+
+### P4 acceptance
+- A user can: set % complete, issue interim cert N (with retention/MOS/previous),
+  raise a variation with omission/addition + star rate, recompute the revised
+  contract sum, run EVM with imported actuals, and export an S-curve and a cost
+  report — all from the panel, end to end.
+
+---
+
+## Cross-cutting deliverables & definition of done (every phase)
+1. `dotnet build` clean (0 errors) against Revit 2025 before each commit.
+2. New data files have corporate baseline + project-override loaders, mirroring
+   existing registry patterns; corporate baseline untouched by project edits.
+3. Additive model changes only — old snapshots/ES entities still deserialise.
+4. A short **Revit manual-test checklist** per phase in the PR/commit body (the
+   agent can't click buttons in CI; the human verifies in Revit).
+5. Update `docs/CHANGELOG.md` with a `#### Completed (Phase N — …)` block;
+   add any new gaps to `docs/ROADMAP.md`. Keep `CLAUDE.md` updated only where
+   structure/commands change.
+6. Honest caveats: if a workflow is wired but not Revit-verified, say so.
+
+## Suggested sequencing
+`P1` (data correctness — biggest felt impact) → `P2` (presentation/grouping,
+depends on P1's aggregation key) → `P3` (QS round-trip, depends on P1+P2 row
+identity) → `P4` (cost control, depends only on P0). Ship each on its own branch;
+get human sign-off in Revit between phases.

--- a/docs/HEALTHCARE_ACCURACY_FIXES_PROMPT.md
+++ b/docs/HEALTHCARE_ACCURACY_FIXES_PROMPT.md
@@ -1,0 +1,222 @@
+# Healthcare Pack — Accuracy Remediation (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Execute
+every workstream below **end to end, without stopping to ask**. Make the calls
+yourself; at each choice pick the **most flexible, sustainable, data-driven
+option** — one canonical source of truth, reused everywhere, changeable without a
+recompile, matching patterns already in the repo. Do not gold-plate; fix exactly
+what is listed, well.
+
+These findings come from a verified accuracy audit of the healthcare pack. Each
+was checked against the actual code — the false positives are called out
+explicitly at the end so you **do not** chase them. Read every cited file before
+editing it.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work autonomously to completion.
+- **Branch / worktree.** This work continues the healthcare gap-fix line. Prefer
+  the existing worktree at `C:\Dev\STINGTOOLS-hc-fixes` on branch
+  `claude/healthcare-gap-fixes`; confirm with `git -C C:\Dev\STINGTOOLS-hc-fixes
+  rev-parse --abbrev-ref HEAD` first. If it is gone, create a fresh worktree off
+  the latest `claude/pm-complete` (`git worktree add ../STINGTOOLS-hc-acc -b
+  claude/healthcare-accuracy`). Do ALL work in the worktree. Never touch the
+  shared `C:\Dev\STINGTOOLS` checkout; never commit to `main`.
+- **Build.** This machine can build the Revit plugin (Revit 2025/2026 + .NET SDK
+  present — do NOT reflexively apply the "no build in sandbox" caveat). Build
+  `StingTools` after code changes and report `0 errors` or the actual errors.
+  `Planscape.sln` is unaffected by this work.
+- **Conventions.** Follow `CLAUDE.md` → Conventions: read before edit, targeted
+  edits, `StingLog` not silent catches, one logical change per commit, commit
+  messages in imperative mood ending with the repo's `Co-Authored-By` trailer.
+- **Docs.** Append a `#### Completed (Phase N — …)` block to `docs/CHANGELOG.md`
+  (use the next free phase number — check the file, do not reuse an existing one)
+  and update `docs/ROADMAP.md` where noted. Correct `CLAUDE.md` only where a
+  caveat becomes false.
+- Leave the branch for review — **no merge, no PR**. Finish with a summary:
+  files changed, the canonical enum decision, build status, verified vs deferred.
+
+---
+
+## WS-1 — RDS noise-field typo (BLOCKING, trivial)
+
+**Verified bug.** `StingTools/Data/HEALTHCARE_RDS_FIELDMAP.json` line ~25 maps
+`"room.noise.nr": "CLN_ROOM_NOISE_NR_NR"`, but that parameter does not exist. The
+registered parameter is `CLN_NOISE_NR_NR` (see `MR_PARAMETERS.txt` ~line 2804 —
+no `ROOM_` segment). Result: the "Noise Rating NR" field is blank in every Room
+Data Sheet, silently.
+
+**Task.** Change the field-map value to `CLN_NOISE_NR_NR`. Then re-run the RDS
+template generator so the generated `.docx` stays in lockstep with the field map:
+`python tools/build_healthcare_rds_docx.py` (it self-verifies token/loop coverage
+and exits non-zero on drift). Confirm the token set still matches.
+
+**Acceptance.** Field map references only registered parameters; generator
+self-test passes; `room.noise.nr` now resolves to `CLN_NOISE_NR_NR`.
+
+## WS-2 — Canonical room-class vocabulary (SYSTEMIC — the main fix)
+
+**Verified problem.** There is no single canonical value set for
+`CLN_ROOM_CLASS_TXT`. Producers and consumers use different spellings for the same
+room, so rooms silently fall through lookups:
+
+| Room | `HbnRoomAutoPopulatorCommand` writes/keys | `HTMStandards` keys | Validators expect |
+|---|---|---|---|
+| Ward | `WARD` | `WARD-INPT` | — |
+| Protective env. | `PE_ROOM` | `PE-PROT` | — |
+| CT | `CT` | (none) | `IMG-CT` (StructuralLoadValidator) |
+| MRI | `MRI` | (none) | `IMG-MRI` |
+| Cath lab | (none) | (none) | `CATHLAB` (StructuralLoad, EesBranch) |
+
+Consequence: a room tagged `IMG-CT` is matched by `StructuralLoadValidator` but
+not by `HbnRoomAutoPopulatorCommand` (keys on `CT`), so its ACH / pressure design
+params never populate → downstream pressure/ACH/acoustic validators silently skip
+it. The full fragmentation matrix spans `HTMStandards`, `ASHRAE170Standards`,
+`FGIStandards`, `USPStandards`, `IhfgStandards`, the validators
+(`PressureRegimeValidator`, `AcousticValidator`, `StructuralLoadValidator`,
+`WasteFlowValidator`, `AntiLigatureValidator`, `AdvancedRadShieldValidator`,
+`EesBranchValidator`, `EndoscopeTraceValidator`, `RtlsCoverageValidator`), the
+specialist audit commands under `Commands/Healthcare/Specialist/`,
+`Core/Adjacency/CleanDirtyFlowSolver.cs`, and the data files
+`HEALTHCARE_ACOUSTIC_NR_TARGETS.csv` / `HEALTHCARE_ADJACENCY_HBN.csv`.
+
+**Most-sustainable approach (do this, not per-file patching):**
+
+1. **Establish ONE canonical code list.** Create a single source of truth for the
+   `CLN_ROOM_CLASS_TXT` vocabulary — e.g. `StingTools.Standards/RoomClassCodes.cs`
+   (a static registry) plus a data companion
+   `StingTools/Data/HEALTHCARE_ROOM_CLASSES.json` so the list is editable without
+   a recompile (mirror how other healthcare data packs load: corporate baseline +
+   optional `<project>/_BIM_COORD/…` override). Each entry carries: canonical code,
+   human label, discipline/department, and cross-reference fields (HTM / ASHRAE /
+   FGI / iHFG names) so existing standards tables can be reached by mapping, not
+   by renaming their keys. **Decide the canonical spelling once** and document the
+   rule (recommended: the codes the validators + RDS + tag config already imply —
+   hyphenated `IMG-CT`, `WARD-INPT`, `PE-PROT`, `OR-ULTRA`, etc. — but you choose;
+   just make everything agree with the choice).
+
+2. **Add a resolver** so lookups never depend on exact spelling: a
+   `RoomClassCodes.Canonicalize(raw)` that maps any known alias (`WARD`,
+   `PE_ROOM`, `CT`, `CT_SCANNER_ROOM`, …) to the canonical code. Route the
+   standards-table lookups and validators through it, OR re-key/alias the tables —
+   whichever keeps a single mapping rather than N ad-hoc dictionaries.
+
+3. **Align every producer and consumer** to the canonical set via the resolver:
+   - `HbnRoomAutoPopulatorCommand` — its `RoomDesignTable` keys and any codes it
+     writes.
+   - All validators listed above that compare `CLN_ROOM_CLASS_TXT` (or read it via
+     `GetRoomClassCached`).
+   - `CleanDirtyFlowSolver` and the specialist audit commands.
+   - Data files `HEALTHCARE_ACOUSTIC_NR_TARGETS.csv`, `HEALTHCARE_ADJACENCY_HBN.csv`
+     (and any room-class column in tag-config CSVs).
+   - `HEALTHCARE_RDS_FIELDMAP.json` room-class token if applicable.
+   Preserve every existing threshold/value during the move — this is a
+   spelling/lookup unification, **not** a re-tuning. Codes with genuinely no
+   backing anywhere (`CATHLAB`, `IMG-BRACHY`, `ENDO-DECON`, `HSDU-S`, `IMG-LIN`)
+   must either get a canonical entry (with its cross-refs, even if a standards
+   design row is a future item) or be reconciled to an existing code — do not
+   leave a validator comparing against a code that the canonical list omits.
+
+4. **Add a load-time / on-demand validator** `RoomClassCodeValidator` (wired into
+   the healthcare validator set + gate, same pattern as the others) that flags any
+   `CLN_ROOM_CLASS_TXT` value not in the canonical list, so future drift surfaces
+   as a warning instead of a silent skip. Gate it through
+   `HealthcareValidatorGate` and register it in `RunAll/RunSelected` +
+   `HealthcareValidatorCommands` + `WorkflowEngine.ResolveCommand` +
+   `StingCommandHandler` like its siblings.
+
+**Acceptance.** One canonical room-class list exists; every producer, consumer,
+and data file resolves through it (no room type has two live spellings across
+producer↔consumer); thresholds unchanged; unknown codes are flagged, not skipped;
+`StingTools` builds clean.
+
+## WS-3 — TEXT-typed numeric params: guard the silent-parse-fail (LOW/MEDIUM)
+
+**Verified nuance.** `HealthcareValidatorBase.GetParamDouble` (line ~51) already
+parses TEXT via `double.TryParse(AsString())`, so the earlier "always null" claim
+is **false** for clean numeric strings. The real residual risk: several params are
+registered TEXT — `HVC_AIR_CHANGES_PER_HR`, `PER_ACOUSTICS_BACKGROUND_NOISE_DB`,
+`PER_ACOUSTICS_RT60_S`, `PLM_HOTWTR_TEMP_C` — so a value like `"12 ACH"` or
+`"45 dB"` fails the parse and the check silently skips.
+
+**Task (sustainable, minimal):** Do NOT re-type the shared parameters (schema
+churn, migration risk). Instead harden the reader: make `GetParamDouble` tolerant
+of a trailing unit/annotation — strip to the leading numeric token before
+`TryParse` (e.g. parse the first number in the string) using
+`InvariantCulture`. Add a `StingLog.Warn` when a non-empty TEXT value fails to
+yield a number, so a malformed cell is visible instead of silent. Keep behaviour
+identical for clean numeric strings. Add/adjust a tiny unit-style check only if a
+test harness already exists in the repo; otherwise verify by reasoning + build.
+
+**Acceptance.** `"12"`, `"12 ACH"`, `"0.6 s"`, `"45 dB"` all parse to their number;
+empty stays null; malformed non-empty logs a warning; no behaviour change for
+existing clean values.
+
+## WS-4 — RadShield non-conservative default distance (LOW, safety-relevant)
+
+**Verified.** `RadShieldValidator` uses a hardcoded 2.0 m default barrier distance
+when none is known. Because required shielding scales with `d²` in `B =
+P·d²/(W·U·T)`, an optimistic distance under-estimates required lead → a too-thin
+barrier can pass the audit. It is audit-only and now QE-gated, but the default
+biases the wrong way.
+
+**Task.** Make the default **conservative** (bias toward MORE shielding when
+distance is unknown) — e.g. a smaller default distance (such as 1.0 m) or an
+explicit "distance unknown" WARNING finding attached to the result, so the audit
+never silently blesses a barrier computed from an optimistic guess. Make the
+default a named constant / project-tunable value rather than a bare literal, and
+note the reasoning in a comment. Record any remaining depth work (true 3D
+barrier-distance geometry) in `docs/ROADMAP.md` (there is already an HC-DEF item
+for radiation write-back — add alongside).
+
+**Acceptance.** Unknown-distance path no longer biases toward under-shielding; the
+default is a documented constant; a warning is surfaced when distance is assumed.
+
+## WS-5 — Medical-gas diversity fallback visibility (LOW, safe already)
+
+**Verified, low risk.** `MgasFlowSolver` applies diversity correctly (NFPA 99
+§5.1.13, multiplier after per-zone-per-gas summation). Gases `N2`, `CO2`, `HE`,
+`DENT` have no entry in `NFPA99Standards` diversity and fall back to `1.0` — which
+over-sizes (safe), but silently.
+
+**Task.** No math change. Just make the fallback **visible**: when a gas has no
+tabulated diversity and defaults to 1.0, `StingLog.Info`/`Warn` it and surface it
+in the audit output (the `MgasNetworkAuditCommand` breakdown, which currently
+computes zone loads but does not display them — show the per-gas/per-zone
+diversified load table while you are there). Optionally add the missing gases'
+diversity factors to `NFPA99Standards` **only** if you can cite HTM 02-01 Table 8 /
+NFPA 99 Table 5.1.13.3.4 values with confidence; otherwise leave 1.0 and log it.
+
+**Acceptance.** No silent diversity=1.0; audit shows the diversified per-gas/zone
+loads.
+
+---
+
+## DO-NOT-TOUCH — verified false positives (do not "fix" these)
+
+An audit flagged these; each was checked and is NOT a bug. Changing them would
+introduce regressions:
+
+1. **`PressureRegimeValidator` "PE" vs "PE-PROT".** Line ~88 reads
+   `CLN_INFECT_CLASS_TXT` (infection class), a **different enum** from room class.
+   `"PE"` (Protective Environment) and `"AIIR"` are the correct infection-class
+   codes here. Leave as-is. (If WS-2's canonical work also standardises the
+   *infection-class* vocabulary, do that as a separate, clearly-scoped step — but
+   do not conflate `"PE"` with the room-class `"PE-PROT"`.)
+2. **"TEXT params always return null in `GetParamDouble`."** False — the reader
+   already `TryParse`s TEXT. WS-3 only hardens the annotated-string edge; it is not
+   a wholesale "these are broken" fix.
+3. **NCRP 147 Archer math / `MgasFlowSolver` diversity math / `AdvancedRadShield`
+   TVL constants / `AdjacencyValidator` ft→m (`* 0.3048`).** All verified correct.
+   Do not "correct" them.
+
+## Definition of done
+
+- WS-1..WS-5 implemented, each its own commit; false positives untouched.
+- `StingTools` build run and result reported (expect 0 errors).
+- One canonical room-class list, reached by every producer/consumer/data file.
+- `docs/CHANGELOG.md` phase block added (next free number); `docs/ROADMAP.md`
+  updated (WS-4 geometry, any deferred canonical-standards rows); `CLAUDE.md`
+  caveats corrected only where now false.
+- Final summary: files changed, canonical spelling chosen + resolver location,
+  build status, and anything deliberately deferred.

--- a/docs/HEALTHCARE_CHANGELOG_ROADMAP_FIX_PROMPT.md
+++ b/docs/HEALTHCARE_CHANGELOG_ROADMAP_FIX_PROMPT.md
@@ -1,0 +1,94 @@
+# Healthcare Pack — CHANGELOG / ROADMAP Coherence Fix (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Execute the
+workstreams below **without stopping to ask**. This is a **docs-only** pass — do NOT
+touch any code or data files. Small, surgical scope; match the existing document
+style exactly. Read the cited files before editing.
+
+A coherence review found the CHANGELOG has one undocumented change plus a subtle
+over-claim; the ROADMAP is already clean and is verify-only.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work to completion.
+- **Branch / worktree.** Continue on the existing worktree
+  `C:\Dev\STINGTOOLS-hc-fixes`, branch `claude/healthcare-gap-fixes` — confirm with
+  `git -C C:\Dev\STINGTOOLS-hc-fixes rev-parse --abbrev-ref HEAD`. Never touch the
+  shared `C:\Dev\STINGTOOLS` checkout; never commit to `main`. One commit; message
+  imperative, ending with the repo's `Co-Authored-By` trailer.
+- **Docs only** — no `.cs`, `.json` data, or migration edits. No build needed; just
+  confirm `git diff --stat` shows only `docs/CHANGELOG.md` (and, only if a genuine
+  inconsistency is found, `docs/ROADMAP.md`).
+- Leave the branch for review — no merge, no PR. Finish with a one-paragraph
+  summary.
+
+---
+
+## WS-1 — Document the profile-coverage follow-up in the CHANGELOG
+
+**Verified gap.** Commit `44b888634` ("add new validators to pack sub-profiles;
+bump phase pointer") edited `StingTools/Data/HEALTHCARE_PACK_PROFILES.json` and
+`CLAUDE.md` but added **no CHANGELOG entry** — the last change on the branch is
+unlogged (grep for "sub-profile" in `docs/CHANGELOG.md` returns nothing).
+
+**Task.** Add a short follow-up note to the **Phase 198** block in
+`docs/CHANGELOG.md` (append it inside that block — a "Follow-up" paragraph or a
+"WS-8" line, matching the block's existing WS-n / prose style). It must record,
+factually and briefly:
+- `RoomClassCodeValidator` (added Phase 197) and `PharmacyRecertValidator` (added
+  Phase 198 WS-5) were present in the gate's `_allValidators` set (so they ran under
+  the **FULL** profile) but were **missing from `HEALTHCARE_PACK_PROFILES.json`**, so
+  the five named sub-profiles silently excluded them.
+- Fix: `RoomClassCodeValidator` added to **all five** sub-profiles (ACUTE,
+  COMMUNITY, DENTAL, IMAGING-ONLY, MENTAL-HEALTH) as facility-agnostic room-class
+  drift hygiene; `PharmacyRecertValidator` added to **ACUTE + COMMUNITY** only (the
+  pharmacy-cleanroom-bearing profiles) — DENTAL/IMAGING-ONLY/MENTAL-HEALTH correctly
+  still skip it. **FULL** is unchanged (`["all"]`). `CLAUDE.md` phase pointer bumped
+  196 → 198.
+
+## WS-2 — Correct the WS-5 "DONE" over-claim (tie to WS-1)
+
+**Verified.** The Phase 198 block's summary table marks **WS-5** (USP 797/800 recert)
+"DONE," but as originally logged the validator only ran under the **FULL** profile —
+it did not actually fire under ACUTE/COMMUNITY until the `44b888634` follow-up. The
+same applies to the Phase 197 `RoomClassCodeValidator`.
+
+**Task.** Adjust the wording so "DONE" is not misleading — e.g. keep WS-5 "DONE" but
+add a brief clause (or footnote) that sub-profile reachability was completed in the
+WS-1 follow-up above. Do not overhaul the table; the minimal honest clarification is
+enough. Keep the Phase 197 block accurate too if it implies `RoomClassCodeValidator`
+was reachable everywhere on landing.
+
+## WS-3 — Verify the ROADMAP (leave clean; do not churn)
+
+The ROADMAP (`docs/ROADMAP.md`) was reviewed and is coherent: `HC-DEF-01..10` are
+sequential and non-colliding, `HC-DEF-06` is correctly struck through as
+"CLOSED (Phase 197)", each open item accurately states shipped-vs-deferred, and the
+orphaned-param list points to its blocking feature (HC-DEF-09/10).
+
+**Task.** Re-verify quickly. **Do NOT edit it unless you find a genuine
+inconsistency** (e.g. an item closed by later work still listed as open, an ID
+collision, or a claim now false). If you do edit, describe exactly what and why in
+your summary. Specifically **do not** renumber `HC-DEF-01b` — the sub-number
+intentionally groups the two radiation-distance items.
+
+---
+
+## DO-NOT-TOUCH
+
+- **Pre-existing repeated phase numbers** in `docs/CHANGELOG.md` (e.g. Phase 184
+  appearing 10×, 188 5×, the 192B/192E sub-parts) predate this branch and are
+  intentional multi-part phase blocks. Do NOT "deduplicate" or renumber them.
+- No code, data, migration, or JSON edits — this pass is CHANGELOG (and only-if-
+  needed ROADMAP) prose.
+- Do not alter the Phase 196/197 block scopes beyond the minimal WS-2 accuracy
+  clarification.
+
+## Definition of done
+
+- Phase 198 CHANGELOG block documents the profile-coverage + pointer follow-up; the
+  WS-5 "DONE" is honestly qualified; ROADMAP left clean (or a described genuine fix).
+- One docs-only commit on `claude/healthcare-gap-fixes`; `git diff --stat` shows only
+  doc files. Branch left for review.
+- Summary: what was added to the CHANGELOG, the WS-5 wording change, and whether the
+  ROADMAP needed anything.

--- a/docs/HEALTHCARE_COMPLETENESS_FIXES_PROMPT.md
+++ b/docs/HEALTHCARE_COMPLETENESS_FIXES_PROMPT.md
@@ -1,0 +1,232 @@
+# Healthcare Pack — Completeness Remediation (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Execute
+every workstream below **end to end, without stopping to ask**. At each choice
+pick the **most flexible, sustainable, data-driven option** — one source of truth,
+reused everywhere, changeable without a recompile, matching existing repo
+patterns. Do not gold-plate; each finding is either FIXED or explicitly
+DEFERRED-with-a-ROADMAP-entry (see WS-7). Read every cited file before editing.
+
+These findings come from a **verified** completeness audit (binding mechanism,
+SignalR wiring, water-flush endpoint, dead-param grep, and doc alignment were all
+checked against the actual code). The verified false positives are fenced off in
+DO-NOT-TOUCH — respect them.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work autonomously to completion.
+- **Branch / worktree.** Continue on the existing worktree
+  `C:\Dev\STINGTOOLS-hc-fixes`, branch `claude/healthcare-gap-fixes` — confirm with
+  `git -C C:\Dev\STINGTOOLS-hc-fixes rev-parse --abbrev-ref HEAD`. If absent, create
+  a fresh worktree off latest `claude/pm-complete`. Never touch the shared
+  `C:\Dev\STINGTOOLS` checkout; never commit to `main`. One logical commit per
+  workstream; commit messages imperative, ending with the repo's `Co-Authored-By`
+  trailer.
+- **Build.** This machine can build the Revit plugin (Revit 2025/2026 + .NET SDK)
+  and `Planscape.Server` — build both where you touch them and report `0 errors`
+  or the actual errors. Do NOT apply a "no build in sandbox" caveat.
+- **New shared parameters MUST be fully registered** in ALL of: `MR_PARAMETERS.txt`,
+  `MR_PARAMETERS.csv`, `PARAMETER_REGISTRY.json`, and `CATEGORY_BINDINGS.csv`
+  (reference), following the exact sibling pattern with a next-free deterministic
+  GUID. (This gap has recurred three times — do not add a param the code reads
+  without registering it.)
+- **Docs.** Append a `#### Completed (Phase N — …)` block to `docs/CHANGELOG.md`
+  (next free phase number — check the file), update `docs/ROADMAP.md` per WS-7, and
+  correct `CLAUDE.md` where a caveat is false. Leave the branch for review — no
+  merge, no PR. Finish with a summary: files changed, build status, what was fixed
+  vs deferred, and any new params + their GUIDs.
+
+---
+
+## DO-NOT-TOUCH — verified false positives / already-correct
+
+Do **not** "fix" these — each was verified; changing them wastes effort or
+regresses:
+
+1. **CATEGORY_BINDINGS.csv "unbound-read" claims.** An audit alleged most
+   validators read params off categories they aren't bound to → silent failure.
+   **This is false.** Binding is group-driven in `LoadSharedParamsCommand`: params
+   bind to the broad `coreCats` set unless their *group* is explicitly narrowed in
+   `BuildGroupCategoryOverrides`. The healthcare groups (RAD_PROTECTION,
+   MGS_SYSTEMS, CLN_CLINICAL, CEQ_CLINICAL, LIG_BEHAVIOURAL, ICT_HEALTHIOT) are
+   **not** narrowed, so they bind to the broad set (which already includes Walls,
+   Pipes, Electrical, Data/Nurse-Call/Comm devices). `CATEGORY_BINDINGS.csv` is a
+   validation/reference artifact (`ValidateBindingsFromCsv`), NOT the binding
+   authority. Do not re-bind params to chase this.
+2. **Validator wiring / findings surfacing.** All 17 validators are already
+   surfaced to the user (dock panel + individual commands + RunAll/Selected).
+3. **Room-class canonicalisation, QE gate, NCRP-147 / medical-gas-diversity math**
+   — verified correct. Do not touch.
+
+---
+
+## WS-1 — Wire the two missing SignalR broadcasts (automation, quick)
+
+**Verified gap.** `HealthcareHub` defines `BroadcastMgasAlarm` and
+`BroadcastAntiLigatureAlert`, but `HealthcareController` only ever calls
+`BroadcastPressureReading` (the POST pressure-log path). MGPS-fail and
+anti-ligature-fail events never reach mobile clients in real time.
+
+**Task.** In `Planscape.Server` `HealthcareController`:
+- In `PostMgasVerification`, after persist, when the verification is a FAIL
+  (`overallPass == false`), `await HealthcareHub.BroadcastMgasAlarm(...)` with the
+  project id + zone/gas/verifier payload, mirroring the pressure-broadcast shape.
+- In `PostLigAudit` (anti-ligature POST), when the audit is a FAIL, `await
+  HealthcareHub.BroadcastAntiLigatureAlert(...)`.
+Match the existing broadcast method signatures; do not invent new hub methods.
+Confirm `Planscape.Server` builds.
+
+**Acceptance.** Both broadcasts fire on FAIL; build clean.
+
+## WS-2 — Documentation alignment (information, trivial)
+
+**Verified.** `CLAUDE.md` caveat #6 ("No dedicated Healthcare tab in the dock
+panel") is **stale** — the BIM-Coordination-Centre Healthcare tab is fully built
+(`UI/BIMCoordinationCenter.cs` ~9181-9323, live dashboard wired to the server
+`GetHealthcareDashboardAsync` endpoint, 16 validator buttons).
+
+**Task.** Rewrite caveat #6 to reflect reality: the Healthcare tab is integrated
+into the BIM Coordination Centre (gated on `PRJ_ORG_HEALTH_FACILITY_TYPE_TXT`),
+surfacing pressure/MGPS/anti-ligature/RDS dashboards + validator dispatch. Keep the
+note that healthcare commands also dispatch via `WorkflowEngine.ResolveCommand` /
+`StingCommandHandler`. While there, confirm the migrations caveat still correctly
+states the documentation-DDL / prod-EF-pipeline (backlog P3-2) status.
+
+**Acceptance.** Caveat #6 is true; no other caveat left false.
+
+## WS-3 — Water-flush end-to-end (integration, the main build)
+
+**Verified gap.** `Planscape/app/healthcare/water-flush.tsx` is display-only: its
+`log()` writes local state, calls no API, enqueues nothing. There is no
+`water-log` endpoint in `HealthcareController`, no `HealthcareWaterLog` entity, and
+no `HC_WATER_FLUSH` offline action. HTM 04-01 sentinel-flush data is lost on app
+restart. The other three mobile actions (pressure/MGAS/anti-ligature) are the
+reference pattern — replicate it exactly.
+
+**Task (full round-trip, mirror the pressure-log slice end to end):**
+1. **Entity** `HealthcareWaterLog` in `Planscape.Core/Entities/` (tenant + project
+   FKs, room ref (bim id + optional IFC GlobalId to match siblings), outlet id,
+   flush type, temperature/duration if the screen captures them, captured-at/by),
+   registered as a `DbSet` in `PlanscapeDbContext` with the same model config +
+   indexes as `HealthcarePressureLog`.
+2. **Migration** creating `HealthcareWaterLogs`, in the same documentation-DDL
+   style as `20260515000000_HealthcarePack.cs` (no `[Migration]` attribute; the
+   repo builds schema from the model). Order it after the existing healthcare
+   migrations. Add the table to `PlanscapeDbContextModelSnapshot` if the repo's
+   convention requires it (mirror how the sibling healthcare tables appear).
+3. **Endpoints** in `HealthcareController`: `POST .../healthcare/water-log`
+   (persist; broadcast a SignalR reading if that fits the pattern) and
+   `GET .../healthcare/water-log` (filter by since/room, capped like siblings).
+   Add the count to the healthcare dashboard DTO if the other logs are counted
+   there.
+4. **Mobile**: add `postWaterFlush()` to the API client, an `HC_WATER_FLUSH`
+   offline action type, its replay handler in the offline queue (mirror
+   `HC_PRESSURE_LOG`), and wire `water-flush.tsx` to call it (POST + enqueue-on-
+   failure), exactly like `pressure-live.tsx`.
+Build `Planscape.Server`.
+
+**Acceptance.** Water-flush captures persist to the server, survive offline via the
+queue, and appear in GET/dashboard — parity with the pressure-log slice.
+
+## WS-4 — Regional HTM variant gating (flexibility)
+
+**Verified gap.** `StingTools.Standards/HTM/HtmRegionalVariants.cs` defines real
+England/Wales/Scotland/NI delta tables, but **no validator reads
+`PRJ_ORG_HEALTH_HTM_REGION_TXT`** — every validator hard-codes NHS-England values.
+Non-England projects silently get England rules.
+
+**Task (sustainable — one resolution point, not per-validator hacks):**
+- Resolve the active region once from `PRJ_ORG_HEALTH_HTM_REGION_TXT` on
+  ProjectInformation (via the existing `HtmRegionalVariants.ParseRegion` /
+  `GetForRegion`), defaulting to NHS-England when unset.
+- Apply the regional delta where the standards lookups feed the validators — the
+  cleanest home is inside `HTMStandards` (or a thin region-aware wrapper the
+  validators already call, e.g. the ACH / pressure / pipe-class / hot-water
+  lookups), so a validator asking for "min ACH for room X" transparently gets the
+  region-adjusted value. Prefer routing through the existing lookup methods over
+  copy-pasting region checks into `PressureRegimeValidator` / `MgasFlowValidator` /
+  `WaterSafetyValidator`.
+- Surface the active region in the relevant audit output so the user can see which
+  code base was applied.
+Preserve England values exactly when region is England/unset (no behaviour change
+for existing projects).
+
+**Acceptance.** Setting `PRJ_ORG_HEALTH_HTM_REGION_TXT` to SHTM/WHTM/NHS-NI shifts
+the affected thresholds per `HtmRegionalVariants`; England/unset is unchanged; the
+region is one resolution point, not N.
+
+## WS-5 — USP 797/800 recertification escalation (automation, life-safety)
+
+**Verified gap.** Design promised: `CLN_ENV_CERT_DUE_DT` within 30 days → warning,
+overdue → blocking error, for rooms with `CLN_ROOM_CLASS_TXT` = pharmacy-cleanroom
+(PH-CSP-797 / PH-CSP-800). Not implemented — `IoTStalenessValidator` checks device
+staleness only and never reads `CLN_ENV_CERT_DUE_DT`.
+
+**Task.** Implement the recert-due check. Put it where it belongs sustainably:
+either extend `IoTStalenessValidator` (it already owns time-based escalation) or add
+a small dedicated check gated through `HealthcareValidatorGate` like its siblings —
+choose the one that keeps the pack's pattern. For each cleanroom room class, read
+`CLN_ENV_CERT_DUE_DT`, and emit: Info/OK if > 30 days out, Warning if within 30
+days, Error if overdue or missing. Use `USPStandards` for the 6-month cycle
+constant and the cleanroom room-class set (route class comparisons through the
+canonical `RoomClassCodes` resolver so spelling variants match). Wire it into
+RunAll/Selected + a command + `WorkflowEngine.ResolveCommand` +
+`StingCommandHandler` if you add a new validator.
+
+**Acceptance.** A pharmacy cleanroom with an overdue/near-due
+`CLN_ENV_CERT_DUE_DT` raises the correct severity; absent date flags as missing;
+cleanroom detection is canonical-code-safe.
+
+## WS-6 — Penetration sign-off offline resilience (automation, minor)
+
+**Verified gap.** `Planscape/app/penetrations/signoff.tsx` PUTs the sign-off
+directly with no offline-queue fallback, unlike the healthcare screens.
+
+**Task.** Wrap the `putPenetrationSignoff()` call so a network failure enqueues a
+`PEN_SIGNOFF` offline action (add the action type + replay handler mirroring
+`HC_PRESSURE_LOG`) and shows the same "saved offline" affordance the healthcare
+screens use.
+
+**Acceptance.** Offline penetration sign-offs queue and replay on reconnect.
+
+## WS-7 — Information hygiene: orphaned params, CEQ/COBie, FGI adoption
+
+**Verified, right-sized.** The earlier "37 dead params" is overstated — several
+(`CLN_NURSECALL_TYPE_TXT`, `CLN_HOIST_TRACK_BOOL`, `CLN_BARI_DESIGN_KG_NR`,
+`CLN_FGI_REF_TXT`) are consumed by the RDS renderer via
+`HEALTHCARE_RDS_FIELDMAP.json` (invisible to a `.cs` grep) — they are RDS-surfaced,
+not dead. The **genuinely unconsumed** items are: the whole `CEQ_CLINICAL` group
+(clinical-equipment decon / endoscope / GMDN / UMDNS / SFG20 codes), the
+`PRJ_ORG_HEALTH_AE_*` assigned-engineer metadata, a few CLN fields
+(`CLN_OCC_VISITOR_INT`, `CLN_RT60_TARGET_S_NR`), plus two standards tables with
+zero callers (`FgiAdoptionTracker`, and the COBie clinical-equipment/SFG20
+overlay).
+
+**Task — clarify status; do not silently leave dead fields:**
+1. First, **verify** each candidate is truly unconsumed by BOTH `.cs` code AND the
+   JSON-driven consumers (`HEALTHCARE_RDS_FIELDMAP.json`, COBie CSVs) before
+   declaring it dead — the RDS fieldmap is the trap.
+2. For params that ARE genuinely orphaned, add a clearly-labelled section to
+   `docs/ROADMAP.md` (e.g. "Healthcare — data-model-ahead-of-logic") listing them
+   and the feature each is waiting on (CEQ cluster → clinical-equipment COBie
+   handover; `PRJ_ORG_HEALTH_AE_*` → assigned-engineer compliance gate; FGI
+   adoption tracker → US-jurisdiction escalation). This stops specifiers populating
+   fields that no logic reads.
+3. **Low-cost wins if quick:** if `FgiAdoptionTracker.ResolveSeverity` can be
+   called from the existing FGI-related validator path with a modest change, wire
+   it; otherwise ROADMAP it. Do **not** build the full COBie clinical-equipment
+   export in this pass — flag it as a scoped future item in ROADMAP with the params
+   it would consume.
+
+**Acceptance.** Every genuinely-orphaned healthcare param is either wired or listed
+in ROADMAP with its blocking feature; no false "dead" claim for RDS-surfaced params.
+
+---
+
+## Definition of done
+
+- WS-1..WS-6 implemented (WS-7 = verify + wire-if-cheap + ROADMAP the rest); DO-NOT-TOUCH respected.
+- `Planscape.Server` and `StingTools` built where touched; results reported.
+- Any new shared param registered across all four data files with a deterministic GUID.
+- `docs/CHANGELOG.md` phase block; `docs/ROADMAP.md` updated; `CLAUDE.md` caveat #6 corrected.
+- Final summary: fixed vs deferred, new params + GUIDs, build status, residual follow-ups.

--- a/docs/HEALTHCARE_DEFERRED_IMPLEMENTATION_PROMPT.md
+++ b/docs/HEALTHCARE_DEFERRED_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,161 @@
+# Healthcare Pack — Deferred Items Implementation (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Implement the
+deferred healthcare ROADMAP items (HC-DEF-01..HC-DEF-10) below, **without stopping to
+ask**. These are real **features**, larger than the prior fix-passes — so this is a
+**phased** build: land each phase fully and commit it before the next. At every choice
+pick the most flexible, sustainable, **data-driven** option; reuse the existing engines
+named below rather than reinventing them. Read every cited file before editing.
+
+## The overriding guardrail — do NOT fake domain data or physics
+
+This effort has been disciplined about never inventing standards values. Keep that:
+- **Where an item needs data that must be authoritative** (medical-gas diversity
+  factors, FGI clause→jurisdiction adoption mapping, full NCRP-151/PET physics, a real
+  BMS transport), build the **mechanism / interface / data-file hook** and leave the
+  actual values **project-supplied** (corporate baseline + `<project>/_BIM_COORD/`
+  override, the pattern `MepSizingRegistry` / `RoomClassCodes` already use). Do NOT
+  hardcode guessed numbers. If a piece genuinely cannot be done in-repo, implement the
+  seam and update its ROADMAP entry — do not stub-and-pretend.
+- Prefer depth over breadth: **fully landing Phase 1 is worth more than shallow-touching
+  all nine.** If scope forces a stop, stop at a phase boundary with Phase 1 complete.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work autonomously; phase-by-phase commits.
+- **Branch / worktree.** Work in a worktree off the latest healthcare branch. Prefer a
+  fresh worktree + branch off `claude/healthcare-gap-fixes` (which carries all prior
+  work): `git worktree add ../STINGTOOLS-hc-def -b claude/healthcare-deferred`. Confirm
+  the base contains the Phase 196-198 commits. Never touch the shared
+  `C:\Dev\STINGTOOLS` checkout; never commit to `main`. One logical commit per HC-DEF
+  item; imperative messages ending with the repo's `Co-Authored-By` trailer.
+- **Build.** This machine builds `StingTools` and `Planscape.Server` — build what you
+  touch and report `0 errors` or the actual errors. Do NOT apply a "no build" caveat.
+- **Any new shared parameter** must be registered in ALL of `MR_PARAMETERS.txt`,
+  `MR_PARAMETERS.csv`, `PARAMETER_REGISTRY.json`, and `CATEGORY_BINDINGS.csv`, with a
+  deterministic sibling GUID. (This gap has recurred — do not read an unregistered param.)
+- **Docs.** New `#### Completed (Phase N — …)` CHANGELOG block (next free number — check
+  the file; the branch is at Phase 198). As each HC-DEF item lands, **strike it through
+  in `docs/ROADMAP.md`** with `CLOSED (Phase N)` like `HC-DEF-06` — and update the
+  "data-model-ahead-of-logic" orphan list (e.g. the `CEQ_*` cluster stops being orphaned
+  once HC-DEF-10 consumes it). Bump the `CLAUDE.md` phase pointer to the new max.
+- Leave the branch for review — no merge, no PR. Final summary: per item DONE / PARTIAL
+  (+ what's deferred and why) / build status, and any new params + GUIDs.
+
+Existing infra confirmed present — REUSE these, do not duplicate:
+`StingTools/Core/Adjacency/RoomGraphBuilder.cs`, `StingTools/UI/CobieMaterialBridge.cs`,
+`StingTools/Temp/COBieDataCommands.cs` + `Docs/HandoverExportCommands.cs`, the
+`StingTools/Data/COBIE_*.csv` pack, `StingTools.Standards/HBN/HBNStandards.cs`
+(`AdjacencyTargets`, department-keyed), `RoomClassCodes` (has a `department` field per
+canonical code), `RadiationSignoffGate`, `FgiAdoptionTracker`, `TwinReadbackBase` in
+`Core/Twin/TwinReadback.cs`, `NFPA99Standards`.
+
+---
+
+## PHASE 1 — high-value, self-contained (build fully)
+
+### HC-DEF-10 — Clinical-equipment COBie / SFG20 handover export
+The `CEQ_CLINICAL` cluster (`CEQ_DECON_METHOD_TXT`, `CEQ_ENDO_AER_REF_TXT`,
+`CEQ_ENDO_CYCLE_COUNT_INT`, `CEQ_ENDO_LAST_REPRO_DT`, `CEQ_ENDO_SCOPE_ID_TXT`,
+`CEQ_GMDN_CODE_TXT`, `CEQ_UMDNS_CODE_TXT`, `CEQ_SFG20_REF_TXT`, `CEQ_INFECT_TIER_TXT`,
+`CEQ_IMAGING_STRUCT_LOAD`, `CEQ_CLINICAL_BOOL`, `CEQ_EQP_TAG`, `CEQ_TAG_7_PARA_TXT`) is
+registered but consumed by nothing (only `CEQ_CATEGORY_TXT` is read, by `HboAuditCommand`).
+**Task:** build a clinical-equipment COBie handover export that reads the `CEQ_*` cluster
+off clinical-equipment elements and emits the COBie Type/Component/Job/Spare rows, driven
+by the existing `COBIE_TYPE_MAP.csv` / `COBIE_JOB_TEMPLATES.csv` / `COBIE_SPARE_PARTS.csv`
+/ `COBIE_ATTRIBUTE_TEMPLATES.csv` (extend those CSVs with the clinical-equipment rows the
+design promised — 50 clinical equipment types / SFG20 job refs — as **data**, not code).
+Slot it into the existing COBie export path (`COBieDataCommands` / `HandoverExportCommands`
+/ `CobieMaterialBridge`) rather than a parallel exporter; add a command + dispatch wiring
+like its siblings. **Acceptance:** a clinical-equipment element with `CEQ_*` populated
+appears in the exported COBie with its SFG20 job template + spare parts + GMDN/UMDNS
+attributes; the `CEQ_*` cluster is removed from the ROADMAP orphan list.
+
+### HC-DEF-08 — Reconcile HBN adjacency to canonical room classes
+`HBNStandards.AdjacencyTargets` and `HEALTHCARE_ADJACENCY_HBN.csv` key on coarse
+department codes (ED/IMAGING/OR/WARD/PHARMACY/MORT), but `AdjacencyValidator` now reads
+canonical room classes (`RoomClassCodes`). **Task:** use `RoomClassCodes`'s `department`
+cross-ref to group rooms by department before matching `AdjacencyTargets`, so canonical
+room reads align with the department-keyed adjacency rules. Make `HEALTHCARE_ADJACENCY_HBN.csv`
+the live data source for the targets (it is currently unused). Preserve existing target
+values. **Acceptance:** adjacency rules fire correctly for rooms tagged with canonical
+codes (e.g. `IMG-CT` maps to `IMAGING`); the CSV is consumed; no double-count.
+
+### HC-DEF-01 — Radiation shielding write-back (QE-gated, audit-trailed)
+`RadCalc*` commands compute but never persist. **Task:** add a write-back path that stamps
+`RAD_LEAD_MM_NR` (+ companions: barrier type, workload/use/occ, distance, computed-at) onto
+a **user-selected barrier element** (Wall/Door/Window/Generic Model — the categories
+`RadShieldValidator` reads and that `RAD_DISTANCE_M_NR` is now bound to). Gate the write
+through `RadiationSignoffGate`: never write an "approved" value without `RAD_QE_NAME_TXT`;
+write with a **draft/approved flag** + an audit stamp (who/when). Reuse the existing gate
++ params; register any genuinely new companion param in all four files. **Acceptance:**
+selecting a barrier and running write-back stamps the computed values with a draft flag
+when unsigned, an approved flag when a QE is on record, and never silently certifies.
+
+## PHASE 2 — moderate, uses existing engines
+
+### HC-DEF-04 — AdjacencyValidator door-graph BFS
+Replace the centroid-distance heuristic (which false-flags corridor-connected rooms) with
+a real door/room-graph BFS via the existing `RoomGraphBuilder`. Distances become "N doors
+apart", matching how `AdjacencyTargets` values are meant (e.g. `ED↔IMAGING ≤ 2`). Keep the
+centroid path as a labelled fallback if the graph can't be built. Coordinate with HC-DEF-08
+(both touch `AdjacencyValidator`) — do them in a sensible order. **Acceptance:** two rooms
+far by centroid but connected by a short corridor are no longer mis-flagged; door-count
+drives the check.
+
+### HC-DEF-01b — True barrier-distance geometry (ties to HC-DEF-01)
+Where feasible, derive the real source-to-barrier distance from model geometry (source
+placement + barrier face) instead of the conservative 1.0 m default. If robust geometry
+derivation is not achievable cleanly, **keep the conservative default** and implement only
+the per-element `RAD_DISTANCE_M_NR` capture from the write-back workflow — then update the
+ROADMAP entry to reflect what shipped. Do not ship a fragile geometry guess.
+
+## PHASE 3 — mechanism + data-hook only; DEFER the authoritative data
+
+For each of these, ship the **wiring/interface/data-file seam** and leave the
+authoritative values project-supplied; update the ROADMAP entry to "mechanism shipped;
+data project-supplied" rather than closing it if the data isn't authoritative.
+
+### HC-DEF-07 — Med-gas diversity factors (N₂ / CO₂ / He / dental)
+Add a **data-driven override** for per-gas diversity in `NFPA99Standards` (corporate JSON
++ project override), so a project can supply HTM 02-01 Pt A Table 8 / NFPA 99 Table
+5.1.13.3.4 values. Keep the 1.0 fallback + the Phase-197 flag when a gas is unset. Do NOT
+hardcode guessed factors. **Acceptance:** a project-supplied diversity value is honoured;
+absent, the flagged 1.0 fallback stands.
+
+### HC-DEF-09 — FGI adoption escalation wiring
+Wire `FgiAdoptionTracker.ResolveSeverity` into the FGI-related validation path. This needs:
+a project **US-jurisdiction** parameter + a **design-freeze date** on ProjectInformation
+(register both in all four files), and a **clause-code → finding mapping** as a data file
+(project-supplied overlay). Ship the mechanism (read jurisdiction + freeze date, map
+findings, escalate Warning→Error once a state has adopted a clause by the freeze date).
+Leave the mapping data as a documented overlay, not guessed. **Acceptance:** with a
+jurisdiction + freeze date + mapping supplied, an adopted FGI clause escalates; without
+them, behaviour is unchanged.
+
+### HC-DEF-02 / HC-DEF-03 — Radiation physics depth (LINAC / PET / SPECT / Brachy)
+Do NOT fake certification-grade physics. Where a **data-driven improvement** is clean, add
+it as a project/QE-supplied table (e.g. per-modality Archer coefficients or a build-up-factor
+hook) behind the existing calculators, keeping output DRAFT/QE-gated. Otherwise leave the
+indicative calc as-is and keep the ROADMAP entry. The goal is a data seam for the QE, not a
+guessed model.
+
+### HC-DEF-05 — Twin live BMS transport
+Do NOT pull a third-party BACnet/OPC-UA stack into the plugin assembly. Solidify the
+pluggable `TwinReadbackBase` contract so a project/host can register a real transport
+adapter (define the interface + a registration/discovery seam + a documented adapter
+contract), keeping the empty built-ins as the default. Update the ROADMAP entry to
+"pluggable transport seam shipped; live adapter external".
+
+---
+
+## Definition of done
+
+- Phase 1 fully implemented (HC-DEF-10, 08, 01), each its own commit, build-verified.
+- Phase 2 implemented where clean; Phase 3 = mechanism/seam shipped with data deferred.
+- Every closed item struck through in ROADMAP with `CLOSED (Phase N)`; partial items'
+  entries updated to state exactly what shipped vs what's project-supplied/external.
+- Orphan list updated (CEQ_* cluster no longer orphaned after HC-DEF-10).
+- New params registered in all four data files with GUIDs; `StingTools` +
+  `Planscape.Server` build where touched; CHANGELOG phase block + CLAUDE.md pointer updated.
+- Final summary: per-item DONE/PARTIAL/deferred with reasons, new params + GUIDs, builds.

--- a/docs/HEALTHCARE_GAP_FIXES_PROMPT.md
+++ b/docs/HEALTHCARE_GAP_FIXES_PROMPT.md
@@ -1,0 +1,200 @@
+# Healthcare Pack — Gap Remediation (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent working in the **StingTools** monorepo
+(`C:\Dev\STINGTOOLS`). Execute all four workstreams below **end to end without
+stopping to ask questions**. Make the decisions yourself; where a choice exists,
+pick the **most flexible, sustainable, data-driven option** — the one that a
+future maintainer can change without recompiling, that reuses existing patterns,
+and that will not need re-doing when the next standard revision lands. Do not
+gold-plate: solve exactly these four items well.
+
+This work follows a read-only audit of the healthcare pack. The findings below
+are verified — you do **not** need to re-discover them, but you **must** read the
+cited files before editing them.
+
+## Ground rules (apply to everything)
+
+- **Do not ask for confirmation.** Work autonomously to completion.
+- **Branch discipline.** You are likely on `claude/pm-complete`. Do **not** commit
+  to `main`. Create/verify a feature branch first (`git rev-parse --abbrev-ref HEAD`).
+  If multiple agents share this checkout, prefer a git worktree for isolation and
+  verify the branch before any `reset`/`checkout` (see repo memory on worktree
+  isolation).
+- **Build caveat.** This environment usually has no .NET/Revit API, so a full
+  `dotnet build` of the Revit plugin may not be possible. Where you cannot build,
+  say so explicitly in the commit message and CHANGELOG entry (matches existing
+  repo convention). The **server** project (`Planscape.Server`) and any pure-.NET
+  test/tool code **should** build — attempt `dotnet build` there and report results.
+- **Conventions.** Follow `CLAUDE.md` → "Conventions for AI Assistants": read
+  before edit, targeted edits over rewrites, `StingLog` not silent catches,
+  `TaskDialog` not `MessageBox`, transactions prefixed `STING`, one logical change
+  per commit.
+- **Logging your work.** Append a `#### Completed (Phase N — Healthcare gap fixes)`
+  block to `docs/CHANGELOG.md`, and move any newly-tracked deferrals into
+  `docs/ROADMAP.md`. Keep `CLAUDE.md` for stable structure only.
+- **Commit** each workstream as its own logical commit. End commit messages with
+  the repo's required trailer.
+
+---
+
+## Workstream 1 — RDS renderer template (BLOCKING)
+
+**Problem.** `RdsRenderer.Render()` looks for
+`StingTools/Docs/_template_sources/healthcare_rds.docx`; only
+`healthcare_rds_README.md` exists there. Every Room Data Sheet issue therefore
+returns `null` ("template missing"), which silently breaks
+`IssueRoomDataSheetCommand`, `BatchIssueRoomDataSheetsCommand`, and the
+`RdsIssue`, `HealthcareCommissioning`, and `HTM-04-01-Annual` workflows. The rest
+of the chain is real and working: `RdsContextBuilder` populates 41 tokens + 4
+loops from `StingTools/Data/HEALTHCARE_RDS_FIELDMAP.json`, and
+`MiniWordAdapter.Render` genuinely writes `.docx` via MiniWord
+(`MiniWord.SaveAsByTemplate`).
+
+**Task.** Produce a real `healthcare_rds.docx` MiniWord template at
+`StingTools/Docs/_template_sources/healthcare_rds.docx` that honours the token
+contract in `healthcare_rds_README.md` and the field map in
+`HEALTHCARE_RDS_FIELDMAP.json` exactly (all `{{token}}` names, all 4 loop tables
+`services` / `equipment` / `finishes` / `signatures`, and any `{{#if}}`
+conditionals the adapter's `PreProcess` supports).
+
+**Most-sustainable guidance.** A hand-crafted opaque binary is *not* the flexible
+option — it can't be diffed or regenerated. Prefer a **reproducible generator**:
+add a small script/tool (e.g. Python `python-docx`, or a .NET
+`DocumentFormat.OpenXml` one-shot under `tools/`) that emits the `.docx` from the
+field map, so the template can be rebuilt when tokens change. Commit both the
+generator **and** the generated `.docx`. Verify the output actually opens and that
+its `{{tokens}}` match `HEALTHCARE_RDS_FIELDMAP.json` (diff the token set
+programmatically — fail loudly if any token in the map is missing from the
+template or vice-versa). Match the visual/structural conventions of the existing
+16 templates in `_template_sources/` (banded header, footer PAGE/NUMPAGES, loop
+tables).
+
+**Acceptance.** `RdsRenderer.Render(doc, room)` would return a written path (not
+null) given a template present on disk; token/loop coverage verified against the
+field map; generator is re-runnable.
+
+## Workstream 2 — PenetrationSignoffs creating migration (BLOCKING)
+
+**Problem.** `PenetrationSignoff` has an entity, a registered `DbSet`
+(`PlanscapeDbContext.cs`), full model config, all 4 controller endpoints, and a
+snapshot entry — but **no `CreateTable` migration**. Worse:
+`Planscape.Server/src/Planscape.Infrastructure/Data/Migrations/20260601000000_CrossHostIdentityFields.cs`
+does `AddColumn`/`CreateIndex` **on `PenetrationSignoffs`** (line ~45) and its own
+header comment (line 23) admits the table "still lacks a creating migration." On a
+clean `dotnet ef database update`, the `20260601` migration fails because the
+table does not exist. It only survives today via any `EnsureCreated()` fallback.
+
+**Task.** Add a proper EF Core migration that **creates the `PenetrationSignoffs`
+table**, ordered **before** `20260601000000_CrossHostIdentityFields` (e.g. a
+timestamp such as `20260517000010_CreatePenetrationSignoffs` — pick an id that
+sorts after `PenetrationSignoff` first appears in the model and before
+`20260601`). Schema must match the entity (`Planscape.Core/Entities/PenetrationSignoff.cs`)
+and the `PlanscapeDbContextModelSnapshot` definition exactly: all columns, the
+tenant/project FKs with cascade behaviour consistent with sibling healthcare
+tables (see `20260515000000_HealthcarePack.cs` as the template), and the idempotency
+index on `(ProjectId, ControlNumber, PfvUuid)` plus any indexes the model config
+declares. **Do not** duplicate the `ElementIfcGlobalId` column/index that
+`20260601` adds — leave that to `20260601`.
+
+**Most-sustainable guidance.** Generate via
+`dotnet ef migrations add …` if the tooling runs in this environment (preferred —
+keeps the snapshot authoritative). If EF tooling is unavailable, hand-author the
+migration in the exact style of `20260515000000_HealthcarePack.cs` **and** confirm
+the existing `PlanscapeDbContextModelSnapshot.cs` already contains the table (it
+does) so no snapshot edit is needed. Then verify by building `Planscape.Server`
+and, if a Postgres is reachable, running `dotnet ef database update` on a scratch
+DB from empty and confirming it applies cleanly through `20260601` and beyond.
+
+**Acceptance.** A from-empty migration run creates `PenetrationSignoffs` and then
+applies `20260601` without error; `Planscape.Server` builds.
+
+## Workstream 3 — Harden the radiation QE sign-off gate
+
+**Problem.** Radiation shielding outputs can be treated as authoritative with no
+Qualified Expert named. `RAD_QE_NAME_TXT` is only a *soft warning* in
+`RadShieldValidator` (opt-in via `RequireQeSignoff`), `AdvancedRadShieldValidator`
+warns only, and the `RadCalc*` commands
+(`StingTools/Commands/Radiation/RadCalcChestRoomCommand.cs`, `RadCalcCtRoomCommand.cs`,
+`RadCalcLinacVaultCommand.cs`) don't check QE at all — they show a TaskDialog and
+exit with no persistence and no draft marking. This is a safety/liability gap, not
+just a feature gap.
+
+**Task.**
+1. Make every `RadCalc*` command output explicitly labelled as an **unsigned
+   draft** unless `RAD_QE_NAME_TXT` (read from ProjectInformation, or the relevant
+   room/barrier element per existing param scoping) is populated — e.g. a
+   prominent "DRAFT — NOT FOR CONSTRUCTION — no Qualified Expert on record" banner
+   in the TaskDialog and log line.
+2. If/when these commands persist any result to BIM (see item 3 below), **refuse
+   to write authoritative values** (or write them flagged as draft) while QE is
+   empty. Never auto-mark anything "verified/approved."
+3. Provide an optional write-back path so a calc result can be stamped onto the
+   barrier/room element (e.g. `RAD_LEAD_MM_NR` and companions) **with an audit
+   trail** — but gated on QE being present, and stamped with a draft/approved flag.
+   If write-back is out of scope to do safely now, at minimum implement the draft
+   labelling (1) and leave a ROADMAP item for persistence.
+
+**Most-sustainable guidance.** Centralise the QE gate rather than copy-pasting the
+check into three commands — add a single helper (e.g. a static
+`RadiationSignoffGate.IsSigned(doc, element)` / `.DraftBanner(...)` next to the
+radiation core) and call it from all `RadCalc*` commands and both radiation
+validators, so the policy has one home. Make the "require QE" behaviour a
+project-level setting (reuse the existing `HcOptions`/panel toggle pattern and/or
+a `PRJ_ORG_HEALTH_*` parameter) so a project can tighten it to *blocking* without
+a code change. Keep the calculators' own disclaimers intact.
+
+**Acceptance.** No `RadCalc*` path presents a number as authoritative without a
+named QE; the gate logic exists in exactly one place and is reused; behaviour is
+configurable per project.
+
+## Workstream 4 — Maintainability: AcousticValidator + tracked deferrals + doc hygiene
+
+**4a. Refactor `AcousticValidator`.**
+`StingTools/Core/Validation/Healthcare/AcousticValidator.cs` hardcodes NR and RT60
+targets as dictionary literals, unlike its siblings (e.g.
+`PressureRegimeValidator` calls `HTMStandards.GetDesignDeltaPa(...)`). Move the
+NR/RT60 targets into the standards library (`StingTools.Standards/HTM/HTMStandards.cs`,
+HTM 08-01) exposed via lookup methods (e.g. `GetNrTarget(roomClass)`,
+`GetRt60Target(roomClass)`), and have the validator call them. Preserve current
+values exactly during the move (no behaviour change) and keep a safe fallback for
+unknown room classes. This keeps threshold governance in one place — the flexible,
+sustainable pattern the rest of the pack already uses.
+
+**4b. File tracked deferrals in `docs/ROADMAP.md`** so their partial/stub status is
+explicit rather than discovered later:
+- `RadCalcLinacVaultCommand` is a first-pass NCRP-151 estimate (no occupancy/use/
+  distance factors, maze = 40% rule-of-thumb, neutron narrative-only) — flag as
+  indicative-only, full calc belongs with the QE.
+- `AdvancedRadShield` PET/SPECT/Brachy use single-TVL constants (no build-up/
+  scatter); NCRP-147 Archer coefficients are approximate digitisations.
+- `AdjacencyValidator` uses centroid distance as a Phase-H-10 placeholder for the
+  planned door-graph BFS (can false-flag corridor-connected rooms).
+- Twin `BacnetReadback`/`OpcUaReadback` return empty — live BMS read-back is an
+  FM/commissioning add-on (hooks only).
+- `MgasNetworkAuditCommand` computes diversified zone loads but doesn't display the
+  per-gas/per-zone breakdown (minor UX follow-up).
+
+**4c. Fix stale caveats in `CLAUDE.md`.** In the Healthcare Pack "Caveats" list,
+**caveat #5 ("EF migration not run yet — `dotnet ef migrations add HealthcarePack`
+is required") is now false** — `20260515000000_HealthcarePack.cs` exists and all
+four healthcare `DbSet`s are registered. Replace #5 with the real remaining gap
+(the `PenetrationSignoffs` creating migration — mark it resolved once Workstream 2
+lands). Also reconcile the RDS caveat once Workstream 1 lands (template now ships).
+Leaving false caveats erodes trust in the whole list.
+
+**Acceptance.** Acoustic thresholds sourced from `HTMStandards` with no behaviour
+change; ROADMAP carries the five deferrals; `CLAUDE.md` caveats reflect reality.
+
+---
+
+## Definition of done
+
+- All four workstreams implemented, each in its own commit on a feature branch
+  (not `main`).
+- Wherever a build was possible it was run and the result reported; wherever it
+  wasn't, the "unverified — no .NET/Revit in sandbox" caveat is stated in the
+  commit + CHANGELOG.
+- `docs/CHANGELOG.md` has a new phase block; `docs/ROADMAP.md` has the deferrals;
+  `CLAUDE.md` caveats corrected.
+- A short final summary listing what changed, what was verified vs unverified, and
+  any residual follow-ups.

--- a/docs/HEALTHCARE_PHASE199_FIXES_PROMPT.md
+++ b/docs/HEALTHCARE_PHASE199_FIXES_PROMPT.md
@@ -1,0 +1,160 @@
+# Healthcare Pack — Phase 199 Fixes + Fresh Gap Hunt (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Execute the
+two parts below **without stopping to ask**: (A) implement the verified findings,
+then (B) hunt for further gaps and fix the real ones. Pick the most flexible,
+sustainable, data-driven option; match existing patterns; do not gold-plate. Read
+every cited file before editing.
+
+Each finding below was **verified against the actual code** (the CSV evidence and
+line numbers are real). The DO-NOT-TOUCH section lists areas already verified
+correct — do not re-chase or "fix" them, and do not trust a fresh grep over a
+verified conclusion.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work to completion; one logical commit per fix.
+- **Branch / worktree.** Continue on the existing worktree `C:\Dev\STINGTOOLS-hc-def`,
+  branch `claude/healthcare-deferred` — confirm with
+  `git -C C:\Dev\STINGTOOLS-hc-def rev-parse --abbrev-ref HEAD`. If absent, create a
+  worktree off the latest `claude/healthcare-deferred`. Never touch the shared
+  `C:\Dev\STINGTOOLS` checkout; never commit to `main`. Commit messages imperative,
+  ending with the repo's `Co-Authored-By` trailer.
+- **Build.** This machine builds `StingTools` and `Planscape.Server` — build what you
+  touch and report `0 errors` or the actual errors.
+- **Any new shared parameter** registered in ALL of `MR_PARAMETERS.txt`,
+  `MR_PARAMETERS.csv`, `PARAMETER_REGISTRY.json`, `CATEGORY_BINDINGS.csv` with a
+  deterministic sibling GUID.
+- **Verify before you report or fix.** This codebase has repeatedly produced
+  plausible-but-false audit claims (a "catastrophic" binding failure that was a
+  false positive; a migration "defect" that wasn't). For every new gap you find in
+  Part B, confirm it against the real code path before acting — quote the exact line,
+  and for "unread param / unreachable command" claims, check the JSON-driven
+  consumers (RDS fieldmap, COBie CSVs, tag-container registry) and the dynamic
+  dispatch paths, not just a literal grep. Report a finding as CONFIRMED only after
+  that check.
+- **Docs.** Update `docs/CHANGELOG.md` (append to the Phase 199 block or add a small
+  Phase 199 follow-up sub-section — do not mint a colliding phase number) and
+  `docs/ROADMAP.md` where a note is warranted. Leave the branch for review — no merge,
+  no PR. Final summary: each finding FIXED / NOT-A-BUG (with why) + any new gaps found
+  and their disposition + build status.
+
+---
+
+## PART A — implement the verified findings
+
+### A-1 (MEDIUM, real bug) — Spare-parts dedup drops distinct spares
+`StingTools/Docs/ClinicalCobieBridge.cs:145` dedups spare rows by `s.SpareName`
+**alone, globally** (`sparesSeen.Add(s.SpareName)`), while the jobs dedup directly
+above (line ~129) correctly uses a compound `{tag1}|{JobName}` key. `COBIE_SPARE_PARTS.csv`
+legitimately carries the same spare name under different type codes with **distinct
+part numbers** (verified: `CEQ-AUTOCLAVE,"Door Seal",…SEAL-AUTO` and
+`CEQ-MORT-FRG,"Door Seal",…SEAL-MORT-FRG`). Because the emitted Spare row includes the
+TypeName (line ~149), those are two valid, distinct COBie rows — but name-only dedup
+silently drops the second, losing that equipment type's spare linkage in the FM handover.
+
+**Task.** Change the spare dedup key to be per-type (and ideally per-part) so distinct
+spares survive — e.g. `sparesSeen.Add($"{typeCode}|{s.SpareName}")`, or key on
+`s.PartNumber` if that is reliably unique in the CSV. Keep it consistent with how the
+jobs dedup is scoped. Verify a element/type pair that shares a spare name with another
+type now emits both rows.
+**Acceptance.** Two clinical types sharing a spare name each emit their own Spare row
+(distinct TypeName/PartNumber); genuine duplicates within one type are still deduped.
+
+### A-2 (LOW, discoverability) — Standalone clinical-COBie command has no button
+`Healthcare_CobieClinical` (`HealthcareCobieClinicalExportCommand`) is dispatchable via
+`StingCommandHandler` + `WorkflowEngine` but is **not** registered in
+`StingTools/UI/Modules/HealthcareCommandModule.cs` nor surfaced as a button in the BCC
+Healthcare tab (`UI/BIMCoordinationCenter.cs`). Note the clinical rows already ship
+unconditionally via the main COBie handover export (`HandoverExportCommands.cs:406`), so
+this is discoverability of a redundant convenience command, **not** unreachable
+functionality.
+
+**Task.** Add the command to `HealthcareCommandModule` (and/or a BCC Healthcare-tab
+button) following exactly how the sibling healthcare commands are registered there, so
+a user can invoke the standalone clinical export from the Healthcare UI. Match the
+existing registration signature — do not invent a new pattern.
+**Acceptance.** The command is reachable from the Healthcare UI surface like its siblings.
+
+### A-3 (note, not a bug) — FGI escalation opt-in scope
+`FgiAdoptionContext.Escalate` is currently called only from `AntiLigatureValidator`
+(lines ~50, ~65). This is acceptable seam scope (validators opt in; the mechanism is
+one-way), **not** a defect — do NOT bulk-wire it into every validator.
+
+**Task.** Add a one-line note to the `HC-DEF-09` ROADMAP entry stating that only
+`AntiLigatureValidator` currently opts into FGI escalation and that extending it to
+other validators is a follow-up. No code change unless you also choose to opt in one or
+two clearly FGI-governed findings (e.g. a behavioural-health rule) — if so, keep it
+minimal and inert-by-default (empty clause map = no change).
+
+---
+
+## PART B — fresh gap hunt (find more, fix the real ones)
+
+Sweep the healthcare pack for gaps NOT yet covered, across integration / alignment /
+correctness / accuracy / flexibility / information / automation. Prioritise the
+Phase-199 surface (least-audited) but do not stop there. Confirm each before acting.
+Specific things worth probing:
+
+- **COBie clinical export edge cases:** does `PatternMatches` (prefix/exact) over-match
+  or miss type codes? Are Job rows deduped consistently with the (now-fixed) spare key?
+  Does an element with `CEQ_CLINICAL_BOOL` false but a CEQ category still get emitted (or
+  correctly skipped)? Are `Esc()`/CSV-escaping applied to every emitted field (comma /
+  quote injection from param values)?
+- **Adjacency BFS:** does `RoomGraphBuilder.Build` handle multi-storey / linked models,
+  and does the centroid fallback use consistent units (ft→m) with the BFS path's
+  thresholds? Is `graphUsable` computed once and reused (perf)?
+- **Radiation write-back:** does it write to element **types** vs **instances**
+  correctly (params are Instance-bound)? Does re-running it on an already-APPROVED
+  barrier downgrade it to DRAFT if the QE param was cleared, or does it preserve
+  provenance sensibly?
+- **Registries (adjacency / diversity / twin / FGI):** do they all fail safe on malformed
+  JSON/CSV (log + empty, not throw)? Is the per-doc cache keyed on a path that is stable
+  for unsaved documents?
+- **Param registration integrity (recurring theme):** re-run the check that every
+  parameter the Phase-199 code *reads or writes* is registered in all four data files
+  and bound to the categories it is read from (remember: binding is group-driven via
+  `coreCats` unless the group is narrowed — CATEGORY_BINDINGS.csv is a reference, not the
+  authority; confirm the actual group binding, don't chase CSV gaps).
+- **Information/orphans:** any Phase-199-introduced param defined but genuinely unread
+  (check code + RDS fieldmap + COBie CSVs + tag-container registry before declaring it
+  orphaned).
+- **Doc/code alignment:** any other stale comment or ROADMAP/CHANGELOG claim that
+  contradicts the shipped code (like the AdjacencyValidator comments just fixed).
+
+For each confirmed gap, fix it if it is a clear, low-risk correctness/accuracy/
+integration defect; if it needs a design decision or authoritative data, implement the
+seam and ROADMAP it rather than guessing. Report anything you investigated and
+concluded was NOT a bug, with the reason (so it isn't re-audited later).
+
+---
+
+## DO-NOT-TOUCH — verified correct; do not re-chase
+
+- **The binding model.** Params bind via group-driven `coreCats` in
+  `LoadSharedParamsCommand`; the healthcare groups are not narrowed, so reads resolve.
+  `CATEGORY_BINDINGS.csv` is a validation/reference artifact, not the binding authority.
+  Do NOT "re-bind" healthcare params chasing CSV gaps.
+- **CEQ_EQP_TAG / CEQ_TAG_7_PARA_TXT** are tag/narrative **containers** (registered in
+  `TAG_CONFIG_v5_0_CONTAINERS.csv`), populated by the tagging pipeline — NOT orphaned
+  data params. Do not "wire" them into the COBie export.
+- **Already verified correct (Phase 199):** adjacency BFS hop logic + cap + self/dedup,
+  radiation write-back QE gate + empty-selection + non-destructive seeding, diversity
+  precedence (project→NFPA99→flagged 1.0 fallback), Twin null-safe resolve, FGI
+  jurisdiction/freeze-date parsing, all three registries' cache+override. Re-verify only
+  the specific edge cases named in Part B; don't rewrite these.
+- **The empty seam data files** (`HEALTHCARE_MGAS_DIVERSITY.json`,
+  `HEALTHCARE_FGI_CLAUSE_MAP.json`) are empty **on purpose** — do not populate them with
+  guessed values.
+- Do not fake domain physics (HC-DEF-02/03) or pull a 3rd-party BMS stack (HC-DEF-05).
+
+## Definition of done
+
+- A-1 fixed (spare dedup), A-2 fixed (command discoverability), A-3 ROADMAP note added.
+- Part B: real gaps fixed or seam+ROADMAP'd; investigated-but-not-a-bug items reported
+  with reasons; DO-NOT-TOUCH respected.
+- `StingTools` (+ `Planscape.Server` if touched) build clean; any new param registered in
+  all four files with a GUID.
+- CHANGELOG updated (no colliding phase number); ROADMAP notes added.
+- Final summary: per-finding disposition, new gaps + disposition, new params + GUIDs,
+  build status.

--- a/docs/HEALTHCARE_PROFILE_COVERAGE_PROMPT.md
+++ b/docs/HEALTHCARE_PROFILE_COVERAGE_PROMPT.md
@@ -1,0 +1,97 @@
+# Healthcare Pack — Profile Coverage + Doc Pointer (Autonomous Agent Prompt)
+
+You are an autonomous engineering agent in the **StingTools** monorepo. Execute
+both workstreams below **without stopping to ask**. Small, surgical scope — do not
+expand it. Pick the most sustainable option (match the existing file's exact
+format; one source of truth). Read every cited file before editing.
+
+These are the two remaining findings from a verified hidden-gap review; the new
+code around them is already correct — do not touch anything outside these two
+items, and respect the DO-NOT-TOUCH note.
+
+## Ground rules
+
+- **Do not ask for confirmation.** Work to completion.
+- **Branch / worktree.** Continue on the existing worktree
+  `C:\Dev\STINGTOOLS-hc-fixes`, branch `claude/healthcare-gap-fixes` — confirm with
+  `git -C C:\Dev\STINGTOOLS-hc-fixes rev-parse --abbrev-ref HEAD`. Never touch the
+  shared `C:\Dev\STINGTOOLS` checkout; never commit to `main`. One logical commit
+  (both items are small — a single commit is fine). Commit message imperative,
+  ending with the repo's `Co-Authored-By` trailer.
+- **Data-only + one doc line** — no plugin build strictly required, but if you
+  touch any `.cs` build `StingTools` and report the result. Validate the profiles
+  JSON parses after editing.
+- Leave the branch for review — no merge, no PR. Finish with a one-paragraph
+  summary of what changed.
+
+---
+
+## WS-1 — Add the two newest validators to the pack profiles
+
+**Verified gap.** `RoomClassCodeValidator` and `PharmacyRecertValidator` are in the
+gate's hardcoded `_allValidators` set (`Core/Validation/Healthcare/HealthcareValidatorGate.cs`)
+and in `RunAllHealthcareValidators`, so under the **FULL** profile they run. But
+they were never added to `StingTools/Data/HEALTHCARE_PACK_PROFILES.json`, so
+`HealthcareValidatorGate.AllowedValidators` silently excludes them under the five
+named sub-profiles (**ACUTE / COMMUNITY / DENTAL / IMAGING-ONLY / MENTAL-HEALTH**).
+Result: ACUTE/COMMUNITY facilities lose USP-797/800 recert checking, and every
+sub-profile loses room-class drift detection — with no error.
+
+**Task.**
+1. **First read `HEALTHCARE_PACK_PROFILES.json`** and the gate to confirm the EXACT
+   string form each profile's validator list uses, and that it matches the strings
+   `AllowedValidators` compares against (`validator.Name`, i.e. the full class-name
+   form like `"PharmacyRecertValidator"` / `"RoomClassCodeValidator"` — verify, do
+   not assume). Match that exact format and casing.
+2. **Add `RoomClassCodeValidator` to ALL five sub-profiles.** It is facility-
+   agnostic data hygiene (flags mis-typed `CLN_ROOM_CLASS_TXT` regardless of
+   building type), so it should run everywhere, not just FULL.
+3. **Add `PharmacyRecertValidator` to the profiles that can contain a pharmacy
+   cleanroom: ACUTE and COMMUNITY.** Do NOT add it to DENTAL, IMAGING-ONLY, or
+   MENTAL-HEALTH — those have no USP-797/800 cleanroom, so excluding it there is
+   correct (don't create noise). If the existing profile semantics clearly argue a
+   different placement, follow the data's own logic and note it.
+4. Do not alter the FULL profile (it already includes everything via the gate's
+   `_allValidators` / "all" handling) unless FULL is represented as an explicit
+   list in the JSON that also needs the two names — check and match reality.
+5. Validate the JSON parses.
+
+**Acceptance.** Under ACUTE/COMMUNITY the recert + room-class validators run; under
+all five sub-profiles the room-class validator runs; DENTAL/IMAGING-ONLY/MENTAL-
+HEALTH still (correctly) skip recert; FULL unchanged; JSON valid.
+
+## WS-2 — Bump the stale CLAUDE.md phase pointer
+
+**Verified.** `CLAUDE.md` line ~19 says "The codebase is currently at **Phase
+196**", but `docs/CHANGELOG.md` now has Phase 197 (accuracy remediation) and Phase
+198 (completeness remediation). No collision — the pointer just wasn't bumped.
+
+**Task.** Update the "currently at **Phase N**" line in `CLAUDE.md` to **198** (the
+highest completed phase in the CHANGELOG on this branch — verify it is 198 and use
+the true maximum). Do not touch anything else in that paragraph.
+
+**Acceptance.** The pointer equals the highest CHANGELOG phase; no other edit.
+
+---
+
+## DO-NOT-TOUCH
+
+- **Water-flush migration `maxLength` vs model `text`.** An adversarial review
+  flagged the `20260627000000_HealthcareWaterLog.cs` migration for specifying
+  `maxLength` on string columns while the model/snapshot uses `text`. This is NOT a
+  defect: these healthcare migrations are documentation-DDL that never executes
+  (schema is built from the model via `CreateTables()`), so the running column is
+  `text` and there is no real DB divergence — and it matches the
+  `HealthcarePressureLog` sibling exactly. Leave it as-is; "fixing" it would only
+  diverge from the sibling pattern.
+- Everything else in the recent healthcare work (regional HTM threading, recert
+  validator logic/registration, SignalR broadcasts, offline queue, water-flush
+  round-trip, room-class canonicalisation, QE gate, NCRP-147/diversity math) was
+  verified correct — do not modify.
+
+## Definition of done
+
+- Both new validators present in the correct profile lists; CLAUDE.md pointer at
+  198; JSON valid; DO-NOT-TOUCH respected.
+- One commit on `claude/healthcare-gap-fixes`; branch left for review.
+- Summary: which profiles gained which validator, and the phase-pointer change.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -61,6 +61,13 @@ documents cover one topic, the **current** one is marked ✅ and the superseded 
 `BOQ_5D_*.md` / `BOQ_COST_MANAGER_5D_WORKSPACE_PROMPT.md` / `BOQ_INLINE_ACTIONS_SLICE3_PROMPT.md` /
 `BOQ_REVIEW_AND_HARDENING_PROMPT.md` (work prompts — intent, check against `CHANGELOG.md`)
 
+Also `BOQ_COST_INTEGRATION_AND_FIXES_PROMPT.md` · `BOQ_QS_IMPLEMENTATION_PROMPT_P1-P4.md` ·
+`PROJECT_MANAGEMENT_COST_CONTROL_PROMPT.md` (work prompts) and
+[`guides/SUSTAINABILITY_CARBON_COSTING_LAYMANS_GUIDE.md`](guides/SUSTAINABILITY_CARBON_COSTING_LAYMANS_GUIDE.md),
+a plain-English guide to the carbon and costing workflow. **Note:** `BOQ_5D_PHASE2_PROMPT.md` and
+`BOQ_5D_P2_PROMPT.md` are different documents with confusingly similar names — the first covers the
+five enhanced-rebuild items, the second the 4D tab, inline forms and link multiplier.
+
 ## Placement, symbols & families
 
 `PLACEMENT_CENTRE_REVIEW.md` · `PLACEMENT_FAMILY_AUTHORING.md` · `PLACEMENT_SEED_VARIANT_COVERAGE.md` ·
@@ -73,7 +80,7 @@ documents cover one topic, the **current** one is marked ✅ and the superseded 
 `MULTI_HOST_INTEGRATION_PLAN.md` · `CROSS_HOST_ROUND_TRIP_RUNBOOK.md` ·
 `CROSS_HOST_VALIDATION_CHECKLIST.md` · `PHASE_186_BONSAI_INTEGRATION.md` ·
 `PHASE_186_VERIFICATION_CHECKLIST.md` · `MVP_SCOPE_BONSAI.md` · `EXPORTER_TEXTURES.md` ·
-`MCP_V2_CAPABILITY_EXPOSURE.md`
+`MCP_V2_CAPABILITY_EXPOSURE.md` · `MCP_V2_AGENT_BRIEF.md` (work prompt)
 
 ## Parameters & tagging internals
 
@@ -146,4 +153,4 @@ CI rather than reaching an issue.
 
 ## Domain packs
 
-`HEALTHCARE_PACK_DESIGN.md` · `PROMPT_KUT_PHASE_192_IMPLEMENTATION.md` (⛔ historical — the `WORKFLOW_GateAudit.json` it specifies has been deleted; `WORKFLOW_KUT_GateAudit.json` is the gate-audit chain) · `PROMPT_KUT_SMOKE_TEST_RECONCILIATION.md`
+`HEALTHCARE_PACK_DESIGN.md` · `HEALTHCARE_*_PROMPT.md` (seven work prompts: accuracy, changelog/roadmap, completeness, deferred implementation, gap fixes, Phase 199 fixes and profile coverage — intent, check against `CHANGELOG.md`) · `PROMPT_KUT_PHASE_192_IMPLEMENTATION.md` (⛔ historical — the `WORKFLOW_GateAudit.json` it specifies has been deleted; `WORKFLOW_KUT_GateAudit.json` is the gate-audit chain) · `PROMPT_KUT_SMOKE_TEST_RECONCILIATION.md`

--- a/docs/MCP_V2_AGENT_BRIEF.md
+++ b/docs/MCP_V2_AGENT_BRIEF.md
@@ -1,0 +1,238 @@
+# StingTools MCP v2 — Autonomous Implementation Brief
+
+> **Hand this file to a coding agent as its complete instruction set.** It is self-contained:
+> mission, grounded architecture, locked decisions, guardrails, a phased plan with
+> per-phase acceptance criteria, an exact file map, the target tool catalogue, and a
+> definition of done. Read it top-to-bottom before writing any code.
+
+---
+
+## 0. Mission (one paragraph)
+
+Upgrade the existing in-process StingTools MCP server from a **fire-and-forget intent
+dispatcher** (5 tools that only return "dispatched") into a **real, synchronous, domain
+model interface** for AI agents. Revit 2027 now ships Autodesk's own *read-only* Public
+MCP Server; StingTools must be the **complementary "hands + standards brain"** — the
+server that *acts*: queries the model with structured read-back, then performs
+ISO-19650 tagging, MEP engineering sizing, compliance validation, and BOQ/cost
+operations that Autodesk's server cannot. The moat is StingTools' **domain** (ISO 19650,
+BS 7671 / HTM, NRM2), not tool count. Ship **~25 curated tools with typed read-back and
+guardrailed writes**, not 763 raw command tags.
+
+---
+
+## 1. Locked decisions (do not re-litigate)
+
+| Decision | Value | Rationale |
+|---|---|---|
+| **Scope** | MCP v2 server **only** | One bounded, verifiable deliverable. |
+| **Build target** | **Revit 2025/26 on `net8.0-windows` first** | This machine + the GOLD deploy are 2025/26; MCP v2 does **not** need .NET 10. Port to 2027/net10 is a *separate* future brief. |
+| **Write posture** | **Writes with guardrails** | Curated write/workflow tools, but every write is dry-run-capable, license-gated, transaction-rolled-back, and confirms destructive/bulk ops. |
+| **Transport (now)** | **HTTP JSON-RPC** on `localhost:5199` (existing) + **shared-secret token** | Claude Code already supports the HTTP `url` form (`.mcp.json`). Keeps all Revit-API logic in-process where the API lives. |
+| **Transport (stretch)** | stdio bridge exe for Claude Desktop parity | Phase 4, optional. Do **not** block core work on it. |
+
+**Out of scope (do NOT do):** .NET 10 / Revit 2027 multi-target; rebuilding Autodesk's
+generic read layer beyond what StingTools' domain needs; auto-dumping all 763 commands
+via `McpToolDescriptorGenerator` (leave that `#if REVIT_2027` file untouched); External
+Data API; tag-leader API; any new WPF UI. Those are other briefs.
+
+---
+
+## 2. Grounded architecture (verified against the real code — read these first)
+
+| Fact | Location | Implication |
+|---|---|---|
+| MCP server is in-process, HTTP JSON-RPC 2.0, background `HttpListener` on `localhost:5199/mcp/`, started from `StingToolsApp.OnStartup` via `StartIfConfigured()` when `mcp_enabled=true` in `STING_LLM_CONFIG.json`. | `StingTools/Mcp/StingMcpServer.cs` | Extend this server; don't replace it. Registration/dispatch is a `switch` in `HandleToolCall`. |
+| **The core gap:** tools call `StingDockPanel.DispatchCommand(tag)` which returns only `bool accepted` (ExternalEvent was queued) — **never the command's outcome.** | `StingMcpServer.cs:216`, `StingDockPanel.xaml.cs:180` | Read-back must be built. This is Phase 1. |
+| A **synchronous** path already exists: `DispatchCommandSync(UIApplication app, tag, …)` runs on the API thread, bypassing `Raise()`. | `StingDockPanel.xaml.cs:194` | Model the new job bridge on this — but the MCP thread has **no** `UIApplication`, so it must marshal onto the API thread via a dedicated `ExternalEvent` + blocking wait (see §4). |
+| **License hard-lock** is enforced *inside the command handler*: `if (!Core.Licensing.LicenseGate.IsLicensed && tag != "STING_Activate") return;` | `StingCommandHandler.cs:120` | Commands dispatched through the handler are already gated. **New query/write tools that touch the document directly (not via the handler) MUST re-check `LicenseGate.IsLicensed` themselves**, or they become a licensing bypass. Non-negotiable. |
+| Existing 5 tools & their data sources: `run_command`, `nlp_query` → `NLPEngine.ProcessQuery`/`IntentPatterns`; `list_commands` → `NLPEngine.IntentPatterns`; `get_status` → `ComplianceScan.GetCached().StatusBarText`; `ask_bim` → `NLPEngine.SearchKnowledge` then `StingLlmService.Instance.AskBimQuestionAsync`. | `StingMcpServer.cs`, `McpToolRegistry.cs` | Keep all 5 working. Upgrade `run_command` with `dryRun` + read-back; keep the others. |
+| JSON-RPC + MCP types (`JsonRpcRequest/Response`, `McpTool`, `McpContent`, `McpCallResult{content[],isError}`). Tool results return `content:[{type:"text",text}]`. | `StingTools/Mcp/McpTypes.cs` | Structured payloads ride as a fenced ```json block inside the text content (see §5). |
+| Re-entrancy guard `_executeDepth`, param passing via `_extraParams` ConcurrentDictionary. | `StingCommandHandler.cs:39,48` | If a write tool needs to pass params to an existing command, set `_extraParams` **before** `SetCommand` (existing convention — respect it). |
+
+---
+
+## 3. House rules (StingTools conventions — enforce in every file you write)
+
+- **`dotnet build` must stay green after every phase.** This machine can build:
+  `dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025"`.
+  A phase is not done until the build is green. **Run it; paste the result; never claim success without it.**
+- Transactions: wrap all model mutation in `Transaction`/`TransactionGroup` named with a `STING ` prefix; roll back on any error. Use `[Transaction(TransactionMode.Manual)]` for state-changing commands, `ReadOnly` for queries.
+- Logging: `StingLog.Info/Warn/Error` only — **no silent catch blocks**. Every `catch` either logs or returns a typed MCP error.
+- User messages in commands use `TaskDialog`, never `MessageBox`. (MCP tools return text, not dialogs — see §4 "no modal" rule.)
+- Reuse shared helpers (`ParameterHelpers`, `TagConfig`, `ComplianceScan`, the `Core/Validation` validators, the BOQ/MEP engines) — do not re-implement domain logic in the MCP layer. The MCP layer is a **thin adapter**.
+- One class per file for the new bridge/tool classes; group closely-related simple handlers per file (existing pattern).
+- **Git:** work on the current feature branch; **commit per phase** with a clear message; **do not merge to `main`**; end commit messages with the standard `Co-Authored-By` line. Note in each commit that it is **unverified in Revit** (Revit API only exercisable manually).
+
+---
+
+## 4. Core design — the read-back job bridge (Phase 1, highest risk)
+
+The MCP handler runs on an HTTP `ThreadPool` thread with no Revit API access. Every tool
+that touches the document must run its work on Revit's API thread and return the result
+**synchronously** to the waiting HTTP thread.
+
+**Build `StingTools/Mcp/McpJobBridge.cs`** implementing this pattern:
+
+1. A dedicated `ExternalEvent` + `IExternalEventHandler` **separate** from `StingCommandHandler` (so MCP jobs never entangle the panel's `_executeDepth` re-entrancy state).
+2. Public API callable from the MCP thread:
+   ```csharp
+   // Runs `job` on the Revit API thread, blocks up to timeoutMs, returns its result.
+   static McpJobResult Run(Func<UIApplication, McpJobResult> job, int timeoutMs = 15000);
+   ```
+3. Mechanics:
+   - Create a job record `{ Guid id, Func, McpJobResult result, ManualResetEventSlim done }`; enqueue on a `ConcurrentQueue`.
+   - `Raise()` the MCP `ExternalEvent`. If it returns **not** `Accepted` → return a typed error `{code:"revit_busy", message:"Revit is in a modal dialog / transaction / sync — retry shortly."}` **without** blocking.
+   - The handler (API thread) drains the queue, runs each `job.Func(uiApp)` inside `try/catch`, stores the result (or an `{code:"exception"}` result), signals `done`.
+   - MCP thread waits `done.Wait(timeoutMs)`; on timeout return `{code:"timeout"}`; else return the stored result.
+4. **Guards inside every job function** (helpers in `McpSafety.cs`):
+   - `if (!LicenseGate.IsLicensed) return McpJobResult.Error("not_licensed", …);`
+   - `if (uiApp.ActiveUIDocument?.Document == null) return McpJobResult.Error("no_document", …);`
+   - **No modal UI.** Jobs must never open `TaskDialog`/`MessageBox` (would deadlock the API thread while the HTTP thread waits). If an underlying command shows a dialog, either call the engine directly (preferred) or document the tool as "fire-and-forget, no read-back" explicitly.
+
+**Prove it end-to-end** before building more tools: implement `get_model_info`
+(returns real `Document.Title`, path, `ProjectInformation`, active view name, phase) using
+the bridge, and confirm via `curl` that a live Revit session returns the actual title
+synchronously.
+
+---
+
+## 5. Result contract (typed read-back)
+
+Add `StingTools/Mcp/McpResult.cs`:
+
+- `McpJobResult { bool Ok; string Code; string Summary; object Data; }` (Data = any serialisable POCO/dict).
+- Serialisation helper that turns an `McpJobResult` into an `McpCallResult`:
+  - `content[0].text` = a short human summary **plus** a fenced block:
+    ````
+    <summary line>
+
+    ```json
+    { …Data… }
+    ```
+    ````
+  - `isError = !Ok`.
+- Rationale: agents parse the JSON block deterministically; humans reading the transcript get the summary. (If you later confirm the client supports MCP `structuredContent`, add it additively — but the fenced-JSON contract must remain.)
+
+---
+
+## 6. Target tool catalogue (~25 curated tools)
+
+Keep the existing 5. Add the rest. **R** = read-only, **W** = write (guardrailed). All new
+tools run via the job bridge and re-check the license gate. The agent MAY merge/rename
+for coherence, but must cover every capability below.
+
+### Existing (keep; upgrade where noted)
+| Tool | R/W | Change |
+|---|---|---|
+| `run_command` | W | Add `dryRun`; route through bridge; return typed outcome instead of "dispatched". Curated allowlist only (reject tags not in an allowlist config). |
+| `nlp_query` | W | Keep; add read-back of the executed command's outcome. |
+| `list_commands` | R | Keep as-is. |
+| `get_status` | R | Keep; becomes a thin alias of `get_compliance`. |
+| `ask_bim` | R | Keep as-is. |
+
+### New — read / query
+| Tool | Args | Returns | Backed by |
+|---|---|---|---|
+| `get_model_info` | — | title, path, project info, active view, phase, discipline | `Document`/`ProjectInformation` |
+| `query_elements` | `category, filter?, limit?` | element ids + key params + bbox | `FilteredElementCollector` |
+| `get_element` | `id` | all params, category, family/type, location, bbox | `Element`/`ParameterHelpers` |
+| `get_parameter` | `id, name` | value + storage type + shared/builtin | `ParameterHelpers` |
+| `get_selection` | — | selected ids + category summary | `UIDocument.Selection` |
+| `set_selection` | `ids` | count set | `Selection.SetElementIds` (non-destructive) |
+| `list_views` | `filter?` | views by type/level | collector |
+| `list_sheets` | `filter?` | sheets + numbers + names | collector |
+| `get_compliance` | `byDiscipline?` | RAG %, tagged/untagged counts, top issues, per-disc breakdown | `ComplianceScan` |
+| `get_tag_status` | `discipline?` | list of untagged/incomplete-tag element ids by discipline | `ComplianceScan` / `ISO19650Validator` |
+| `run_validator` | `name` | structured findings (pass/warn/fail + element refs) | `Core/Validation/*`, `RunAllValidators` |
+
+### New — domain write / workflow (all `dryRun`-capable, gated, rolled back)
+| Tool | Args | Guardrail | Backed by |
+|---|---|---|---|
+| `set_parameter` | `ids, name, value, dryRun?, confirm?` | `confirm:true` required when `ids.Count > 25`; TransactionGroup rollback | `ParameterHelpers.SetString/…` |
+| `auto_tag` | `scope(view\|selection\|project), dryRun?, confirm?` | `confirm` required for `project`; report count | `AutoTag`/`BatchTag` engines (call `TagPipelineHelper` directly, not the dialog) |
+| `tag_scheme_render` | `dryRun?` | — | `TagScheme_Render` engine |
+| `size_ducts` / `size_pipes` / `size_cables` | `scope, dryRun?` | report changed sizes | `MepAutoSize*`, `CableSizer` engines |
+| `export_boq` | `format(xlsx\|csv)` | returns output file path | `BOQ_Export` engine |
+| `generate_panel_schedules` | `dryRun?` | — | `Panel_BatchSchedules` |
+| `run_workflow` | `name, dryRun?, confirm?` | per-step results; `confirm` required | `WorkflowEngine` |
+
+> If any of the above only exists as a dialog-driven command (opens `TaskDialog`), call
+> its **engine** directly inside the job. If no dialog-free path exists, expose it as a
+> `run_command`-style fire-and-forget tool and **label it clearly** in the description as
+> "no read-back". Do not fake a result.
+
+---
+
+## 7. Security & config
+
+- Add to `StingTools/Data/STING_LLM_CONFIG.json`: `mcp_auth_token` (string), `mcp_tool_allowlist` (array of command tags `run_command` may execute), and keep `mcp_enabled`, `mcp_port`.
+- Server: require header `X-Sting-Mcp-Token` to equal `mcp_auth_token` on every POST when the token is non-empty; return JSON-RPC error `-32001 unauthorized` otherwise. Keep the `localhost`-only binding. If token is empty/absent in config, log a `StingLog.Warn` that the server is unauthenticated.
+- Every query/write tool: license gate (§4). `run_command`: allowlist check.
+
+---
+
+## 8. Phased plan (each phase independently build-verifiable)
+
+| Phase | Deliverable | Acceptance criteria |
+|---|---|---|
+| **0 — Scaffolding** | `McpResult.cs`, `McpSafety.cs` (license gate + dryRun + TransactionGroup helper), auth-token check on server, config keys added. | Build green. Existing 5 tools unchanged and still answer. `GET /mcp/` lists tools. Bad token → `-32001`. |
+| **1 — Read-back bridge** | `McpJobBridge.cs` + its `ExternalEvent`/handler, registered in `StingToolsApp.OnStartup` (alongside existing wireup). `get_model_info` proves it. | In a live Revit session, `curl` `tools/call get_model_info` returns the **real document title** synchronously. Revit-busy → typed `revit_busy`. No-doc → typed `no_document`. |
+| **2 — Query suite** | All §6 read tools. | Each returns correct structured JSON for a test model. `query_elements` respects `limit`. License-off → `not_licensed`. Build green. |
+| **3 — Write suite** | All §6 write tools with dry-run + confirm + rollback. | For each: `dryRun:true` reports intended change and mutates nothing; real run mutates and returns counts; forced error mid-op rolls back cleanly. `confirm` enforced on bulk/project ops. Build green. |
+| **4 — stdio bridge (stretch)** | `StingTools.McpBridge/` console exe: MCP stdio ↔ HTTP forwarder + a `--emit-claude-config` that prints the Claude Desktop JSON. | Claude Desktop launches the exe and lists StingTools tools. *Optional — do not block 0–3 on this.* |
+| **5 — Docs & samples** | `.mcp.json` sample, a `docs/` usage note, `docs/CHANGELOG.md` entry, an in-Revit smoke-test checklist for every tool. | CHANGELOG appended; sample config committed. |
+
+Commit at the end of each phase. Do not merge.
+
+---
+
+## 9. File map
+
+**New:**
+- `StingTools/Mcp/McpJobBridge.cs` — API-thread job/read-back bridge + its ExternalEvent handler.
+- `StingTools/Mcp/McpResult.cs` — `McpJobResult` + serialisation to `McpCallResult`.
+- `StingTools/Mcp/McpSafety.cs` — license gate, dry-run, confirm, TransactionGroup rollback helpers.
+- `StingTools/Mcp/McpQueryTools.cs` — read/query tool handlers.
+- `StingTools/Mcp/McpWorkflowTools.cs` — domain write/workflow tool handlers.
+- *(Phase 4)* `StingTools.McpBridge/` — stdio↔HTTP console project + Claude Desktop config emitter.
+- *(Phase 5)* `docs/mcp/README.md`, `.mcp.json` sample.
+
+**Modified:**
+- `StingTools/Mcp/StingMcpServer.cs` — auth token; register new tools in `HandleToolCall`; upgrade `run_command`/`nlp_query` to read-back.
+- `StingTools/Mcp/McpToolRegistry.cs` — add new `McpTool` definitions with precise descriptions + JSON input schemas.
+- `StingTools/Data/STING_LLM_CONFIG.json` — new config keys.
+- `StingTools/Core/StingToolsApp.cs` — register the `McpJobBridge` ExternalEvent at startup (only if not auto-created lazily).
+- `docs/CHANGELOG.md` — new phase entry.
+
+**Do NOT touch:** `Core/Mcp/McpToolDescriptorGenerator.cs` (the `#if REVIT_2027` file), any WPF panel XAML, `StingCommandHandler`'s existing switch (except reading `_extraParams` convention).
+
+---
+
+## 10. Verification
+
+- **Build:** green `dotnet build` after every phase (mandatory, paste output).
+- **Static MCP handshake test:** a PowerShell/`curl` script that POSTs `initialize` → `tools/list` → a `tools/call` for each tool, asserting shapes. Commit it under `docs/mcp/`. (Runs without Revit for the handshake/error paths; live tools need Revit open.)
+- **In-Revit smoke test (manual, user-run):** a checklist in Phase 5 covering: server starts on project open; `get_model_info` returns real title; one query tool; one dry-run write; one real write with rollback proof; bad-token rejection; license-off rejection.
+- Follow the repo's existing convention: commits carry the **"unverified in Revit"** caveat because the Revit API can only be exercised manually.
+
+---
+
+## 11. Definition of done
+
+1. Phases 0–3 complete; Phase 5 docs written. (Phase 4 optional.)
+2. `dotnet build` green; the MCP handshake script passes its no-Revit assertions.
+3. All 5 original tools still function; ~20 new tools registered and individually spec-compliant.
+4. Every query/write tool re-checks the license gate; every write is dry-run-capable, confirm-guarded on bulk/project, and TransactionGroup-rolled-back on error.
+5. Auth token enforced; server localhost-bound.
+6. `docs/CHANGELOG.md` entry added; `.mcp.json` sample + smoke-test checklist committed.
+7. Work committed per-phase on the feature branch, **not merged**, with the Revit-unverified caveat.
+
+---
+
+## 12. When blocked / uncertainties
+
+- **A capability only exists as a dialog command with no engine entry point:** expose it as fire-and-forget `run_command`-style, label "no read-back", and note it in CHANGELOG — do not invent a result.
+- **`ExternalEvent` never returns `Accepted` in testing:** it requires an idle Revit UI thread; document the retry/timeout behaviour and move on — do not busy-loop.
+- **A domain engine's public surface is unclear:** read the engine source (paths in `CLAUDE.md`), prefer the lowest-level dialog-free method, and if genuinely ambiguous, implement the tool as read-only for now and flag it in CHANGELOG for follow-up. Do not stall the whole phase on one tool.
+- Keep a running `## Open questions` note in the PR/commit description for anything a human must confirm in Revit.

--- a/docs/PROJECT_MANAGEMENT_COST_CONTROL_PROMPT.md
+++ b/docs/PROJECT_MANAGEMENT_COST_CONTROL_PROMPT.md
@@ -1,0 +1,328 @@
+# Implementation Brief — Project-Management & Cost-Control Completion (PM-1 … PM-8)
+
+> **For the implementing agent.** This is a self-contained spec born of a deep
+> research + code-audit pass (June 2026). Read it fully before touching code.
+> It targets one outcome: **a project manager / quantity surveyor can control a
+> project's cost and delivery from first estimate to final account entirely
+> within StingTools + Planscape, without reaching for a tool StingTools lacks.**
+>
+> Every finding below was produced by reading the *actual* code — file:line
+> references are given. **Verify each reference before editing** (line numbers
+> drift); the audit was taken at commit `55ac92fe3`. Do **not** assume a finding
+> still holds without opening the file.
+>
+> This brief does **not** ask you to rebuild a scheduling engine (P6) or a cloud
+> cost platform (ACC) inside Revit. It asks you to (1) fix correctness bugs,
+> (2) wire the existing silos together, (3) fill the genuine QS/PM gaps, and
+> (4) correct the carbon/EDGE/Uganda defaults — each on the correct side of the
+> Revit API line.
+
+---
+
+## 0. Mission & context
+
+StingTools already contains a **substantial** PM/cost platform — it is not
+greenfield. The audit confirmed solid, production-grade engines for: BOQ/5D cost
+(`BOQCostManager`), EVM (`Core/Evm`), payment certificates (`Core/PaymentCert`),
+variations (`Core/Variation`), 4D scheduling (`SchedulingCommands` + `FourdGanttReader`),
+clash + issues (`Clash/`, `IssueTrackerDashboard`), transmittals/CDE
+(`TransmittalOrchestrator`, `DeliverableLifecycle`), a workflow engine + 40
+presets, a 13-tab BIM Coordination Center, server-side meetings/issues/workflows
+(`Planscape.Server`), and a full Phase-195 EDGE/LEED sustainability engine
+(`Core/Sustainability/`).
+
+**The problem is not absence — it is correctness, integration, and finish.** The
+modules largely work in isolation but do not pass data to one another, several
+carry real arithmetic bugs, and a handful of QS lifecycle stages are missing.
+
+**Guiding principle (unchanged from the BOQ briefs):** the model owns
+*quantities*; the QS owns *rates and commercial judgement*; the cloud
+(Planscape) owns *multi-party, time-phased, contractual state*. Revit's job is
+**model-anchored capture at authoring/measurement time**; everything contractual
+and longitudinal is brokered by the server.
+
+**Deployment reality:** Uganda / East-Africa practice (Planscape). Dual currency
+**UGX/USD** (NOT GBP). VAT **18%** (Uganda), not 20%. High-inflation market →
+**fluctuations matter**. Intermittent connectivity → **offline-tolerant +
+Excel/CSV + QuickBooks/Sage export** matter more than a live ACC connector.
+Measurement: **NRM2** primary (NRM1 cost plan is a gap — see PM-3). ISO 19650
+naming throughout. Carbon defaults must follow **EDGE methodology + Uganda grid
+(0.05 kgCO2e/kWh)**, not UK/ICE defaults.
+
+### Revit-API reality the implementation must respect
+
+The single hardest constraint: **the Revit API is single-threaded and never
+thread-safe.** All model reads/writes run on Revit's main thread inside a valid
+API context (command, `IExternalEventHandler`, or `ExternalEvent.Raise()`). This
+dictates where each PM feature can live:
+
+| Capability | Verdict | API reason |
+|---|---|---|
+| Stamp cost/carbon/date/status/WBS on elements (shared params + Extensible Storage) | **In-process ✓** | `ExtensibleStorage.Schema` (16 MB/string cap — keep light); `Core/Storage/` already does this |
+| Generate ViewSchedules, sheets, revisions, PDF/DWG/IFC/NWC exports | **In-process ✓** | `ViewSchedule`, `Revision`, `Document.Export` (NWC gated on `OptionalFunctionalityUtils.IsNavisworksExporterAvailable()`) |
+| WPF Gantt / kanban / dashboard / S-curve **rendering** in a dockable pane | **In-process ✓** | Pure WPF; you already ship 13-tab panels. All model writes via `ExternalEvent`, never a timer thread |
+| Read worksets/owners for a coordination view | **In-process ✓ (advisory)** | `WorksharingUtils` — but data is cached/**stale**; cannot be an authoritative lock |
+| Background HTTP sync to Planscape, file watchers | **In-process ✓** | OK on worker threads; **funnel all model writes through `ExternalEvent`** (existing `BoqSyncCoordinator`/StingBridge pattern) |
+| Read **ViewSchedule row data** as a live source | **Avoid** | No row-data API — `ViewSchedule.Export()`-and-parse only. Compute PM metrics from elements/ES instead |
+| CPM/Gantt **scheduling engine**, 4D time simulation | **In your code or hand off** | `Phase` is an ordered enum with **no dates/dependencies**. The *engine* (forward/backward pass) is yours to write or delegate to P6/Asta/SYNCHRO; Revit gives you zero scheduling math |
+| Real-time multi-user task boards, presence, locking, audit history, attachments | **Planscape only** | No real-time collaboration API; ES perf degrades with size |
+| eTransmit-style packaging | **DIY in-process** | eTransmit has no public API — build your own collector (you already do) |
+
+**Do NOT build inside Revit:** a CPM solver UI replacing P6, resource leveling,
+or the contractual valuation/pay-cycle. Build the *measurement + capture* hooks
+in Revit; the *engine and ledger* in Planscape; export to P6/Excel/QuickBooks.
+
+---
+
+## 1. Current state — verified strengths (do not re-discover; do verify before editing)
+
+| Concern | File(s) | Status |
+|---|---|---|
+| 5D BOQ build | `BOQ/BOQCostManager.cs` (`BuildBOQDocument`, `DeriveQuantity`, `GroupIntoSections`, `AssignBoqLineRefs`) | Solid; bugs in §2 |
+| Rate provider chain | `BOQ/Rates/` (`RateProviders`, `RateProviderRegistry`, `MaterialLibraryRateProvider`, `Providers/`) | **Clean & extensible — model for new work** |
+| Markup waterfall | `BOQ/BOQModels.cs` `BoqTotals.Compute` | Single canonical source — good |
+| EVM | `Core/Evm/EvmCalculator.cs` | Works; EAC/BAC bugs in §2 |
+| Payment certs | `Core/PaymentCert/` | Works; VAT/SOV/retention bugs in §2 |
+| Variations / VO | `Core/Variation/`, WP4a VO approval | Works; not wired to certs/EVM (§3) |
+| Final account + tender adjudication | `Commands/Cost/FinalAccountCommands.cs` (WP4a) | **Genuine strength** — but ignores cert series (§3) |
+| Carbon (fossil + biogenic split) | `BOQ/CarbonFactorResolver.cs`, `BiogenicCarbon.cs`, `Data/STING_CARBON_FACTORS_UG.json` | **Methodologically correct**; B6/benchmark bugs in §4 |
+| EDGE/LEED engine | `Core/Sustainability/` (~45 files), `Data/STING_GREEN_SCHEMES.json`, `GridCarbonRegistry` | **EDGE 20/20/20 byte-exact; Uganda grid correct** — see §4 |
+| 4D scheduling | `BIMManager/SchedulingCommands.cs`, `V6/FourdGanttReader.cs` | Foundation; no CPM/float, parser bugs (§3) |
+| Workflow + presets | `Core/WorkflowEngine.cs`, `Docs/Workflow/`, `Data/WORKFLOW_*.json` | Solid; naming collision + SLA bug (§2/§3) |
+| Dashboards | `UI/BIMCoordinationCenter.cs`, `SchedulingCostDashboard.cs`, `IssueTrackerDashboard.cs` | Solid; data-source inconsistencies (§3) |
+| Server | `Planscape.Server` Issues/Meetings/Transmittals/Workflows/Compliance controllers | Solid |
+
+**Mandatory conventions (read `CLAUDE.md` §"Conventions for AI Assistants"):**
+- Doc acquisition: `var doc = ParameterHelpers.GetDoc(commandData);` (dock-panel commands receive **null** `ExternalCommandData`).
+- `[Transaction(TransactionMode.Manual)]` for mutating, `ReadOnly` for diagnostics; wrap DB writes in a named `Transaction` (`"STING …"`).
+- `StingLog.Info/Warn/Error` — **no silent catches**. `TaskDialog`, not `MessageBox`.
+- Data-driven: new behaviour → JSON/CSV under `StingTools/Data/` with a project override under `<project>/_BIM_COORD/`; corporate baseline stays pristine; project edits flip `origin` via checksum drift (mirror existing registries).
+- Reuse UI hosts: `StingListPicker`, `StingResultPanel`, `StingDataGridDialog`, `StingProgressDialog`, `StingExportDialog`.
+- **Build to verify:** `dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:\Program Files\Autodesk\Revit 2025"` → 0 errors before each commit (note in commit if the sandbox cannot build).
+- **No snapshot regressions** — additive JSON model fields only, with safe defaults so old `deliverables.json`/snapshot/VO/cert JSON still deserialises.
+- **Branch hygiene:** one branch per work package off latest `main` (e.g. `claude/pm1-cost-correctness`). Commit logically; do not push/PR unless asked. End commit messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## 2. Findings — CORRECTNESS BUGS (fix first; highest commercial risk)
+
+Each is a real defect found in code. Severity in brackets. **Verify line, then fix.**
+
+### Cost / EVM / Cert
+- **[HIGH] EVM EAC collapses to 0 when CPI=0.** `Core/Evm/EvmCalculator.cs:51-53` — `Eac => Cpi > 0 ? Bac/Cpi : 0`. At project start (AC>0, EV=0 → CPI=0), EAC=0, ETC goes **negative**, VAC falsely reads full-BAC "on budget" exactly when a PM needs the forecast. **Fix:** `EAC = AC + (BAC−EV)` fallback when CPI=0; add the `AC + (BAC−EV)/(CPI×SPI)` schedule-blended variant; derive ETC from the chosen EAC.
+- **[HIGH] EVM BAC is re-derived from the *live* BOQ every run, not a frozen baseline.** `Commands/Cost/VariationAndEvmCommands.cs:632,638` — `bac = boq.GrandTotalUGX`; as the model grows, BAC/EV/PV drift with zero progress. **Fix:** anchor BAC on the frozen contract sum (the FinalAccount/AFC code already resolves one — `FinalAccountCommands.cs:156-167`) plus approved variations.
+- **[HIGH] Cost-plan vs BOQ variance compares GBP to UGX with no FX.** `Commands/Cost/CostPlanCommands.cs:212-217` diffs `CostPlanDocument.TotalLikely` (defaults **GBP**, `Core/CostPlan/CostPlanLine.cs:64`) against UGX BOQ totals — every variance is ~3700× wrong. **Fix:** default cost plan to project currency (UGX); FX-convert before any cross-document diff.
+- **[HIGH] `AssignBoqLineRefs` middle segment is a hard-coded constant.** `BOQCostManager.cs:3437-3441` — `string sectionIndex = "1";` never incremented, so every ref is `{prefix}.1.{n}`; the hierarchy the format promises is dead, and the wrong ref is **stamped onto elements** (`ASS_BOQ_LINE_REF`). **Fix:** increment per section group.
+- **[MED] Cert VAT defaults to UK 20% on Uganda projects.** `Core/PaymentCert/PaymentCertModels.cs:93` (`VatPercent = 20.0`); `PaymentCertEngine.CreateDraft` never sets it from the project. **Fix:** seed VAT from project/BOQ (18%).
+- **[MED] Cert SOV omits prelims/OH&P/contingency.** `PaymentCertEngine.SovFromSnapshot:100-111` sets `ContractValue = BOQSection.TotalUGX` (works-only, ex-markup), while AFC/FinalAccount use grossed-up `GrandTotalUGX` — two contract bases for one project. **Fix:** value certs against the same grossed-up basis (or explicitly carry prelims as an SOV line).
+- **[MED] Cert progress vs valuation inconsistent.** `PaymentCertModels.cs:113-122` — `OverallPercentComplete` excludes MaterialsOnSite while `GrossThisCert` (`:52`) includes it; retention-halving keys off the MoS-excluding %. **Fix:** reconcile the two.
+- **[MED] PERT mean computed from pre-rounded line totals.** `Core/CostPlan/CostPlanLine.cs:41-46`. **Fix:** weight then round.
+- **[MED] `StarRateLine.LineTotal` uses `Max(Hours,Quantity)`.** `Core/Variation/VariationModels.cs:237` — silently mis-costs a line with both fields set. **Fix:** select by resource type, not `Max`.
+- **[LOW] Retention never halves** — `EffectiveRetentionPercent` default `HalfRetentionAtPercent = 100.0` makes the feature inert (`PaymentCertModels.cs:126`). **Fix:** default to practical-completion trigger, not 100%.
+
+### Scheduling / Workflow
+- **[HIGH] SLA deadlines fire at the wrong time (timezone).** `Docs/Workflow/WorkflowEngine.cs:128` parses the `…Z` UTC deadline with `DateTime.TryParse` (no `AssumeUniversal`) → `Local` kind, compared against `DateTime.UtcNow`. In Kampala (UTC+3) breaches fire **3h early**. (`AuditLog.cs:111` does it correctly — copy that.) Same defect `:114`. **Fix:** `DateTimeStyles.AssumeUniversal | AdjustToUniversal`.
+- **[HIGH] Two MS Project duration parsers disagree.** `SchedulingCommands.cs:587` (`XmlConvert.ToTimeSpan / 8h`) vs `FourdGanttReader.cs:51` (derives from Start/Finish only) — same `.xml`, different durations; neither applies the project calendar. **Fix:** converge on one parser.
+- **[MED] P6 predecessor links dropped → no schedule logic.** `SchedulingCommands.cs:546` (`predecessors = []`), `FourdGanttReader.ParsePrimaveraXer:84` never reads `TASKPRED`. Without this, CPM/float (PM-4) is impossible. **Fix:** parse the relationship table.
+- **[MED] XER date parse over-strict, silently drops rows.** `FourdGanttReader.cs:103-106` — only `yyyy-MM-dd HH:mm`/`yyyy-MM-dd`; real XER often has seconds. **Fix:** add formats + warn on skip.
+- **[MED] % complete normalized in one of three import paths only.** `SchedulingCommands.cs:532` rescales 0..1→0..100 for P6 but MSP-XML (`FourdGanttReader.cs:67-69`) and XER do not. **Fix:** normalize once, centrally.
+- **[MED] Working-calendar is computed but never used; UK bank holidays hard-wired.** `SchedulingCommands.cs:2241-2284` (Computus) feeds only a CSV; `AutoGenerateSchedule` (`:328,349`) uses calendar-days and only nudges weekend end-dates. Wrong holiday set for Uganda. **Fix:** feed a Uganda working-calendar into schedule generation.
+- **[LOW] Silent quantity fabrication in 5D estimate.** `SchedulingCommands.cs:900` defaults rebar `0.888 kg/m`; `qty += 1` fallbacks (`:866,878,890`) substitute "1 unit" when geometry missing, not surfaced in `skipped`. **Fix:** surface as low-confidence.
+
+### Robustness
+- **[MED] Silent `catch {}` swallow cert write failures.** `PaymentCertEngine.cs:224,235,246`; `CostControlCommands.cs:119`. **Fix:** `StingLog.Warn` with the reason.
+- **[MED] Non-atomic cert save (delete-then-write).** `PaymentCertCommands.cs:254-255` — crash between = lost certificate; filename embeds `ValuationDate` so re-save can orphan/duplicate. **Fix:** write-temp-then-rename; stable filename keyed on cert id.
+- **[MED] Snapshot hasher drops zero-valued lines.** `BoqSnapshotHasher.cs:40` (`DefaultValueHandling.Ignore`) — an unmeasured (qty 0) row is invisible to the checksum/dedupe. **Fix:** include zeros in the canonical JSON.
+- **[MED] EVM actuals CSV header heuristic can mis-count.** `EvmCalculator.cs:114-131` — silent `continue` on parse failure under-reports ACWP with no warning. **Fix:** explicit header flag + surfaced parse-error count.
+- **[LOW] Money math is all `double`.** UGX billions × thousands of lines accumulates float residue; rounding masks it. **Consider** `decimal` for money totals (scoped, optional).
+
+---
+
+## 3. Findings — INTEGRATION & AUTOMATION GAPS (the silos)
+
+The modules work alone but **do not pass data to each other**. This is the
+central structural gap — a PM must hand-re-key the same numbers between stages.
+
+- **[HIGH] CostPlan → budget → EVM PV is unwired.** EVM BAC comes from the live BOQ, never the cost plan's `GrandTotalLikely`; nothing seeds `PROJECT_BUDGET_UGX` from the plan. (`CostPlanEngine` NRM1→NRM2 map is one-way, hard-coded.)
+- **[HIGH] Variation → Cert → EVM is unwired.** An approved VO (`VariationApproveCommand`) adds no SOV line, adjusts no contract value (`PaymentCertEngine.CreateDraft`), and never moves EVM BAC (`VariationAndEvmCommands.cs:632`). A £500k VO is invisible to the next valuation and the forecast. Only the read-only AFC/FinalAccount reports see variations.
+- **[HIGH] No schedule-driven cash-flow / S-curve.** `GenerateCashFlow` (`SchedulingCommands.cs:1036,1061-1093`) spreads the **grand total only** over a fixed sigmoid — ignores per-task start/finish/value, so a front-loaded and a back-loaded programme give the *same* curve. EVM PV is hand-keyed (`VariationAndEvmCommands.cs:634-637` "No 4D wiring yet"). There is no true time-phased Planned Value.
+- **[HIGH] Clash → Issue → Transmittal chain not wired.** `ClashSlaIntegration.CreateIssues` builds in-memory `CoordIssue` that flow to BCF only (`ClashRunCommand.cs:252,287`); clashes never reach `issues.json`; nothing escalates or bundles into a transmittal.
+- **[HIGH] Issue-status enum diverges across four subsystems.** `"OPEN"` (BIMManager) vs `"Open"` (Clash `ClashSlaIntegration.cs:55-57`) vs `"open"` (ACC `AccIssueSync.cs:62`) vs `"Resolved"/"Void"` (KPI `KutKpiDashboardCommand.cs:185-188`). The workflow gate `has_open_issues` matches only `"OPEN"` (`Core/WorkflowEngine.cs:688`) → never sees clash/ACC issues. **Fix:** one shared `IssueStatus` normalizer + reconcile `clashes.json` ↔ `issues.json`.
+- **[MED] FinalAccount/AFC compute "contract sum" from different sources** (`FinalAccountCommands.cs:156-167` vs `CostControlCommands.cs:332-345`) → two final numbers for one project. FinalAccount also ignores the cert series entirely (uses config/snapshot, not certified-to-date).
+- **[MED] PaymentCert carry-forward keyed by free-text section string** (`PaymentCertEngine.CreateDraft:57-60`) — renaming a section silently resets cumulative valuation to 0 and over-pays. **Fix:** element-id/line-id binding for cumulative valuation.
+- **[MED] KPI dashboard has honesty gaps** — three headline KPIs are literal strings, not computed (`KutKpiDashboardCommand.cs:347-349`); no auto-snapshot (manual trigger only).
+- **[MED] MIDP/TIDP exists only as a CSV template, not data/engine** — deliverable lifecycle isn't joined to a delivery *plan*, so "is delivery X on programme?" is unanswerable.
+
+**Automation a PM/QS currently does by hand that should be automated:** cost
+plan → budget → EVM PV; VO approval → next cert SOV line; cash-flow generation;
+retention half-release at PC; schedule % complete from model state; clash →
+tracked issue with SLA; KPI fortnightly snapshot; MIDP drift detection.
+
+---
+
+## 4. Findings — MATERIAL / CARBON vs EDGE & UGANDA
+
+The carbon system is **largely correct and EDGE-aware** — the Phase-195 engine
+(`Core/Sustainability/`) implements EDGE 20/20/20 byte-exact, keeps embodied
+**energy (MJ)** separate from **carbon (kgCO2e)** as EDGE requires, and resolves
+the **Uganda grid at 0.05 kgCO2e/kWh** (`GridCarbonRegistry`). Biogenic carbon
+is handled per RICS WLCA (reported separately, not netted). **Do not "fix" these.**
+
+The defects are in the **older BOQ/V6 carbon path** that bypasses the new engine:
+
+| Item | StingTools value | Expected (EDGE/Uganda) | Action |
+|---|---|---|---|
+| **B6 operational factor** | `0.233 kgCO2e/kWh` **hard-coded** (`V6/CarbonStageTracker.cs:54`) | Uganda 0.05 (already in `GridCarbonRegistry`) | **[HIGH]** Route B6 through `GridCarbonRegistry` — currently ~**5× too high** for Uganda |
+| **Benchmarks in ISO-14064 export** | LETI 625 / RIBA 300 kgCO2e/m² hard-coded (`CarbonStageTracker.cs:206`) | UK targets, inappropriate | **[HIGH]** Replace with project/region targets or remove |
+| **Ugandan fired-clay brick** | 350 kgCO2e/m³ | Clamp-fired artisan brick ≈17 MJ/kg (5.7× generic) → likely understated; block (140) correctly < brick | **[MED]** Raise UG brick factor + note clamp-kiln biomass; reinforce "block greener than brick locally" |
+| **Per-material waste** | single `COST_DEFAULT_WASTE_PCT` knob (`WasteFactor.cs`) | NRM2: rebar ~2.5%, masonry ~5%, timber ~10%, concrete ~5% | **[MED]** Add a per-material/category waste table |
+| **Green baselines** | no Uganda rows; Kampala falls back to 0A hot-humid proxy | Kampala ~1200 m → behaves ~2A/3A, much milder | **[MED]** Add UG/Kampala baseline rows (`STING_GREEN_BASELINES.json`) |
+| **Two carbon subsystems** | BOQ path (kgCO2e/m³) + Phase-195 engine (MJ + carbon) reconciled only partly | One source of truth | **[LOW]** Consolidate grid factor + benchmarks on `GridCarbonRegistry` everywhere |
+| **Stainless steel** | plain-steel carbon (`MATERIAL_LOOKUP.csv`) | ~6.15 kg/kg (≈4× higher) | **[LOW]** Correct factor |
+
+**Already correct (keep):** EDGE 20/20/20 thresholds; EDGE-as-energy (MJ) with
+materials gate delegated to EDGE app; Uganda grid 0.05; CEM I high-clinker
+concrete + imported-primary steel/aluminium provenance; biogenic separate-line.
+
+---
+
+## 5. PM cost-control lifecycle — coverage matrix & missing capabilities
+
+The benchmark: **a PM must be tooled for every stage from feasibility to final
+account.** Mapping the 8-stage QS/PM journey (RICS NRM + RICS Black Book) against
+StingTools, and where each belongs relative to the Revit API line:
+
+| Stage | Belongs | StingTools today | Gap |
+|---|---|---|---|
+| 1. Order of cost estimate / feasibility (NRM1, £/m² GIFA) | QS tool / Revit GIFA export | GIFA schedules exist | **No OCE / benchmark workflow** → PM-3 |
+| 2. Elemental cost plan (NRM1) | Hybrid (Revit-assisted, QS-owned) | `Core/CostPlan` exists but **GBP silo, NRM2-led, no FX** | **NRM1 elemental structure + currency fix** → PM-1/PM-3 |
+| 3. NRM2 BoQ / tender pricing | Revit authoring-time ✓ | **Strong** (BOQ export, tender adjudication WP4a) | OK |
+| 4. Contract sum / baseline budget | Cloud + Revit stamp | CostStamp/budget basis exists | **Frozen baseline → EVM not wired** → PM-2 |
+| 5. Cost control (valuations, retention, variations, dayworks, PC/provisional, fluctuations, L&E) | Cloud + QS tool; Revit = VO remeasure | Certs ✓, variations ✓, retention partial | **Variation→cert unwired; retention release; dayworks; fluctuations; L&E** → PM-2/PM-3 |
+| 6. Forecasting (CTC / AFC / EVM / cash-flow S-curve) | Cloud / BI | EVM ✓ (buggy), AFC ✓ | **Schedule-driven S-curve; CTC at line level; EAC fix** → PM-1/PM-2 |
+| 7. Final account / retention release | QS tool / cloud | FinalAccount reconciliation ✓ (WP4a) | **Ignores cert series; no retention-release ledger** → PM-2/PM-3 |
+| 8. CVR + client cost report | Cloud / QS tool | — | **No CVR report** → PM-3 |
+
+**"No PM should lack this" — capabilities entirely absent today:**
+1. **Commitments register** (sub-contracts / POs linked to budget lines) — absent.
+2. **Schedule-driven cash-flow S-curve** (planned vs actual cumulative) — synthetic only.
+3. **Retention-release ledger** (withholds only today; no release entries).
+4. **Fluctuations** (NEDO/BCIS index-linked) — flat config number only.
+5. **Dayworks** sheet/build-up workflow — enum value exists, no workflow.
+6. **Loss & expense / compensation events** — EOT days captured, no valuation.
+7. **CVR** (cost-value reconciliation) — absent.
+8. **NRM1 elemental cost plan + OCE** — NRM2-led only.
+9. **Cost-to-complete at line level** — only the (broken) EVM aggregate.
+10. **ERP/accounting export** (QuickBooks/Sage/Excel) — the Uganda-pragmatic bridge.
+
+---
+
+## 6. Work packages
+
+Sequenced so correctness lands before integration before new features. Each WP is
+its own branch off latest `main`. **PM-1 → PM-2 are mandatory before PM-3+**
+(you cannot build forecasting on broken EVM or unwired silos).
+
+### PM-1 — Cost & schedule correctness (fix the bugs in §2)
+Branch `claude/pm1-correctness`. Fix, with a regression note per item:
+- EVM EAC/CPI=0 guard + EAC variants + ETC (`EvmCalculator.cs:51-53`).
+- EVM BAC anchored on frozen contract sum + approved variations (`VariationAndEvmCommands.cs:632`).
+- CostPlan default currency = project (UGX) + FX before any diff (`CostPlanLine.cs:64`, `CostPlanCommands.cs:212-217`).
+- `AssignBoqLineRefs` section increment (`BOQCostManager.cs:3437`).
+- Cert VAT from project (`PaymentCertModels.cs:93`, `CreateDraft`).
+- SLA timezone `AssumeUniversal` (`Docs/Workflow/WorkflowEngine.cs:114,128`).
+- B6 grid factor via `GridCarbonRegistry`; remove UK benchmarks (`CarbonStageTracker.cs:54,206`).
+- Cert atomic save; silent-catch logging; hasher zero-inclusion (§2 robustness).
+**Done = each bug has a before/after and the build is clean.**
+
+### PM-2 — Wire the silos (integration, §3)
+Branch `claude/pm2-integration`. No new features — connect what exists:
+- **CostPlan → budget → EVM PV**: cost plan `GrandTotalLikely` auto-seeds `PROJECT_BUDGET_UGX`; EVM reads it as BAC.
+- **Variation → Cert → EVM**: approving a VO appends an "Adjustments / Variations" SOV section to the next cert and moves EVM BAC.
+- **Clash → Issue → Transmittal**: clash run optionally raises tracked issues (one `IssueStatus` normalizer) into `issues.json` with SLA; reconcile `clashes.json` ↔ `issues.json`; `has_open_issues` sees all.
+- **Unify the contract-sum source** so FinalAccount and AFC agree; FinalAccount reconciles against certified-to-date.
+- **PaymentCert cumulative valuation** keyed by line/element id, not section string.
+
+### PM-3 — Close the QS lifecycle gaps (§5 missing capabilities)
+Branch `claude/pm3-lifecycle`. Each is model-anchored capture in Revit + engine/ledger in `Core/` (server later):
+- **Schedule-driven cash-flow S-curve** — time-phase per-task value over its start/finish (needs PM-4 dates); planned vs actual cumulative; this becomes the real EVM PV.
+- **Retention-release ledger** — release entries (half at PC, final at end-of-defects) alongside withholds (`PaymentCertEngine.ComputeLedger`).
+- **Fluctuations engine** — index-linked (NEDO/BCIS-style) instead of the flat config number (`FinalAccountCommands.cs:185`).
+- **Dayworks** — labour/plant/material build-up sheet using the existing `StarRate` model, surfaced as a `BOQRowSource.Dayworks` flow.
+- **Loss & expense / compensation events** — valuation tied to the EOT days already captured on VOs.
+- **CVR report** — cost vs value at a common cut-off (over/under-claim, WIP, margin).
+- **NRM1 elemental cost plan + OCE** — map Revit categories → NRM1 element groups; £/m² (UGX/m²) GIFA benchmarking.
+- **Cost-to-complete at line level**; **commitments register** (sub-contracts/POs → budget lines).
+- **QuickBooks/Sage/Excel export** path (offline-first).
+
+### PM-4 — Scheduling depth (CPM, the engine Revit won't give you)
+Branch `claude/pm4-scheduling`. This is *your* engine (Revit has no scheduler):
+- Converge the two MSP/XER parsers; **read P6 predecessors** (`TASKPRED`) and MSP links.
+- **Forward/backward pass → critical path, total/free float.**
+- **Baseline-vs-actual variance**; **model-driven % complete** (phase reached / elements placed vs planned — currently always 0, `SchedulingCommands.cs:391`).
+- Uganda working-calendar fed into generation (not UK bank holidays).
+- Keep exporting parameter-driven 4D to Navisworks/SYNCHRO/P6 — do **not** try to be P6.
+
+### PM-5 — Carbon/EDGE/Uganda accuracy (§4)
+Branch `claude/pm5-carbon`. Mostly data + one wiring fix:
+- Per-material waste table; UG brick factor; Kampala/UG green-baseline rows; stainless factor; consolidate grid/benchmarks on `GridCarbonRegistry`. (B6/benchmark wiring already in PM-1.)
+
+### PM-6 — Performance & robustness (§2 perf, §3 perf)
+Branch `claude/pm6-perf`:
+- Add `ElementMulticategoryFilter(SharedParamGuids.AllCategoryEnums)` to `AutoGenerateSchedule` (`:245`) and `GenerateCostEstimate` (`:760`) — the heaviest unfiltered UI-thread sweeps.
+- Cache one `BuildBOQDocument(doc)` across cert→EVM→AFC in a command run (currently rebuilt 3×).
+- Replace per-element `LookupParameter` sweeps in `WeightedPctComplete`/`AggregatePercentComplete` (`VariationAndEvmCommands.cs:718`, `PaymentCertCommands.cs:114`).
+- `AuditLog` last-hash in memory (`:168`); `MilestoneRegister` collect-once (`:2129`); `VariationEngine.ListVariations` single-load (`:177`).
+
+### PM-7 — Architecture hygiene
+Branch `claude/pm7-hygiene`:
+- **Rename one `WorkflowEngine`** — `Core` = preset runner, `Docs/Workflow` = doc state-machine; the name collision is worked around with a `using` alias (`TransmittalOrchestrator.cs:24-28`) and is a latent wrong-bind hazard. Suggest `PresetRunner` vs `DocWorkflowEngine`.
+- Consolidate two `ContractForm` enums (`PaymentCertModels.cs:27` 3-value vs `VariationModels.cs:57` 8-value).
+- De-duplicate `SuggestLiability` (`VariationAndEvmCommands.cs:353,1033`) and `MapProviderIdToLegacySource` (`BOQCostManager.cs:826`, `CostStamp.cs:227`).
+- Unify CST_* param storage types (string vs number drift) and the three sidecar-folder root strategies (`_BIM_COORD` vs `STING_BIM_MANAGER` vs `_bim_manager`).
+
+### PM-8 — Delivery-management layer (the ISO 19650 PM surface)
+Branch `claude/pm8-delivery`. Thin in Revit, engine in Planscape:
+- **MIDP/TIDP engine** — promote the CSV template to a tracked deliverable register joined to the lifecycle; stamp each sheet/container's suitability + delivery status; **drift detection** ("which deliverables are off-programme").
+- **KPI time-series** — make `KutKpiDashboard` real (compute the three string-only KPIs; persist auto-snapshots server-side; trend multiple metrics).
+- **Risk register** — the clearest missing PM primitive (only a narrow Lightning model exists). Data model + lifecycle in Planscape; thin "raise risk against this element/zone" hook in Revit, reusing issue/SLA/audit machinery.
+
+---
+
+## 7. How a PM uses the finished system (acceptance narrative)
+
+When PM-1…PM-8 land, a Planscape PM/QS should be able to, **without leaving
+StingTools + Planscape**: take a model at RIBA 2 → produce an NRM1 elemental cost
+plan in UGX with GIFA benchmarks (PM-3) → that plan seeds the budget and EVM PV
+(PM-2) → produce an NRM2 BoQ + tender pricing and adjudicate tenders (exists) →
+freeze a contract-sum baseline (PM-2) → run monthly interim valuations + payment
+certificates with correct VAT/retention (PM-1), with approved variations flowing
+straight into the next cert and the forecast (PM-2) → track dayworks,
+fluctuations, loss & expense (PM-3) → see a **schedule-driven cash-flow S-curve**
+and correct EVM CPI/SPI/EAC/CTC (PM-1/PM-4) → run a CVR and client cost report
+(PM-3) → close with a final account reconciled against certified-to-date and a
+retention-release ledger (PM-2/PM-3) → with carbon reported on EDGE/Uganda
+defaults throughout (PM-5) — and export the lot to QuickBooks/Sage/Excel offline
+(PM-3). **If any of those steps still needs a tool outside StingTools, the work
+package that owns it is incomplete.**
+
+---
+
+## 8. Out of scope (deliberately not built in Revit)
+
+- A CPM **UI** replacing P6/Asta; resource leveling histograms — export to those tools instead.
+- A live ACC/Procore connector as a dependency — Uganda connectivity is intermittent; Excel/CSV/QuickBooks first, ACC API as an *optional* later bridge.
+- Real-time multi-user valuation/locking inside the model — Planscape is the system of record.
+- True 4D animation/time simulation — parameter-driven export to Navisworks/SYNCHRO.
+
+---
+
+### Appendix — research basis
+
+This brief consolidates: a full codebase PM inventory; a cost-engine code audit;
+a scheduling/automation/dashboard code audit; a material/carbon-vs-EDGE/Uganda
+audit; deep research on ACC Cost Management + the RICS NRM/Black Book cost
+lifecycle; PM-platform feature landscape (ACC, Procore, Aconex, P6, Asta,
+SYNCHRO, CostX/Candy); and Revit API feasibility limits. Sources are recorded in
+the session that produced this document. All file:line references were valid at
+commit `55ac92fe3` — **re-verify before editing.**

--- a/docs/guides/SUSTAINABILITY_CARBON_COSTING_LAYMANS_GUIDE.md
+++ b/docs/guides/SUSTAINABILITY_CARBON_COSTING_LAYMANS_GUIDE.md
@@ -1,0 +1,756 @@
+# A Beginner's Guide to Sustainability & Carbon Costing in STINGTOOLS
+
+*From "what does green even mean?" to mastering the STING Sustainability Center.*
+
+This guide assumes **zero prior knowledge**. If you have never heard of LEED, EDGE,
+embodied carbon or an "EUI", you are in the right place. We start with the very
+basics, build up the ideas one at a time, then show you exactly how to use the
+STING Sustainability Center to put real numbers against a building. The last third
+of the guide ("Mastering the topic") goes deep enough to make you the person in the
+room who actually understands what the numbers mean.
+
+> **How to read this guide.** Read Parts 1–3 once to understand the *ideas*. Keep
+> Part 4 open beside Revit the first few times you use the panel. Come back to
+> Part 5 when you want to stop trusting the tool blindly and start judging its
+> answers yourself.
+
+---
+
+## Table of contents
+
+1. [Part 1 — Why any of this matters (the absolute basics)](#part-1)
+2. [Part 2 — Green-building certifications: LEED and EDGE](#part-2)
+3. [Part 3 — The engineering ideas behind the numbers](#part-3)
+4. [Part 4 — Carbon costing with STINGTOOLS (the hands-on walkthrough)](#part-4)
+5. [Part 5 — Mastering the topic (advanced lessons)](#part-5)
+6. [Part 6 — Glossary, checklists & references](#part-6)
+
+---
+
+<a name="part-1"></a>
+## Part 1 — Why any of this matters (the absolute basics)
+
+### 1.1 What is a "green building"?
+
+A green building is simply a building that does **more with less harm**: it uses
+less energy and water to run, and it is built from materials that took less damage
+to the planet to produce. That's it. Everything else — LEED, EDGE, carbon
+factors, EUIs — is just a way of **measuring** how green a building actually is,
+so you can prove it instead of just claiming it.
+
+Think of it like the fuel-economy sticker on a car. A car salesman can *say* a car
+is "efficient", but the sticker gives you a number (litres per 100 km) you can
+compare against other cars. Green-building certifications are the fuel-economy
+sticker for buildings.
+
+### 1.2 Why should a designer care?
+
+Buildings are responsible for roughly **40% of global energy-related carbon
+emissions**. Roughly:
+
+- **~28%** is *operational* — the energy a building burns every day to run lights,
+  air-conditioning, lifts, hot water.
+- **~11%** is *embodied* — the carbon released **once**, up front, to make and
+  transport the concrete, steel, glass, brick and insulation the building is made of.
+
+So a building has **two carbon bills**:
+
+| Bill | When it's "paid" | Driven by |
+|---|---|---|
+| **Operational carbon** | Every year, for the building's whole life | How efficient the design is (insulation, glazing, plant, lighting) |
+| **Embodied carbon** | Once, before anyone moves in | How much material you use and *which* materials |
+
+A real client increasingly cares about both — because of regulations (UK Part L,
+EU EPBD, NZ Building Code), because of funders (the World Bank, IFC and green-bond
+investors *require* it), and because of cost (energy is expensive and getting more so).
+
+### 1.3 What is "carbon costing"?
+
+"Carbon costing" means **putting a number on the carbon a design will emit**, the
+same way "cost estimating" puts a number on the money a design will cost. The unit
+is **kgCO₂e** — kilograms of carbon-dioxide *equivalent*. The little "e" matters:
+buildings emit several greenhouse gases (CO₂, methane, refrigerants), and we convert
+them all into "the equivalent amount of CO₂" so we can add them up into one number.
+
+There are two things people mean by "carbon cost":
+
+1. **The carbon itself**, measured in kgCO₂e (or tonnes). This is what STINGTOOLS
+   calculates — embodied + operational.
+2. **The money**, measured in your currency. This is the *life-cycle cost* (LCC):
+   what a sustainability feature costs to install versus how much money it saves
+   over the building's life. STINGTOOLS calculates this too, and feeds it into
+   the BOQ / Cost Manager.
+
+This guide covers both, because in practice the question a client asks is always
+*"What does it cost me — in carbon AND in money — to make this building greener?"*
+
+### 1.4 The one mental model to remember
+
+```
+            ┌─────────────────────────────────────────────┐
+            │              A BUILDING'S CARBON              │
+            ├───────────────────────┬─────────────────────-┤
+            │   EMBODIED (one-off)   │  OPERATIONAL (yearly) │
+            │                        │                       │
+            │  concrete, steel,      │  electricity, gas,    │
+            │  glass, brick,         │  cooling, heating,    │
+            │  insulation, finishes  │  fans, lighting, DHW  │
+            │                        │                       │
+            │  measured in kgCO₂e    │  measured in kgCO₂e/yr │
+            │  (A1–A3 product stage) │  (grid factor × kWh)   │
+            └───────────────────────┴─────────────────────-─┘
+                        ▲                        ▲
+                you reduce it by             you reduce it by
+              using less / smarter         better fabric, plant,
+                  material                   PV, efficient systems
+```
+
+Hold that picture. Everything below hangs off it.
+
+---
+
+<a name="part-2"></a>
+## Part 2 — Green-building certifications: LEED and EDGE
+
+A **certification** is a recognised, third-party scorecard that says "this building
+meets a defined standard of greenness." Two matter most for the projects
+STINGTOOLS serves: **LEED** (global, premium, points-based) and **EDGE**
+(emerging-market focused, simple, threshold-based). STINGTOOLS supports both, and —
+importantly — treats them as **data, not code**: the rules live in JSON files, so a
+third scheme (BREEAM, Green Star) could be added without changing the engine.
+
+### 2.1 LEED — the global gold standard
+
+**LEED** = **L**eadership in **E**nergy and **E**nvironmental **D**esign. It is run
+by the **U.S. Green Building Council (USGBC)** and is the most widely recognised
+green-building label in the world (you'll see "LEED Platinum" on trophy office
+towers).
+
+**How LEED works — a points game.** You *earn points* across several categories.
+The more points, the higher the award level:
+
+| LEED level | Points (out of 110) |
+|---|---|
+| Certified | 40–49 |
+| Silver | 50–59 |
+| Gold | 60–79 |
+| Platinum | 80+ |
+
+The point categories (LEED v4 / v5 BD+C) are:
+
+- **Location & Transportation** — is the site walkable, near transit?
+- **Sustainable Sites** — rainwater, heat-island, light pollution.
+- **Water Efficiency** — low-flow fixtures, no potable water for irrigation.
+- **Energy & Atmosphere** — *the big one* — energy efficiency, renewables, refrigerants.
+- **Materials & Resources** — **embodied carbon (WBLCA)**, recycled content, EPDs.
+- **Indoor Environmental Quality** — daylight, air quality, acoustics.
+- **Innovation** and **Regional Priority** — bonus points.
+
+**The key idea:** LEED is *flexible*. You don't have to be good at everything — you
+trade off. Weak on water? Make it up on energy and materials. There is a
+**prerequisite** in Materials & Resources to complete a **Whole-Building Life-Cycle
+Assessment (WBLCA)** — i.e. you *must* calculate embodied carbon to play. That's
+exactly the number STINGTOOLS produces.
+
+**Where LEED sits in design:** LEED is registered early, but points are *documented*
+across all RIBA stages, with the big modelling effort (energy model, WBLCA) around
+**RIBA Stage 3–4 (Developed/Technical Design)**.
+
+### 2.2 EDGE — deep dive (the one to really understand)
+
+**EDGE** = **E**xcellence in **D**esign for **G**reater **E**fficiencies. It was
+created by **IFC**, the private-sector arm of the **World Bank Group**, specifically
+for **emerging markets** (Africa, South Asia, Latin America) where LEED's cost and
+complexity are barriers. If you work on a World Bank / IFC / green-bond financed
+project, EDGE is very often **mandatory**.
+
+EDGE's genius is **simplicity**. Forget 110 points across nine categories. EDGE has
+**three gates**, and you must clear a single percentage on each:
+
+```
+                 ┌──────────────────────────────────────────┐
+                 │                THE EDGE 3 GATES            │
+                 ├──────────┬──────────────┬─────────────────┤
+                 │  ENERGY  │     WATER     │    MATERIALS    │
+                 │  ≥ 20%   │    ≥ 20%      │     ≥ 20%       │
+                 │ savings  │   savings     │  savings (in    │
+                 │  vs base │   vs base     │  embodied       │
+                 │          │               │  ENERGY, MJ)    │
+                 └──────────┴──────────────┴─────────────────┘
+                  ALL THREE must pass → EDGE Certified
+```
+
+**What "savings vs base" means.** EDGE imagines a **base case**: a "typical"
+building of the same type, in the same city, built to standard local practice. Your
+design is compared against that base case. If your design uses **20% less energy,
+20% less water, and 20% less embodied energy in its materials** than the base case,
+you earn **EDGE Certified**.
+
+**The three EDGE levels:**
+
+| EDGE level | Requirement |
+|---|---|
+| **EDGE Certified** | ≥20% energy **and** ≥20% water **and** ≥20% materials savings |
+| **EDGE Advanced** | ≥**40%** energy savings (water & materials still ≥20%) |
+| **EDGE Zero Carbon** | EDGE Advanced **plus** the remaining operational carbon is covered by on-site or off-site renewables / offsets |
+
+**Why 20%?** It's a deliberately *achievable* threshold — enough to make a real
+difference, low enough that good design (not exotic technology) gets you there. This
+is why EDGE works in markets where Platinum-level spending isn't realistic.
+
+**EDGE's three big differences from LEED:**
+
+1. **Threshold, not points.** You either clear 20% on all three gates or you don't.
+   No trading off. This makes it brutally clear what to fix.
+2. **Whole-building, not credits.** EDGE cares about the building's *total* energy,
+   water and material-energy performance, not a checklist of features.
+3. **One free app owns the certified number.** EDGE provides a **free web app**
+   (app.edgebuildings.com) with the official base-case data for each country. You
+   enter your building's parameters, and the app computes the *certified* %.
+
+> **This last point is crucial and it shapes how STINGTOOLS works.** STINGTOOLS does
+> **not** pretend to issue the certified EDGE number — only the EDGE app can do that.
+> What STINGTOOLS gives you is an **indicative** figure during design ("you're
+> around 32% on energy") so you can steer the design *before* you ever open the
+> EDGE app, plus an **export** that hands the EDGE app the model quantities it needs.
+> When you later get the official EDGE app number, you can type it back into
+> STINGTOOLS and it will show you the *real* EDGE level. (More on this in Part 4.)
+
+**The EDGE base case (baseline) — why it's climate-driven.** A "20% saving" only
+means something relative to a baseline. EDGE's baseline depends on **building type +
+climate** — a hospital in hot-humid Bangui has a very different base energy use than
+an office in temperate London. STINGTOOLS mirrors this: it resolves a baseline by
+**climate zone** (not country), using a four-hop fallback
+(`country+zone+use → zone+use → use → global`) and always labels the result
+"indicative" with a provenance log, so you can see *where the baseline came from*.
+
+### 2.3 LEED vs EDGE at a glance
+
+| | **EDGE** | **LEED** |
+|---|---|---|
+| Run by | IFC / World Bank Group | USGBC |
+| Best for | Emerging markets, fast/affordable | Premium / trophy projects, global recognition |
+| Scoring | 3 thresholds (≥20% each) | Points (40–110) → Certified/Silver/Gold/Platinum |
+| Embodied carbon | "Materials" gate (embodied **energy**, MJ) | WBLCA prerequisite + Reduce-EC credits (embodied **carbon**, kgCO₂e) |
+| Certified number from | The free EDGE web app | Documentation reviewed by GBCI |
+| Cost & effort | Low | High |
+
+> STINGTOOLS reports **both metrics** for materials and never conflates them:
+> embodied **carbon (kgCO₂e/m²)** for LEED and dashboards, and embodied **energy
+> (MJ/m²)** for the EDGE materials gate. They are different numbers and live in
+> different columns.
+
+### 2.4 Why certify *in design*, not after?
+
+Because **the cheapest time to change a building is when it only exists on a
+screen**. This is the famous "cost of change" curve:
+
+```
+  cost / effort to change the design
+        │                                              ● Construction
+        │                                         ●
+        │                                  ●  Technical design
+        │                        ●  Developed design
+        │             ●  Concept
+        │   ●  Brief
+        └──────────────────────────────────────────────────► project time
+```
+
+A decision made at concept (orientation, form, glazing ratio, structural material)
+locks in the *majority* of a building's lifetime carbon — and costs almost nothing
+to change at that point. By the time you're on site, changing the structure to
+reduce embodied carbon is ruinously expensive. So sustainability is a **design-stage
+discipline**, and a design-stage tool (like the STING Sustainability Center inside
+Revit) is exactly where it belongs.
+
+---
+
+<a name="part-3"></a>
+## Part 3 — The engineering ideas behind the numbers
+
+You don't need to be an engineer to use the panel, but understanding these five
+ideas turns the panel's output from "magic numbers" into "numbers I trust."
+
+### 3.1 EUI — Energy Use Intensity
+
+**EUI** = the energy a building uses **per square metre per year**, written
+**kWh/m²·yr**. It is the single most useful efficiency number, because it lets you
+compare a small house and a huge tower fairly (you've divided out the size).
+
+- A leaky old office might be **250 kWh/m²·yr**.
+- A good new office might be **90 kWh/m²·yr**.
+- A Passivhaus might be **40 kWh/m²·yr**.
+
+EDGE's energy gate is really *"is your design's EUI at least 20% below the base
+case's EUI?"* STINGTOOLS computes a **design EUI** from your model and compares it
+to a **baseline EUI**.
+
+### 3.2 Baselines and "% savings"
+
+A **saving %** is always `(baseline − design) ÷ baseline × 100`.
+
+- Baseline EUI 200, design EUI 150 → `(200−150)/200 = 25%` saving. 
+- Design EUI *higher* than baseline → a **negative** saving ("over baseline").
+
+STINGTOOLS guards this calculation against the classic traps: if the baseline is
+zero or unknown it returns "not meaningful" rather than a nonsense number, and an
+over-baseline design is phrased plainly ("design 240 vs baseline 200") instead of a
+confusing "−20%".
+
+### 3.3 Operational carbon — turning kWh into kgCO₂e
+
+Energy isn't carbon until you multiply it by a **grid carbon factor** — how much CO₂
+your local electricity grid emits per kWh:
+
+```
+operational carbon (kgCO₂e/yr) = energy used (kWh/yr) × grid factor (kgCO₂e/kWh)
+```
+
+- A coal-heavy grid might be **0.8 kgCO₂e/kWh**.
+- A clean/hydro grid might be **0.05 kgCO₂e/kWh**.
+- The UK grid is around **0.2** and falling.
+
+This is why **the same building emits different carbon in different countries** — and
+why **on-site solar (PV)** and **fuel choice** (electric vs gas heating) matter so
+much. STINGTOOLS' supply layer takes your design's energy demand, subtracts on-site
+PV generation, then applies the grid (or diesel, or a hybrid blend) factor to the
+**net imported** energy.
+
+### 3.4 Embodied carbon — A1–A3, fossil vs biogenic, EPDs
+
+When you make a tonne of concrete or steel, you emit carbon **before it ever reaches
+site**. Engineers split a material's whole life into stages (A, B, C, D). The part
+STINGTOOLS focuses on is **A1–A3 — the "product stage":**
+
+- **A1** raw material supply (quarrying, mining)
+- **A2** transport to the factory
+- **A3** manufacturing (the kiln, the furnace)
+
+This "**upfront carbon**" is what you can actually influence at design time, and it's
+the headline for benchmarks like **RIBA 2030**, **LETI** and **RICS WLCA**.
+
+Two refinements that STINGTOOLS handles correctly (and many tools get wrong):
+
+- **Fossil vs biogenic carbon.** Timber is special: growing the tree *absorbs* CO₂
+  (a **biogenic** credit, a negative number), while processing it still emits
+  **fossil** carbon. The professional convention (RICS, RIBA, LETI) is to report the
+  **fossil/upfront** figure as the headline and show the **biogenic** credit
+  *separately*. STINGTOOLS tracks both: it credits the timber sequestration into the
+  *net* figure but keeps a separate fossil column so a timber scheme isn't
+  flattered.
+- **Carbon factors and EPDs.** A **carbon factor** says "this material emits X
+  kgCO₂e per m³ (or per kg)." Generic factors come from databases like the **ICE
+  database**. A product-specific **EPD** (Environmental Product Declaration) is a
+  manufacturer's published, verified factor for *their* product — more accurate, and
+  preferred when available. STINGTOOLS resolves factors through a chain: a
+  material-stamped EPD value first, then a corporate library, then generic
+  per-kg data (applied via material density).
+
+### 3.5 Water — per-person-day, low-flow, rainwater
+
+Water is the simplest gate. The base case assumes "standard" fixtures (a 6 L/flush
+WC, a 10 L/min tap). Your design uses **low-flow fixtures** (a 4.5 L dual-flush WC, a
+aerated tap), so it consumes fewer **litres per person per day**. EDGE also credits
+**alternative water**: rainwater harvesting (catching roof runoff) and greywater
+reuse (recycling basin/shower water for flushing). STINGTOOLS reads real low-flow
+fixtures from the model when present, computes a rainwater-harvesting yield from roof
+area + local rainfall (BS 8515), and folds that alternative water into the EDGE water
+% — not just fixture efficiency.
+
+### 3.6 The two material metrics, side by side
+
+This trips everyone up, so it gets its own box:
+
+| Metric | Unit | Standard | Used for |
+|---|---|---|---|
+| Embodied **carbon** | kgCO₂e/m² (GWP) | EN 15978 | LEED Reduce-EC, dashboards, "carbon cost" |
+| Embodied **energy** | MJ/m² (CED) | — | The **EDGE materials gate** (indicative) |
+
+They are correlated but **not the same number**, and STINGTOOLS keeps them in
+separate tracks on purpose.
+
+---
+
+<a name="part-4"></a>
+## Part 4 — Carbon costing with STINGTOOLS (the hands-on walkthrough)
+
+Now the practical bit. This section assumes the STING plugin is installed and you
+have a Revit model open. We'll go control-by-control through the **STING
+Sustainability Center**.
+
+### 4.0 Opening the panel
+
+On the Revit ribbon: **STING Tools** tab → **STING Panels** group → **STING
+Sustain**. A dockable panel appears on the right (look for the **♻ STING
+Sustainability** title). It has **four tabs**:
+
+```
+  ┌────────────────────────────────────────────────────────┐
+  │  ♻ STING Sustainability                                │
+  │  [ SETUP ] [ DASHBOARD ] [ MATERIALS ] [ COST ]        │
+  └────────────────────────────────────────────────────────┘
+```
+
+The flow is left to right: **SETUP** (tell it about your project) →
+**DASHBOARD** (run it, read the EDGE result) → **MATERIALS** (dig into carbon) →
+**COST** (turn savings into money).
+
+> **The golden rule of green tools:** *garbage in, garbage out.* The five minutes
+> you spend on the SETUP tab decide whether every number after it is meaningful.
+
+### 4.1 The SETUP tab — tell STING about your project
+
+This tab is the "zero-hardcoding options surface." Nothing about your project is
+assumed in code; you declare it here. Field by field:
+
+**Schemes & target**
+- **EDGE / LEED checkboxes** — tick the scheme(s) you're chasing. You can do both.
+- **EDGE level** — your target: *Certified*, *Advanced* or *ZeroCarbon*.
+- **Units** — *SI* (metric: kWh/m²·yr, litres, m²) or *IP* (imperial: kBtu/ft²·yr,
+  gallons, ft²). LEED reports are often IP; EDGE is SI. The whole panel + exports
+  convert live when you switch.
+
+**Location (drives the baseline & climate)**
+- **Country** — ISO code (or `*` for "any"). Editable; type a code your baseline
+  catalogue knows (e.g. `UGA`, `CAF`, `GBR`).
+- **Climate site id** — the city whose monthly weather drives PV yield and the
+  energy estimate. Leave blank to use the project's stamped site.
+- **Climate zone (ASHRAE 169)** — `0A`/`1A` = very hot humid (e.g. Bangui), `4A`/`5A`
+  = temperate. This drives the **baseline**. *Leave it blank and STING auto-derives
+  it* from the site's heating/cooling degree-days, telling you what it assumed.
+
+**Building**
+- **Building use** — office / residential / healthcare / retail / hotel / education
+  / warehouse / lab / restaurant / industrial. **This list is data-driven** — it's
+  the union of what the baseline + water-profile data files actually support, so it
+  grows automatically as data is added.
+- **Floor area (GFA)** and **Occupancy** — needed for the per-m² and per-person
+  numbers. Don't have them to hand? Click **⤓ From model (area + occupancy)** and
+  STING reads them from the model's Spaces/Rooms.
+
+**Mixed-use zones (optional)**
+- A real building is often mixed-use (ground-floor retail + offices above). The
+  **ZONES** grid lets you add a row per use (Use / Area / Occupancy / COP).
+  When you add rows, they **override** the single building-use above; the result
+  rolls up area-weighted (energy/materials) and occupancy-weighted (water). For a
+  simple single-use building, ignore the grid entirely.
+
+**Plant & supply**
+- **Cooling COP/SEER** — how efficient your cooling plant is (higher = better; blank
+  = use the baseline). A heat-pump might be 3–4; old kit ~2.
+- **Supply mode** — `grid_tied`, `off_grid` (diesel) or `hybrid`.
+- **PV (kWp)** and **PV performance ratio** — on-site solar size and a derating
+  factor (~0.75 typical). This offsets imported energy.
+- **Grid / Diesel carbon (kgCO₂e/kWh)** and **Diesel fraction** — the carbon factors
+  for the energy you import. This is what turns kWh into kgCO₂e (§3.3).
+
+Click **Save setup** (and **Save supply**) to persist everything to the project. The
+settings live in `<project>/_BIM_COORD/sustainability/project_setup.json`.
+
+### 4.2 The DASHBOARD tab — run it and read the EDGE result
+
+Click **Run dashboard**. STINGTOOLS now:
+
+1. Resolves the **climate** (monthly weather for your site).
+2. Resolves the **baseline** (by climate zone + building use, with provenance).
+3. Runs the **energy** estimator (annual kWh → design EUI → energy saving %).
+4. Runs the **water** estimator (litres/person·day → water saving %).
+5. Runs the **materials** rollup (model material volumes → embodied carbon kgCO₂e/m²
+   + embodied energy MJ/m²).
+6. Evaluates **each scheme** (EDGE's three gates, LEED's points).
+
+The **EDGE GATES** section shows, for each gate, the **STING-indicative %** beside an
+**EDGE-official %** box (which you fill in later — see §4.5). A headline line tells
+you the **STING-determinable EDGE level** and whether you're on target.
+
+**Reading the result — the "Computed" idea.** A gate only shows a real **pass** if
+its number was genuinely computed from model data. If your model has no Spaces and no
+floor area, the energy estimate can't be trusted, so STING marks the gate
+**not computed** and refuses to flash a green "pass" off a meaningless 100%. The
+**warnings** box at the bottom explains every not-computed gate ("no Spaces / floor
+area — add Spaces or enter GFA in Setup"). *Trust the warnings; they're telling you
+what data the model is missing.*
+
+**Set baseline** — if you have a project-specific baseline (e.g. a client's reference
+building), set it here; otherwise STING uses the climate-zone baseline.
+
+### 4.3 The MATERIALS tab — where the carbon cost lives
+
+This is the heart of "carbon costing." STINGTOOLS takes the **same takeoff the BOQ
+uses** (so the carbon matches the bill of quantities — one source of truth), walks
+the model's structural + enclosure elements (walls, floors, roofs, columns, framing,
+foundations, rebar, glazing), and for each material:
+
+1. Measures the **volume** (m³), grossed up by the **same waste allowance** the BOQ
+   applies.
+2. Resolves a **carbon factor** (EPD → corporate library → generic per-kg via
+   density).
+3. Computes **net carbon** = fossil + biogenic (so timber gets its sequestration
+   credit).
+4. Computes **embodied energy** (MJ) for the EDGE gate.
+
+The tab shows the **three biggest carbon "hotspots"** — the materials responsible for
+most of your embodied carbon. **This is the most useful output in the whole panel**,
+because it tells you *where to act*: concrete and steel are almost always #1 and #2,
+so a small % cut in your concrete mix (e.g. cement replacement) beats a big cut in
+something trivial.
+
+Buttons here:
+- **EDGE export** — produces a ClosedXML workbook of model quantities + selections,
+  formatted for upload to the **official EDGE app**. This is your bridge to the
+  certified number.
+- **EPD register** — manage product-specific EPD references on materials (better
+  accuracy than generic factors).
+- **LEED scorecard** — a LEED-oriented view when LEED is selected.
+
+### 4.4 The COST tab — carbon savings in money (LCC)
+
+Carbon is one cost; **money** is the other. The COST tab runs **Life-Cycle Costing
+(LCC)** on the green **measures** (PV, low-flow fixtures, better glazing, LED, etc.):
+
+- For each measure it estimates a **capex** (install cost) sized from **real model
+  quantities** where possible (PV kWp, glazing m², fixture count) — not crude
+  guesses.
+- It estimates an **annual operational saving** (energy/water cost avoided).
+- Over a 25-year analysis it computes the **lifetime saving** and **net benefit**.
+
+Crucially, these rows are **fed into the BOQ Cost Manager** as real cost lines (not
+just a side spreadsheet), so the "sustainability targets in the Cost/Budget Estimate"
+become contractual numbers. Click **LCC benefit** to run it; the grid fills with
+per-measure capex / annual saving / lifetime saving / net benefit, and the rows land
+in the cost model.
+
+### 4.5 The EDGE round-trip (indicative → official)
+
+This is the workflow that makes STINGTOOLS honest about EDGE:
+
+```
+  1. Design in Revit ──► 2. Run dashboard (STING indicative %)
+            │                          │
+            │                          ▼
+            │                3. Steer the design until the
+            │                   indicative % clears the gates
+            │                          │
+            ▼                          ▼
+  4. EDGE export ──► upload to the official EDGE app ──► 5. EDGE app
+                                                            gives the
+                                                            CERTIFIED %
+                                                              │
+                                                              ▼
+            6. Type the certified % into the "EDGE official"
+               boxes on the DASHBOARD → STING shows the REAL
+               EDGE level (the official number now drives the
+               level determination, not the indicative one)
+```
+
+Step 6 is **EDGE-official feedback**: once you record the certified figure, STING
+stops treating that gate as "the EDGE app's business" and uses your official number
+to determine the real, defensible EDGE level.
+
+### 4.6 (Optional) Publish to your team — server sync
+
+If your firm runs the Planscape Server, **Publish to server** (DASHBOARD tab) pushes
+the latest dashboard snapshot to the cloud so the whole team / the mobile app can see
+the project's live sustainability state and trend it over time. It's gated behind the
+project's offline-mode flag — a single-machine project is unaffected and keeps a
+local log.
+
+### 4.7 A complete first-run, step by step
+
+1. Open the model. Make sure it has **Rooms or MEP Spaces** and real **materials**
+   on walls/floors/roofs (or at least enter GFA + occupancy in SETUP).
+2. **SETUP:** tick **EDGE**, level **Advanced**; set country, climate zone (or leave
+   blank to auto-derive), building use; click **From model** for area + occupancy;
+   set cooling COP and PV if known. **Save setup**.
+3. **DASHBOARD:** click **Run dashboard**. Read the three EDGE gate %s and the
+   headline level. Read the **warnings** — fix any "not computed" causes.
+4. **MATERIALS:** look at the three carbon **hotspots**. Note your embodied carbon
+   (kgCO₂e/m²) and embodied energy (MJ/m²).
+5. **COST:** click **LCC benefit** to see what the green measures cost vs save.
+6. Iterate the design (more insulation, better glazing, PV, low-carbon concrete) and
+   **Run dashboard** again — watch the %s move.
+7. When close, **EDGE export** → upload to the EDGE app → get the certified % → type
+   it back into the **EDGE official** boxes.
+
+---
+
+<a name="part-5"></a>
+## Part 5 — Mastering the topic (advanced lessons)
+
+This section is for when you want to *judge* the numbers, not just read them.
+
+### 5.1 How the energy number is actually computed
+
+STINGTOOLS' `AnnualEnergyEstimator` is a **monthly quasi-steady-state energy
+balance** following **EN ISO 13790** (the same family of method the EDGE app uses
+internally). For each zone, for each of 12 months, it balances:
+
+- **Gains** — internal (people, lighting, equipment, from the ASHRAE/CIBSE load
+  profile for that space type) + **solar** (monthly irradiance projected onto each
+  glazing façade *by its orientation* — south glass gains more than north).
+- **Losses/transfer** — conduction through the envelope (U-value × area) + ventilation
+  + infiltration, driven by the indoor-vs-outdoor temperature difference.
+- A **gain/loss utilisation factor** (the real EN ISO 13790 factor, dependent on the
+  gain/loss ratio and the building's thermal mass / time constant) so that gains and
+  losses aren't naively double-counted.
+
+Thermal demand is then converted to **delivered energy** via the cooling **COP** and
+the **heating efficiency** (electric resistance = 1.0, gas boiler ~0.9, heat-pump =
+its COP). Non-electric heating fuel is tracked separately so PV/grid carbon isn't
+wrongly applied to a gas boiler. The supply layer subtracts PV and applies the right
+fuel's carbon factor.
+
+**Why this matters to you:** a *hot* climate and a *cold* climate produce
+sensibly different EUIs from the *same* model — because the climate, orientation and
+plant efficiency genuinely drive the result. If two very different projects give
+suspiciously identical EUIs, your inputs (climate site, building use, COP) are
+probably wrong.
+
+### 5.2 The "indicative vs certified" discipline
+
+Internalise this: **STINGTOOLS never claims to issue a certified number.** Three
+mechanisms enforce it:
+
+- **The `Computed` flag** — a gate can only show a pass if it was computed from real
+  model data. Zero-design artefacts (100% saving from an empty model) and hardcoded
+  defaults can never read as a pass.
+- **"Delegated" gates** — the EDGE *materials* gate is the EDGE app's to certify, so
+  by default it's caveated, not blocking — *unless* you supply the official figure.
+- **Provenance everywhere** — the baseline always logs where it came from
+  ("fell back to climate-zone 0A office proxy"), and material lines carry their
+  factor source (EPD / library / generic).
+
+When you present numbers to a client, say "indicative" until you have the EDGE app's
+certified figure. The tool is built to keep you honest here; don't fight it.
+
+### 5.3 FactorSources — controlling which carbon dataset wins
+
+Different projects/regions prefer different carbon databases (EPD-specific, EC3,
+ICE, Ecoinvent). The **FactorSources** order (a project setting) drives which source
+the materials resolver prefers, and whether a **mass-based (per-kg) database** is
+even permitted. Remove the mass DBs from the order and a material that *only* has a
+per-kg factor resolves to zero carbon (with a clear note) instead of silently using
+a dataset your project disallows. This is how a QS / sustainability lead enforces a
+data policy across a job.
+
+### 5.4 Single source of truth — BOQ ↔ carbon
+
+The materials carbon uses the **same takeoff, waste factor, density and
+fossil/biogenic split** as the BOQ Cost Manager. Practical consequence: **the carbon
+figure and the bill of quantities agree** for the same model. If they ever diverge,
+something is wrong (different category scope, a stale BOQ). This is deliberate —
+"carbon costing" and "cost estimating" should measure the *same building*.
+
+### 5.5 Mixed-use & per-room realism
+
+For a mixed-use tower, the **zones grid** (SETUP) lets each use carry its own area,
+occupancy and COP; energy/materials roll up **area-weighted**, water **occupancy-
+weighted**. For a Room-based architectural model with no MEP Spaces, the engine falls
+back to using **Rooms as zones** (real per-room areas) before the single synthetic
+zone — so an architect's model still gets a per-room load picture.
+
+### 5.6 Reading hotspots like a pro
+
+The three carbon hotspots almost always rank: **concrete → steel → glass/finishes**.
+The professional moves, in order of impact:
+
+1. **Concrete mix** — replace cement with GGBS/fly-ash (can cut concrete carbon
+   30–50%). Biggest single lever on most buildings.
+2. **Structural efficiency** — less material for the same performance (post-tensioning,
+   voided slabs, right-sizing).
+3. **Steel** — high recycled content (EAF), efficient sections.
+4. **Material substitution** — timber (CLT/glulam) where appropriate, for its
+   biogenic credit.
+
+Then re-run and watch the hotspots and the kgCO₂e/m² fall.
+
+### 5.7 Benchmarks to aim at (embodied / upfront carbon)
+
+| Benchmark | Office upfront carbon (A1–A5) |
+|---|---|
+| Typical (business as usual) | ~1000+ kgCO₂e/m² |
+| RIBA 2030 target | < 750 kgCO₂e/m² |
+| LETI "good" | < 600 kgCO₂e/m² |
+| Best practice / 2030-aligned | < 500 kgCO₂e/m² |
+
+(STINGTOOLS reports A1–A3 product-stage upfront carbon; A4 transport-to-site and A5
+construction are smaller and project-specific.)
+
+### 5.8 Common pitfalls (and what the warnings are telling you)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Energy gate "not computed" | No Spaces/Rooms, no GFA | Place Spaces/Rooms or enter GFA in SETUP |
+| Materials 0 carbon-stamped | Materials have no carbon factor | Run a carbon pass / add EPDs / use the corporate library |
+| Water always shows ~25% indicative | No low-flow fixture data in the model | Stamp `PLM_*` flows or accept the indicative default |
+| Suspiciously identical EUIs | Wrong climate site / building use / COP | Fix the SETUP inputs |
+| Savings reads "over baseline" | Design worse than the base case | That's real — improve the design, don't blame the tool |
+
+---
+
+<a name="part-6"></a>
+## Part 6 — Glossary, checklists & references
+
+### 6.1 Glossary
+
+- **A1–A3 / upfront / embodied carbon** — carbon emitted making + transporting +
+  manufacturing materials, before site. Measured in kgCO₂e.
+- **Baseline / base case** — the "typical" reference building you're compared against.
+- **Biogenic carbon** — CO₂ absorbed by growing bio-based materials (timber); a
+  credit (negative), reported separately from fossil carbon.
+- **COP / SEER** — cooling/heat-pump efficiency (output ÷ input; higher = better).
+- **EDGE** — IFC/World Bank green-building certification: 3 gates (energy/water/
+  materials ≥20%), levels Certified/Advanced/Zero Carbon.
+- **EPD** — Environmental Product Declaration; a manufacturer's verified carbon
+  factor for a specific product.
+- **EUI** — Energy Use Intensity, kWh/m²·yr.
+- **GFA** — Gross Floor Area.
+- **Grid factor** — kgCO₂e emitted per kWh of grid electricity.
+- **kgCO₂e** — kilograms of CO₂ *equivalent* (all greenhouse gases converted to a
+  CO₂ basis).
+- **LCC** — Life-Cycle Cost; capex vs lifetime operational savings, in money.
+- **LEED** — USGBC points-based certification (Certified/Silver/Gold/Platinum).
+- **Operational carbon** — carbon from running the building each year (energy × grid
+  factor).
+- **WBLCA** — Whole-Building Life-Cycle Assessment; the embodied-carbon calculation
+  LEED requires.
+
+### 6.2 First-project checklist
+
+- [ ] Model has Rooms/Spaces **or** GFA + occupancy entered in SETUP.
+- [ ] Walls/floors/roofs carry real **materials**.
+- [ ] SETUP: scheme, level, country, climate zone (or auto-derive), building use set.
+- [ ] Plant & supply: cooling COP, supply mode, PV entered.
+- [ ] **Save setup** clicked.
+- [ ] **Run dashboard** — all gates **computed** (no blocking warnings).
+- [ ] **MATERIALS:** carbon factors present (no "0 carbon-stamped").
+- [ ] **COST:** LCC run, measures sized from model quantities.
+- [ ] **EDGE export** generated; certified % from the EDGE app typed back into the
+      **EDGE official** boxes before quoting an EDGE level to the client.
+
+### 6.3 Where things live (for the curious)
+
+- Panel: ribbon **STING Tools → STING Panels → STING Sustain** (♻ pane).
+- Project settings: `<project>/_BIM_COORD/sustainability/project_setup.json`.
+- KPI history (for trends): `<project>/_BIM_COORD/sustainability/edge_kpi_log.jsonl`.
+- Corporate data (schemes, baselines, water profiles, measures, monthly climate):
+  the `STING_GREEN_*.json` / `STING_WATER_USAGE_PROFILES.json` /
+  `STING_CLIMATE_MONTHLY.json` data files (project overrides in `_BIM_COORD/`).
+
+### 6.4 External references
+
+- **EDGE** — edgebuildings.com (free app + country base-case data; IFC/World Bank).
+- **LEED** — usgbc.org (USGBC) / gbci.org (review body).
+- **RICS** — "Whole Life Carbon Assessment for the Built Environment", 2nd ed.
+- **RIBA 2030 Climate Challenge** — upfront-carbon targets.
+- **LETI** — Embodied Carbon Primer; Climate Emergency Design Guide.
+- **ICE database** — Inventory of Carbon & Energy (generic material factors).
+- **EN ISO 13790 / EN 15978** — the energy-balance and LCA standards behind the
+  engines.
+
+---
+
+*This guide describes the STING Sustainability Center (Phase 195). The figures it
+produces during design are **indicative** — the EDGE app and a qualified assessor
+own the certified result. Use STINGTOOLS to steer the design early and cheaply, then
+confirm with the official tools before you certify.*

--- a/docs/images/wire-annotation/worked-example.svg
+++ b/docs/images/wire-annotation/worked-example.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 300" font-family="Segoe UI, Arial, sans-serif">
+  <rect x="0.5" y="0.5" width="819" height="299" rx="10" fill="#ffffff" stroke="#CFD8DC"/>
+  <text x="24" y="34" font-size="18" font-weight="700" fill="#263238">Worked example — before and after W-Ann</text>
+
+  <!-- BEFORE panel -->
+  <rect x="20" y="56" width="380" height="220" rx="8" fill="#FAFAFA" stroke="#E0E0E0"/>
+  <text x="40" y="82" font-size="14" font-weight="700" fill="#607D8B">BEFORE</text>
+  <!-- board -->
+  <rect x="48" y="150" width="26" height="48" rx="3" fill="#90A4AE" stroke="#455A64" stroke-width="1.5"/>
+  <text x="61" y="216" font-size="11" fill="#455A64" text-anchor="middle">DB-1</text>
+  <!-- conduit -->
+  <line x1="74" y1="174" x2="330" y2="174" stroke="#455A64" stroke-width="6" stroke-linecap="round"/>
+  <!-- luminaire symbol -->
+  <circle cx="352" cy="174" r="14" fill="#ffffff" stroke="#455A64" stroke-width="2"/>
+  <line x1="342" y1="164" x2="362" y2="184" stroke="#455A64" stroke-width="1.5"/>
+  <line x1="362" y1="164" x2="342" y2="184" stroke="#455A64" stroke-width="1.5"/>
+  <text x="210" y="252" font-size="12.5" fill="#78909C" text-anchor="middle">Plain conduit — no wire information</text>
+
+  <!-- AFTER panel -->
+  <rect x="420" y="56" width="380" height="220" rx="8" fill="#F1F8F4" stroke="#C8E6C9"/>
+  <text x="440" y="82" font-size="14" font-weight="700" fill="#2E7D32">AFTER</text>
+  <!-- board -->
+  <rect x="448" y="150" width="26" height="48" rx="3" fill="#90A4AE" stroke="#455A64" stroke-width="1.5"/>
+  <text x="461" y="216" font-size="11" fill="#455A64" text-anchor="middle">DB-1</text>
+  <!-- conduit -->
+  <line x1="474" y1="174" x2="730" y2="174" stroke="#455A64" stroke-width="6" stroke-linecap="round"/>
+  <!-- 2 ticks -->
+  <line x1="585" y1="190" x2="603" y2="158" stroke="#00897B" stroke-width="4" stroke-linecap="round"/>
+  <line x1="601" y1="190" x2="619" y2="158" stroke="#00897B" stroke-width="4" stroke-linecap="round"/>
+  <!-- luminaire -->
+  <circle cx="752" cy="174" r="14" fill="#ffffff" stroke="#455A64" stroke-width="2"/>
+  <line x1="742" y1="164" x2="762" y2="184" stroke="#455A64" stroke-width="1.5"/>
+  <line x1="762" y1="164" x2="742" y2="184" stroke="#455A64" stroke-width="1.5"/>
+  <!-- leader + label -->
+  <polyline points="610,158 640,120 660,120" fill="none" stroke="#1565C0" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <rect x="512" y="98" width="286" height="26" rx="5" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.3"/>
+  <text x="524" y="116" font-size="12.5" font-weight="600" fill="#0D47A1">2 &#215; 1.5mm&#178; Cu | 1&#216; | L1-06 | DB-1</text>
+  <text x="610" y="252" font-size="12.5" fill="#2E7D32" text-anchor="middle">Annotated — 2 ticks (L+N) + full spec</text>
+</svg>


### PR DESCRIPTION
These were untracked in the visibility-centre worktree, which was otherwise **safe to prune** — its PR had merged, it was clean by every check that mattered, and nothing on `main` referenced any of it. Removing the worktree would have destroyed all of this without a warning.

Twelve implementation prompts and a guide:

- three BOQ and cost prompts, plus a project-management cost-control prompt
- seven healthcare prompts — accuracy, completeness, gap fixes, deferred implementation, profile coverage, Phase 199 fixes, changelog/roadmap reconciliation
- an MCP v2 agent brief
- a plain-English guide to the sustainability and carbon-costing workflow, which had **no equivalent anywhere in the repository**

They are work prompts — statements of intent, not records of what landed. `docs/INDEX.md` says so where they're listed, and points at `CHANGELOG.md` for what was actually built.

## Two near-name collisions, checked rather than assumed

`BOQ_5D_PHASE2_PROMPT.md` is **not** `BOQ_5D_P2_PROMPT.md`, and `BOQ_QS_IMPLEMENTATION_PROMPT_P1-P4.md` is **not** `BOQ_QS_GAPS_PROMPT.md`. Both pairs were compared line by line before committing; both are genuinely different documents with different scopes. The index now says so, because the next person to notice the similarity will otherwise assume a duplicate and delete one.

## Not committed

| | Why | Where it went |
|---|---|---|
| `WIRE_ANNOTATION_GUIDE.docx` (1.8 MB) | `docs/WIRE_ANNOTATION_GUIDE.md` is already here and is the source. There's no generator between them, so committing the Word copy would put a second, unmaintained version of one document in the repo — the failure this workstream has spent its time removing, not adding. | Downloads |
| `seed` (71 bytes) | One line of console output from the retired deploy-gold script, redirected into a file by accident. | Downloads |

Both preserved outside the repository so the keep-or-discard decision stays open.

`worked-example.svg` **is** committed, but as an orphan: it belongs to the wire-annotation asset set and nothing references it — the guide on `main` is complete without it — so the guide is left alone rather than edited to justify keeping the file.

Scanned for credentials before committing; every match was a STING tag token or a template token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)