### PR TITLE
Resolve the app the way the panel dispatcher expects

### DIFF
--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -298,13 +298,36 @@ namespace StingTools.Commands.Baseline
         }
     }
 
+    internal static class BaselineDoc
+    {
+        /// <summary>
+        /// The panel dispatcher calls Execute(null, ...) on purpose and expects
+        /// CurrentApp as the fallback. A command that only reads
+        /// commandData.Application works from a ribbon button and is silently
+        /// dead from the dock panel — no exception, no dialog, a clean
+        /// start/done in the log.
+        /// </summary>
+        public static Document Resolve(ExternalCommandData data)
+            => (data?.Application ?? StingTools.UI.StingCommandHandler.CurrentApp)
+               ?.ActiveUIDocument?.Document;
+    }
+
     [Transaction(TransactionMode.ReadOnly)]
     public class BaselineAuditCommand : IExternalCommand
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
         {
-            var doc = data?.Application?.ActiveUIDocument?.Document;
-            if (doc == null) return Result.Cancelled;
+            // StingCommandHandler.RunCommand passes NULL for ExternalCommandData
+            // and expects commands to fall back to CurrentApp. Reading
+            // data.Application here returned null, so both commands returned
+            // Cancelled instantly and showed nothing — a dead button that logged
+            // a clean start/done and no error.
+            var doc = BaselineDoc.Resolve(data);
+            if (doc == null)
+            {
+                TaskDialog.Show("STING Project Baseline", "No active document.");
+                return Result.Cancelled;
+            }
 
             var audit = BaselineAuditor.Audit(BaselineRegistry.Load(doc), BaselineModelReader.Read(doc));
             TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
@@ -318,8 +341,12 @@ namespace StingTools.Commands.Baseline
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
         {
-            var doc = data?.Application?.ActiveUIDocument?.Document;
-            if (doc == null) return Result.Cancelled;
+            var doc = BaselineDoc.Resolve(data);
+            if (doc == null)
+            {
+                TaskDialog.Show("STING Project Baseline", "No active document.");
+                return Result.Cancelled;
+            }
 
             var baseline = BaselineRegistry.Load(doc);
             var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc));


### PR DESCRIPTION
Both baseline buttons were lifeless. The log said exactly why:

```
10:12:01  RunCommand<BaselineAuditCommand>: start
10:12:01  RunCommand<BaselineAuditCommand>: done
```

They **ran** — five times — returned instantly, and showed nothing. No exception, no error line.

### Cause

`StingCommandHandler.RunCommand` calls `cmd.Execute(null, ...)` **on purpose**, and expects commands to fall back to `StingCommandHandler.CurrentApp`:

```csharp
// Pass null for ExternalCommandData — commands use
// StingCommandHandler.CurrentApp as fallback.
cmd.Execute(null, ref message, elSet);
```

Both baseline commands read `data?.Application?.ActiveUIDocument?.Document`, got null, and returned `Result.Cancelled` before doing anything. **The standard ribbon-command pattern is silently dead from the dock panel.**

Fixed with a shared `BaselineDoc.Resolve` that prefers `commandData` and falls back to `CurrentApp` — the idiom already in `TitleBlockFactoryCommands` and `PlatformLinkCommands`. A null document now *says so* rather than returning quietly: "nothing happened" must never be a valid outcome for a click.

### Wider finding

This shape is not unique to my commands. **33 files under `Commands/` read `commandData.Application` with no `CurrentApp` fallback, and at least 20 of them have a dispatch case in `StingCommandHandler`** — meaning they are likely dead from the panel in exactly this way, including `AdjacencyAuditCommand`, `FolderConsolidateCommand`, `MgasVerifyCommand` and ten healthcare validators. Not touched here; worth its own pass.

### Note

Third reachability failure on this feature in a row: a `case` label with no button (#792), then a button with no working app handle. Each looked correct at the layer I checked. Only the log settled it.

Build **0 warnings / 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)