### PR TITLE
Baseline layer 2: mint types inside families that already exist

### DIFF
--- a/StingTools.Boq.Tests/BaselineFamilyTypeTests.cs
+++ b/StingTools.Boq.Tests/BaselineFamilyTypeTests.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// BASELINE LAYER 2 — family types.
+    ///
+    /// Layer 1 creates host types outright. Layer 2 mints a TYPE inside a
+    /// family that is already loaded, and cannot conjure the family: with none
+    /// loaded the entry is guidance, exactly as the family expectations report
+    /// today. A baseline that claimed to create a door family would be
+    /// inventing its own deliverable.
+    ///
+    /// The audit half is Revit-free and is what these pin. The MINT is
+    /// Revit-bound and has never run — nothing in this codebase duplicates a
+    /// FamilySymbol.
+    /// </summary>
+    public class BaselineFamilyTypeAuditTests
+    {
+        private static BaselineFamilyType Door(string typeName = "STING Flush Door 900x2100") =>
+            new BaselineFamilyType
+            {
+                Category = "Doors",
+                FamilyNamePatterns = new List<string> { "M_Single-Flush", "Single-Flush", "Door" },
+                TypeName = typeName,
+                Purpose = "Standard internal single leaf",
+                Parameters = new List<BaselineTypeParameter>
+                {
+                    new BaselineTypeParameter { Name = "Width", ValueMm = 900 },
+                    new BaselineTypeParameter { Name = "Height", ValueMm = 2100 },
+                }
+            };
+
+        private static ProjectBaseline With(params BaselineFamilyType[] types) =>
+            new ProjectBaseline { FamilyTypes = types.ToList() };
+
+        private static ModelInventory Model(string family = "M_Single-Flush",
+                                            string existingType = null,
+                                            Dictionary<string, double> existingParams = null)
+        {
+            var m = new ModelInventory();
+            if (family != null)
+                m.FamiliesByCategory["Doors"] = new List<string> { family };
+            if (existingType != null)
+            {
+                m.FamilyTypesByCategory["Doors"] = new List<string> { existingType };
+                if (existingParams != null)
+                    m.FamilyTypeParametersMm[ModelInventory.TypeKey("Doors", existingType)] = existingParams;
+            }
+            return m;
+        }
+
+        [Fact]
+        public void A_Missing_Type_With_A_Loaded_Family_Is_Creatable()
+        {
+            var r = BaselineAuditor.Audit(With(Door()), Model());
+
+            var f = r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup);
+            Assert.Equal(BaselineFindingKind.Missing, f.Kind);
+            Assert.Equal("M_Single-Flush", f.HostFamily);
+        }
+
+        [Fact]
+        public void The_Report_Names_The_Family_The_Type_Will_Be_Minted_Inside()
+        {
+            // A user confirming an Apply is agreeing to a change inside somebody
+            // else's family. Naming it is the difference between consent and a
+            // surprise.
+            string report = BaselineAuditor.Report(BaselineAuditor.Audit(With(Door()), Model()));
+
+            Assert.Contains("STING Flush Door 900x2100", report);
+            Assert.Contains("M_Single-Flush", report);
+        }
+
+        [Fact]
+        public void With_No_Loaded_Family_It_Is_Guidance_Never_Missing()
+        {
+            // Layer 2 mints a type; it cannot conjure the family. Listing this
+            // as Missing would promise work Apply cannot do.
+            var r = BaselineAuditor.Audit(With(Door()), Model(family: null));
+
+            var f = r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup);
+            Assert.Equal(BaselineFindingKind.Guidance, f.Kind);
+            Assert.Equal(0, r.MissingCount);
+        }
+
+        [Fact]
+        public void A_Family_In_Another_Category_Is_Never_Substituted()
+        {
+            // A window family is not a door family, however well its name matches.
+            var m = new ModelInventory();
+            m.FamiliesByCategory["Windows"] = new List<string> { "M_Single-Flush" };
+
+            var f = BaselineAuditor.Audit(With(Door()), m).Findings
+                .Single(x => x.Group == BaselineAuditor.FamilyTypeGroup);
+
+            Assert.Equal(BaselineFindingKind.Guidance, f.Kind);
+        }
+
+        [Fact]
+        public void The_Pattern_List_Is_An_ORDERED_Preference()
+        {
+            // "the FIRST loaded family in that category whose name contains any
+            // pattern" — in the order the patterns are declared. A model holding
+            // both must get the preferred one, not whichever the collector
+            // happened to return first.
+            var m = new ModelInventory();
+            m.FamiliesByCategory["Doors"] = new List<string> { "Generic Door", "M_Single-Flush" };
+
+            Assert.Equal("M_Single-Flush", BaselineAuditor.ChooseHostFamily(Door(), m));
+        }
+
+        [Fact]
+        public void A_Later_Pattern_Wins_When_The_Earlier_One_Is_Absent()
+        {
+            var m = new ModelInventory();
+            m.FamiliesByCategory["Doors"] = new List<string> { "Vendor Panel Door 2024" };
+
+            Assert.Equal("Vendor Panel Door 2024", BaselineAuditor.ChooseHostFamily(Door(), m));
+        }
+
+        [Fact]
+        public void An_Existing_Type_At_The_Same_Size_Is_Present()
+        {
+            var r = BaselineAuditor.Audit(With(Door()),
+                Model(existingType: "STING Flush Door 900x2100",
+                      existingParams: new Dictionary<string, double> { { "Width", 900 }, { "Height", 2100 } }));
+
+            Assert.Equal(BaselineFindingKind.Present,
+                r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup).Kind);
+        }
+
+        [Fact]
+        public void An_Existing_Type_At_A_DIFFERENT_Size_Is_A_Conflict_Not_An_Overwrite()
+        {
+            // The model's 800x2100 may be the deliberate one. #798 is the
+            // standing reminder that a wrongly-"conforming" type is the most
+            // expensive kind of wrong.
+            var r = BaselineAuditor.Audit(With(Door()),
+                Model(existingType: "STING Flush Door 900x2100",
+                      existingParams: new Dictionary<string, double> { { "Width", 800 }, { "Height", 2100 } }));
+
+            var f = r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup);
+            Assert.Equal(BaselineFindingKind.Conflict, f.Kind);
+            Assert.Contains("800", f.Detail);
+            Assert.Equal(0, r.MissingCount);
+        }
+
+        [Fact]
+        public void A_Conflicting_Type_Is_Never_Offered_As_Something_To_Create()
+        {
+            var r = BaselineAuditor.Audit(With(Door()),
+                Model(existingType: "STING Flush Door 900x2100",
+                      existingParams: new Dictionary<string, double> { { "Width", 800 } }));
+
+            Assert.DoesNotContain(r.Missing, f => f.Group == BaselineAuditor.FamilyTypeGroup);
+        }
+
+        [Fact]
+        public void A_Feet_To_Millimetre_Round_Trip_Is_Not_A_Conflict()
+        {
+            // Revit stores lengths in feet, so 900 mm comes back as
+            // 899.9999999. Comparing exactly would report a conflict on every
+            // single type, and a report that cries wolf gets switched off.
+            var r = BaselineAuditor.Audit(With(Door()),
+                Model(existingType: "STING Flush Door 900x2100",
+                      existingParams: new Dictionary<string, double>
+                      { { "Width", 899.99999997 }, { "Height", 2100.0000001 } }));
+
+            Assert.Equal(BaselineFindingKind.Present,
+                r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup).Kind);
+        }
+
+        [Fact]
+        public void An_Unreadable_Parameter_Is_Not_Reported_As_A_Difference()
+        {
+            // The Revit reader records nothing for a parameter it cannot read.
+            // Treating that absence as 0 mm would report a fabricated conflict
+            // at "0mm" on a type that is very likely correct.
+            var r = BaselineAuditor.Audit(With(Door()),
+                Model(existingType: "STING Flush Door 900x2100",
+                      existingParams: new Dictionary<string, double> { { "Width", 900 } }));
+
+            Assert.Equal(BaselineFindingKind.Present,
+                r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup).Kind);
+        }
+
+        [Fact]
+        public void A_Type_With_No_Read_Back_Values_At_All_Is_Present_Not_A_Conflict()
+        {
+            var r = BaselineAuditor.Audit(With(Door()), Model(existingType: "STING Flush Door 900x2100"));
+
+            Assert.Equal(BaselineFindingKind.Present,
+                r.Findings.Single(x => x.Group == BaselineAuditor.FamilyTypeGroup).Kind);
+        }
+
+        [Fact]
+        public void Layer_2_Findings_Carry_Their_Own_Group_So_The_Minter_Can_Find_Them()
+        {
+            // The minter looks up Missing findings by Group|Name. A group string
+            // spelled two ways is a silent no-op, not an error.
+            var f = BaselineAuditor.Audit(With(Door()), Model()).Missing.Single();
+
+            Assert.Equal("Family types", f.Group);
+            Assert.Equal("Doors / STING Flush Door 900x2100", f.Name);
+        }
+    }
+
+    /// <summary>
+    /// BASELINE LAYER 2 — validation. Every one of these would otherwise
+    /// surface as a per-type mint failure on somebody's live model, which is a
+    /// far more expensive place to learn that a name was blank.
+    /// </summary>
+    public class BaselineFamilyTypeValidationTests
+    {
+        private static BaselineFamilyType Ok() => new BaselineFamilyType
+        {
+            Category = "Doors",
+            FamilyNamePatterns = new List<string> { "Door" },
+            TypeName = "STING Flush Door 900x2100",
+            Parameters = new List<BaselineTypeParameter>
+            { new BaselineTypeParameter { Name = "Width", ValueMm = 900 } }
+        };
+
+        private static List<string> Problems(BaselineFamilyType t) =>
+            new ProjectBaseline { FamilyTypes = new List<BaselineFamilyType> { t } }.Validate();
+
+        [Fact]
+        public void A_Well_Formed_Family_Type_Validates()
+            => Assert.Empty(Problems(Ok()));
+
+        [Fact]
+        public void A_Type_Name_Without_The_STING_Prefix_Is_Caught()
+        {
+            // The prefix is the CONTRACT that makes a minted type identifiable
+            // after a vendor reloads their family. Without it, a type we added
+            // to somebody else's family cannot be told from one of theirs.
+            var t = Ok();
+            t.TypeName = "Flush Door 900x2100";
+
+            Assert.Contains(Problems(t), p => p.Contains("STING"));
+        }
+
+        [Theory]
+        [InlineData("sting Flush Door 900x2100")]
+        [InlineData("Sting Flush Door 900x2100")]
+        [InlineData("STINGFlush Door")]
+        public void The_Prefix_Is_Case_And_Space_Exact(string typeName)
+        {
+            // "STING " with that capitalisation and that trailing space is the
+            // contract. A tool looking for minted types after a vendor reload
+            // matches the literal prefix; accepting "sting " would let a type
+            // through that the tool then cannot find.
+            //
+            // Added because the break-it pass showed that relaxing the
+            // comparison to OrdinalIgnoreCase moved no test at all.
+            var t = Ok();
+            t.TypeName = typeName;
+
+            Assert.Contains(Problems(t), p => p.Contains("STING"));
+        }
+
+        [Fact]
+        public void A_Type_With_No_Category_Is_Caught()
+        {
+            var t = Ok(); t.Category = "";
+            Assert.Contains(Problems(t), p => p.IndexOf("category", StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        [Fact]
+        public void A_Type_With_No_Family_Patterns_Could_Never_Choose_A_Host()
+        {
+            var t = Ok(); t.FamilyNamePatterns = new List<string>();
+            Assert.Contains(Problems(t), p => p.Contains("familyNamePatterns"));
+        }
+
+        [Fact]
+        public void A_Patterns_List_Of_Blanks_Counts_As_None()
+        {
+            var t = Ok(); t.FamilyNamePatterns = new List<string> { "", "   " };
+            Assert.Contains(Problems(t), p => p.Contains("familyNamePatterns"));
+        }
+
+        [Fact]
+        public void A_Parameter_With_No_Name_Or_No_Value_Is_Caught()
+        {
+            var t = Ok();
+            t.Parameters = new List<BaselineTypeParameter>
+            {
+                new BaselineTypeParameter { Name = "", ValueMm = 900 },
+                new BaselineTypeParameter { Name = "Height", ValueMm = 0 },
+            };
+
+            var p = Problems(t);
+            Assert.Contains(p, x => x.Contains("no name"));
+            Assert.Contains(p, x => x.Contains("Height"));
+        }
+
+        [Fact]
+        public void The_Same_Type_Declared_Twice_In_One_Category_Is_Caught()
+        {
+            var b = new ProjectBaseline { FamilyTypes = new List<BaselineFamilyType> { Ok(), Ok() } };
+
+            Assert.Contains(b.Validate(), p => p.Contains("more than once"));
+        }
+
+        [Fact]
+        public void The_Same_Type_Name_In_TWO_Categories_Is_Legal()
+        {
+            // "STING 900x2100" may legitimately exist for both a door and a
+            // window. Rejecting that would be a false positive on a real model.
+            var a = Ok();
+            var w = Ok(); w.Category = "Windows";
+
+            Assert.Empty(new ProjectBaseline { FamilyTypes = new List<BaselineFamilyType> { a, w } }.Validate());
+        }
+
+        [Fact]
+        public void A_Broken_Layer_2_Entry_Stops_Apply_Before_Any_Model_Is_Touched()
+        {
+            // The audit reports baseline problems, and BaselineApplyCommand
+            // refuses to run while any exist. That refusal is the whole value of
+            // validating: a bad name found here costs nothing, found in a live
+            // model it costs a rollback.
+            var t = Ok(); t.TypeName = "no prefix";
+
+            var r = BaselineAuditor.Audit(
+                new ProjectBaseline { FamilyTypes = new List<BaselineFamilyType> { t } }, new ModelInventory());
+
+            Assert.NotEmpty(r.BaselineProblems);
+            Assert.Contains("THE BASELINE ITSELF HAS PROBLEMS", BaselineAuditor.Report(r));
+        }
+    }
+
+    /// <summary>
+    /// BASELINE LAYER 2 — the shipped corporate file. It ships with NO family
+    /// types on purpose; see the test that says so.
+    /// </summary>
+    public class ShippedBaselineFamilyTypeTests
+    {
+        private static ProjectBaseline Shipped() =>
+            JsonConvert.DeserializeObject<ProjectBaseline>(
+                File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Data", "STING_PROJECT_BASELINE.json")));
+
+        [Fact]
+        public void The_Shipped_Baseline_Still_Validates_With_The_New_Layer()
+            => Assert.Empty(Shipped().Validate());
+
+        [Fact]
+        public void Family_Types_Ship_EMPTY_Because_The_Catalogue_Is_Not_Adopted()
+        {
+            // Sizes and naming are a project decision that needs human sign-off
+            // (spec §8 D3). A corporate default here would push a type list into
+            // every model that runs Apply, which is exactly the "adopted by
+            // nobody" line the catalogue packs are held to.
+            Assert.Empty(Shipped().FamilyTypes ?? new List<BaselineFamilyType>());
+        }
+
+        [Fact]
+        public void The_Schema_Round_Trips_Through_The_Real_Serialiser()
+        {
+            // Newtonsoft leaves a mistyped field at its default rather than
+            // throwing, so valid JSON plus a green build can still be
+            // runtime-dead. This proves the new fields deserialise by the names
+            // the JSON will actually use.
+            var b = JsonConvert.DeserializeObject<ProjectBaseline>(@"{
+                ""familyTypes"": [{
+                    ""category"": ""Doors"",
+                    ""familyNamePatterns"": [""M_Single-Flush""],
+                    ""typeName"": ""STING Flush Door 900x2100"",
+                    ""purpose"": ""Standard internal single leaf"",
+                    ""parameters"": [{ ""name"": ""Width"", ""valueMm"": 900 }]
+                }]}");
+
+            var t = b.FamilyTypes.Single();
+            Assert.Equal("Doors", t.Category);
+            Assert.Equal("STING Flush Door 900x2100", t.TypeName);
+            Assert.Equal("M_Single-Flush", t.FamilyNamePatterns.Single());
+            Assert.Equal(900, t.Parameters.Single().ValueMm);
+            Assert.Equal("Width", t.Parameters.Single().Name);
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -49,6 +49,9 @@ namespace StingTools.Commands.Baseline
             Merge(b.CeilingTypes, over.CeilingTypes, t => t.Name);
             Merge(b.Levels, over.Levels, l => l.Name);
             Merge(b.FamilyExpectations, over.FamilyExpectations, f => f.Category);
+            // Keyed on category+name: "STING 900x2100" may legitimately
+            // exist for both a door and a window.
+            Merge(b.FamilyTypes, over.FamilyTypes, t => t.Category + "|" + t.TypeName);
             return b;
         }
 
@@ -78,7 +81,10 @@ namespace StingTools.Commands.Baseline
 
     internal static class BaselineModelReader
     {
-        public static ModelInventory Read(Document doc)
+        /// <summary><paramref name="baseline"/> is needed only to know WHICH
+        /// type parameters to read back — see ReadDeclaredTypeParameters. Null
+        /// is legal and simply skips that pass.</summary>
+        public static ModelInventory Read(Document doc, ProjectBaseline baseline = null)
         {
             var inv = new ModelInventory();
             if (doc == null) return inv;
@@ -98,7 +104,73 @@ namespace StingTools.Commands.Baseline
                     inv.FamilyTypesByCategory[cat] = list = new List<string>();
                 list.Add(s.Name ?? "");
             }
+
+            // LAYER 2 — the FAMILIES loaded in each category. A type can only be
+            // minted inside one that is already there, so this is what decides
+            // Missing from Guidance.
+            foreach (var f in Collect<Family>(doc))
+            {
+                string cat = f.FamilyCategory?.Name;
+                if (string.IsNullOrWhiteSpace(cat) || string.IsNullOrWhiteSpace(f.Name)) continue;
+                if (!inv.FamiliesByCategory.TryGetValue(cat, out var fams))
+                    inv.FamiliesByCategory[cat] = fams = new List<string>();
+                if (!fams.Contains(f.Name.Trim(), StringComparer.OrdinalIgnoreCase))
+                    fams.Add(f.Name.Trim());
+            }
+
+            ReadDeclaredTypeParameters(doc, inv, baseline);
             return inv;
+        }
+
+        /// <summary>
+        /// LAYER 2 — read back the parameters the baseline DECLARES, for the
+        /// types it names, so a name match with different sizes is a conflict
+        /// rather than a pass.
+        ///
+        /// Deliberately narrow: only the declared names, only on the declared
+        /// types. Walking every parameter of every type in the model would cost
+        /// far more and answer a question nobody asked.
+        /// </summary>
+        private static void ReadDeclaredTypeParameters(Document doc, ModelInventory inv,
+                                                       ProjectBaseline baseline)
+        {
+            var wanted = (baseline?.FamilyTypes ?? new List<BaselineFamilyType>())
+                .Where(t => t != null && !string.IsNullOrWhiteSpace(t.Category)
+                                      && !string.IsNullOrWhiteSpace(t.TypeName))
+                .ToList();
+            if (wanted.Count == 0) return;
+
+            foreach (var sym in Collect<FamilySymbol>(doc))
+            {
+                string cat = sym.Category?.Name;
+                if (string.IsNullOrWhiteSpace(cat) || string.IsNullOrWhiteSpace(sym.Name)) continue;
+
+                var spec = wanted.FirstOrDefault(t =>
+                    string.Equals(t.Category.Trim(), cat, StringComparison.OrdinalIgnoreCase)
+                 && string.Equals(t.TypeName.Trim(), sym.Name.Trim(), StringComparison.OrdinalIgnoreCase));
+                if (spec == null) continue;
+
+                var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                foreach (var pd in spec.Parameters ?? new List<BaselineTypeParameter>())
+                {
+                    if (pd == null || string.IsNullOrWhiteSpace(pd.Name)) continue;
+                    try
+                    {
+                        var p = sym.LookupParameter(pd.Name.Trim());
+                        // An UNREADABLE parameter is not a difference. Recording
+                        // 0 here would report every such type as a conflict at
+                        // "0mm", which is a fabricated finding.
+                        if (p == null || !p.HasValue || p.StorageType != StorageType.Double) continue;
+                        values[pd.Name.Trim()] = p.AsDouble() * 304.8;
+                    }
+                    catch (Exception ex)
+                    {
+                        StingLog.Warn($"BaselineModelReader param '{pd.Name}' on '{sym.Name}': {ex.Message}");
+                    }
+                }
+                if (values.Count > 0)
+                    inv.FamilyTypeParametersMm[ModelInventory.TypeKey(cat, sym.Name)] = values;
+            }
         }
 
         private static IEnumerable<T> Collect<T>(Document doc) where T : Element
@@ -174,6 +246,8 @@ namespace StingTools.Commands.Baseline
             MintHosts<RoofType>(doc, r, missing, "Roof types", baseline.RoofTypes, byName);
             MintHosts<CeilingType>(doc, r, missing, "Ceiling types", baseline.CeilingTypes, byName);
 
+            MintFamilyTypes(doc, r, baseline, audit);
+
             foreach (var l in baseline.Levels ?? new List<BaselineLevel>())
                 if (l != null && missing.Contains("Levels|" + l.Name?.Trim()))
                     Try(r, $"level '{l.Name}'", () =>
@@ -183,6 +257,112 @@ namespace StingTools.Commands.Baseline
                     });
 
             return r;
+        }
+
+        /// <summary>
+        /// LAYER 2 — mint a TYPE inside a family that is already loaded.
+        ///
+        /// UNPROVEN. Nothing in this codebase duplicates a FamilySymbol; only
+        /// TextNoteType and DimensionType (TemplateManagerCommands). Every type
+        /// is therefore attempted and reported individually, the way #798 forced
+        /// the host-type path to be.
+        ///
+        /// The rollback is the load-bearing part. Duplicate COMMITS before the
+        /// parameter set runs, so a failed set leaves a baseline-NAMED type
+        /// carrying the source type's sizes — which the next audit reads as
+        /// existing and refuses to touch, making the failure permanent and
+        /// invisible. Either the type is what the baseline describes or it is
+        /// not there at all.
+        ///
+        /// Catalog-driven families refuse to duplicate. That is expected, not
+        /// exceptional: it is reported per type and never crashes the run. An
+        /// EXISTING vendor type is never edited — the auditor only ever marks
+        /// absent types Missing.
+        /// </summary>
+        private static void MintFamilyTypes(Document doc, MintResult r,
+                                            ProjectBaseline baseline, BaselineAuditResult audit)
+        {
+            var wanted = audit.Missing
+                .Where(f => string.Equals(f.Group, BaselineAuditor.FamilyTypeGroup,
+                                          StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (wanted.Count == 0) return;
+
+            var specs = baseline.FamilyTypes ?? new List<BaselineFamilyType>();
+            var symbolsByFamily = new Dictionary<string, List<FamilySymbol>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var sym in new FilteredElementCollector(doc).OfClass(typeof(FamilySymbol))
+                                    .Cast<FamilySymbol>())
+            {
+                string fam = sym.Family?.Name;
+                if (string.IsNullOrWhiteSpace(fam)) continue;
+                if (!symbolsByFamily.TryGetValue(fam.Trim(), out var list))
+                    symbolsByFamily[fam.Trim()] = list = new List<FamilySymbol>();
+                list.Add(sym);
+            }
+
+            foreach (var finding in wanted)
+            {
+                // The spec is found by the finding's Name, which the auditor
+                // composed as "Category / TypeName". Re-matching on the pattern
+                // list here could pick a DIFFERENT family than the one the audit
+                // told the user about.
+                var spec = specs.FirstOrDefault(t => t != null
+                    && string.Equals($"{t.Category?.Trim()} / {t.TypeName?.Trim()}", finding.Name,
+                                     StringComparison.OrdinalIgnoreCase));
+                if (spec == null)
+                {
+                    r.Failed.Add($"family type '{finding.Name}': no matching baseline entry");
+                    continue;
+                }
+
+                if (!symbolsByFamily.TryGetValue((finding.HostFamily ?? "").Trim(), out var symbols)
+                 || symbols.Count == 0)
+                {
+                    r.Failed.Add($"family type '{finding.Name}': family "
+                               + $"'{finding.HostFamily}' has no loaded type to duplicate from");
+                    continue;
+                }
+
+                FamilySymbol created = null;
+                try
+                {
+                    created = symbols[0].Duplicate(spec.TypeName.Trim()) as FamilySymbol;
+                    if (created == null) throw new InvalidOperationException("Duplicate returned null");
+
+                    foreach (var pd in spec.Parameters ?? new List<BaselineTypeParameter>())
+                    {
+                        if (pd == null || string.IsNullOrWhiteSpace(pd.Name)) continue;
+                        var p = created.LookupParameter(pd.Name.Trim());
+                        // A parameter the family does not have is a FAILURE with
+                        // the parameter named, not a silent skip: a type minted
+                        // at the wrong size looks finished.
+                        if (p == null)
+                            throw new InvalidOperationException(
+                                $"family '{finding.HostFamily}' has no parameter '{pd.Name.Trim()}'");
+                        if (p.IsReadOnly)
+                            throw new InvalidOperationException(
+                                $"parameter '{pd.Name.Trim()}' is read-only in '{finding.HostFamily}'");
+                        p.Set(pd.ValueMm * MmToFt);
+                    }
+                    r.Created++;
+                }
+                catch (Exception ex)
+                {
+                    if (created != null)
+                    {
+                        try { doc.Delete(created.Id); }
+                        catch (Exception delEx)
+                        {
+                            StingLog.Warn($"BaselineMinter rollback '{finding.Name}': {delEx.Message}");
+                            r.Failed.Add($"family type '{finding.Name}': {ex.Message} "
+                                       + "— AND the half-made type could not be removed, so delete it by hand");
+                            continue;
+                        }
+                    }
+                    r.Failed.Add($"family type '{finding.Name}': {ex.Message}");
+                    StingLog.Warn($"BaselineMinter family type '{finding.Name}': {ex.Message}");
+                }
+            }
         }
 
         private static void Try(MintResult r, string what, Action a)
@@ -387,7 +567,8 @@ namespace StingTools.Commands.Baseline
                 return Result.Cancelled;
             }
 
-            var audit = BaselineAuditor.Audit(BaselineRegistry.Load(doc), BaselineModelReader.Read(doc));
+            var baselineForAudit = BaselineRegistry.Load(doc);
+            var audit = BaselineAuditor.Audit(baselineForAudit, BaselineModelReader.Read(doc, baselineForAudit));
             TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
             return Result.Succeeded;
         }
@@ -407,7 +588,7 @@ namespace StingTools.Commands.Baseline
             }
 
             var baseline = BaselineRegistry.Load(doc);
-            var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc));
+            var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc, baseline));
 
             if (audit.BaselineProblems.Count > 0)
             {

--- a/StingTools/Core/Baseline/BaselineAudit.cs
+++ b/StingTools/Core/Baseline/BaselineAudit.cs
@@ -38,6 +38,12 @@ namespace StingTools.Core.Baseline
         public string Name = "";
         public string Detail = "";
 
+        /// <summary>LAYER 2 — the loaded family a Missing family type will be
+        /// minted INSIDE. Empty for every other finding. Carried on the finding
+        /// so the minter does not re-run the pattern match and risk choosing a
+        /// different family than the one the audit told the user about.</summary>
+        public string HostFamily = "";
+
         public bool IsActionable => Kind == BaselineFindingKind.Missing;
     }
 
