### PR TITLE
Floors and ceilings could not be created, and failure left debris

### DIFF
--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -239,12 +239,42 @@ namespace StingTools.Commands.Baseline
             }
 
             foreach (var t in wanted)
-                Try(r, $"{group} '{t.Name}'", () =>
+            {
+                // NOT the shared Try() helper: minting a host type is two steps,
+                // and the first real run failed on the SECOND one. Duplicate had
+                // already committed, so the model kept five types named for the
+                // baseline that carried the SOURCE type's layers — a floor called
+                // "Ceramic Tiled" with no tile in it. Worse, the next audit reads
+                // those as existing and refuses to touch them, so the failure
+                // becomes permanent and silent.
+                //
+                // A half-made type is deleted. Either the type is what the
+                // baseline describes or it is not there at all.
+                HostObjAttributes created = null;
+                try
                 {
-                    var created = source.Duplicate(t.Name.Trim()) as HostObjAttributes;
+                    created = source.Duplicate(t.Name.Trim()) as HostObjAttributes;
                     if (created == null) throw new InvalidOperationException("Duplicate returned null");
-                    created.SetCompoundStructure(BuildStructure(t, materials));
-                });
+                    created.SetCompoundStructure(BuildStructure(t, materials, SafeStructure(source)));
+                    r.Created++;
+                }
+                catch (Exception ex)
+                {
+                    if (created != null)
+                    {
+                        try { doc.Delete(created.Id); }
+                        catch (Exception delEx)
+                        {
+                            StingLog.Warn($"BaselineMinter rollback '{t.Name}': {delEx.Message}");
+                            r.Failed.Add($"{group} '{t.Name}': {ex.Message} "
+                                       + "— AND the half-made type could not be removed, so delete it by hand");
+                            continue;
+                        }
+                    }
+                    r.Failed.Add($"{group} '{t.Name}': {ex.Message}");
+                    StingLog.Warn($"BaselineMinter {group} '{t.Name}': {ex.Message}");
+                }
+            }
         }
 
         private static CompoundStructure SafeStructure(HostObjAttributes t)
@@ -253,8 +283,27 @@ namespace StingTools.Commands.Baseline
             catch (Exception ex) { StingLog.Warn($"Suppressed: {ex.Message}"); return null; }
         }
 
+        /// <summary>
+        /// <paramref name="template"/> is the SOURCE type's own structure, and it
+        /// is what makes this work for floors and ceilings.
+        ///
+        /// CreateSimpleCompoundStructure returns a structure with a wall-shaped
+        /// EndCapCondition. Revit accepts that on a WallType and rejects it
+        /// everywhere else — "Input compound structure has wrong EndCap
+        /// condition for this element type" — which is why the first real run
+        /// created 12 materials, 4 walls and 3 roofs and failed on all 4 floor
+        /// types and the ceiling. The floors are the ones carrying the tiled
+        /// finish layer, so the one thing the baseline exists to fix was the one
+        /// thing that did not get created.
+        ///
+        /// Editing the source's structure in place inherits every class-specific
+        /// property already valid for that element type, rather than guessing
+        /// which ones Revit will object to. GetCompoundStructure returns a copy,
+        /// so the source type is untouched.
+        /// </summary>
         private static CompoundStructure BuildStructure(BaselineHostType t,
-                                                        Dictionary<string, ElementId> materials)
+                                                        Dictionary<string, ElementId> materials,
+                                                        CompoundStructure template = null)
         {
             var layers = new List<CompoundStructureLayer>();
             foreach (var l in t.Layers)
@@ -265,7 +314,16 @@ namespace StingTools.Commands.Baseline
                     matId ?? ElementId.InvalidElementId));
             }
 
-            var cs = CompoundStructure.CreateSimpleCompoundStructure(layers);
+            CompoundStructure cs;
+            if (template != null)
+            {
+                cs = template;
+                cs.SetLayers(layers);
+            }
+            else
+            {
+                cs = CompoundStructure.CreateSimpleCompoundStructure(layers);
+            }
 
             // Shell layers are everything OUTSIDE the structural core. Revit
             // rejects a structure whose core is empty or discontiguous, so the


### PR DESCRIPTION
First real run of `Baseline_Apply`. **19 created, 5 failed** — and the split fell exactly along element class:

```
Created 19 item(s); 5 could not be created:
  • Floor types 'STING RC Slab 150 - Ceramic Tiled': Input compound structure
    has wrong EndCap condition for this element type. Parameter name: srcStructure
  • … the other 3 floor types, and the ceiling
```

12 materials, 4 wall types and 3 roof types went in. **All 4 floor types and the ceiling were rejected.**

### Cause

`CompoundStructure.CreateSimpleCompoundStructure` returns a structure with a **wall-shaped `EndCapCondition`**. Revit accepts that on a `WallType` and rejects it on floors and ceilings. Hence the clean split by class.

The floor types are the ones carrying the **tiled finish layer** — so the single thing this baseline exists to fix was the one thing that did not get created.

The structure is now built by editing the **source type's own** compound structure, which inherits every class-specific property already valid for that element type instead of guessing which ones Revit will object to. `GetCompoundStructure` returns a copy, so the source is untouched.

### The second defect is worse than the first

Minting is two steps and it failed on the **second**, so `Duplicate` had already committed. The model kept five types *named for the baseline* while carrying the source type's layers — **a floor called "Ceramic Tiled" with no tile in it.**

The next audit reads those as existing and refuses to touch them, because a name match with a different build-up is a conflict, not something to overwrite. **The failure would have become permanent** — and the audit would have reported the model as closer to conforming than before Apply ran.

A half-made type is now deleted. Either the type is what the baseline describes, or it is not there at all. If even the rollback fails, the report says so and names the type to remove by hand.

### Action required for anyone who already ran Apply

Delete these five types before re-running:

- `STING RC Slab 150 - Ceramic Tiled`
- `STING RC Slab 200 - Porcelain Tiled`
- `STING RC Slab 150 - Screed Only`
- `STING Ground Slab 150 on Blinding`
- `STING Suspended Gypsum Ceiling`

Build **0/0**, tests **465 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)