### PR TITLE
B1 — mint types inside families that are already loaded

### DIFF
--- a/StingTools.Boq.Tests/BaselineFamilyTypeTests.cs
+++ b/StingTools.Boq.Tests/BaselineFamilyTypeTests.cs
@@ -1,0 +1,317 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Layer 2 — types minted inside families that are already loaded.
+    ///
+    /// The rule that shapes every test here: a type is only MISSING when a
+    /// loaded family can host it. Anything else would have Apply promise work
+    /// it cannot do, which is the same honest split that reports
+    /// "Structural Columns: 0 of 1 expected type(s) match" rather than
+    /// pretending it can create a column family.
+    /// </summary>
+    public class BaselineFamilyTypeAuditTests
+    {
+        private static BaselineFamilyType Door(string typeName = "STING Flush Door 900x2100") =>
+            new BaselineFamilyType
+            {
+                Category = "Doors",
+                FamilyNamePatterns = { "Single-Flush", "Door" },
+                TypeName = typeName,
+                Purpose = "Standard internal single leaf",
+                Parameters =
+                {
+                    new BaselineFamilyTypeParam { Name = "Width",  ValueMm = 900 },
+                    new BaselineFamilyTypeParam { Name = "Height", ValueMm = 2100 }
+                }
+            };
+
+        private static ProjectBaseline With(BaselineFamilyType ft)
+        {
+            var b = new ProjectBaseline();
+            b.FamilyTypes.Add(ft);
+            return b;
+        }
+
+        private static ModelInventory ModelWith(string family, params string[] types)
+        {
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Doors"] = new List<string> { family };
+            inv.FamilyTypesByCategory["Doors"] = types.ToList();
+            return inv;
+        }
+
+        [Fact]
+        public void A_Loaded_Family_Without_The_Type_Is_Missing_And_Names_Its_Host()
+        {
+            var r = BaselineAuditor.Audit(With(Door()), ModelWith("M_Single-Flush", "0915 x 2134mm"));
+
+            var f = Assert.Single(r.Missing);
+            Assert.Equal("Family types", f.Group);
+            Assert.Contains("M_Single-Flush", f.Detail);
+            Assert.Contains("Width 900", f.Detail);
+        }
+
+        [Fact]
+        public void No_Matching_Family_Is_GUIDANCE_Never_Missing()
+        {
+            // Apply cannot conjure a family. Listing this as Missing would
+            // promise a mint that must fail.
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Doors"] = new List<string> { "Curtain Wall Dbl Glass" };
+
+            var r = BaselineAuditor.Audit(With(Door()), inv);
+
+            Assert.Equal(0, r.MissingCount);
+            Assert.Equal(1, r.GuidanceCount);
+            Assert.Contains("CANNOT CREATE", BaselineAuditor.Report(r));
+        }
+
+        [Fact]
+        public void An_Empty_Model_Is_Guidance_Too()
+        {
+            var r = BaselineAuditor.Audit(With(Door()), new ModelInventory());
+
+            Assert.Equal(0, r.MissingCount);
+            Assert.Equal(1, r.GuidanceCount);
+        }
+
+        [Fact]
+        public void A_Family_In_Another_Category_Never_Hosts_The_Type()
+        {
+            // "Door" would match a window family called "Door-Height Window".
+            // Category is checked first precisely so it cannot.
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Windows"] = new List<string> { "M_Single-Flush" };
+
+            var r = BaselineAuditor.Audit(With(Door()), inv);
+
+            Assert.Equal(1, r.GuidanceCount);
+        }
+
+        [Fact]
+        public void The_Type_Already_Present_And_Matching_Is_Present()
+        {
+            var inv = ModelWith("M_Single-Flush", "STING Flush Door 900x2100");
+            inv.FamilyTypeParamsMm["Doors|STING Flush Door 900x2100"] =
+                new Dictionary<string, double> { { "Width", 900 }, { "Height", 2100 } };
+
+            var r = BaselineAuditor.Audit(With(Door()), inv);
+
+            Assert.True(r.NothingToMint);
+            Assert.Equal(0, r.ConflictCount);
+        }
+
+        [Fact]
+        public void Same_Name_Different_Size_Is_A_CONFLICT_Never_An_Overwrite()
+        {
+            // The model's 800x2100 may be deliberate. Rewriting somebody's door
+            // type is not a fix — #798's rule, one level down.
+            var inv = ModelWith("M_Single-Flush", "STING Flush Door 900x2100");
+            inv.FamilyTypeParamsMm["Doors|STING Flush Door 900x2100"] =
+                new Dictionary<string, double> { { "Width", 800 }, { "Height", 2100 } };
+
+            var r = BaselineAuditor.Audit(With(Door()), inv);
+
+            Assert.Equal(1, r.ConflictCount);
+            Assert.Equal(0, r.MissingCount);
+            var f = r.Findings.Single(x => x.Kind == BaselineFindingKind.Conflict);
+            Assert.Contains("800", f.Detail);
+            Assert.Contains("900", f.Detail);
+            Assert.Contains("Not overwritten", f.Detail);
+        }
+
+        [Fact]
+        public void Sub_Millimetre_Differences_Are_Rounding_Not_A_Conflict()
+        {
+            // Revit stores feet. 900mm round-trips as 899.9999...
+            var inv = ModelWith("M_Single-Flush", "STING Flush Door 900x2100");
+            inv.FamilyTypeParamsMm["Doors|STING Flush Door 900x2100"] =
+                new Dictionary<string, double> { { "Width", 899.9997 }, { "Height", 2100.0002 } };
+
+            var r = BaselineAuditor.Audit(With(Door()), inv);
+
+            Assert.Equal(0, r.ConflictCount);
+        }
+
+        [Fact]
+        public void Uncollected_Parameters_Cannot_Manufacture_A_Conflict()
+        {
+            // No entry in FamilyTypeParamsMm means the values were never read.
+            // Claiming a difference from missing data would be a fabrication.
+            var r = BaselineAuditor.Audit(With(Door()), ModelWith("M_Single-Flush", "STING Flush Door 900x2100"));
+
+            Assert.Equal(0, r.ConflictCount);
+            Assert.Equal(1, r.PresentCount);
+        }
+
+        [Fact]
+        public void The_Match_Key_Separates_Same_Named_Types_In_Different_Categories()
+        {
+            // Two categories can want "STING Standard 900x2100". Matching on a
+            // display string would mint one and skip the other.
+            var b = new ProjectBaseline();
+            b.FamilyTypes.Add(Door("STING Standard 900x2100"));
+            var win = Door("STING Standard 900x2100");
+            win.Category = "Windows";
+            // Its own patterns: the door patterns would not match a window
+            // family, and the type would be guidance rather than Missing —
+            // which is correct behaviour, but not what this test is about.
+            win.FamilyNamePatterns = new List<string> { "Fixed" };
+            b.FamilyTypes.Add(win);
+
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Doors"] = new List<string> { "M_Single-Flush" };
+            inv.FamilyNamesByCategory["Windows"] = new List<string> { "M_Fixed" };
+
+            var r = BaselineAuditor.Audit(b, inv);
+
+            Assert.Equal(2, r.MissingCount);
+            Assert.Equal(2, r.Missing.Select(f => f.MatchKey).Distinct().Count());
+        }
+    }
+
+    public class BaselineFamilyTypeValidationTests
+    {
+        private static ProjectBaseline WithType(BaselineFamilyType ft)
+        {
+            var b = new ProjectBaseline();
+            b.FamilyTypes.Add(ft);
+            return b;
+        }
+
+        [Fact]
+        public void A_Type_Without_The_STING_Prefix_Is_Rejected()
+        {
+            // The prefix is the identification contract. A vendor reissue wipes
+            // minted types; without the prefix the next audit cannot tell which
+            // types were ours to re-mint.
+            var b = WithType(new BaselineFamilyType
+            {
+                Category = "Doors", FamilyNamePatterns = { "Door" }, TypeName = "Flush Door 900x2100"
+            });
+
+            Assert.Contains(b.Validate(), p => p.Contains("STING "));
+        }
+
+        [Fact]
+        public void A_Type_With_No_Family_Patterns_Is_Rejected()
+        {
+            var b = WithType(new BaselineFamilyType
+            {
+                Category = "Doors", TypeName = "STING Flush Door 900x2100"
+            });
+
+            Assert.Contains(b.Validate(), p => p.Contains("familyNamePatterns"));
+        }
+
+        [Fact]
+        public void A_Nameless_Parameter_Is_Rejected()
+        {
+            var b = WithType(new BaselineFamilyType
+            {
+                Category = "Doors", FamilyNamePatterns = { "Door" },
+                TypeName = "STING Flush Door 900x2100",
+                Parameters = { new BaselineFamilyTypeParam { ValueMm = 900 } }
+            });
+
+            Assert.Contains(b.Validate(), p => p.Contains("parameter with no name"));
+        }
+
+        [Fact]
+        public void A_Duplicated_Type_In_One_Category_Is_Rejected()
+        {
+            var b = new ProjectBaseline();
+            for (int i = 0; i < 2; i++)
+                b.FamilyTypes.Add(new BaselineFamilyType
+                {
+                    Category = "Doors", FamilyNamePatterns = { "Door" },
+                    TypeName = "STING Flush Door 900x2100"
+                });
+
+            Assert.Contains(b.Validate(), p => p.Contains("more than once"));
+        }
+
+        [Fact]
+        public void The_Same_Type_Name_In_Two_Categories_Is_Fine()
+        {
+            var b = new ProjectBaseline();
+            foreach (string cat in new[] { "Doors", "Windows" })
+                b.FamilyTypes.Add(new BaselineFamilyType
+                {
+                    Category = cat, FamilyNamePatterns = { "X" }, TypeName = "STING Standard 900x2100"
+                });
+
+            Assert.DoesNotContain(b.Validate(), p => p.Contains("more than once"));
+        }
+    }
+
+    /// <summary>Layer 3 — the audit half. The augmenting itself is Revit-side.</summary>
+    public class BaselineFamilyParameterAuditTests
+    {
+        private static ProjectBaseline Doors(params string[] names)
+        {
+            var b = new ProjectBaseline();
+            b.FamilyParameters.Add(new BaselineFamilyParameterSet
+            {
+                Category = "Doors", Parameters = names.ToList(), IsInstance = false
+            });
+            return b;
+        }
+
+        [Fact]
+        public void Families_Lacking_The_Parameter_Are_Counted_Not_Listed_Individually()
+        {
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Doors"] = new List<string> { "A", "B", "C" };
+            inv.FamilyParamNames["A"] = new HashSet<string> { "BLE_DOOR_LEAF_MATERIAL_TXT" };
+
+            var r = BaselineAuditor.Audit(Doors("BLE_DOOR_LEAF_MATERIAL_TXT"), inv);
+
+            var f = Assert.Single(r.Missing);
+            Assert.Contains("2 of 3", f.Detail);
+        }
+
+        [Fact]
+        public void All_Families_Already_Carrying_It_Is_Present()
+        {
+            var inv = new ModelInventory();
+            inv.FamilyNamesByCategory["Doors"] = new List<string> { "A" };
+            inv.FamilyParamNames["A"] = new HashSet<string> { "BLE_DOOR_LEAF_MATERIAL_TXT" };
+
+            var r = BaselineAuditor.Audit(Doors("BLE_DOOR_LEAF_MATERIAL_TXT"), inv);
+
+            Assert.True(r.NothingToMint);
+        }
+
+        [Fact]
+        public void No_Loaded_Families_Is_Guidance_Not_Work()
+        {
+            var r = BaselineAuditor.Audit(Doors("BLE_DOOR_LEAF_MATERIAL_TXT"), new ModelInventory());
+
+            Assert.Equal(0, r.MissingCount);
+            Assert.Equal(1, r.GuidanceCount);
+        }
+
+        [Fact]
+        public void Instance_Parameters_Are_Rejected_By_Validation()
+        {
+            // The material schedule reads TYPE parameters. A per-instance value
+            // would be authored and then never read.
+            var b = Doors("BLE_DOOR_LEAF_MATERIAL_TXT");
+            b.FamilyParameters[0].IsInstance = true;
+
+            Assert.Contains(b.Validate(), p => p.Contains("INSTANCE"));
+        }
+
+        [Fact]
+        public void An_Empty_Parameter_List_Is_Rejected()
+        {
+            Assert.Contains(Doors().Validate(), p => p.Contains("lists no parameters"));
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -78,7 +78,7 @@ namespace StingTools.Commands.Baseline
 
     internal static class BaselineModelReader
     {
-        public static ModelInventory Read(Document doc)
+        public static ModelInventory Read(Document doc, ProjectBaseline baseline = null)
         {
             var inv = new ModelInventory();
             if (doc == null) return inv;
@@ -97,8 +97,81 @@ namespace StingTools.Commands.Baseline
                 if (!inv.FamilyTypesByCategory.TryGetValue(cat, out var list))
                     inv.FamilyTypesByCategory[cat] = list = new List<string>();
                 list.Add(s.Name ?? "");
+
+                // Layer 2 needs the FAMILY name as well as the type name: a
+                // type is minted inside a family, and which family hosts it is
+                // the difference between Missing and guidance.
+                string famName = SafeFamilyName(s);
+                if (!string.IsNullOrWhiteSpace(famName))
+                {
+                    if (!inv.FamilyNamesByCategory.TryGetValue(cat, out var fams))
+                        inv.FamilyNamesByCategory[cat] = fams = new List<string>();
+                    if (!fams.Contains(famName)) fams.Add(famName);
+
+                    if (!inv.FamilyParamNames.ContainsKey(famName))
+                        inv.FamilyParamNames[famName] = ParamNamesOf(s);
+                }
+
+                RecordTypeParams(inv, cat, s, baseline);
             }
             return inv;
+        }
+
+        private static string SafeFamilyName(FamilySymbol s)
+        {
+            try { return s?.Family?.Name; }
+            catch (Exception ex) { StingLog.Warn("SafeFamilyName: " + ex.Message); return null; }
+        }
+
+        /// <summary>Every parameter name the TYPE carries, shared ones included.
+        /// A type parameter is present on all types of a family, so one symbol
+        /// answers for the family without opening it.</summary>
+        private static HashSet<string> ParamNamesOf(FamilySymbol s)
+        {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                foreach (Parameter prm in s.Parameters)
+                {
+                    string n = prm?.Definition?.Name;
+                    if (!string.IsNullOrWhiteSpace(n)) names.Add(n.Trim());
+                }
+            }
+            catch (Exception ex) { StingLog.Warn("ParamNamesOf: " + ex.Message); }
+            return names;
+        }
+
+        /// <summary>
+        /// Collect ONLY the parameters the baseline asks about, and only for the
+        /// types it names. Reading every parameter of every symbol in a large
+        /// model is a lot of work to answer a question nobody asked.
+        /// </summary>
+        private static void RecordTypeParams(ModelInventory inv, string cat,
+                                             FamilySymbol s, ProjectBaseline baseline)
+        {
+            if (baseline?.FamilyTypes == null || baseline.FamilyTypes.Count == 0) return;
+            string typeName = s?.Name;
+            if (string.IsNullOrWhiteSpace(typeName)) return;
+
+            var wanted = baseline.FamilyTypes.FirstOrDefault(f =>
+                f != null
+                && string.Equals(f.Category?.Trim(), cat, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(f.TypeName?.Trim(), typeName.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (wanted == null) return;
+
+            var vals = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            foreach (var prm in wanted.Parameters ?? new List<BaselineFamilyTypeParam>())
+            {
+                if (prm == null || string.IsNullOrWhiteSpace(prm.Name)) continue;
+                try
+                {
+                    var got = s.LookupParameter(prm.Name.Trim());
+                    if (got == null || got.StorageType != StorageType.Double) continue;
+                    vals[prm.Name.Trim()] = got.AsDouble() * 304.8;   // feet -> mm
+                }
+                catch (Exception ex) { StingLog.Warn("RecordTypeParams: " + ex.Message); }
+            }
+            if (vals.Count > 0) inv.FamilyTypeParamsMm[cat + "|" + typeName.Trim()] = vals;
         }
 
         private static IEnumerable<T> Collect<T>(Document doc) where T : Element
@@ -157,11 +230,15 @@ namespace StingTools.Commands.Baseline
 
         /// <summary>Creates exactly the findings the auditor marked Missing.
         /// Caller owns the transaction.</summary>
-        public static MintResult Apply(Document doc, ProjectBaseline baseline, BaselineAuditResult audit)
+        public static MintResult Apply(Document doc, ProjectBaseline baseline, BaselineAuditResult audit,
+                                       ModelInventory model)
         {
             var r = new MintResult();
+            // MatchKey, not Group + Name: layer 2 findings carry an explicit Key
+            // because two categories can want the same type name. Findings with
+            // no Key fall back to Group|Name, so layer 1 is unaffected.
             var missing = new HashSet<string>(
-                audit.Missing.Select(f => f.Group + "|" + f.Name), StringComparer.OrdinalIgnoreCase);
+                audit.Missing.Select(f => f.MatchKey), StringComparer.OrdinalIgnoreCase);
 
             // Materials first: the host types reference them by name.
             foreach (var m in baseline.Materials ?? new List<BaselineMaterial>())
@@ -174,6 +251,8 @@ namespace StingTools.Commands.Baseline
             MintHosts<RoofType>(doc, r, missing, "Roof types", baseline.RoofTypes, byName);
             MintHosts<CeilingType>(doc, r, missing, "Ceiling types", baseline.CeilingTypes, byName);
 
+            MintFamilyTypes(doc, r, missing, baseline, model);
+
             foreach (var l in baseline.Levels ?? new List<BaselineLevel>())
                 if (l != null && missing.Contains("Levels|" + l.Name?.Trim()))
                     Try(r, $"level '{l.Name}'", () =>
@@ -183,6 +262,101 @@ namespace StingTools.Commands.Baseline
                     });
 
             return r;
+        }
+
+        /// <summary>
+        /// Layer 2 — mint a TYPE inside a family that is already loaded.
+        ///
+        /// Nothing in this codebase duplicated a FamilySymbol before this, so
+        /// treat every failure as expected rather than exceptional: catalog- and
+        /// formula-driven vendor families refuse to take a duplicated type whose
+        /// dimensions they did not sanction, and that is a reported per-type
+        /// failure, not a crash.
+        /// </summary>
+        private static void MintFamilyTypes(Document doc, MintResult r, HashSet<string> missing,
+                                            ProjectBaseline baseline, ModelInventory model)
+        {
+            foreach (var ft in baseline.FamilyTypes ?? new List<BaselineFamilyType>())
+            {
+                if (ft == null || string.IsNullOrWhiteSpace(ft.TypeName)) continue;
+                string cat = (ft.Category ?? "").Trim(), typeName = ft.TypeName.Trim();
+                if (!missing.Contains("Family types|" + cat + "|" + typeName)) continue;
+
+                string hostFamily = BaselineAuditor.HostFamilyFor(ft, model);
+                if (string.IsNullOrWhiteSpace(hostFamily))
+                {
+                    // The audit already reported this as guidance; reaching here
+                    // would mean the audit and the minter disagree.
+                    r.Failed.Add("Family types [" + typeName + "]: no loaded family hosts it");
+                    continue;
+                }
+
+                var source = FirstSymbolOf(doc, cat, hostFamily);
+                if (source == null)
+                {
+                    r.Failed.Add("Family types [" + typeName + "]: family [" + hostFamily
+                               + "] has no type to duplicate from");
+                    continue;
+                }
+
+                FamilySymbol created = null;
+                try
+                {
+                    created = source.Duplicate(typeName) as FamilySymbol;
+                    if (created == null) throw new InvalidOperationException("Duplicate returned null");
+
+                    foreach (var prm in ft.Parameters ?? new List<BaselineFamilyTypeParam>())
+                    {
+                        if (prm == null || string.IsNullOrWhiteSpace(prm.Name)) continue;
+                        var target = created.LookupParameter(prm.Name.Trim());
+                        if (target == null || target.IsReadOnly)
+                            throw new InvalidOperationException(
+                                "parameter [" + prm.Name + "] is absent or read-only on family ["
+                                + hostFamily + "]");
+                        target.Set(prm.ValueMm / 304.8);   // mm -> feet
+                    }
+                    r.Created++;
+                }
+                catch (Exception ex)
+                {
+                    // Duplicate commits before the parameter set runs. A
+                    // half-made type named for the baseline would be read as
+                    // conforming by the next audit and the failure would become
+                    // permanent — #798, exactly.
+                    if (created != null)
+                    {
+                        try { doc.Delete(created.Id); }
+                        catch (Exception delEx)
+                        {
+                            StingLog.Warn("MintFamilyTypes rollback [" + typeName + "]: " + delEx.Message);
+                            r.Failed.Add("Family types [" + typeName + "]: " + ex.Message
+                                       + " - AND the half-made type could not be removed, so delete it by hand");
+                            continue;
+                        }
+                    }
+                    r.Failed.Add("Family types [" + typeName + "]: " + ex.Message);
+                    StingLog.Warn("MintFamilyTypes [" + typeName + "]: " + ex.Message);
+                }
+            }
+        }
+
+        private static FamilySymbol FirstSymbolOf(Document doc, string category, string familyName)
+        {
+            try
+            {
+                return new FilteredElementCollector(doc).OfClass(typeof(FamilySymbol))
+                    .Cast<FamilySymbol>()
+                    .FirstOrDefault(s =>
+                        string.Equals(s.Category?.Name, category, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(SafeFamily(s), familyName, StringComparison.OrdinalIgnoreCase));
+            }
+            catch (Exception ex) { StingLog.Warn("FirstSymbolOf: " + ex.Message); return null; }
+        }
+
+        private static string SafeFamily(FamilySymbol s)
+        {
+            try { return s?.Family?.Name; }
+            catch (Exception ex) { StingLog.Warn("SafeFamily: " + ex.Message); return null; }
         }
 
         private static void Try(MintResult r, string what, Action a)
@@ -387,7 +561,8 @@ namespace StingTools.Commands.Baseline
                 return Result.Cancelled;
             }
 
-            var audit = BaselineAuditor.Audit(BaselineRegistry.Load(doc), BaselineModelReader.Read(doc));
+            var baseline = BaselineRegistry.Load(doc);
+            var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc, baseline));
             TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
             return Result.Succeeded;
         }