@@ -59,6 +65,26 @@ namespace StingTools.Core.Baseline
         /// Absent means the type was not inspected.</summary>
         public Dictionary<string, bool> HostTypeHasTiledFinish =
             new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>LAYER 2 — category display name → the FAMILY names loaded in
+        /// it. Distinct from FamilyTypesByCategory: a type can only be minted
+        /// inside a family that is already loaded, so the family list is what
+        /// decides Missing from Guidance.</summary>
+        public Dictionary<string, List<string>> FamiliesByCategory =
+            new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>LAYER 2 — "Category|TypeName" → that type's parameter values
+        /// in millimetres, for the names the baseline declares. Present only for
+        /// types whose name the baseline also declares; the reader does not walk
+        /// every parameter of every type in the model.
+        ///
+        /// This is what turns a name match into a CONFLICT rather than a pass:
+        /// the model's 800x2100 may be the deliberate one.</summary>
+        public Dictionary<string, Dictionary<string, double>> FamilyTypeParametersMm =
+            new Dictionary<string, Dictionary<string, double>>(StringComparer.OrdinalIgnoreCase);
+
+        public static string TypeKey(string category, string typeName)
+            => (category ?? "").Trim() + "|" + (typeName ?? "").Trim();
 
         private static HashSet<string> New() => new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     }
