### PR TITLE
Report what the tile scan looked at

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\ManualRowPlacer.cs" Link="MaterialSchedule\ManualRowPlacer.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\SiteToolsCalculator.cs" Link="MaterialSchedule\SiteToolsCalculator.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\IntermediateMeasures.cs" Link="MaterialSchedule\IntermediateMeasures.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\TileScanTally.cs" Link="MaterialSchedule\TileScanTally.cs" />
     <Compile Include="..\StingTools\Core\ExportRouteMerge.cs" Link="ExportRouteMerge.cs" />
   </ItemGroup>
 

--- a/StingTools.Boq.Tests/TileScanTallyTests.cs
+++ b/StingTools.Boq.Tests/TileScanTallyTests.cs
@@ -1,0 +1,96 @@
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED-3 — the diagnostic that turns "no tiling appeared" into an
+    /// answer. Its entire value is that the message is right, so the message is
+    /// what is pinned here.
+    /// </summary>
+    public class TileScanTallyTests
+    {
+        [Fact]
+        public void Nothing_Inspected_Reports_Nothing()
+        {
+            // A scan that never ran must stay silent. An invented "0 of 0" would
+            // read as a finding and send someone looking for a fault.
+            Assert.Null(new TileScanTally().Summary());
+        }
+
+        [Fact]
+        public void No_Finish_Layers_Says_The_Model_Is_Silent_Not_The_Plugin_Broken()
+        {
+            var t = new TileScanTally { TypesInspected = 47 };
+
+            string s = t.Summary();
+
+            Assert.Contains("47 wall/floor type(s) inspected", s);
+            Assert.Contains("0 carry a finish layer", s);
+            Assert.Contains("does not describe its finishes", s);
+        }
+
+        [Fact]
+        public void Unrecognised_Materials_Are_Named_So_The_Pattern_Can_Be_Fixed()
+        {
+            var t = new TileScanTally { TypesInspected = 12, TypesWithFinishLayer = 5 };
+            t.RejectedMaterials.Add("FF-01 Floor Finish");
+            t.RejectedMaterials.Add("Screed");
+
+            string s = t.Summary();
+
+            Assert.Contains("FF-01 Floor Finish", s);
+            Assert.Contains("Screed", s);
+            Assert.Contains("widen the tile pattern", s);
+        }
+
+        [Fact]
+        public void The_Name_List_Is_Capped_And_Says_So()
+        {
+            var t = new TileScanTally { TypesInspected = 30, TypesWithFinishLayer = 30 };
+            for (int i = 0; i < 20; i++) t.RejectedMaterials.Add($"Material {i:D2}");
+
+            string s = t.Summary();
+
+            Assert.Contains("…", s);
+            Assert.Equal(8, System.Text.RegularExpressions.Regex.Matches(s, "Material ").Count);
+        }
+
+        [Fact]
+        public void A_Successful_Scan_Reports_Counts_Without_The_Advice()
+        {
+            var t = new TileScanTally { TypesInspected = 12, TypesWithFinishLayer = 5, TypesMatched = 3 };
+            t.RejectedMaterials.Add("Screed");   // present, but irrelevant once tiling was found
+
+            string s = t.Summary();
+
+            Assert.Contains("3 name a tile material", s);
+            Assert.DoesNotContain("widen the tile pattern", s);
+            Assert.DoesNotContain("Screed", s);
+        }
+
+        [Fact]
+        public void Finish_Layers_With_No_Named_Material_Get_Their_Own_Advice()
+        {
+            // Distinct from "no finish layers": the layers exist, so the fix is
+            // to assign materials, not to model finishes at all.
+            var t = new TileScanTally { TypesInspected = 9, TypesWithFinishLayer = 4 };
+
+            string s = t.Summary();
+
+            Assert.Contains("carry no named material", s);
+        }
+
+        [Fact]
+        public void Reset_Clears_Everything_So_A_Run_Never_Reports_A_Previous_One()
+        {
+            var t = new TileScanTally { TypesInspected = 5, TypesWithFinishLayer = 2, TypesMatched = 1 };
+            t.RejectedMaterials.Add("Screed");
+
+            t.Reset();
+
+            Assert.Null(t.Summary());
+            Assert.Empty(t.RejectedMaterials);
+        }
+    }
+}

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -42,6 +42,11 @@ namespace StingTools.BOQ.MaterialSchedule
 
             result.CompoundTakeoffWasOff = !Takeoff.CompoundTakeoffBuilder.Enabled();
 