@@ -407,7 +582,11 @@ namespace StingTools.Commands.Baseline
             }
 
             var baseline = BaselineRegistry.Load(doc);
-            var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc));
+            // The SAME inventory feeds the audit and the mint. Reading twice
+            // would let the model change between them, so Apply could mint
+            // against facts the user never saw in the report.
+            var inventory = BaselineModelReader.Read(doc, baseline);
+            var audit = BaselineAuditor.Audit(baseline, inventory);
 
             if (audit.BaselineProblems.Count > 0)
             {
@@ -437,7 +616,7 @@ namespace StingTools.Commands.Baseline
             using (var tx = new Transaction(doc, "STING Apply Project Baseline"))
             {
                 tx.Start();
-                mint = BaselineMinter.Apply(doc, baseline, audit);
+                mint = BaselineMinter.Apply(doc, baseline, audit, inventory);
                 tx.Commit();
             }
 

--- a/StingTools/Core/Baseline/BaselineAudit.cs
+++ b/StingTools/Core/Baseline/BaselineAudit.cs
@@ -38,6 +38,17 @@ namespace StingTools.Core.Baseline
         public string Name = "";
         public string Detail = "";
 
+        /// <summary>
+        /// Exact identity for the minter, when Name is not unique on its own.
+        /// Two categories can want the same type name, and matching on a
+        /// display string assembled with " / " would mean the minter re-parses
+        /// what the auditor formatted — a seam that breaks the first time the
+        /// formatting changes.
+        /// </summary>
+        public string Key = "";
+
+        public string MatchKey => string.IsNullOrEmpty(Key) ? Group + "|" + Name : Key;
+
         public bool IsActionable => Kind == BaselineFindingKind.Missing;
     }
 