@@ -129,7 +155,129 @@ namespace StingTools.Core.Baseline
                 r.Findings.Add(AuditFamilyExpectation(f, model));
             }
 
+            foreach (var t in baseline.FamilyTypes ?? new List<BaselineFamilyType>())
+            {
+                if (t == null || string.IsNullOrWhiteSpace(t.TypeName)
+                              || string.IsNullOrWhiteSpace(t.Category)) continue;
+                r.Findings.Add(AuditFamilyType(t, model));
+            }
+
             return r;
+        }
+
+        /// <summary>LAYER 2 group label. One constant so the auditor, the
+        /// minter's Missing lookup and the report cannot drift apart — the
+        /// lookup is keyed on Group|Name.</summary>
+        public const string FamilyTypeGroup = "Family types";
+
+        /// <summary>
+        /// Millimetre tolerance for "the same size". Revit stores lengths in
+        /// feet, so a 900 mm parameter round-trips as 899.9999999; comparing
+        /// exactly would report a conflict on every single type.
+        /// </summary>
+        private const double MmTolerance = 0.5;
+
+        private static BaselineFinding AuditFamilyType(BaselineFamilyType t, ModelInventory model)
+        {
+            string cat = t.Category.Trim();
+            string typeName = t.TypeName.Trim();
+            string summary = t.ParameterSummary();
+
+            model.FamilyTypesByCategory.TryGetValue(cat, out var existingTypes);
+            bool exists = (existingTypes ?? new List<string>())
+                .Any(x => string.Equals((x ?? "").Trim(), typeName, StringComparison.OrdinalIgnoreCase));
+
+            if (exists)
+            {
+                // A name match with DIFFERENT parameters is a conflict, never an
+                // overwrite. The model's 800x2100 may be deliberate, and #798 is
+                // the standing reminder that a wrongly-"conforming" type is the
+                // most expensive kind of wrong.
+                var differences = Differences(t, model);
+                if (differences.Count > 0)
+                    return new BaselineFinding
+                    {
+                        Kind = BaselineFindingKind.Conflict,
+                        Group = FamilyTypeGroup,
+                        Name = $"{cat} / {typeName}",
+                        Detail = "exists at " + string.Join(", ", differences)
+                               + ". Not overwritten — the model's version may be the correct one."
+                    };
+
+                return new BaselineFinding
+                {
+                    Kind = BaselineFindingKind.Present, Group = FamilyTypeGroup,
+                    Name = $"{cat} / {typeName}", Detail = t.Purpose
+                };
+            }
+
+            // Not present. It can only be minted inside a family already loaded
+            // in that category — this layer mints a TYPE, it cannot conjure the
+            // family.
+            string host = ChooseHostFamily(t, model);
+            if (string.IsNullOrEmpty(host))
+                return new BaselineFinding
+                {
+                    Kind = BaselineFindingKind.Guidance,
+                    Group = FamilyTypeGroup,
+                    Name = $"{cat} / {typeName}",
+                    Detail = $"no loaded family in {cat} matches ["
+                           + string.Join(" | ", (t.FamilyNamePatterns ?? new List<string>())
+                                 .Where(x => !string.IsNullOrWhiteSpace(x)))
+                           + "]. Load one, then re-run."
+                };
+
+            return new BaselineFinding
+            {
+                Kind = BaselineFindingKind.Missing,
+                Group = FamilyTypeGroup,
+                Name = $"{cat} / {typeName}",
+                HostFamily = host,
+                Detail = (summary.Length > 0 ? summary + " — " : "")
+                       + $"in family \"{host}\"" + (string.IsNullOrWhiteSpace(t.Purpose)
+                            ? "" : " — " + t.Purpose)
+            };
+        }
+
+        /// <summary>
+        /// The FIRST loaded family in the category whose name contains any
+        /// pattern, in the order the patterns are declared — that ordering is
+        /// the whole point of the list. Never a family from another category.
+        /// </summary>
+        public static string ChooseHostFamily(BaselineFamilyType t, ModelInventory model)
+        {
+            if (t == null || model == null || string.IsNullOrWhiteSpace(t.Category)) return "";
+            if (!model.FamiliesByCategory.TryGetValue(t.Category.Trim(), out var families)) return "";
+            families = families ?? new List<string>();
+
+            foreach (string pattern in t.FamilyNamePatterns ?? new List<string>())
+            {
+                if (string.IsNullOrWhiteSpace(pattern)) continue;
+                string p = pattern.Trim();
+                foreach (string f in families)
+                    if (!string.IsNullOrWhiteSpace(f)
+                     && f.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0) return f.Trim();
+            }
+            return "";
+        }
+
+        /// <summary>Declared parameters whose model value differs, described as
+        /// the model has them — "Width 800mm" — so the report says what IS, not
+        /// what was wanted.</summary>
+        private static List<string> Differences(BaselineFamilyType t, ModelInventory model)
+        {
+            var outList = new List<string>();
+            if (!model.FamilyTypeParametersMm.TryGetValue(
+                    ModelInventory.TypeKey(t.Category, t.TypeName), out var actual)) return outList;
+
+            foreach (var p in t.Parameters ?? new List<BaselineTypeParameter>())
+            {
+                if (p == null || string.IsNullOrWhiteSpace(p.Name)) continue;
+                if (!actual.TryGetValue(p.Name.Trim(), out double have)) continue;   // unreadable: not a conflict
+                if (Math.Abs(have - p.ValueMm) > MmTolerance)
+                    outList.Add($"{p.Name.Trim()} {have:0.###}mm");
+            }
+            return outList;
         }
 
         private static void AuditHostTypes(BaselineAuditResult r, string group,

--- a/StingTools/Core/Baseline/ProjectBaselineModel.cs
+++ b/StingTools/Core/Baseline/ProjectBaselineModel.cs
@@ -90,6 +90,72 @@ namespace StingTools.Core.Baseline
         public string Purpose = "";
     }
 
