### PR TITLE
Correct the last comment that still names the retired seeds folder

### DIFF
--- a/StingTools/Core/Content/ContentManifest.cs
+++ b/StingTools/Core/Content/ContentManifest.cs
@@ -7,7 +7,8 @@
 // engines (SymbolLibraryCreator, TagFamilyCreator seed-load, MEP-from-DWG
 // placement) resolve against, so one version + checksum envelope covers content
 // that is otherwise scattered across Data/Seeds, Data/Symbols and
-// Data/TagFamilies/Seeds.
+// Data/TagFamilies.  (Data/TagFamilies/Seeds was retired: its 137 files were
+// superseded duplicates that shadowed the flat set, and nothing searches it.)
 //
 // ContentManifestRegistry mirrors DrawingTypeRegistry exactly:
 //   1. Loads Data/STING_CONTENT_MANIFEST.json (shipped corporate baseline)


### PR DESCRIPTION
Follow-up to #785. `ContentManifest`'s header described its index as covering content scattered across `Data/Seeds`, `Data/Symbols` and `Data/TagFamilies/Seeds`. The third was retired in #785 and nothing searches it, so the comment named a folder that no longer exists — which is how a reader concludes the code looks somewhere it doesn't.

No source reference to the folder now remains outside the two comments that explain its removal.

Build: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)