### PR TITLE
38 dead dispatched commands, and a gate so this is the last round

### DIFF
--- a/.github/workflows/stingtools-plugin.yml
+++ b/.github/workflows/stingtools-plugin.yml
@@ -62,6 +62,10 @@ jobs:
         shell: pwsh
         run: ./tools/check_workflow_wiring.ps1
 
+      - name: Command doc-acquisition discipline
+        shell: pwsh
+        run: ./tools/check_command_doc_acquisition.ps1
+
       - name: Check for duplicate parameter GUIDs
         run: |
           python3 - <<'EOF'

--- a/StingTools/Clash/ClashBcfExportCommand.cs
+++ b/StingTools/Clash/ClashBcfExportCommand.cs
@@ -27,7 +27,7 @@ namespace StingTools.Core.Clash
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
                 string outDir = OutputLocationHelper.GetOutputDirectory(doc) ?? Path.GetTempPath();

--- a/StingTools/Clash/ClashDetectionCommands.cs
+++ b/StingTools/Clash/ClashDetectionCommands.cs
@@ -476,7 +476,7 @@ namespace StingTools.Clash
         {
             try
             {
-                if (commandData?.Application?.ActiveUIDocument == null)
+                if (ParameterHelpers.GetUIDoc(commandData) == null)
                 {
                     TaskDialog.Show("Clash Detection", "No active document.");
                     return Result.Failed;
@@ -607,7 +607,7 @@ namespace StingTools.Clash
         {
             try
             {
-                if (commandData?.Application?.ActiveUIDocument == null)
+                if (ParameterHelpers.GetUIDoc(commandData) == null)
                 {
                     TaskDialog.Show("Cross-Model Clash", "No active document.");
                     return Result.Failed;
@@ -823,7 +823,7 @@ namespace StingTools.Clash
         {
             try
             {
-                if (commandData?.Application?.ActiveUIDocument == null)
+                if (ParameterHelpers.GetUIDoc(commandData) == null)
                 {
                     TaskDialog.Show("MEP Clearance", "No active document.");
                     return Result.Failed;
@@ -1152,7 +1152,7 @@ namespace StingTools.Clash
         {
             try
             {
-                if (commandData?.Application?.ActiveUIDocument == null)
+                if (ParameterHelpers.GetUIDoc(commandData) == null)
                 {
                     TaskDialog.Show("Naming Audit", "No active document.");
                     return Result.Failed;

--- a/StingTools/Clash/ClashRunCommand.cs
+++ b/StingTools/Clash/ClashRunCommand.cs
@@ -38,7 +38,7 @@ namespace StingTools.Core.Clash
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var uiDoc = commandData?.Application?.ActiveUIDocument;
+            var uiDoc = ParameterHelpers.GetUIDoc(commandData);
             var doc = uiDoc?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
             try { return ExecuteOnDocument(doc, silent: false, out _); }

--- a/StingTools/Clash/ClashSessionCommands.cs
+++ b/StingTools/Clash/ClashSessionCommands.cs
@@ -26,7 +26,7 @@ namespace StingTools.Core.Clash
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (doc == null) return Result.Cancelled;
                 ClashSession.Clear(doc);
                 TaskDialog.Show("STING Clash",
@@ -51,7 +51,7 @@ namespace StingTools.Core.Clash
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (doc != null) ClashSession.Clear(doc);
                 return Result.Succeeded;
             }

--- a/StingTools/Clash/ClashXlsxExportCommand.cs
+++ b/StingTools/Clash/ClashXlsxExportCommand.cs
@@ -23,7 +23,7 @@ namespace StingTools.Core.Clash
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
                 string outDir = OutputLocationHelper.GetOutputDirectory(doc) ?? Path.GetTempPath();

--- a/StingTools/Commands/Content/ContentCoverageCommand.cs
+++ b/StingTools/Commands/Content/ContentCoverageCommand.cs
@@ -24,7 +24,7 @@ namespace StingTools.Commands.Content
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
             try

--- a/StingTools/Commands/Folders/FolderConsolidateCommand.cs
+++ b/StingTools/Commands/Folders/FolderConsolidateCommand.cs
@@ -38,7 +38,7 @@ namespace StingTools.Commands.Folders
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(data);
                 if (doc == null) { message = "No active document."; return Result.Failed; }
                 return RunWithConsent(doc) ? Result.Succeeded : Result.Cancelled;
             }

--- a/StingTools/Commands/Placement/ManufacturerCatalogueAutoPopulateCommand.cs
+++ b/StingTools/Commands/Placement/ManufacturerCatalogueAutoPopulateCommand.cs
@@ -10,6 +10,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using StingTools.Core.Placement;
+using StingTools.Core;
 
 namespace StingTools.Commands.Placement
 {
@@ -19,7 +20,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
             var (created, updated, contributing) = ManufacturerCatalogueRegistry.AutoPopulateFromFamilies(doc);

--- a/StingTools/Commands/Placement/NogginRequirementExportCommand.cs
+++ b/StingTools/Commands/Placement/NogginRequirementExportCommand.cs
@@ -28,7 +28,7 @@ namespace StingTools.Commands.Placement
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
             string text;

--- a/StingTools/Commands/Placement/PlaceToiletRoomCommand.cs
+++ b/StingTools/Commands/Placement/PlaceToiletRoomCommand.cs
@@ -21,7 +21,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
         {
-            var uiDoc = data?.Application?.ActiveUIDocument;
+            var uiDoc = ParameterHelpers.GetUIDoc(data);
             var doc   = uiDoc?.Document;
             if (doc == null) { message = "No active document."; return Result.Failed; }
 

--- a/StingTools/Commands/Placement/PlacementDiagnoseCommand.cs
+++ b/StingTools/Commands/Placement/PlacementDiagnoseCommand.cs
@@ -24,7 +24,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData cd, ref string message, ElementSet elements)
         {
-            var doc = cd?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(cd);
             if (doc == null) { message = "No active document."; return Result.Failed; }
 
             var (text, txtPath) = BuildReportText(doc);

--- a/StingTools/Commands/Placement/PlacementRulesExcelCommands.cs
+++ b/StingTools/Commands/Placement/PlacementRulesExcelCommands.cs
@@ -27,7 +27,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             var rules = PlacementRuleLoader.Load(doc?.PathName ?? "");
 
             string outDir = OutputLocationHelper.GetOutputPath(doc, "PlacementRules") ?? Path.GetTempPath();
@@ -57,7 +57,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             string projectPath = doc?.PathName ?? "";
             if (string.IsNullOrEmpty(projectPath))
             {

--- a/StingTools/Commands/Placement/PlacementSetupAuditCommand.cs
+++ b/StingTools/Commands/Placement/PlacementSetupAuditCommand.cs
@@ -66,7 +66,7 @@ namespace StingTools.Commands.Placement
 
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var doc = commandData?.Application?.ActiveUIDocument?.Document;
+            var doc = ParameterHelpers.GetDoc(commandData);
             if (doc == null) { message = "No active document."; return Result.Failed; }
             try
             {

--- a/StingTools/Commands/Placement/RunWallChaseCommand.cs
+++ b/StingTools/Commands/Placement/RunWallChaseCommand.cs
@@ -24,7 +24,7 @@ namespace StingTools.Commands.Placement
     {
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
-            var uiapp = commandData?.Application;
+            var uiapp = ParameterHelpers.GetApp(commandData);
             if (uiapp?.ActiveUIDocument?.Document == null) { message = "No active document."; return Result.Failed; }
             try { RunInteractive(uiapp)?.Show(); return Result.Succeeded; }
             catch (Autodesk.Revit.Exceptions.OperationCanceledException) { return Result.Cancelled; }

--- a/StingTools/Core/DocumentRegister.cs
+++ b/StingTools/Core/DocumentRegister.cs
@@ -178,7 +178,7 @@ namespace StingTools.Core
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(data);
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
                 var rows = DocumentRegister.BuildUnified(doc);
@@ -215,7 +215,7 @@ namespace StingTools.Core
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(data);
                 if (doc == null) { message = "No active document."; return Result.Failed; }
 
                 var rows = DocumentRegister.BuildUnified(doc);

--- a/StingTools/Core/MaterialGateCommands.cs
+++ b/StingTools/Core/MaterialGateCommands.cs
@@ -17,7 +17,7 @@ namespace StingTools.Core
         public class CoverageGateCommand : IExternalCommand
         {
             public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
-            { MatActions.RunCoverageCheck(data?.Application); return Result.Succeeded; }
+            { MatActions.RunCoverageCheck(ParameterHelpers.GetApp(data)); return Result.Succeeded; }
         }
 
         [Transaction(TransactionMode.ReadOnly)]
@@ -25,7 +25,7 @@ namespace StingTools.Core
         public class SustainabilityGateCommand : IExternalCommand
         {
             public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
-            { MatActions.RunSustainabilityGate(data?.Application); return Result.Succeeded; }
+            { MatActions.RunSustainabilityGate(ParameterHelpers.GetApp(data)); return Result.Succeeded; }
         }
 
         [Transaction(TransactionMode.ReadOnly)]
@@ -33,7 +33,7 @@ namespace StingTools.Core
         public class HealthcareGateCommand : IExternalCommand
         {
             public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
-            { MatActions.RunHealthcareGate(data?.Application); return Result.Succeeded; }
+            { MatActions.RunHealthcareGate(ParameterHelpers.GetApp(data)); return Result.Succeeded; }
         }
 
         [Transaction(TransactionMode.ReadOnly)]
@@ -41,7 +41,7 @@ namespace StingTools.Core
         public class FireWallGateCommand : IExternalCommand
         {
             public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
-            { MatActions.RunFireWallGate(data?.Application); return Result.Succeeded; }
+            { MatActions.RunFireWallGate(ParameterHelpers.GetApp(data)); return Result.Succeeded; }
         }
     }
 }

--- a/StingTools/Core/StingAutoTagger.cs
+++ b/StingTools/Core/StingAutoTagger.cs
@@ -1259,7 +1259,7 @@ namespace StingTools.Core
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (doc == null || string.IsNullOrEmpty(doc.PathName)) return;
                 string dir = System.IO.Path.GetDirectoryName(doc.PathName);
                 if (string.IsNullOrEmpty(dir)) return;

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1360,7 +1360,10 @@ namespace StingTools.Core
                 // Try plugin hook custom commands before failing
                 try
                 {
-                    var uiApp = data?.Application;
+                    // Not data?.Application: dispatched from the panel that is
+                    // always null, so plugin-hook commands were skipped in
+                    // silence — the tag simply "did not resolve".
+                    var uiApp = ParameterHelpers.GetApp(data);
                     if (uiApp != null)
                     {
                         var (found, result) = StingPluginHooks.TryExecuteCommand(tag, uiApp);

--- a/StingTools/Docs/ScheduledExportRunner.cs
+++ b/StingTools/Docs/ScheduledExportRunner.cs
@@ -115,7 +115,7 @@ namespace StingTools.Docs
         {
             try
             {
-                var doc = data?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(data);
                 if (doc == null) { message = "No document open."; return Result.Failed; }
 
                 int ran = ScheduledExportRunner.RunDue(doc, fromSave: false);

--- a/StingTools/Model/StructuralDWGEnhancements.cs
+++ b/StingTools/Model/StructuralDWGEnhancements.cs
@@ -546,7 +546,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var doc = app?.ActiveUIDocument?.Document ?? commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = app?.ActiveUIDocument?.Document ?? ParameterHelpers.GetDoc(commandData);
                 if (doc == null)
                 {
                     TaskDialog.Show("STING", "No active document.");
@@ -613,7 +613,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var doc = app?.ActiveUIDocument?.Document ?? commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = app?.ActiveUIDocument?.Document ?? ParameterHelpers.GetDoc(commandData);
                 if (doc == null)
                 {
                     TaskDialog.Show("STING", "No active document.");
@@ -665,7 +665,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var doc = app?.ActiveUIDocument?.Document ?? commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = app?.ActiveUIDocument?.Document ?? ParameterHelpers.GetDoc(commandData);
                 if (doc == null)
                 {
                     TaskDialog.Show("STING", "No active document.");
@@ -746,7 +746,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var uidoc = app?.ActiveUIDocument ?? commandData?.Application?.ActiveUIDocument;
+                var uidoc = app?.ActiveUIDocument ?? ParameterHelpers.GetUIDoc(commandData);
                 var doc = uidoc?.Document;
                 if (doc == null || uidoc == null)
                 {
@@ -887,7 +887,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var uidoc = app?.ActiveUIDocument ?? commandData?.Application?.ActiveUIDocument;
+                var uidoc = app?.ActiveUIDocument ?? ParameterHelpers.GetUIDoc(commandData);
                 var doc = uidoc?.Document;
                 if (doc == null || uidoc == null)
                 {
@@ -967,7 +967,7 @@ namespace StingTools.Model
             try
             {
                 var app = ParameterHelpers.GetApp(commandData);
-                var uidoc = app?.ActiveUIDocument ?? commandData?.Application?.ActiveUIDocument;
+                var uidoc = app?.ActiveUIDocument ?? ParameterHelpers.GetUIDoc(commandData);
                 var doc = uidoc?.Document;
                 if (doc == null || uidoc == null)
                 {

--- a/StingTools/Tags/FamilyConformanceCheckCommand.cs
+++ b/StingTools/Tags/FamilyConformanceCheckCommand.cs
@@ -375,7 +375,7 @@ namespace StingTools.Tags
             // Prefer the project's _BIM_COORD folder; fall back to %TEMP%.
             try
             {
-                var doc = cd?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(cd);
                 if (doc != null && !string.IsNullOrEmpty(doc.PathName))
                 {
                     string projDir = Path.GetDirectoryName(doc.PathName);

--- a/StingTools/Temp/MasterSetupCommand.cs
+++ b/StingTools/Temp/MasterSetupCommand.cs
@@ -273,7 +273,10 @@ namespace StingTools.Temp
             // Step 20: Healthcare Pack setup (HC-09) — only runs if facility type profile is set.
             try
             {
-                var hcDoc = commandData?.Application?.ActiveUIDocument?.Document;
+                // Was commandData?.Application?...: null from the panel, so the
+                // profile read returned null and Step 20 skipped ITSELF on every
+                // panel-run Master Setup. A skipped step logs nothing.
+                var hcDoc = ParameterHelpers.GetDoc(commandData);
                 var pi = hcDoc?.ProjectInformation;
                 var healthProfile = pi?.LookupParameter("PRJ_ORG_HEALTH_PACK_PROFILE_TXT")?.AsString();
                 if (!string.IsNullOrEmpty(healthProfile))

--- a/StingTools/UI/PlacementCenter/PlacementExcelCommands.cs
+++ b/StingTools/UI/PlacementCenter/PlacementExcelCommands.cs
@@ -30,7 +30,7 @@ namespace StingTools.UI.PlacementCenter
         {
             try
             {
-                var doc  = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc  = ParameterHelpers.GetDoc(commandData);
                 var rules = PlacementRuleLoader.Load(doc?.PathName ?? "");
                 if (rules == null || rules.Count == 0)
                 {
@@ -68,7 +68,7 @@ namespace StingTools.UI.PlacementCenter
         {
             try
             {
-                var doc = commandData?.Application?.ActiveUIDocument?.Document;
+                var doc = ParameterHelpers.GetDoc(commandData);
                 if (string.IsNullOrEmpty(doc?.PathName))
                 {
                     TaskDialog.Show("STING Placement",

--- a/tools/check_command_doc_acquisition.ps1
+++ b/tools/check_command_doc_acquisition.ps1
@@ -1,0 +1,92 @@
+# ══════════════════════════════════════════════════════════════════════════
+#  check_command_doc_acquisition.ps1
+#
+#  Fails the build when an IExternalCommand that the dock panel DISPATCHES
+#  reads commandData.Application directly instead of going through
+#  ParameterHelpers.GetDoc / GetUIDoc / GetApp.
+#
+#  WHY THIS GATE EXISTS. StingCommandHandler.RunCommand<T> calls
+#  cmd.Execute(NULL, ...) by design and expects commands to fall back to
+#  StingCommandHandler.CurrentApp. A command that reads
+#  commandData?.Application?.ActiveUIDocument?.Document gets null, returns on
+#  its first line, and produces a DEAD BUTTON that logs a clean start/done
+#  and no error. Nothing about it looks wrong: it compiles, it has a handler
+#  case, it has a button, and the log says it ran.
+#
+#  This has now been fixed three separate times — 28 sites across
+#  Commands/Drawing, then Commands/Cost, then 36 sites found only because a
+#  user clicked a button and reported that nothing happened. Three rounds of
+#  the same defect is a missing gate, not three mistakes.
+#
+#  Baseline is ZERO. If a command genuinely must read commandData directly,
+#  give it the ?? StingCommandHandler.CurrentApp fallback on the same
+#  expression and this script will accept it.
+# ══════════════════════════════════════════════════════════════════════════
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+
+$handler = Join-Path $root 'StingTools\UI\StingCommandHandler.cs'
+if (-not (Test-Path $handler)) {
+    Write-Host "SKIP: StingCommandHandler.cs not found"
+    exit 0
+}
+
+# Every command class the panel can dispatch.
+$handlerText = Get-Content $handler -Raw
+$dispatched = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($m in [regex]::Matches($handlerText, 'RunCommand<(?:[\w\.]*\.)?(\w+)>')) {
+    [void]$dispatched.Add($m.Groups[1].Value)
+}
+Write-Host "Dispatched command classes: $($dispatched.Count)"
+
+# The broken shape: a null-conditional read of commandData with no fallback
+# anywhere in the file.
+$bad = [regex]'(?<![\w\.])(commandData|data|cd)\s*\?\s*\.\s*Application'
+$violations = @()
+
+Get-ChildItem -Path (Join-Path $root 'StingTools') -Filter *.cs -Recurse |
+    Where-Object { $_.FullName -notmatch '\\(obj|bin)\\' } |
+    ForEach-Object {
+        $text = Get-Content $_.FullName -Raw
+        if ($text -notmatch 'IExternalCommand') { return }
+        if ($text -match 'StingCommandHandler\.CurrentApp') { return }   # has the fallback
+
+        # Blank out comments before matching, preserving newlines so the
+        # reported line numbers stay right. Without this the gate flags the
+        # comments EXPLAINING the fix — which it did on its first run, against
+        # the very commit that fixed the last two sites. A gate that cries wolf
+        # over prose is a gate somebody disables.
+        $text = [regex]::Replace($text, '(?s)/\*.*?\*/', { param($m) ($m.Value -replace '[^\r\n]', ' ') })
+        $text = [regex]::Replace($text, '//[^\r\n]*',    { param($m) ' ' * $m.Value.Length })
+
+        $classes = [regex]::Matches($text, 'class\s+(\w+)\s*:\s*IExternalCommand')
+        $isDispatched = $false
+        foreach ($c in $classes) {
+            if ($dispatched.Contains($c.Groups[1].Value)) { $isDispatched = $true; break }
+        }
+        if (-not $isDispatched) { return }
+
+        foreach ($hit in $bad.Matches($text)) {
+            $line = ($text.Substring(0, $hit.Index) -split "`n").Count
+            $violations += [pscustomobject]@{
+                File = $_.FullName.Substring($root.Length + 1)
+                Line = $line
+            }
+        }
+    }
+
+if ($violations.Count -eq 0) {
+    Write-Host "PASS: every dispatched command resolves its document through ParameterHelpers."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "FAIL: $($violations.Count) dispatched command site(s) read commandData.Application"
+Write-Host "      directly. From the dock panel that is always null, so the button is dead:"
+Write-Host "      it logs start/done, shows nothing, and throws nothing."
+Write-Host ""
+foreach ($v in $violations) { Write-Host ("  {0}:{1}" -f $v.File, $v.Line) }
+Write-Host ""
+Write-Host "Fix: ParameterHelpers.GetDoc(commandData) / GetUIDoc(commandData) / GetApp(commandData),"
+Write-Host "     or add '?? StingTools.UI.StingCommandHandler.CurrentApp' to the expression."
+exit 1


### PR DESCRIPTION
`StingCommandHandler.RunCommand<T>` calls `cmd.Execute(null, …)` **by design** and expects commands to fall back to `StingCommandHandler.CurrentApp`. A command reading `commandData?.Application?.ActiveUIDocument?.Document` gets null, returns on its first line, and produces a **dead button that logs a clean start/done, shows nothing, and throws nothing.**

**38 sites across 23 files**, all routed through the helpers that already exist for exactly this — `ParameterHelpers.GetDoc` / `GetUIDoc` / `GetApp`.

### Two are worse than dead buttons

- **`MasterSetupCommand` step 20** read the healthcare profile through the null `commandData`, so **Healthcare Pack setup skipped itself on every panel-run Master Setup.** A skipped step logs nothing.
- **`WorkflowEngine`'s plugin-hook fallback** took the same path, so custom plugin commands could never resolve from the panel — the tag simply "did not resolve".

Also fixed: 5 Clash commands, 9 Placement commands, `FolderConsolidateCommand`, `ContentCoverageCommand`, `FamilyConformanceCheckCommand`, `ScheduledExportRunner`, `DocumentRegister`, `MaterialGateCommands`, `StingAutoTagger`, `StructuralDWGEnhancements` (6 sites), the Placement Center Excel round-trip.

### The gate is the actual deliverable

This has now been fixed **three times**: 28 sites across `Commands/Drawing`, then `Commands/Cost` — documented in `BOQ_COST_INTEGRATION_AND_FIXES_PROMPT.md` §A.4, which even prescribes the grep — and now these 38, found only because a user clicked a button and said nothing happened.

**Three rounds of one defect is a missing gate, not three mistakes.** `tools/check_command_doc_acquisition.ps1` fails the build on any dispatched command that reads `commandData` directly, and runs in `stingtools-plugin.yml` beside the path-discipline and wiring checks. Baseline is zero.

### The gate was verified both ways before being kept

Its **first run failed on the comments explaining the fix** — so it now blanks comments while preserving line numbers. A gate that cries wolf over prose is a gate somebody disables. Then a fixed site was deliberately re-broken and it caught it:

```
FAIL: 1 dispatched command site(s) read commandData.Application directly.
  StingTools\Commands\Content\ContentCoverageCommand.cs:27
```

Build **0/0**, tests **465 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)