+    /// <summary>
+    /// One type parameter a minted family type must carry, in millimetres.
+    ///
+    /// Set by NAME, never by built-in enum: door and window families vary, and
+    /// a family that names its opening "Rough Width" is not wrong. A parameter
+    /// the family does not have is a per-type FAILURE with the parameter named,
+    /// not a silent skip — a type minted at the wrong size is worse than one
+    /// that was never minted, because it looks finished.
+    /// </summary>
+    public sealed class BaselineTypeParameter
+    {
+        public string Name = "";
+        public double ValueMm;
+    }
+
+    /// <summary>
+    /// LAYER 2 — a TYPE inside a family that is already loaded.
+    ///
+    /// The honest split of layer 1 survives here unchanged: this can mint a
+    /// type, it cannot conjure the family. With no matching family loaded the
+    /// entry is guidance, exactly as `Structural Columns: 0 of 1 expected
+    /// type(s) match` reports today.
+    /// </summary>
+    public sealed class BaselineFamilyType
+    {
+        /// <summary>Revit category display name, e.g. "Doors".</summary>
+        public string Category = "";
+
+        /// <summary>
+        /// Ordered preference list. The host is the FIRST loaded family in that
+        /// category whose name contains any pattern. Absent that: guidance —
+        /// never a substitute family from another category.
+        /// </summary>
+        public List<string> FamilyNamePatterns = new List<string>();
+
+        /// <summary>
+        /// The minted type's name. Must carry the STING prefix: after a vendor
+        /// reloads their family, the prefix is the only thing that says which
+        /// types were ours. See <see cref="StingPrefix"/>.
+        /// </summary>
+        public string TypeName = "";
+        public string Purpose = "";
+
+        public List<BaselineTypeParameter> Parameters = new List<BaselineTypeParameter>();
+
+        /// <summary>
+        /// The contract that makes a minted type identifiable after a vendor
+        /// reload (spec §8 D4). Vendor families ARE in scope; a type minted in
+        /// one must be findable and removable without guessing.
+        /// </summary>
+        public const string StingPrefix = "STING ";
+
+        public bool HasStingPrefix =>
+            (TypeName ?? "").TrimStart().StartsWith(StingPrefix, StringComparison.Ordinal);
+
+        /// <summary>Compact "900x2100" style summary of the declared parameters,
+        /// for the audit line. Empty when the type declares none.</summary>
+        public string ParameterSummary()
+        {
+            var ps = (Parameters ?? new List<BaselineTypeParameter>())
+                .Where(p => p != null && !string.IsNullOrWhiteSpace(p.Name)).ToList();
+            if (ps.Count == 0) return "";
+            return string.Join(", ", ps.Select(p => $"{p.Name} {p.ValueMm:0.###}mm"));
+        }
+    }
+
     public sealed class ProjectBaseline
     {
         public string SchemaVersion = "1.0";
@@ -101,6 +167,9 @@ namespace StingTools.Core.Baseline
         public List<BaselineHostType> CeilingTypes = new List<BaselineHostType>();
         public List<BaselineLevel> Levels = new List<BaselineLevel>();
         public List<BaselineFamilyExpectation> FamilyExpectations = new List<BaselineFamilyExpectation>();
+
+        /// <summary>LAYER 2 — types minted inside families already loaded.</summary>
+        public List<BaselineFamilyType> FamilyTypes = new List<BaselineFamilyType>();
 
         public IEnumerable<BaselineHostType> AllHostTypes =>
             (WallTypes ?? new List<BaselineHostType>())
@@ -145,10 +214,68 @@ namespace StingTools.Core.Baseline
                 }
             }
 
