### PR TITLE
Give the baseline commands a button, so they can be run

### DIFF
--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1945,6 +1945,19 @@
                             </StackPanel>
                         </Border>
 
+                        <!-- MODEL-AUTHORING BASELINE -->
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="&#x1F3D7; MODEL BASELINE"/>
+                        <Border Style="{StaticResource GroupBorder}" BorderBrush="#6A1B9A">
+                            <StackPanel>
+                                <Button Style="{StaticResource ActionBtn}" Content="Audit model baseline" Tag="Baseline_Audit" Click="Cmd_Click"
+                                        ToolTip="READ-ONLY. Compares this project to the STING model-authoring baseline: which materials and wall/floor/roof/ceiling types are missing, which exist but differ, and which need families loaded by hand. Writes nothing."
+                                        HorizontalAlignment="Stretch"/>
+                                <Button Style="{StaticResource OrangeBtn}" Content="Apply baseline (asks first)" Tag="Baseline_Apply" Click="Cmd_Click"
+                                        ToolTip="Shows the full list of what it would create, then writes only after you confirm. Creates ONLY what is missing — an existing type is never edited, even when its build-up differs from the baseline. A material schedule can only measure finishes the model actually describes; this is what gives it something to read."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
+                            </StackPanel>
+                        </Border>
+
                         <!-- MATERIALS -->
                         <TextBlock Style="{StaticResource SectionLabel}" Text="MATERIALS"/>
                         <Border Style="{StaticResource GroupBorder}">


### PR DESCRIPTION
#789 added `Baseline_Audit` and `Baseline_Apply` plus a dispatch case for each, and its commit message said *"neither is born unreachable"*. **That was wrong.**

A handler `case` is necessary and not sufficient. Nothing dispatches to it without a button; the commands are not in the `.addin` as external commands; neither is in `WorkflowEngine.ResolveCommand`. **There was no way to run either one.**

This is the exact defect class the repo already tracks in `UNREACHABLE_COMMANDS_TRIAGE.md` and `SILENT_BUTTONS_TODO.md` — and I shipped a new instance of it while claiming the opposite. The claim is what made it invisible: a green build and a present `case` label read as wired.

Both buttons now sit on the **SETUP** tab under `MODEL BASELINE`, beside the project setup wizard where model-authoring standards belong. Audit is a plain action button, Apply is orange — one reads, the other writes.

Build **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)