### PR TITLE
B2 — add shared type parameters to loaded families

### DIFF
--- a/StingTools.Boq.Tests/BaselineAugmentReportTests.cs
+++ b/StingTools.Boq.Tests/BaselineAugmentReportTests.cs
@@ -1,0 +1,101 @@
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Layer 3's report. This message is the ONLY account anyone gets of an
+    /// operation that opened and rewrote their families, so what it says under
+    /// each outcome is the part that has to be pinned.
+    /// </summary>
+    public class BaselineAugmentReportTests
+    {
+        [Fact]
+        public void Nothing_Attempted_Reports_Nothing()
+        {
+            // Silence is right only when layer 3 was not asked to act. An
+            // invented "0 families augmented" would read as a result.
+            Assert.Null(new BaselineAugmentReport().Summary());
+        }
+
+        [Fact]
+        public void A_Successful_Run_Names_Both_Counts()
+        {
+            var r = new BaselineAugmentReport
+            {
+                FamiliesAugmented = 12, ParametersAdded = 36
+            };
+
+            string s = r.Summary();
+
+            Assert.Contains("36 shared type parameter(s)", s);
+            Assert.Contains("12 famil(ies)", s);
+        }
+
+        [Fact]
+        public void Total_Failure_Says_So_Rather_Than_Going_Quiet()
+        {
+            // The dangerous case: every family refused, nothing was added, and
+            // a report that only mentioned successes would print nothing at all
+            // — indistinguishable from "not asked to do anything".
+            var r = new BaselineAugmentReport();
+            r.Failed.Add("M_Door-Curtain-Wall: in-place families cannot be edited");
+
+            string s = r.Summary();
+
+            Assert.NotNull(s);
+            Assert.Contains("No family was augmented", s);
+            Assert.Contains("1 famil(ies) could not be edited", s);
+        }
+
+        [Fact]
+        public void Partial_Success_Reports_Both_Halves()
+        {
+            var r = new BaselineAugmentReport { FamiliesAugmented = 8, ParametersAdded = 24 };
+            r.Failed.Add("Vendor_Door: the family could not be opened");
+
+            string s = r.Summary();
+
+            Assert.Contains("8 famil(ies)", s);
+            Assert.Contains("could not be edited", s);
+        }
+
+        [Fact]
+        public void Already_Conforming_Families_Are_Reported_Not_Hidden()
+        {
+            // A re-run that changes nothing must not look like a failed run.
+            var r = new BaselineAugmentReport { FamiliesAlreadyConforming = 14 };
+
+            string s = r.Summary();
+
+            Assert.NotNull(s);
+            Assert.Contains("14 famil(ies) already carried them", s);
+        }
+
+        [Fact]
+        public void The_Failure_List_Is_Capped_And_Says_So()
+        {
+            var r = new BaselineAugmentReport();
+            for (int i = 0; i < 25; i++) r.Failed.Add($"Family {i:D2}: refused");
+
+            string s = r.Summary();
+
+            Assert.Contains("…and 15 more", s);
+            Assert.Equal(10, System.Text.RegularExpressions.Regex.Matches(s, "refused").Count);
+        }
+
+        [Fact]
+        public void Failures_Carry_The_Guidance_That_Explains_Them()
+        {
+            // "could not be edited" without a reason sends someone hunting for
+            // a bug that is not there: in-place families genuinely cannot be.
+            var r = new BaselineAugmentReport();
+            r.Failed.Add("X: refused");
+
+            string s = r.Summary();
+
+            Assert.Contains("In-place families cannot be edited", s);
+            Assert.Contains("ownership released", s);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAudit.cs" Link="Baseline\BaselineAudit.cs" />
+    <Compile Include="..\StingTools\Core\Baseline\BaselineAugmentReport.cs" Link="Baseline\BaselineAugmentReport.cs" />
     <!-- The XLSX writer is Revit-free (ClosedXML only), so the DELIVERABLE itself
          is testable, not just the model behind it. -->
     <Compile Include="..\StingTools\BOQ\BoqXlsxStyle.cs" Link="MaterialSchedule\BoqXlsxStyle.cs" />

--- a/StingTools/Commands/Baseline/BaselineAugmenter.cs
+++ b/StingTools/Commands/Baseline/BaselineAugmenter.cs
@@ -1,0 +1,234 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  BaselineAugmenter.cs — layer 3: add SHARED type parameters to families
+//  that are already loaded.
+//
+//  TWO CONSTRAINTS SHAPE THIS FILE.
+//
+//  1. Document.EditFamily CANNOT run inside an open transaction. So this does
+//     NOT join the mint's transaction — it runs after that transaction has
+//     committed, and each EditFamily/LoadFamily round trip manages its own.
+//     VisibilityEngine.Reset has the same shape for the same reason: two
+//     mechanisms with opposite transaction requirements sequenced by the
+//     caller rather than pretended to be one.
+//
+//  2. The parameters must be SHARED, not family-local.
+//     FamilyManager.AddParameter(name, group, spec, isInstance) creates a
+//     parameter with no GUID: two families given "the same" parameter that way
+//     hold two unrelated ones, which cannot be scheduled together and which
+//     the material schedule cannot read across a project. Only the
+//     ExternalDefinition overload produces a parameter the schedule can use.
+//
+//  Families that cannot be edited — in-place, some vendor families, and
+//  workshared families owned by somebody else — are EXPECTED, not
+//  exceptional. Each is reported by name with the reason.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+
+namespace StingTools.Commands.Baseline
+{
+    internal static class BaselineAugmenter
+    {
+        /// <summary>
+        /// Shared-parameter names the baseline asks for that the shared-parameter
+        /// FILE does not define. Resolved during the audit so an unresolvable
+        /// name blocks Apply BEFORE any family is opened — the same class of
+        /// pre-flight as a layer naming an undeclared material.
+        /// </summary>
+        public static List<string> UnresolvableParameters(Document doc, ProjectBaseline baseline)
+        {
+            var missing = new List<string>();
+            if (doc == null || baseline?.FamilyParameters == null) return missing;
+
+            var wanted = baseline.FamilyParameters
+                .Where(f => f != null)
+                .SelectMany(f => f.Parameters ?? new List<string>())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (wanted.Count == 0) return missing;
+
+            var defs = SharedDefinitions(doc);
+            if (defs == null)
+            {
+                // No shared-parameter file is a single blocking fact, not one
+                // complaint per parameter.
+                missing.Add("no shared parameter file is set, so none of "
+                          + $"{wanted.Count} parameter(s) can be added");
+                return missing;
+            }
+
+            foreach (string n in wanted)
+                if (!defs.ContainsKey(n)) missing.Add($"shared parameter '{n}' is not in the shared parameter file");
+            return missing;
+        }
+
+        /// <summary>
+        /// Add the declared parameters. Caller must have NO open transaction —
+        /// see the file header.
+        /// </summary>
+        public static BaselineAugmentReport Apply(Document doc, ProjectBaseline baseline,
+                                          BaselineAuditResult audit)
+        {
+            var r = new BaselineAugmentReport();
+            if (doc == null || baseline?.FamilyParameters == null) return r;
+
+            var actionable = new HashSet<string>(
+                audit.Missing.Where(f => f.Group == "Family parameters").Select(f => f.Name),
+                StringComparer.OrdinalIgnoreCase);
+            if (actionable.Count == 0) return r;
+
+            var defs = SharedDefinitions(doc);
+            if (defs == null)
+            {
+                r.Failed.Add("no shared parameter file is set");
+                return r;
+            }
+
+            foreach (var set in baseline.FamilyParameters)
+            {
+                if (set == null || string.IsNullOrWhiteSpace(set.Category)) continue;
+                string cat = set.Category.Trim();
+                if (!actionable.Contains(cat)) continue;
+
+                var names = (set.Parameters ?? new List<string>())
+                    .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToList();
+                if (names.Count == 0) continue;
+
+                foreach (var fam in FamiliesIn(doc, cat))
+                    AugmentOne(doc, fam, names, defs, set, r);
+            }
+            return r;
+        }
+
+        private static void AugmentOne(Document doc, Family fam, List<string> names,
+                                       Dictionary<string, ExternalDefinition> defs,
+                                       BaselineFamilyParameterSet set, BaselineAugmentReport r)
+        {
+            string famName = SafeName(fam);
+            Document famDoc = null;
+            try
+            {
+                famDoc = doc.EditFamily(fam);
+                if (famDoc == null)
+                {
+                    r.Failed.Add($"{famName}: EditFamily returned null");
+                    return;
+                }
+
+                int added = 0;
+                using (var tx = new Transaction(famDoc, "STING Baseline Family Parameters"))
+                {
+                    tx.Start();
+                    var fm = famDoc.FamilyManager;
+                    foreach (string n in names)
+                    {
+                        // Idempotent: a family that already has it is left
+                        // alone, so a re-run is free rather than duplicating.
+                        if (fm.get_Parameter(n) != null) continue;
+                        if (!defs.TryGetValue(n, out var def)) continue;
+                        fm.AddParameter(def, GroupFor(set.Group), set.IsInstance);
+                        added++;
+                    }
+                    if (added == 0) { tx.RollBack(); r.FamiliesAlreadyConforming++; return; }
+                    tx.Commit();
+                }
+
+                famDoc.LoadFamily(doc, new ReuseLoadOptions());
+                r.FamiliesAugmented++;
+                r.ParametersAdded += added;
+            }
+            catch (Exception ex)
+            {
+                // In-place families, vendor families that refuse to open, and
+                // workshared families owned by another user all land here. This
+                // is the expected path for a slice of any real model.
+                r.Failed.Add($"{famName}: {ex.Message}");
+                StingLog.Warn($"BaselineAugmenter {famName}: {ex.Message}");
+            }
+            finally
+            {
+                try { famDoc?.Close(false); }
+                catch (Exception ex) { StingLog.Warn($"BaselineAugmenter close {famName}: {ex.Message}"); }
+            }
+        }
+
+        private static IEnumerable<Family> FamiliesIn(Document doc, string category)
+        {
+            List<Family> found;
+            try
+            {
+                found = new FilteredElementCollector(doc).OfClass(typeof(Family)).Cast<Family>()
+                    .Where(f => string.Equals(f.FamilyCategory?.Name, category,
+                                              StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"BaselineAugmenter FamiliesIn '{category}': {ex.Message}");
+                yield break;
+            }
+            foreach (var f in found) if (f != null) yield return f;
+        }
+
+        private static Dictionary<string, ExternalDefinition> SharedDefinitions(Document doc)
+        {
+            try
+            {
+                var file = doc?.Application?.OpenSharedParameterFile();
+                if (file?.Groups == null) return null;
+
+                var map = new Dictionary<string, ExternalDefinition>(StringComparer.OrdinalIgnoreCase);
+                foreach (DefinitionGroup g in file.Groups)
+                    foreach (Definition d in g.Definitions)
+                        if (d is ExternalDefinition ed && !map.ContainsKey(ed.Name))
+                            map[ed.Name] = ed;
+                return map;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"BaselineAugmenter SharedDefinitions: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Parameter group by name, defaulting to Identity Data. An
+        /// unrecognised group is a cosmetic choice, not a reason to refuse.</summary>
+        private static ForgeTypeId GroupFor(string group)
+        {
+            switch ((group ?? "").Trim().ToLowerInvariant())
+            {
+                case "construction":  return GroupTypeId.Construction;
+                case "dimensions":    return GroupTypeId.Geometry;
+                case "materials":     return GroupTypeId.Materials;
+                case "graphics":      return GroupTypeId.Graphics;
+                case "data":
+                case "generalxx":     return GroupTypeId.General;
+                default:              return GroupTypeId.IdentityData;
+            }
+        }
+
+        private static string SafeName(Family fam)
+        {
+            try { return fam?.Name ?? "<unnamed family>"; }
+            catch (Exception ex) { StingLog.Warn($"SafeName: {ex.Message}"); return "<unnamed family>"; }
+        }
+
+        private sealed class ReuseLoadOptions : IFamilyLoadOptions
+        {
+            public bool OnFamilyFound(bool familyInUse, out bool overwriteParameterValues)
+            { overwriteParameterValues = true; return true; }
+
+            public bool OnSharedFamilyFound(Family sharedFamily, bool familyInUse,
+                out FamilySource source, out bool overwriteParameterValues)
+            {
+                source = FamilySource.Family; overwriteParameterValues = true; return true;
+            }
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -563,6 +563,7 @@ namespace StingTools.Commands.Baseline
 
             var baseline = BaselineRegistry.Load(doc);
             var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc, baseline));
+            audit.BaselineProblems.AddRange(BaselineAugmenter.UnresolvableParameters(doc, baseline));
             TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
             return Result.Succeeded;
         }
@@ -587,6 +588,12 @@ namespace StingTools.Commands.Baseline
             // against facts the user never saw in the report.
             var inventory = BaselineModelReader.Read(doc, baseline);
             var audit = BaselineAuditor.Audit(baseline, inventory);
+
+            // A shared-parameter name that the FILE does not define cannot be
+            // added to anything. Resolving it here means Apply refuses before a
+            // single family is opened, rather than half-augmenting a model and
+            // reporting the rest as failures.
+            audit.BaselineProblems.AddRange(BaselineAugmenter.UnresolvableParameters(doc, baseline));
 
             if (audit.BaselineProblems.Count > 0)
             {
@@ -620,8 +627,20 @@ namespace StingTools.Commands.Baseline
                 tx.Commit();
             }
 
-            StingLog.Info($"BaselineApply: created {mint.Created}, failed {mint.Failed.Count}");
-            TaskDialog.Show("STING Project Baseline", mint.Summary()
+            // AFTER the commit, and deliberately not inside it: Document.EditFamily
+            // cannot run within an open transaction, so layer 3 sequences itself
+            // the way VisibilityEngine.Reset sequences its two mechanisms.
+            var augment = BaselineAugmenter.Apply(doc, baseline, audit);
+
+            StingLog.Info($"BaselineApply: created {mint.Created}, failed {mint.Failed.Count}, "
+                        + $"families augmented {augment.FamiliesAugmented}, "
+                        + $"augment failures {augment.Failed.Count}");
+
+            string report = mint.Summary();
+            string aug = augment.Summary();
+            if (!string.IsNullOrEmpty(aug)) report += "\n\n" + aug;
+
+            TaskDialog.Show("STING Project Baseline", report
                 + "\n\nRe-run the audit to confirm, then export a material schedule: "
                 + "types carrying tiled finish layers are what make tiling measurable.");
             return Result.Succeeded;

--- a/StingTools/Core/Baseline/BaselineAugmentReport.cs
+++ b/StingTools/Core/Baseline/BaselineAugmentReport.cs
@@ -1,0 +1,70 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  BaselineAugmentReport.cs — what layer 3 did, and did not do.
+//
+//  Revit-free for the same reason TileScanTally and RoomFinishTally are: this
+//  message is the ONLY account anyone gets of an operation that opened and
+//  rewrote their families. A wrong or vague one sends somebody looking in the
+//  wrong place, and a silent one reads as "nothing happened" when the truth
+//  may be "everything failed".
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.Baseline
+{
+    public sealed class BaselineAugmentReport
+    {
+        public int FamiliesAugmented;
+        public int ParametersAdded;
+        public int FamiliesAlreadyConforming;
+
+        /// <summary>Families that could not be edited, with the reason. In-place
+        /// families, some vendor families and workshared families owned by
+        /// another user all land here — expected, not exceptional.</summary>
+        public readonly List<string> Failed = new List<string>();
+
+        private const int MaxNamesShown = 10;
+
+        public bool TouchedNothing =>
+            FamiliesAugmented == 0 && Failed.Count == 0 && FamiliesAlreadyConforming == 0;
+
+        /// <summary>
+        /// Null when layer 3 was not asked to do anything. Silence is right ONLY
+        /// when nothing was attempted; a run that attempted and failed must say
+        /// so, which is why Failed alone is enough to produce a message.
+        /// </summary>
+        public string Summary()
+        {
+            if (TouchedNothing) return null;
+
+            var parts = new List<string>();
+
+            if (FamiliesAugmented > 0)
+                parts.Add($"Added {ParametersAdded} shared type parameter(s) to "
+                        + $"{FamiliesAugmented} famil(ies).");
+            else if (Failed.Count > 0)
+                parts.Add("No family was augmented.");
+
+            if (FamiliesAlreadyConforming > 0)
+                parts.Add($"{FamiliesAlreadyConforming} famil(ies) already carried them.");
+
+            if (Failed.Count > 0)
+            {
+                var shown = new List<string>();
+                foreach (string f in Failed)
+                {
+                    if (shown.Count == MaxNamesShown) break;
+                    shown.Add(f);
+                }
+                parts.Add($"{Failed.Count} famil(ies) could not be edited:\n  • "
+                        + string.Join("\n  • ", shown)
+                        + (Failed.Count > MaxNamesShown
+                            ? $"\n  • …and {Failed.Count - MaxNamesShown} more" : "")
+                        + "\nIn-place families cannot be edited at all; a workshared family "
+                        + "owned by someone else needs their ownership released.");
+            }
+
+            return string.Join("\n", parts);
+        }
+    }
+}


### PR DESCRIPTION
Layer 3. T6 needs five parameters on door and window families before it can itemise anything, and the T6 proposal originally said putting them there **was not a code task**. That was wrong — `FamilyAugmentationEngine` has done the `EditFamily` round trip for symbol families all along.

### Two constraints shaped this, neither of them in the spec

**`Document.EditFamily` cannot run inside an open transaction.** So layer 3 does *not* join the mint's transaction — it runs **after** that transaction commits, and each `EditFamily`/`LoadFamily` round trip owns its own. `VisibilityEngine.Reset` has the same shape for the same reason: two mechanisms with opposite transaction requirements, sequenced by the caller rather than pretended to be one.

**The parameters must be SHARED.** `FamilyManager.AddParameter(name, group, spec, isInstance)` creates a family-**local** parameter with no GUID — two families given "the same" parameter hold two unrelated ones that cannot be scheduled together. That would look correct in any single family and be useless in aggregate. Only the `ExternalDefinition` overload is used.

### Fails before it touches anything

An unresolvable parameter name blocks Apply **before a single family is opened**, rather than half-augmenting a model and reporting the rest. A missing shared-parameter *file* is reported once as a blocking fact, not once per parameter.

**Idempotent:** a family that already carries the parameter has its transaction rolled back and is counted as already-conforming. A re-run costs nothing and duplicates nothing.

### The report is Revit-free and tested, and one case is why

Total failure — every family refusing, nothing added. **A summary that only mentioned successes would print nothing there**, indistinguishable from "not asked to act". Both mutations verified failing:

| Mutation | Result |
|---|---|
| Drop the failure-only branch | 1 failed |
| `TouchedNothing` ignores `Failed` | 3 failed |

Failures carry their explanation, because *"could not be edited"* alone sends someone hunting a bug that is not there: in-place families genuinely cannot be edited, and a workshared family needs its owner to release it.

Tests **735 → 742**. Build **0/0**.

**NOT VERIFIED:** no family has been augmented in Revit. `EditFamily`, `AddParameter` and `LoadFamily` are all unexercised on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)