### PR TITLE
Read finishes from rooms, not only from layers

### DIFF
--- a/StingTools.Boq.Tests/RoomFinishSourceTests.cs
+++ b/StingTools.Boq.Tests/RoomFinishSourceTests.cs
@@ -1,0 +1,175 @@
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MAT-SCHED-3 — the second finish source.
+    ///
+    /// The layer source found ONE finish layer across ten wall/floor types on a
+    /// real model, and it was Gypsum Wall Board. Most architects record finishes
+    /// on the ROOM instead. These pin the two Revit-free halves: what a finish
+    /// NAME means, and what the scan reports when nothing is found.
+    /// </summary>
+    public class FinishTextClassifierTests
+    {
+        [Theory]
+        [InlineData("Ceramic Tile")]
+        [InlineData("Porcelain tiles 600x600")]
+        [InlineData("TERRAZZO")]
+        [InlineData("Granite slab")]
+        [InlineData("Mosaic")]
+        [InlineData("Vitrified tile")]
+        public void Tiled_Finishes_Are_Recognised(string name) => Assert.True(FinishTextClassifier.IsTile(name));
+
+        [Theory]
+        [InlineData("Gypsum Wall Board")]   // the one this model actually had
+        [InlineData("Screed")]
+        [InlineData("Paint")]
+        [InlineData("Timber flooring")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Non_Tiled_Finishes_Are_Not(string name) => Assert.False(FinishTextClassifier.IsTile(name));
+
+        [Theory]
+        [InlineData("Carpet tile")]      // laid, not bedded and grouted
+        [InlineData("Vinyl tile")]
+        [InlineData("LVT")]
+        [InlineData("Ceiling tile")]     // not a floor or wall surface
+        [InlineData("Roof tile")]        // a mis-typed schedule, not a floor
+        [InlineData("Acoustic tile")]
+        public void Things_Named_Tile_That_Are_Not_Ceramic_Are_Excluded(string name)
+        {
+            // Each of these contains "tile" and would otherwise be priced with
+            // adhesive and grout at ceramic rates — wrong in both quantity and
+            // rate. A narrow classifier beats a confident wrong number.
+            Assert.False(FinishTextClassifier.IsTile(name));
+        }
+
+        [Theory]
+        [InlineData("Porcelain", "PORCELAIN")]
+        [InlineData("Vitrified tile", "PORCELAIN")]
+        [InlineData("Terrazzo tile", "TERRAZZO")]
+        [InlineData("Marble", "STONE")]
+        [InlineData("Granite", "STONE")]
+        [InlineData("Glass mosaic", "MOSAIC")]
+        [InlineData("Ceramic Tile", "CERAMIC")]
+        [InlineData("Something else", "CERAMIC")]
+        public void Tile_Keys_Map_To_The_MATERIAL_LOOKUP_Rows(string name, string key)
+            => Assert.Equal(key, FinishTextClassifier.TileKey(name));
+
+        [Theory]
+        [InlineData("None")]
+        [InlineData("none")]
+        [InlineData("N/A")]
+        [InlineData("n/a")]
+        [InlineData("NIL")]
+        [InlineData("-")]
+        [InlineData("---")]
+        [InlineData("TBC")]
+        [InlineData("x")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void Placeholder_Finish_Text_Is_Not_A_Real_Finish(string name)
+        {
+            // Rooms carry these literals far more often than they carry nothing,
+            // and each would otherwise mint a skirting run around a room that
+            // has none.
+            Assert.False(FinishTextClassifier.IsRealFinish(name));
+        }
+
+        [Theory]
+        [InlineData("Ceramic Tile")]
+        [InlineData("Timber skirting")]
+        [InlineData("Cement skirting 100mm")]
+        public void A_Named_Finish_Is_Real(string name) => Assert.True(FinishTextClassifier.IsRealFinish(name));
+    }
+
+    public class RoomFinishTallyTests
+    {
+        [Fact]
+        public void No_Placed_Rooms_Reports_Nothing()
+        {
+            // Silence, not an invented "0 of 0" that would read as a finding.
+            Assert.Null(new RoomFinishTally().Summary());
+        }
+
+        [Fact]
+        public void Rooms_Without_Finish_Text_Say_So_And_Name_Both_Fixes()
+        {
+            var t = new RoomFinishTally { RoomsRead = 24 };
+
+            string s = t.Summary();
+
+            Assert.Contains("24 placed room(s) read", s);
+            Assert.Contains("carry no finish text", s);
+            Assert.Contains("tiled finish layer", s);   // the other route out
+        }
+
+        [Fact]
+        public void Unrecognised_Floor_Finishes_Are_Named()
+        {
+            var t = new RoomFinishTally { RoomsRead = 12 };
+            t.UnrecognisedFloorFinishes.Add("Screed");
+            t.UnrecognisedFloorFinishes.Add("Timber flooring");
+
+            string s = t.Summary();
+
+            Assert.Contains("Screed", s);
+            Assert.Contains("Timber flooring", s);
+        }
+
+        [Fact]
+        public void Suppression_By_The_Layer_Source_Is_Stated_Not_Silent()
+        {
+            // Otherwise a model whose types ARE tiled shows zero room tiling and
+            // looks broken, when it is the double-count guard doing its job.
+            var t = new RoomFinishTally
+            {
+                RoomsRead = 20, SkirtingRuns = 6, TilingSuppressedByLayerSource = true
+            };
+
+            string s = t.Summary();
+
+            Assert.Contains("NOT measured", s);
+            Assert.Contains("price the same surface twice", s);
+            Assert.Contains("Skirting still comes from the rooms", s);
+        }
+
+        [Fact]
+        public void A_Working_Scan_Reports_Counts_Without_Advice()
+        {
+            var t = new RoomFinishTally { RoomsRead = 20, FloorsTiled = 7, WallsTiled = 3, SkirtingRuns = 12 };
+
+            string s = t.Summary();
+
+            Assert.Contains("7 name a tiled floor", s);
+            Assert.Contains("3 a tiled wall", s);
+            Assert.Contains("12 a skirting", s);
+            Assert.DoesNotContain("carry no finish text", s);
+        }
+
+        [Fact]
+        public void Skirting_Alone_Is_Not_Reported_As_Nothing_Found()
+        {
+            // Skirting is measured even when no tiling is — a room with only a
+            // Base Finish is a working scan, not an empty one.
+            var t = new RoomFinishTally { RoomsRead = 20, SkirtingRuns = 12 };
+
+            Assert.DoesNotContain("carry no finish text", t.Summary());
+        }
+
+        [Fact]
+        public void Reset_Clears_Everything()
+        {
+            var t = new RoomFinishTally { RoomsRead = 5, FloorsTiled = 2, TilingSuppressedByLayerSource = true };
+            t.UnrecognisedFloorFinishes.Add("Screed");
+
+            t.Reset();
+
+            Assert.Null(t.Summary());
+            Assert.False(t.TilingSuppressedByLayerSource);
+            Assert.Empty(t.UnrecognisedFloorFinishes);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -49,6 +49,8 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\SiteToolsCalculator.cs" Link="MaterialSchedule\SiteToolsCalculator.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\IntermediateMeasures.cs" Link="MaterialSchedule\IntermediateMeasures.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\TileScanTally.cs" Link="MaterialSchedule\TileScanTally.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\FinishTextClassifier.cs" Link="MaterialSchedule\FinishTextClassifier.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\RoomFinishTally.cs" Link="MaterialSchedule\RoomFinishTally.cs" />
     <Compile Include="..\StingTools\Core\ExportRouteMerge.cs" Link="ExportRouteMerge.cs" />
   </ItemGroup>
 

--- a/StingTools.Boq.Tests/TilingTakeoffTests.cs
+++ b/StingTools.Boq.Tests/TilingTakeoffTests.cs
@@ -214,6 +214,26 @@ namespace StingTools.Boq.Tests
             Assert.Equal("kg", units.ResolveByKind("tile_adhesive").SourceUnit);
             Assert.Equal("kg", units.ResolveByKind("tile_grout").SourceUnit);
         }
+
+        [Fact]
+        public void Skirting_Routes_To_Finishes_And_Is_Bought_By_The_Metre()
+        {
+            // Skirting comes from the ROOM source and is measured in linear
+            // metres. A rule declaring anything else would trip the unit guard
+            // and print bare metres instead of a priced run.
+            var lib = Newtonsoft.Json.JsonConvert.DeserializeObject<StingTools.Core.MaterialSchedule.StageLibrary>(
+                System.IO.File.ReadAllText(DataFile("STING_MATERIAL_STAGES.json")));
+            var ix = StingTools.Core.MaterialSchedule.StageIndex.Build(lib.Stages, lib.DefaultStageId);
+            Assert.Equal("finishes", ix.Resolve("skirting", "Rooms", ""));
+
+            var units = Newtonsoft.Json.JsonConvert.DeserializeObject<StingTools.Core.MaterialSchedule.SupplierUnitTable>(
+                System.IO.File.ReadAllText(DataFile("STING_SUPPLIER_UNITS.json")));
+            var rule = units.ResolveByKind("skirting");
+            Assert.NotNull(rule);
+            Assert.Equal("m", rule.SourceUnit);
+            Assert.False(rule.RoundUpToWhole);   // you can buy 12.4 m of skirting
+        }
+
     }
 
 }

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -82,6 +82,23 @@ namespace StingTools.BOQ.MaterialSchedule
                 });
             }
 