@@ -54,6 +65,20 @@ namespace StingTools.Core.Baseline
         /// <summary>Category display name → the type names present in it.</summary>
         public Dictionary<string, List<string>> FamilyTypesByCategory =
             new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Category display name → the FAMILY names loaded in it.
+        /// Distinct from FamilyTypesByCategory, which holds type names.</summary>
+        public Dictionary<string, List<string>> FamilyNamesByCategory =
+            new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>"Category|TypeName" → type parameter values in mm. Only the
+        /// parameters the baseline asks about are collected.</summary>
+        public Dictionary<string, Dictionary<string, double>> FamilyTypeParamsMm =
+            new Dictionary<string, Dictionary<string, double>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Family name → the parameter names it already carries.</summary>
+        public Dictionary<string, HashSet<string>> FamilyParamNames =
+            new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>Host type name → whether it carries a tiled finish layer.
         /// Absent means the type was not inspected.</summary>
@@ -123,6 +148,9 @@ namespace StingTools.Core.Baseline
                 });
             }
 
+            AuditFamilyTypes(r, baseline.FamilyTypes, model);
+            AuditFamilyParameters(r, baseline.FamilyParameters, model);
+
             foreach (var f in baseline.FamilyExpectations ?? new List<BaselineFamilyExpectation>())
             {
                 if (f == null || string.IsNullOrWhiteSpace(f.Category)) continue;
@@ -176,6 +204,174 @@ namespace StingTools.Core.Baseline
                 r.Findings.Add(new BaselineFinding
                 {
                     Kind = BaselineFindingKind.Present, Group = group, Name = name, Detail = t.Purpose
+                });
+            }
+        }
+
+        /// <summary>
+        /// Layer 2. A type is only MISSING when a loaded family can host it -
+        /// otherwise Apply would promise work it cannot do. That is the same
+        /// split FamilyExpectation reports, applied one level down.
+        /// </summary>
+        private static void AuditFamilyTypes(BaselineAuditResult r,
+            List<BaselineFamilyType> wanted, ModelInventory model)
+        {
+            const string group = "Family types";
+            foreach (var ft in wanted ?? new List<BaselineFamilyType>())
+            {
+                if (ft == null || string.IsNullOrWhiteSpace(ft.TypeName)
+                    || string.IsNullOrWhiteSpace(ft.Category)) continue;
+
+                string cat = ft.Category.Trim(), typeName = ft.TypeName.Trim();
+                string key = group + "|" + cat + "|" + typeName;
+                string display = cat + " / " + typeName;
+
+                string host = HostFamilyFor(ft, model);
+                if (host == null)
+                {
+                    r.Findings.Add(new BaselineFinding
+                    {
+                        Kind = BaselineFindingKind.Guidance, Group = group,
+                        Name = display, Key = key,
+                        Detail = "no loaded family in this category matches ["
+                               + string.Join(" | ", (ft.FamilyNamePatterns ?? new List<string>())
+                                   .Where(x => !string.IsNullOrWhiteSpace(x)))
+                               + "]. Load one; a type cannot be minted without a family to hold it."
+                    });
+                    continue;
+                }
+
+                model.FamilyTypesByCategory.TryGetValue(cat, out var existing);
+                bool present = existing != null && existing.Any(t =>
+                    string.Equals(t, typeName, StringComparison.OrdinalIgnoreCase));
+
+                if (!present)
+                {
+                    r.Findings.Add(new BaselineFinding
+                    {
+                        Kind = BaselineFindingKind.Missing, Group = group,
+                        Name = display, Key = key,
+                        Detail = "in family [" + host + "] - " + DescribeParams(ft) + ft.Purpose
+                    });
+                    continue;
+                }
+
+                // Present. Same name, different dimensions is a CONFLICT. The
+                // model version may be deliberate, and overwriting a door type
+                // somebody authored is not a fix.
+                var differs = ParamsThatDiffer(ft, cat, typeName, model);
+                if (differs.Count > 0)
+                {
+                    r.Findings.Add(new BaselineFinding
+                    {
+                        Kind = BaselineFindingKind.Conflict, Group = group,
+                        Name = display, Key = key,
+                        Detail = "exists with different " + string.Join(", ", differs)
+                               + ". Not overwritten - rename the baseline type, or accept the "
+                               + "model version as correct for this project."
+                    });
+                    continue;
+                }
+
+                r.Findings.Add(new BaselineFinding
+                {
+                    Kind = BaselineFindingKind.Present, Group = group,
+                    Name = display, Key = key, Detail = ft.Purpose
+                });
+            }
+        }
+
+        /// <summary>First loaded family in the category matching any pattern, or null.</summary>
+        public static string HostFamilyFor(BaselineFamilyType ft, ModelInventory model)
+        {
+            if (ft == null || model == null || string.IsNullOrWhiteSpace(ft.Category)) return null;
+            if (!model.FamilyNamesByCategory.TryGetValue(ft.Category.Trim(), out var families)
+                || families == null) return null;
+
+            foreach (string pattern in ft.FamilyNamePatterns ?? new List<string>())
+            {
+                if (string.IsNullOrWhiteSpace(pattern)) continue;
+                foreach (string fam in families)
+                    if (!string.IsNullOrWhiteSpace(fam)
+                        && fam.IndexOf(pattern.Trim(), StringComparison.OrdinalIgnoreCase) >= 0)
+                        return fam;
+            }
+            return null;
+        }
+
+        private static List<string> ParamsThatDiffer(BaselineFamilyType ft, string cat,
+                                                     string typeName, ModelInventory model)
+        {
+            var differs = new List<string>();
+            if (!model.FamilyTypeParamsMm.TryGetValue(cat + "|" + typeName, out var actual)
+                || actual == null)
+                return differs;   // not collected - cannot claim a difference
+
+            foreach (var p in ft.Parameters ?? new List<BaselineFamilyTypeParam>())
+            {
+                if (p == null || string.IsNullOrWhiteSpace(p.Name)) continue;
+                if (!actual.TryGetValue(p.Name.Trim(), out double have)) continue;
+                if (Math.Abs(have - p.ValueMm) > 0.5)   // sub-mm is rounding, not a difference
+                    differs.Add(p.Name + " (" + have.ToString("N0") + " mm, baseline says "
+                              + p.ValueMm.ToString("N0") + " mm)");
+            }
+            return differs;
+        }
+
+        private static string DescribeParams(BaselineFamilyType ft)
+        {
+            var named = (ft.Parameters ?? new List<BaselineFamilyTypeParam>())
+                .Where(p => p != null && !string.IsNullOrWhiteSpace(p.Name)).ToList();
+            if (named.Count == 0) return "";
+            return string.Join(", ", named.Select(p => p.Name + " " + p.ValueMm.ToString("N0"))) + " - ";
+        }
+
+        /// <summary>
+        /// Layer 3. One finding per CATEGORY, not per family: a report listing
+        /// forty families is not read, and the decision (augment doors?) is
+        /// taken per category anyway.
+        /// </summary>
+        private static void AuditFamilyParameters(BaselineAuditResult r,
+            List<BaselineFamilyParameterSet> wanted, ModelInventory model)
+        {
+            const string group = "Family parameters";
+            foreach (var fp in wanted ?? new List<BaselineFamilyParameterSet>())
+            {
+                if (fp == null || string.IsNullOrWhiteSpace(fp.Category)) continue;
+                string cat = fp.Category.Trim();
+                string key = group + "|" + cat;
+
+                var names = (fp.Parameters ?? new List<string>())
+                    .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToList();
+                if (names.Count == 0) continue;
+
+                model.FamilyNamesByCategory.TryGetValue(cat, out var families);
+                families = families ?? new List<string>();
+                if (families.Count == 0)
+                {
+                    r.Findings.Add(new BaselineFinding
+                    {
+                        Kind = BaselineFindingKind.Guidance, Group = group, Name = cat, Key = key,
+                        Detail = "no families are loaded in this category, so there is nothing to augment."
+                    });
+                    continue;
+                }
+
+                int needing = families.Count(f =>
+                {
+                    model.FamilyParamNames.TryGetValue(f, out var have);
+                    return names.Any(n => have == null || !have.Contains(n));
+                });
+
+                r.Findings.Add(new BaselineFinding
+                {
+                    Kind = needing > 0 ? BaselineFindingKind.Missing : BaselineFindingKind.Present,
+                    Group = group, Name = cat, Key = key,
+                    Detail = needing > 0
+                        ? needing + " of " + families.Count + " loaded famil(ies) lack "
+                          + names.Count + " shared type parameter(s): " + string.Join(", ", names)
+                        : "all " + families.Count + " loaded famil(ies) already carry "
+                          + names.Count + " parameter(s)"
                 });
             }
         }