+            problems.AddRange(ValidateFamilyTypes());
+
             var dupes = AllHostTypes.Where(t => t != null && !string.IsNullOrWhiteSpace(t.Name))
                 .GroupBy(t => t.Name.Trim(), StringComparer.OrdinalIgnoreCase)
                 .Where(g => g.Count() > 1).Select(g => g.Key);
             foreach (string d in dupes) problems.Add($"host type '{d}' is declared more than once");
+
+            return problems;
+        }
+
+        /// <summary>
+        /// LAYER 2 problems, found before any model is touched.
+        ///
+        /// Every one of these would otherwise surface as a per-type mint
+        /// failure on somebody's live model, which is a far more expensive
+        /// place to learn that a name was blank.
+        /// </summary>
+        private List<string> ValidateFamilyTypes()
+        {
+            var problems = new List<string>();
+            var ft = FamilyTypes ?? new List<BaselineFamilyType>();
+
+            foreach (var t in ft)
+            {
+                if (t == null) continue;
+                string label = string.IsNullOrWhiteSpace(t.TypeName) ? "(unnamed)" : t.TypeName.Trim();
+
+                if (string.IsNullOrWhiteSpace(t.TypeName))
+                    problems.Add("a family type has no typeName");
+                else if (!t.HasStingPrefix)
+                    problems.Add($"family type '{label}' does not start with '{BaselineFamilyType.StingPrefix}' "
+                               + "— the prefix is what identifies a minted type after a vendor reloads "
+                               + "their family, so without it the type cannot be found again");
+
+                if (string.IsNullOrWhiteSpace(t.Category))
+                    problems.Add($"family type '{label}' names no category");
+
+                if (t.FamilyNamePatterns == null
+                 || !t.FamilyNamePatterns.Any(p => !string.IsNullOrWhiteSpace(p)))
+                    problems.Add($"family type '{label}' declares no familyNamePatterns, so no host "
+                               + "family could ever be chosen for it");
+
+                foreach (var p in t.Parameters ?? new List<BaselineTypeParameter>())
+                {
+                    if (p == null) continue;
+                    if (string.IsNullOrWhiteSpace(p.Name))
+                        problems.Add($"family type '{label}' has a parameter with no name");
+                    else if (p.ValueMm <= 0)
+                        problems.Add($"family type '{label}' parameter '{p.Name}' has value "
+                                   + $"{p.ValueMm}mm");
+                }
+            }
+
+            // Duplicates are per CATEGORY: "STING 900x2100" may legitimately
+            // exist for both a door and a window.
+            var dupes = ft.Where(t => t != null
+                             && !string.IsNullOrWhiteSpace(t.TypeName)
+                             && !string.IsNullOrWhiteSpace(t.Category))
+                .GroupBy(t => t.Category.Trim() + "|" + t.TypeName.Trim(), StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1).Select(g => g.Key);
+            foreach (string d in dupes)
+                problems.Add($"family type '{d.Replace("|", " / ")}' is declared more than once");
 
             return problems;
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 252 — baseline layer 2: types inside families that already exist)
+
+Layer 1 (#789) creates host types outright. **Layer 2 mints a TYPE inside a family that is already
+loaded** — and it cannot conjure the family. With none loaded the entry is guidance, exactly as the
+family expectations report today. A baseline that claimed to create a door family would be inventing
+its own deliverable.
+
+Same `STING_PROJECT_BASELINE.json`, same project override, same read-only `Baseline_Audit`, same
+single confirm. **No new command**, per the spec's §9.
+
+**The rollback is the load-bearing part, and it is inherited from a defect already paid for.**
+`FamilySymbol.Duplicate` **commits before** the parameter set runs. A failed set would leave a
+baseline-NAMED type carrying the source type's sizes — which the next audit reads as existing and
+refuses to touch, making the failure permanent and invisible. That is #798 exactly, on five floor
+types. Either the type is what the baseline describes or it is not there at all.
+
+**The mint is UNPROVEN and is written as such.** Nothing in this codebase duplicates a
+`FamilySymbol` — only `TextNoteType` and `DimensionType`. Every type is attempted and reported
+individually. Catalog-driven families refuse to duplicate; that is expected, not exceptional, and is
+reported per type without crashing the run. **An existing vendor type is never edited** — the auditor
+only ever marks *absent* types Missing.
+
+**Vendor families are in scope (§8 D4), and the `"STING "` prefix is the contract that makes that
+safe.** After a vendor reloads their family, the prefix is the only thing that says which types were
+ours. `Validate()` rejects a type name without it — **case- and space-exact**, because a tool looking
+for minted types matches the literal string.
+
+**Four decisions worth naming.**
+
+* **A name match with different parameters is a CONFLICT, never an overwrite.** The model's 800×2100
+  may be the deliberate one. Reported as *"exists at Width 800mm"* — what IS, not what was wanted.
+* **A 0.5 mm tolerance on that comparison.** Revit stores lengths in feet, so 900 mm round-trips as
+  899.9999999; comparing exactly would report a conflict on every single type, and a report that
+  cries wolf gets switched off.
+* **An unreadable parameter is not a difference.** Treating an absent read-back as 0 mm would report
+  a fabricated conflict at "0mm" on a type that is very likely correct.
+* **A parameter the family does not have is a per-type FAILURE with the parameter named**, not a
+  silent skip. A type minted at the wrong size looks finished.
+
+**`familyTypes` ships EMPTY.** Sizes and naming need human sign-off (§8 D3); a corporate default
+would push a type list into every model that runs Apply.
+
+**What was VERIFIED.** Build 0 errors / 0 warnings. `StingTools.Boq.Tests` 716 → **744 green**. All
+four gates pass. **Twenty-five deliberately wrong inputs were each shown to make the matching gate
+FAIL, then restored** — including the delete-the-thing-it-protects check on every new gate.
+
+Two results needed a second pass, and both were findings rather than passes. Relaxing the prefix
+comparison to `OrdinalIgnoreCase` moved **no test at all**, so a `The_Prefix_Is_Case_And_Space_Exact`
+theory was added and re-verified. And the no-read-back test was guarding the OUTER early return, not
+the inner one; the correct mutation was written and it fires.
+
+**What was NOT verified.** *Nothing Revit-side has been run by anyone* — across T1–T5 and both
+baseline layers. `MintFamilyTypes`, the `FamiliesByCategory` reader and `ReadDeclaredTypeParameters`
+have **never executed against a real model**. The audit half is Revit-free and fully tested; the mint
+is the unproven half and says so in its own header.
+
 #### Completed (Phase 240 — branch and workspace triage: unreviewed work found, landed or laid to rest)
 
 Two pools of work were invisible: **40 remote branches that had never had a PR opened on


### PR DESCRIPTION
## What this adds

Layer 1 (#789) creates host types outright. **Layer 2 mints a TYPE inside a family that is already loaded** — and it cannot conjure the family. With none loaded the entry is guidance, exactly as the family expectations report today. A baseline that claimed to create a door family would be inventing its own deliverable.

Same `STING_PROJECT_BASELINE.json`, same project override, same read-only `Baseline_Audit`, same single confirm. **No new command**, per spec §9.

## The rollback is the load-bearing part

`FamilySymbol.Duplicate` **commits before** the parameter set runs. A failed set would leave a baseline-**named** type carrying the *source* type's sizes — which the next audit reads as existing and refuses to touch, making the failure permanent and invisible.

That is **#798 exactly**, on five floor types. So: either the type is what the baseline describes, or it is not there at all.

## The mint is UNPROVEN, and is written as such

Nothing in this codebase duplicates a `FamilySymbol` — only `TextNoteType` and `DimensionType`. Every type is attempted and **reported individually**. Catalog-driven families will refuse to duplicate; that is expected, not exceptional, and is reported per type without crashing the run. **An existing vendor type is never edited** — the auditor only ever marks *absent* types Missing.

## Vendor families are in scope, and the prefix is what makes that safe

Per §8 D4 / §10.4, layer 2 mints into vendor families too. After a vendor reloads their family with "overwrite existing", the STING types are gone — and the audit/apply cycle is idempotent, so the next audit reports them Missing and Apply re-mints them.

The `"STING "` name prefix is the contract that makes a minted type identifiable as ours afterwards. `Validate()` rejects a type name without it — **case- and space-exact**, because a tool looking for minted types matches the literal string.

## Four decisions worth naming

| Decision | Why |
|---|---|
| A name match with **different** parameters is a **CONFLICT**, never an overwrite | The model's 800×2100 may be the deliberate one. Reported as *"exists at Width 800mm"* — what **is**, not what was wanted |
| **0.5 mm tolerance** on that comparison | Revit stores lengths in feet, so 900 mm round-trips as 899.9999999. Comparing exactly would report a conflict on every single type, and a report that cries wolf gets switched off |
| An **unreadable** parameter is not a difference | Treating an absent read-back as 0 mm would report a fabricated conflict at "0mm" on a type that is very likely correct |
| A parameter the family **does not have** is a per-type FAILURE with the parameter named | Not a silent skip. A type minted at the wrong size looks finished |

`familyTypes` **ships empty**. Sizes and naming need human sign-off (§8 D3, settled in §10 as opt-in packs); a corporate default would push a type list into every model that runs Apply.

## Verified

- `dotnet build StingTools/StingTools.csproj -c Release` (`-t:Rebuild`) → **0 errors, 0 warnings**
- `dotnet test StingTools.Boq.Tests` → **744 green**, up from 716
- `tools/check_command_doc_acquisition.ps1` → **PASS**
- `tools/check_path_discipline.ps1` → **PASS**
- `tools/check_workflow_wiring.ps1` → **PASS** (Tier 4: 0)

**Twenty-five deliberately wrong inputs, each shown to make the matching gate FAIL, then restored** — including the delete-the-thing-it-protects check on every new gate: the STING-prefix contract dropped · a category-less entry allowed through · an entry with no family patterns · a blank pattern counted as real · parameter name/value checks dropped · duplicates keyed on name only · the duplicate check removed · layer-2 validation never called · a missing type offered with no family loaded · the host search ignoring the category · the pattern list no longer ordered · a differing type silently present · an existing type offered for creation · the mm tolerance removed · the tolerance widened until a real difference passes · an unreadable parameter read as 0mm · the finding no longer naming the host family · the report no longer naming it · the group label drifting so the minter finds nothing · layer 2 never audited · a family type adopted into the corporate baseline · an **invalid** one adopted (which also fires the pre-existing `The_Shipped_Baseline_Validates`).

**Two results needed a second pass, and both were findings rather than passes:**

1. Relaxing the prefix comparison to `OrdinalIgnoreCase` moved **no test at all** — so `The_Prefix_Is_Case_And_Space_Exact` was added and re-verified firing.
2. The no-read-back test was guarding the **outer** early return, not the inner one. The correct mutation was written; it fires.

## NOT verified

**Nothing Revit-side has been run by anyone** — across T1–T5 and both baseline layers.

`MintFamilyTypes`, the `FamiliesByCategory` reader and `ReadDeclaredTypeParameters` have **never executed against a real model**. The audit half is Revit-free and fully tested; the mint is the unproven half and says so in its own header. Do not read this PR as evidence that minting a family type works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln3G9zFMNri66K13obgcW2