+            // SECOND finish source. The layer source reads a TYPE's compound
+            // structure; this reads what the ROOM says. Gated so the two can
+            // never measure the same surface: if any type carried a tiled
+            // layer, room tiling is skipped entirely. Skirting is never
+            // suppressed — no layer source produces it.
+            var roomTally = new RoomFinishTally();
+            try
+            {
+                bool layerTiling = Takeoff.CompoundTakeoffBuilder.TileFinishScan.Tally.TypesMatched > 0;
+                inputs.Constituents.AddRange(RoomFinishGatherer.Gather(doc, layerTiling, roomTally));
+            }
+            catch (Exception ex)
+            {
+                result.Warnings.Add($"Room finishes could not be read: {ex.Message}");
+                StingLog.Warn($"MaterialScheduleBuilder room finishes: {ex.Message}");
+            }
+
             var msDoc = CommodityAggregator.Build(inputs);
             msDoc.ProjectName = doc.ProjectInformation?.Name ?? "";
             msDoc.ProjectCode = doc.ProjectInformation?.Number ?? "";
@@ -112,6 +129,9 @@ namespace StingTools.BOQ.MaterialSchedule
             // failed to recognise them, and only the denominator tells them apart.
             string tileScan = Takeoff.CompoundTakeoffBuilder.TileFinishScan.Summary();
             if (!string.IsNullOrEmpty(tileScan)) result.Warnings.Add(tileScan);