+            // Before the take-off, not after: the scan counts what THIS run
+            // inspected, and a stale count from a previous export would answer
+            // the wrong question.
+            Takeoff.CompoundTakeoffBuilder.TileFinishScan.Reset();
+
             var boq = BOQCostManager.BuildBOQDocument(doc);
             var inputs = new AggregatorInputs
             {
@@ -101,6 +106,12 @@ namespace StingTools.BOQ.MaterialSchedule
                 result.Warnings.Add(
                     $"{result.RowsWithoutKind} of {result.ConstituentRowsSeen} model rows carried no "
                   + $"constituent kind and were routed to the default stage.");
+
+            // Reported whether or not tiling was found. A schedule with no tiling
+            // rows is either a model that describes no finishes or a pattern that
+            // failed to recognise them, and only the denominator tells them apart.
+            string tileScan = Takeoff.CompoundTakeoffBuilder.TileFinishScan.Summary();
+            if (!string.IsNullOrEmpty(tileScan)) result.Warnings.Add(tileScan);
 
             StingLog.Info($"MaterialScheduleBuilder: {msDoc.Stages.Count} stage(s), "
                         + $"{msDoc.Stages.Sum(s => s.Commodities.Count)} commodity row(s), "

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -642,17 +642,61 @@ namespace StingTools.BOQ.Takeoff
                 System.Text.RegularExpressions.RegexOptions.IgnoreCase
                 | System.Text.RegularExpressions.RegexOptions.Compiled);
 
+        /// <summary>
+        /// What the tile scan looked at, so "no tiling appeared" stops being
+        /// silence and starts being evidence.
+        ///
+        /// The first export after tiling shipped produced ZERO tiling rows and
+        /// no errors, and two very different causes fit that output exactly:
+        /// the model describes no finish layers at all, or it describes them
+        /// under names the pattern does not recognise. Nothing in the workbook
+        /// or the log separated the two. An absent side effect never tells you
+        /// why — so the scan now reports its own denominator.
+        ///
+        /// Keyed by TYPE: a compound structure belongs to the type, so this also
+        /// stops re-walking the same layers once per instance.
+        /// </summary>
+        /// <summary>
+        /// Per-run tile-scan cache and tally. Keyed by TYPE: a compound
+        /// structure belongs to the type, so this also stops re-walking the same
+        /// layers once per instance. See TileScanTally for why the counts exist.
+        /// </summary>
+        internal static class TileFinishScan
+        {
+            private static readonly Dictionary<long, (int Faces, string Label)> Cache =
+                new Dictionary<long, (int, string)>();
+
+            public static readonly StingTools.Core.MaterialSchedule.TileScanTally Tally =
+                new StingTools.Core.MaterialSchedule.TileScanTally();
+
+            public static void Reset() { Cache.Clear(); Tally.Reset(); }
+
+            public static bool TryGet(long typeId, out (int Faces, string Label) hit)
+                => Cache.TryGetValue(typeId, out hit);
+
+            public static void Store(long typeId, (int Faces, string Label) hit)
+                => Cache[typeId] = hit;
+
+            public static string Summary() => Tally.Summary();
+        }
+
         /// <summary>Tiled finish layers on a host type: how many, and named by the first.</summary>
         private static (int Faces, string Label) ReadTiledFinish(Document doc, Element el)
         {
             try
             {
-                var hoa = doc?.GetElement(el.GetTypeId()) as HostObjAttributes;
+                var typeId = el?.GetTypeId();
+                if (typeId == null || typeId == ElementId.InvalidElementId) return (0, "");
+                long key = typeId.Value;
+                if (TileFinishScan.TryGet(key, out var cached)) return cached;
+
+                var hoa = doc?.GetElement(typeId) as HostObjAttributes;
                 var cs = hoa?.GetCompoundStructure();
                 var layers = cs?.GetLayers();
-                if (layers == null) return (0, "");
+                if (layers == null) { TileFinishScan.Store(key, (0, "")); return (0, ""); }
 
-                int faces = 0; string label = "";
+                TileFinishScan.Tally.TypesInspected++;
+                int faces = 0; string label = ""; bool anyFinishLayer = false;
                 foreach (var layer in layers)
                 {
                     if (layer == null) continue;
@@ -660,15 +704,27 @@ namespace StingTools.BOQ.Takeoff
                     // and admitting those would count a screed as tiling.
                     if (layer.Function != MaterialFunctionAssignment.Finish1
                      && layer.Function != MaterialFunctionAssignment.Finish2) continue;
+                    anyFinishLayer = true;
                     if (layer.MaterialId == null || layer.MaterialId == ElementId.InvalidElementId) continue;
                     if (!(doc.GetElement(layer.MaterialId) is Material mat)) continue;
                     if (string.IsNullOrWhiteSpace(mat.Name)) continue;
-                    if (!TileMaterialPattern.IsMatch(mat.Name)) continue;
+                    if (!TileMaterialPattern.IsMatch(mat.Name))
+                    {
+                        // Recorded, not discarded: if the pattern is the thing
+                        // that is wrong, these names are the evidence for it.
+                        TileFinishScan.Tally.RejectedMaterials.Add(mat.Name.Trim());
+                        continue;
+                    }
 
                     faces++;
                     if (label.Length == 0) label = mat.Name.Trim();
                 }
-                return (faces, label);
+                if (anyFinishLayer) TileFinishScan.Tally.TypesWithFinishLayer++;
+                if (faces > 0) TileFinishScan.Tally.TypesMatched++;
+
+                var hit = (faces, label);
+                TileFinishScan.Store(key, hit);
+                return hit;
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/MaterialSchedule/TileScanTally.cs
+++ b/StingTools/Core/MaterialSchedule/TileScanTally.cs
@@ -1,0 +1,82 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TileScanTally.cs — MAT-SCHED-3 diagnostic: what the tile scan looked at.
+//
+//  The first export after tiling shipped produced ZERO tiling rows and no
+//  errors, and two very different causes fit that output exactly: the model
+//  describes no finish layers at all, or it describes them under names the
+//  pattern does not recognise. Nothing in the workbook or the log separated
+//  the two.
+//
+//  An absent side effect never tells you why. This reports the DENOMINATOR,
+//  so the next export answers the question instead of restating it.
+//
+//  Revit-free on purpose: the value of a diagnostic is entirely in whether
+//  its message is right, so the message is the part that has to be testable.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public sealed class TileScanTally
+    {
+        /// <summary>Host TYPES whose compound structure was read. Types, not
+        /// instances: a compound structure belongs to the type.</summary>
+        public int TypesInspected;
+        public int TypesWithFinishLayer;
+        public int TypesMatched;
+
+        /// <summary>Finish-layer materials that did NOT read as tiling. Kept,
+        /// not discarded: if the pattern is the thing that is wrong, these names
+        /// are the evidence for it.</summary>
+        public readonly SortedSet<string> RejectedMaterials =
+            new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private const int MaxNamesShown = 8;
+
+        public void Reset()
+        {
+            TypesInspected = TypesWithFinishLayer = TypesMatched = 0;
+            RejectedMaterials.Clear();
+        }
+
+        /// <summary>
+        /// The line reported on every export, or NULL when nothing was
+        /// inspected — no scan means nothing to report, and an invented zero
+        /// would read as a finding.
+        /// </summary>
+        public string Summary()
+        {
+            if (TypesInspected <= 0) return null;
+
+            string s = $"Tiling scan: {TypesInspected} wall/floor type(s) inspected, "
+                     + $"{TypesWithFinishLayer} carry a finish layer, "
+                     + $"{TypesMatched} name a tile material.";
+
+            if (TypesMatched > 0) return s;
+
+            if (RejectedMaterials.Count > 0)
+            {
+                var names = new List<string>();
+                foreach (string n in RejectedMaterials)
+                {
+                    if (names.Count == MaxNamesShown) break;
+                    names.Add(n);
+                }
+                return s + " Finish materials found but not recognised as tiling: "
+                         + string.Join(", ", names)
+                         + (RejectedMaterials.Count > MaxNamesShown ? ", …" : "")
+                         + ". Rename the material, or widen the tile pattern in the plugin.";
+            }
+
+            if (TypesWithFinishLayer == 0)
+                return s + " No finish layers at all means the model does not describe its "
+                         + "finishes, so no tiled area can be measured from it — this is not "
+                         + "a plugin fault to chase.";
+
+            // Finish layers exist, none carried a usable material name.
+            return s + " The finish layers carry no named material, so nothing could be "
+                     + "classified. Assign materials to the finish layers.";
+        }
+    }
+}


### PR DESCRIPTION
The first export after tiling shipped produced **zero tiling rows and no errors**. Two very different causes fit that output exactly:

- the model describes no finish layers at all, or
- it describes them under names the pattern doesn't recognise.

Nothing in the workbook or the log separated them. **An absent side effect never tells you why.**

### What it reports now

```
Tiling scan: 47 wall/floor type(s) inspected, 0 carry a finish layer,
0 name a tile material. No finish layers at all means the model does not
describe its finishes, so no tiled area can be measured from it — this is
not a plugin fault to chase.
```

And when the layers *are* there and the pattern missed them, it **names the materials it rejected** — if the pattern is the thing that's wrong, those names are the evidence for it.

Four outcomes, each with its own advice: nothing scanned · no finish layers · layers without materials · materials that didn't match. A scan that never ran stays **silent** rather than inventing a `0 of 0` that would read as a finding.

### Why the tally is Revit-free

A diagnostic's entire value is that its message is right, so the message is the part that has to be testable. `TileScanTally` is a plain class with 7 unit tests covering all four branches, the name cap, and reset.

### Caching, and a miscount it caught

The layer walk is now cached by **type** — a compound structure belongs to the type, so it stops re-reading the same layers once per instance. That fixed a real miscount on the way: walls read their finish **twice** (once for the paint deduction, once for the tiling), so the naive counter would have reported double the types inspected.

Tests **386 → 393**. Build **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)