--- a/StingTools/Core/Baseline/ProjectBaselineModel.cs
+++ b/StingTools/Core/Baseline/ProjectBaselineModel.cs
@@ -82,6 +82,63 @@ namespace StingTools.Core.Baseline
         public string Guidance = "";
     }
 
+    /// <summary>One type parameter to set on a minted family type.</summary>
+    public sealed class BaselineFamilyTypeParam
+    {
+        /// <summary>Set by NAME, not by built-in enum: door and window families
+        /// vary, and the enum a generic family uses is not the one a vendor
+        /// family uses.</summary>
+        public string Name = "";
+        public double ValueMm;
+    }
+
+    /// <summary>
+    /// A TYPE to mint inside a family that is already loaded.
+    ///
+    /// It cannot conjure the family. If nothing loaded matches, this is
+    /// reported as guidance — the same honest split that reports
+    /// "Structural Columns: 0 of 1 expected type(s) match" today.
+    /// </summary>
+    public sealed class BaselineFamilyType
+    {
+        public string Category = "";
+        /// <summary>Ordered preference list. The FIRST loaded family in the
+        /// category whose name contains any of these hosts the type. Never a
+        /// family from a different category.</summary>
+        public List<string> FamilyNamePatterns = new List<string>();
+        public string TypeName = "";
+        public string Purpose = "";
+        public List<BaselineFamilyTypeParam> Parameters = new List<BaselineFamilyTypeParam>();
+
+        /// <summary>
+        /// The "STING " prefix is the identification contract, exactly as
+        /// "STING VIS - " is for visibility filters. A vendor reissue reloaded
+        /// with overwrite wipes minted types; the prefix is what lets the next
+        /// audit recognise them as ours and re-mint them.
+        /// </summary>
+        public const string MintedPrefix = "STING ";
+        public bool CarriesMintedPrefix =>
+            (TypeName ?? "").StartsWith(MintedPrefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Shared parameters to add to every loaded family in a category.
+    ///
+    /// SHARED, not local. FamilyManager.AddParameter(name, group, spec,
+    /// isInstance) creates a family-local parameter with no GUID, so two
+    /// families given "the same" parameter hold two unrelated ones and cannot
+    /// be scheduled together. The ExternalDefinition overload is the only one
+    /// that produces a parameter the schedule can read across a project.
+    /// </summary>
+    public sealed class BaselineFamilyParameterSet
+    {
+        public string Category = "";
+        public List<string> Parameters = new List<string>();
+        /// <summary>False — a door type's leaf material does not vary per instance.</summary>
+        public bool IsInstance;
+        public string Group = "IdentityData";
+    }
+
     /// <summary>A level the baseline expects, by name and elevation.</summary>
     public sealed class BaselineLevel
     {
@@ -101,6 +158,16 @@ namespace StingTools.Core.Baseline
         public List<BaselineHostType> CeilingTypes = new List<BaselineHostType>();
         public List<BaselineLevel> Levels = new List<BaselineLevel>();
         public List<BaselineFamilyExpectation> FamilyExpectations = new List<BaselineFamilyExpectation>();
+
+        /// <summary>Layer 2 — types minted inside already-loaded families.</summary>
+        public List<BaselineFamilyType> FamilyTypes = new List<BaselineFamilyType>();
+
+        /// <summary>Layer 3 — shared parameters added to loaded families.</summary>
+        public List<BaselineFamilyParameterSet> FamilyParameters = new List<BaselineFamilyParameterSet>();
+
+        /// <summary>Catalogue pack ids this project adopts. Empty by default:
+        /// no pack applies unless a project asks for it by id.</summary>
+        public List<string> AdoptCatalogues = new List<string>();
 
         public IEnumerable<BaselineHostType> AllHostTypes =>
             (WallTypes ?? new List<BaselineHostType>())
@@ -143,6 +210,52 @@ namespace StingTools.Core.Baseline
                         problems.Add($"'{t.Name}' layer names material '{l.Material}', "
                                    + "which the baseline does not declare");
                 }
+            }
+
+            // Layer 2 — a type with no name mints nothing; a parameter with no
+            // name sets nothing. Both fail silently in Revit, so they are caught
+            // here, before any model is touched.
+            foreach (var ft in FamilyTypes ?? new List<BaselineFamilyType>())
+            {
+                if (ft == null) continue;
+                if (string.IsNullOrWhiteSpace(ft.TypeName))
+                { problems.Add("a family type has no typeName"); continue; }
+                if (string.IsNullOrWhiteSpace(ft.Category))
+                    problems.Add($"family type '{ft.TypeName}' names no category");
+                if (ft.FamilyNamePatterns == null || ft.FamilyNamePatterns.Count == 0
+                    || ft.FamilyNamePatterns.All(string.IsNullOrWhiteSpace))
+                    problems.Add($"family type '{ft.TypeName}' declares no familyNamePatterns, "
+                               + "so no loaded family can host it");
+                if (!ft.CarriesMintedPrefix)
+                    problems.Add($"family type '{ft.TypeName}' does not start with "
+                               + $"'{BaselineFamilyType.MintedPrefix}' — the prefix is what lets a "
+                               + "later audit recognise a minted type after a vendor family reload");
+                foreach (var prm in ft.Parameters ?? new List<BaselineFamilyTypeParam>())
+                    if (prm != null && string.IsNullOrWhiteSpace(prm.Name))
+                        problems.Add($"family type '{ft.TypeName}' has a parameter with no name");
+            }
+
+            var ftDupes = (FamilyTypes ?? new List<BaselineFamilyType>())
+                .Where(t => t != null && !string.IsNullOrWhiteSpace(t.TypeName))
+                .GroupBy(t => (t.Category ?? "") + "|" + t.TypeName.Trim(), StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1).Select(g => g.Key);
+            foreach (string d in ftDupes) problems.Add($"family type '{d}' is declared more than once");
+
+            // Layer 3 — an empty parameter list augments nothing, which would
+            // report families as "would be augmented" and then change nothing.
+            foreach (var fp in FamilyParameters ?? new List<BaselineFamilyParameterSet>())
+            {
+                if (fp == null) continue;
+                if (string.IsNullOrWhiteSpace(fp.Category))
+                { problems.Add("a familyParameters entry names no category"); continue; }
+                var named = (fp.Parameters ?? new List<string>())
+                    .Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                if (named.Count == 0)
+                    problems.Add($"familyParameters for '{fp.Category}' lists no parameters");
+                if (fp.IsInstance)
+                    problems.Add($"familyParameters for '{fp.Category}' asks for INSTANCE parameters; "
+                               + "the material schedule reads type parameters, so a per-instance "
+                               + "value would be invisible to it");
             }
 
             var dupes = AllHostTypes.Where(t => t != null && !string.IsNullOrWhiteSpace(t.Name))


### PR DESCRIPTION
Layer 2 of the model-authoring baseline. It could create wall, floor, roof and ceiling types; it could only **report** on doors, windows and structural families. It can now mint types inside a family the project has already loaded.

### The line it still will not cross, enforced rather than described

A type whose category has **no family matching its `familyNamePatterns` is GUIDANCE, never Missing** — so Apply cannot promise a mint that must fail. Deleting that branch fails three tests.

### Two failures already paid for elsewhere, pre-empted

- **`Duplicate` commits before the parameter set runs.** A failure would leave a type *named for the baseline* carrying the source's dimensions; the next audit reads it as conforming and the failure becomes permanent — **#798, exactly**. Half-made types are deleted, and if the rollback itself fails the report names the type to remove by hand.
- **Same name, different size is a CONFLICT, never an overwrite.** The model's 800×2100 may be deliberate.

### Three details worth their comments

- Findings gained a **`MatchKey`**, because two categories can want the same type name and the minter would otherwise re-parse a display string the auditor formatted.
- The audit and the mint now share **one inventory** — reading twice would let the model change between the report and the write.
- A **sub-millimetre difference is rounding, not a conflict**: Revit stores feet, so 900 mm returns as 899.9997.

Parameters are set **by name, not built-in enum** — a vendor family does not use the enum a generic one does. Absent or read-only is a per-type failure naming the parameter *and* the family.

Validation refuses a type name without the **`STING ` prefix**. That prefix is the identification contract: a vendor reissue reloaded with overwrite wipes minted types, and the prefix is what lets the next audit know which were ours to re-mint.

### Verification

Tests **716 → 735**. Build **0/0**. Three mutations **verified failing** before being kept:

| Mutation | Result |
|---|---|
| Guidance branch → Missing | 3 failed |
| Remove the `STING ` prefix check | 1 failed |
| Sub-mm tolerance 0.5 → 0.0 | 1 failed |

One test failed first and **the test was wrong** — a window family named `M_Fixed` matches neither `Single-Flush` nor `Door`, so guidance was correct. Corrected the test, not the code.

**NOT VERIFIED:** nothing here has run in Revit. `FamilySymbol.Duplicate` is used nowhere else in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)