+
+            string roomScan = roomTally.Summary();
+            if (!string.IsNullOrEmpty(roomScan)) result.Warnings.Add(roomScan);
 
             StingLog.Info($"MaterialScheduleBuilder: {msDoc.Stages.Count} stage(s), "
                         + $"{msDoc.Stages.Sum(s => s.Commodities.Count)} commodity row(s), "

--- a/StingTools/BOQ/MaterialSchedule/RoomFinishGatherer.cs
+++ b/StingTools/BOQ/MaterialSchedule/RoomFinishGatherer.cs
@@ -1,0 +1,188 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RoomFinishGatherer.cs — MAT-SCHED-3: finishes as the model actually
+//  records them.
+//
+//  The layer-based source (CompoundTakeoffBuilder.ReadTiledFinish) reads a
+//  type's compound structure. On the first real model it found ONE finish
+//  layer across ten wall/floor types, and that one was Gypsum Wall Board. That
+//  is not a broken model — most architects never layer finishes. They record
+//  them on the ROOM, and Revit has first-class fields for it.
+//
+//  So this is a SECOND source, not a fallback guess: it measures what the room
+//  states, from the room's own Area and Perimeter. A model that layers its
+//  finishes keeps using the layer source; a model that schedules them starts
+//  working. Neither invents a finish the model does not name.
+//
+//  Skirting arrives here for free. It runs to a room's PERIMETER, which is
+//  exactly why the layer source could not measure it and said so.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
+using StingTools.BOQ.Takeoff;
+using StingTools.Core;
+using StingTools.Core.MaterialSchedule;
+
+namespace StingTools.BOQ.MaterialSchedule
+{
+    public static class RoomFinishGatherer
+    {
+        private const string TracePrefix = "room";
+
+        /// <summary>
+        /// Constituent rows derived from room finish fields.
+        ///
+        /// <paramref name="layerSourceProducedTiling"/> suppresses the TILE rows
+        /// only. Both sources measure the same surface from opposite ends, so
+        /// running them together would price it twice; skirting has no layer
+        /// equivalent and is never suppressed.
+        /// </summary>
+        public static List<ConstituentInput> Gather(Document doc, bool layerSourceProducedTiling,
+                                                    RoomFinishTally tally)
+        {
+            var rows = new List<ConstituentInput>();
+            if (doc == null) return rows;
+            if (tally == null) tally = new RoomFinishTally();
+            tally.TilingSuppressedByLayerSource = layerSourceProducedTiling;
+
+            try
+            {
+                var rooms = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_Rooms)
+                    .WhereElementIsNotElementType();
+
+                foreach (Element el in rooms)
+                {
+                    var room = el as Room;
+                    if (room == null) continue;
+
+                    // An unplaced or redundant room reports Area 0. Measuring it
+                    // would mint finishes for a room not in the building.
+                    double areaM2 = ToM2(SafeDouble(() => room.Area));
+                    if (areaM2 <= 0) continue;
+                    tally.RoomsRead++;
+
+                    double perimM = ToM(SafeDouble(() => room.Perimeter));
+                    double heightM = ToM(SafeDouble(() => room.UnboundedHeight));
+
+                    string floorFinish = Finish(room, BuiltInParameter.ROOM_FINISH_FLOOR, ParamRegistry.ROOM_FINISH_FLR);
+                    string wallFinish = Finish(room, BuiltInParameter.ROOM_FINISH_WALL, ParamRegistry.ROOM_FINISH_WALL);
+                    string baseFinish = Finish(room, BuiltInParameter.ROOM_FINISH_BASE, ParamRegistry.ROOM_FINISH_BASE);
+
+                    if (!layerSourceProducedTiling)
+                    {
+                        if (FinishTextClassifier.IsTile(floorFinish))
+                        {
+                            tally.FloorsTiled++;
+                            AddTiling(rows, doc, el, areaM2, false, floorFinish);
+                        }
+                        else if (FinishTextClassifier.IsRealFinish(floorFinish))
+                        {
+                            tally.UnrecognisedFloorFinishes.Add(floorFinish.Trim());
+                        }
+
+                        // Wall tiling measures the room's own height, because
+                        // that is what the model states. A splashback modelled
+                        // as a full-height tiled wall is a modelling decision,
+                        // not a number for this code to second-guess.
+                        if (FinishTextClassifier.IsTile(wallFinish) && perimM > 0 && heightM > 0)
+                        {
+                            tally.WallsTiled++;
+                            AddTiling(rows, doc, el, perimM * heightM, true, wallFinish);
+                        }
+                    }
+
+                    if (FinishTextClassifier.IsRealFinish(baseFinish) && perimM > 0)
+                    {
+                        tally.SkirtingRuns++;
+                        rows.Add(new ConstituentInput
+                        {
+                            ConstituentKind = "skirting",
+                            Category = "Rooms",
+                            TypeName = baseFinish,
+                            Description = "Skirting — " + baseFinish,
+                            Unit = "m",
+                            Quantity = Math.Round(perimM, 4),
+                            LevelCode = LevelOf(doc, el),
+                            TraceRef = TracePrefix + ":" + el.Id
+                        });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("RoomFinishGatherer.Gather: " + ex.Message);
+            }
+            return rows;
+        }
+
+        private static void AddTiling(List<ConstituentInput> rows, Document doc, Element el,
+                                      double areaM2, bool isWall, string finishName)
+        {
+            var cover = CompoundTakeoffBuilder.TileCoverages(finishName);
+            var lines = CompoundTakeoff.TiledFinish(new TiledFinishInput
+            {
+                AreaM2 = areaM2,
+                IsWall = isWall,
+                TileLabel = finishName,
+                AdhesiveKgPerM2 = cover.AdhesiveKgPerM2,
+                GroutKgPerM2 = cover.GroutKgPerM2
+            });
+
+            foreach (var l in lines)
+                rows.Add(new ConstituentInput
+                {
+                    ConstituentKind = l.Kind,
+                    Category = "Rooms",
+                    TypeName = finishName,
+                    Description = l.Description,
+                    Unit = l.Unit,
+                    Quantity = l.Quantity,
+                    LevelCode = LevelOf(doc, el),
+                    TraceRef = TracePrefix + ":" + el.Id
+                });
+        }
+
+        /// <summary>
+        /// Built-in first: it is what the architect typed. The BLE_* copy is
+        /// written by the parameter-mapping pass, which may never have run in
+        /// this document.
+        /// </summary>
+        private static string Finish(Room room, BuiltInParameter bip, string sharedName)
+        {
+            try
+            {
+                var p = room.get_Parameter(bip);
+                string v = p == null ? null : p.AsString();
+                if (!string.IsNullOrWhiteSpace(v)) return v;
+            }
+            catch (Exception ex) { StingLog.Warn("Suppressed: " + ex.Message); }
+            return ParameterHelpers.GetString(room, sharedName) ?? "";
+        }
+
+        private static string LevelOf(Document doc, Element el)
+        {
+            try { return ParameterHelpers.GetLevelCode(doc, el) ?? ""; }
+            catch (Exception ex) { StingLog.Warn("Suppressed: " + ex.Message); return ""; }
+        }
+
+        private static double SafeDouble(Func<double> f)
+        {
+            try { return f(); }
+            catch (Exception ex) { StingLog.Warn("Suppressed: " + ex.Message); return 0; }
+        }
+
+        private static double ToM2(double internalUnits)
+        {
+            try { return UnitUtils.ConvertFromInternalUnits(internalUnits, UnitTypeId.SquareMeters); }
+            catch (Exception ex) { StingLog.Warn("Suppressed: " + ex.Message); return 0; }
+        }
+
+        private static double ToM(double internalUnits)
+        {
+            try { return UnitUtils.ConvertFromInternalUnits(internalUnits, UnitTypeId.Meters); }
+            catch (Exception ex) { StingLog.Warn("Suppressed: " + ex.Message); return 0; }
+        }
+    }
+}

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -632,17 +632,6 @@ namespace StingTools.BOQ.Takeoff
         // ── Tiling from the finish layer (MAT-SCHED-3) ──────────────────────
 
         /// <summary>
-        /// Material names that read as a tiled finish. Deliberately narrow: a
-        /// false positive prices a whole floor as tiling, which is the defect
-        /// the withdrawn unit-table rules produced.
-        /// </summary>
-        private static readonly System.Text.RegularExpressions.Regex TileMaterialPattern =
-            new System.Text.RegularExpressions.Regex(
-                @"tile|ceramic|porcelain|terrazzo|mosaic|vitrified|granite|marble",
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase
-                | System.Text.RegularExpressions.RegexOptions.Compiled);
-
-        /// <summary>
         /// What the tile scan looked at, so "no tiling appeared" stops being
         /// silence and starts being evidence.
         ///
@@ -708,7 +697,7 @@ namespace StingTools.BOQ.Takeoff
                     if (layer.MaterialId == null || layer.MaterialId == ElementId.InvalidElementId) continue;
                     if (!(doc.GetElement(layer.MaterialId) is Material mat)) continue;
                     if (string.IsNullOrWhiteSpace(mat.Name)) continue;
-                    if (!TileMaterialPattern.IsMatch(mat.Name))
+                    if (!StingTools.Core.MaterialSchedule.FinishTextClassifier.IsTile(mat.Name))
                     {
                         // Recorded, not discarded: if the pattern is the thing
                         // that is wrong, these names are the evidence for it.
@@ -751,26 +740,29 @@ namespace StingTools.BOQ.Takeoff
             int measured = Math.Min(found.Faces, Math.Max(0, faces));
             if (measured <= 0) return empty;
 
-            string key = TileKeyFor(found.Label);
+            var cover = TileCoverages(found.Label);
             return CompoundTakeoff.TiledFinish(new TiledFinishInput
             {
                 AreaM2 = areaM2 * measured,
                 IsWall = isWall,
                 TileLabel = found.Label,
-                AdhesiveKgPerM2 = Prop($"TILE {key}", "ADHESIVE_KG_PER_M2", "TILE DEFAULT"),
-                GroutKgPerM2 = Prop($"TILE {key}", "GROUT_KG_PER_M2", "TILE DEFAULT")
+                AdhesiveKgPerM2 = cover.AdhesiveKgPerM2,
+                GroutKgPerM2 = cover.GroutKgPerM2
             });
         }
 
-        /// <summary>Material name → MATERIAL_LOOKUP TypeKey. Unmatched falls to DEFAULT.</summary>
-        private static string TileKeyFor(string materialName)
+
+        /// <summary>
+        /// Tile coverages for a finish name, from MATERIAL_LOOKUP. Internal so
+        /// the ROOM-driven source reads the same rows through the same key
+        /// composition — two lookups spelling the key differently is exactly the
+        /// silent-zero failure the tiling data test was written for.
+        /// </summary>
+        internal static (double AdhesiveKgPerM2, double GroutKgPerM2) TileCoverages(string finishName)
         {
-            string n = (materialName ?? "").ToLowerInvariant();
-            if (n.Contains("porcelain") || n.Contains("vitrified")) return "PORCELAIN";
-            if (n.Contains("terrazzo")) return "TERRAZZO";
-            if (n.Contains("granite") || n.Contains("marble")) return "STONE";
-            if (n.Contains("mosaic")) return "MOSAIC";
-            return "CERAMIC";
+            string key = StingTools.Core.MaterialSchedule.FinishTextClassifier.TileKey(finishName);
+            return (Prop($"TILE {key}", "ADHESIVE_KG_PER_M2", "TILE DEFAULT"),
+                    Prop($"TILE {key}", "GROUT_KG_PER_M2", "TILE DEFAULT"));
         }
 
         private static double Prop(string key, string property, string fallbackKey)

--- a/StingTools/Core/MaterialSchedule/FinishTextClassifier.cs
+++ b/StingTools/Core/MaterialSchedule/FinishTextClassifier.cs
@@ -1,0 +1,69 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  FinishTextClassifier.cs — MAT-SCHED-3: what a finish NAME means.
+//
+//  Two independent places need this answer and must agree:
+//    * a compound-structure finish LAYER's material name, and
+//    * a Room's Floor / Wall / Base Finish text.
+//
+//  They were about to hold two copies of the same regex, which is how the
+//  supplier-unit and stage files came to disagree (MATSCHED-3c). One copy,
+//  Revit-free, unit-tested.
+//
+//  Deliberately NARROW. A false positive prices a whole floor as tiling, which
+//  is the defect the withdrawn unit-table rules produced; a false negative is
+//  visible, because the scan reports every name it rejected.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Text.RegularExpressions;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public static class FinishTextClassifier
+    {
+        private static readonly Regex TilePattern = new Regex(
+            @"tile|ceramic|porcelain|terrazzo|mosaic|vitrified|granite|marble",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Names that read as tiling but are NOT a tiled surface. "Roof tile"
+        /// on a floor finish is a mis-typed schedule, and "carpet tile" is
+        /// carpet — it is laid, not bedded in adhesive and grouted, so pricing
+        /// it as ceramic would be wrong in both quantity and rate.
+        /// </summary>
+        private static readonly Regex NotTilePattern = new Regex(
+            @"carpet|vinyl tile|lvt|ceiling tile|roof tile|acoustic",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static bool IsTile(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return false;
+            if (NotTilePattern.IsMatch(name)) return false;
+            return TilePattern.IsMatch(name);
+        }
+
+        /// <summary>Finish name → MATERIAL_LOOKUP TypeKey. Unmatched falls to DEFAULT.</summary>
+        public static string TileKey(string name)
+        {
+            string n = (name ?? "").ToLowerInvariant();
+            if (n.Contains("porcelain") || n.Contains("vitrified")) return "PORCELAIN";
+            if (n.Contains("terrazzo")) return "TERRAZZO";
+            if (n.Contains("granite") || n.Contains("marble")) return "STONE";
+            if (n.Contains("mosaic")) return "MOSAIC";
+            return "CERAMIC";
+        }
+
+        /// <summary>
+        /// True when a Base Finish names something real to buy. Rooms carry the
+        /// literal strings "None", "N/A" and "-" far more often than they carry
+        /// nothing at all, and each of those would otherwise mint a skirting run
+        /// around a room that has none.
+        /// </summary>
+        public static bool IsRealFinish(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return false;
+            string n = name.Trim();
+            if (n.Length <= 1) return false;
+            return !Regex.IsMatch(n, @"^\s*(none|n/?a|nil|-+|tbc|tbd|x)\s*$", RegexOptions.IgnoreCase);
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/RoomFinishTally.cs
+++ b/StingTools/Core/MaterialSchedule/RoomFinishTally.cs
@@ -1,0 +1,81 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RoomFinishTally.cs — MAT-SCHED-3: what the ROOM finish scan looked at.
+//
+//  Same contract as TileScanTally, for the same reason: a schedule with no
+//  tiling rows must say whether the rooms were silent, whether their finish
+//  names went unrecognised, or whether the layer source already covered the
+//  surface. Three very different situations, one identical-looking output.
+//
+//  Revit-free so the MESSAGE is testable — a diagnostic that misreports is
+//  worse than none, because it sends someone looking in the wrong place.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public sealed class RoomFinishTally
+    {
+        /// <summary>Placed rooms only. An unplaced room has Area 0 and is skipped.</summary>
+        public int RoomsRead;
+        public int FloorsTiled;
+        public int WallsTiled;
+        public int SkirtingRuns;
+
+        /// <summary>True when the wall/floor TYPES already carried tiled finish
+        /// layers, so room tiling was deliberately not measured.</summary>
+        public bool TilingSuppressedByLayerSource;
+
+        /// <summary>Floor finishes that named something real but did not read as
+        /// tiling. Kept as evidence: if the classifier is what is wrong, these
+        /// are the names that prove it.</summary>
+        public readonly SortedSet<string> UnrecognisedFloorFinishes =
+            new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private const int MaxNamesShown = 8;
+
+        public void Reset()
+        {
+            RoomsRead = FloorsTiled = WallsTiled = SkirtingRuns = 0;
+            TilingSuppressedByLayerSource = false;
+            UnrecognisedFloorFinishes.Clear();
+        }
+
+        /// <summary>The line reported on every export, or NULL when there were
+        /// no placed rooms — nothing scanned, nothing to report.</summary>
+        public string Summary()
+        {
+            if (RoomsRead <= 0) return null;
+
+            string s = $"Room finishes: {RoomsRead} placed room(s) read, "
+                     + $"{FloorsTiled} name a tiled floor, {WallsTiled} a tiled wall, "
+                     + $"{SkirtingRuns} a skirting.";
+
+            if (TilingSuppressedByLayerSource)
+                return s + " Room tiling was NOT measured: the wall/floor types already carry "
+                         + "tiled finish layers, and measuring both sources would price the same "
+                         + "surface twice. Skirting still comes from the rooms.";
+
+            if (FloorsTiled == 0 && UnrecognisedFloorFinishes.Count > 0)
+            {
+                var names = new List<string>();
+                foreach (string n in UnrecognisedFloorFinishes)
+                {
+                    if (names.Count == MaxNamesShown) break;
+                    names.Add(n);
+                }
+                return s + " Floor finishes named but not recognised as tiling: "
+                         + string.Join(", ", names)
+                         + (UnrecognisedFloorFinishes.Count > MaxNamesShown ? ", …" : "")
+                         + ". Rename the finish, or price the surface by hand.";
+            }
+
+            if (FloorsTiled == 0 && WallsTiled == 0 && SkirtingRuns == 0)
+                return s + " The rooms carry no finish text, so no finish can be measured from "
+                         + "them — record Floor / Wall / Base Finish on the rooms, or give the "
+                         + "floor and wall types a tiled finish layer.";
+
+            return s;
+        }
+    }
+}

--- a/StingTools/Data/STING_COMMODITY_RATES.csv
+++ b/StingTools/Data/STING_COMMODITY_RATES.csv
@@ -33,3 +33,4 @@ floor-tile,Boxes,55000,Ceramic floor tile 600x600 box of 4 (1.44 m2)
 wall-tile,Boxes,45000,Ceramic wall tile 300x600 box of 8 (1.44 m2)
 tile-adhesive,Bags,35000,Cementitious tile adhesive 20kg bag
 tile-grout,Bags,25000,Tile grout 5kg bag
+skirting,m,15000,Skirting per linear metre (tile / cement / timber, as scheduled)

--- a/StingTools/Data/STING_MATERIAL_STAGES.json
+++ b/StingTools/Data/STING_MATERIAL_STAGES.json
@@ -139,7 +139,8 @@
         "floor_tile",
         "wall_tile",
         "tile_adhesive",
-        "tile_grout"
+        "tile_grout",
+        "skirting"
       ],
       "categories": [
         "Ceilings"

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -248,6 +248,22 @@
       "matchCategories": [],
       "matchTypePatterns": [],
       "stageId": ""
+    },
+    {
+      "commodityKey": "skirting",
+      "description": "Skirting",
+      "spec": "per linear metre, as scheduled",
+      "supplierUnit": "m",
+      "sourceUnit": "m",
+      "sourceUnitsPerSupplierUnit": 1.0,
+      "roundUpToWhole": false,
+      "defaultWastagePct": 5,
+      "matchKinds": [
+        "skirting"
+      ],
+      "matchCategories": [],
+      "matchTypePatterns": [],
+      "stageId": ""
     }
   ]
 }


### PR DESCRIPTION
The tile scan answered the question it was built for:

```
Tiling scan: 10 wall/floor type(s) inspected, 1 carry a finish layer,
0 name a tile material. Finish materials found but not recognised as
tiling: Gypsum Wall Board.
```

**That is not a broken model.** Most architects never layer finishes — they record them on the **Room**, and Revit has first-class fields for it, which this plugin has been harvesting into `BLE_ROOM_FINISH_*` all along ([ParameterHelpers.cs:2907](StingTools/Core/ParameterHelpers.cs:2907)).

So finishes now have a **second source**, not one narrow one.

### Not a fallback guess

It measures what the room *states*, from the room's own `Area` and `Perimeter`. A model that layers its finishes keeps using the layer source; a model that schedules them starts working. Neither invents a finish the model does not name.

### The two sources can never measure the same surface

If **any** wall/floor type carried a tiled layer, room tiling is skipped whole — and the export **says so**. Otherwise a correctly-layered model shows zero room tiling and looks broken, when it is the double-count guard doing its job. Skirting is never suppressed, because no layer source produces it.

### Skirting, closing something I said was out of reach

I wrote that skirting couldn't be measured because it needs a perimeter an area can't yield. `Room.Perimeter` is exactly that, and `ROOM_FINISH_BASE` names the material. It falls out of this work for free.

### Two guards worth naming

- **"Carpet tile", "vinyl tile", "LVT", "ceiling tile", "roof tile", "acoustic tile"** all contain the word and would otherwise be priced with adhesive and grout at ceramic rates — wrong in quantity *and* rate.
- Rooms carry the literals **"None", "N/A", "-", "TBC"** far more often than they carry nothing. Each would mint a skirting run around a room that has none.

### One classifier, not two

Two places needed the same answer — a layer material name and a room finish string — and were about to hold two copies of one regex. That is precisely how the supplier-unit and stage files came to disagree (MATSCHED-3c). One copy, Revit-free, unit-tested; the MATERIAL_LOOKUP key is composed at one site for both sources.

Tests **393 → 441**. Build **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)