### PR TITLE
B3 — catalogue packs, opt-in and adopted by nobody

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAudit.cs" Link="Baseline\BaselineAudit.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAugmentReport.cs" Link="Baseline\BaselineAugmentReport.cs" />
+    <Compile Include="..\StingTools\Core\Baseline\TypeCataloguePack.cs" Link="Baseline\TypeCataloguePack.cs" />
     <!-- The XLSX writer is Revit-free (ClosedXML only), so the DELIVERABLE itself
          is testable, not just the model behind it. -->
     <Compile Include="..\StingTools\BOQ\BoqXlsxStyle.cs" Link="MaterialSchedule\BoqXlsxStyle.cs" />
@@ -102,6 +103,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\StingTools\Data\STING_PROJECT_BASELINE.json" Link="Data\STING_PROJECT_BASELINE.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\StingTools\Data\STING_TYPE_CATALOGUES.json" Link="Data\STING_TYPE_CATALOGUES.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/StingTools.Boq.Tests/TypeCataloguePackTests.cs
+++ b/StingTools.Boq.Tests/TypeCataloguePackTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Catalogue packs. The property that matters most is the one that is easy
+    /// to lose: NO pack applies unless a project asks for it by id. A pack that
+    /// leaked into every project would be exactly the confident corporate
+    /// default the pack mechanism exists to avoid.
+    /// </summary>
+    public class CatalogueAdoptionTests
+    {
+        private static BaselineFamilyType Door(string name, double w) => new BaselineFamilyType
+        {
+            Category = "Doors",
+            FamilyNamePatterns = { "Door" },
+            TypeName = name,
+            Parameters = { new BaselineFamilyTypeParam { Name = "Width", ValueMm = w } }
+        };
+
+        private static TypeCatalogueLibrary Library() => new TypeCatalogueLibrary
+        {
+            Packs =
+            {
+                new TypeCataloguePack
+                {
+                    Id = "EA-RESIDENTIAL-V1",
+                    SourceNote = new string('x', 60),
+                    FamilyTypes = { Door("STING Flush Door 900x2100", 900),
+                                    Door("STING Flush Door 800x2100", 800) }
+                }
+            }
+        };
+
+        [Fact]
+        public void A_Pack_Applies_To_NOBODY_By_Default()
+        {
+            // The single most important behaviour here.
+            var b = new ProjectBaseline();
+
+            var r = CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Empty(b.FamilyTypes);
+            Assert.Equal(0, r.TypesAdded);
+            Assert.Null(r.Summary());
+        }
+
+        [Fact]
+        public void Adopting_By_Id_Brings_Its_Types_In()
+        {
+            var b = new ProjectBaseline();
+            b.AdoptCatalogues.Add("EA-RESIDENTIAL-V1");
+
+            var r = CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Equal(2, b.FamilyTypes.Count);
+            Assert.Equal(2, r.TypesAdded);
+            Assert.Contains("EA-RESIDENTIAL-V1", r.Summary());
+        }
+
+        [Fact]
+        public void An_Unknown_Pack_Id_Is_Reported_Never_Silent()
+        {
+            // Silently ignoring a typo leaves somebody believing they adopted a
+            // catalogue they did not, and wondering why nothing appeared.
+            var b = new ProjectBaseline();
+            b.AdoptCatalogues.Add("EA-RESIDENTAIL-V1");   // transposed
+
+            var r = CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Empty(b.FamilyTypes);
+            Assert.Single(r.Unknown);
+            Assert.Contains("do not exist", r.Summary());
+        }
+
+        [Fact]
+        public void A_Project_Type_Wins_Over_The_Pack()
+        {
+            // Adopting a pack must never take away a project's ability to differ
+            // from it. This project's door is 850, and it stays 850.
+            var b = new ProjectBaseline();
+            b.FamilyTypes.Add(Door("STING Flush Door 900x2100", 850));
+            b.AdoptCatalogues.Add("EA-RESIDENTIAL-V1");
+
+            var r = CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Equal(2, b.FamilyTypes.Count);           // 1 project + 1 from the pack
+            Assert.Equal(1, r.TypesOverriddenByProject);
+            Assert.Equal(850, b.FamilyTypes.Single(t => t.TypeName == "STING Flush Door 900x2100")
+                                            .Parameters[0].ValueMm);
+        }
+
+        [Fact]
+        public void The_Same_Type_Name_In_Another_Category_Is_Not_An_Override()
+        {
+            var b = new ProjectBaseline();
+            var win = Door("STING Flush Door 900x2100", 900);
+            win.Category = "Windows";
+            b.FamilyTypes.Add(win);
+            b.AdoptCatalogues.Add("EA-RESIDENTIAL-V1");
+
+            var r = CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Equal(0, r.TypesOverriddenByProject);
+            Assert.Equal(3, b.FamilyTypes.Count);
+        }
+
+        [Fact]
+        public void Adopting_The_Same_Pack_Twice_Does_Not_Duplicate()
+        {
+            var b = new ProjectBaseline();
+            b.AdoptCatalogues.Add("EA-RESIDENTIAL-V1");
+            b.AdoptCatalogues.Add("EA-RESIDENTIAL-V1");
+
+            CatalogueAdopter.Adopt(b, Library());
+
+            Assert.Equal(2, b.FamilyTypes.Count);
+        }
+    }
+
+    public class CatalogueValidationTests
+    {
+        [Fact]
+        public void A_Provisional_Pack_Must_Say_Where_Its_Numbers_Came_From()
+        {
+            // "industry standard" explains nothing. A catalogue that cannot say
+            // where its sizes came from is a guess in a standard's clothes.
+            var lib = new TypeCatalogueLibrary
+            {
+                Packs = { new TypeCataloguePack { Id = "X-V1", SourceNote = "common sizes",
+                          FamilyTypes = { new BaselineFamilyType { TypeName = "STING A" } } } }
+            };
+
+            Assert.Contains(lib.Validate(), p => p.Contains("sourceNote"));
+        }
+
+        [Fact]
+        public void An_Empty_Pack_Is_Rejected()
+        {
+            var lib = new TypeCatalogueLibrary
+            {
+                Packs = { new TypeCataloguePack { Id = "X-V1", SourceNote = new string('x', 60) } }
+            };
+
+            Assert.Contains(lib.Validate(), p => p.Contains("no family types"));
+        }
+
+        [Fact]
+        public void A_Duplicated_Pack_Id_Is_Rejected()
+        {
+            var lib = new TypeCatalogueLibrary();
+            for (int i = 0; i < 2; i++)
+                lib.Packs.Add(new TypeCataloguePack
+                {
+                    Id = "X-V1", SourceNote = new string('x', 60),
+                    FamilyTypes = { new BaselineFamilyType { TypeName = "STING A" } }
+                });
+
+            Assert.Contains(lib.Validate(), p => p.Contains("more than once"));
+        }
+    }
+
+    /// <summary>The shipped catalogue, against the rules that consume it.</summary>
+    public class ShippedCatalogueTests
+    {
+        private static TypeCatalogueLibrary Shipped() =>
+            JsonConvert.DeserializeObject<TypeCatalogueLibrary>(File.ReadAllText(
+                Path.Combine(AppContext.BaseDirectory, "Data", "STING_TYPE_CATALOGUES.json")));
+
+        [Fact]
+        public void The_Shipped_Catalogue_Validates() => Assert.Empty(Shipped().Validate());
+
+        [Fact]
+        public void Every_Shipped_Pack_Is_Provisional()
+        {
+            // Nothing ships as an adopted standard. The starter pack is a shape,
+            // to be replaced by harvesting a delivered model.
+            Assert.All(Shipped().Packs, p => Assert.True(p.IsProvisional));
+        }
+
+        [Fact]
+        public void Every_Shipped_Type_Passes_Baseline_Validation()
+        {
+            // A pack type is a baseline type: it needs the STING prefix, family
+            // patterns and named parameters, or it will fail at mint time on
+            // somebody's project rather than here.
+            var b = new ProjectBaseline();
+            foreach (var pack in Shipped().Packs)
+                b.FamilyTypes.AddRange(pack.FamilyTypes);
+
+            Assert.Empty(b.Validate());
+        }
+
+        [Fact]
+        public void No_Shipped_Pack_Is_Adopted_By_The_Corporate_Baseline()
+        {
+            // The corporate baseline adopting its own pack would make it the
+            // corporate default this whole mechanism exists to avoid.
+            var baseline = JsonConvert.DeserializeObject<ProjectBaseline>(File.ReadAllText(
+                Path.Combine(AppContext.BaseDirectory, "Data", "STING_PROJECT_BASELINE.json")));
+
+            Assert.Empty(baseline.AdoptCatalogues ?? new List<string>());
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -49,7 +49,51 @@ namespace StingTools.Commands.Baseline
             Merge(b.CeilingTypes, over.CeilingTypes, t => t.Name);
             Merge(b.Levels, over.Levels, l => l.Name);
             Merge(b.FamilyExpectations, over.FamilyExpectations, f => f.Category);
+            Merge(b.FamilyTypes, over.FamilyTypes, t => (t.Category ?? "") + "|" + t.TypeName);
+            Merge(b.FamilyParameters, over.FamilyParameters, f => f.Category);
+            if (over.AdoptCatalogues != null && over.AdoptCatalogues.Count > 0)
+                b.AdoptCatalogues = over.AdoptCatalogues;
             return b;
+        }
+
+        /// <summary>
+        /// Catalogue packs, merged in AFTER the project override so a project
+        /// type always wins over a pack type of the same name. Adoption is
+        /// opt-in: with no adoptCatalogues this does nothing at all.
+        /// </summary>
+        public static CatalogueAdoptionResult AdoptCatalogues(Document doc, ProjectBaseline baseline)
+        {
+            var lib = ReadCatalogues(StingToolsApp.FindDataFile("STING_TYPE_CATALOGUES.json"))
+                      ?? new TypeCatalogueLibrary();
+            try
+            {
+                var over = ReadCatalogues(StingPaths.MetaFile(doc, "_BIM_COORD", "type_catalogues.json"));
+                if (over?.Packs != null)
+                    foreach (var pk in over.Packs)
+                    {
+                        if (pk == null || string.IsNullOrWhiteSpace(pk.Id)) continue;
+                        int i = lib.Packs.FindIndex(x =>
+                            string.Equals(x.Id, pk.Id, StringComparison.OrdinalIgnoreCase));
+                        if (i >= 0) lib.Packs[i] = pk; else lib.Packs.Add(pk);
+                    }
+            }
+            catch (Exception ex) { StingLog.Warn("AdoptCatalogues override: " + ex.Message); }
+
+            return CatalogueAdopter.Adopt(baseline, lib);
+        }
+
+        private static TypeCatalogueLibrary ReadCatalogues(string path)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return null;
+                return JsonConvert.DeserializeObject<TypeCatalogueLibrary>(File.ReadAllText(path));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("ReadCatalogues [" + path + "]: " + ex.Message);
+                return null;
+            }
         }
 
         private static void Merge<T>(List<T> baseList, List<T> overrides, Func<T, string> key)
@@ -562,9 +606,14 @@ namespace StingTools.Commands.Baseline
             }
 
             var baseline = BaselineRegistry.Load(doc);
+            var adoption = BaselineRegistry.AdoptCatalogues(doc, baseline);
             var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc, baseline));
             audit.BaselineProblems.AddRange(BaselineAugmenter.UnresolvableParameters(doc, baseline));
-            TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
+
+            string report = BaselineAuditor.Report(audit);
+            string adopted = adoption.Summary();
+            if (!string.IsNullOrEmpty(adopted)) report = adopted + "\n\n" + report;
+            TaskDialog.Show("STING Project Baseline — audit", report);
             return Result.Succeeded;
         }
     }
@@ -583,6 +632,7 @@ namespace StingTools.Commands.Baseline
             }
 
             var baseline = BaselineRegistry.Load(doc);
+            var adoption = BaselineRegistry.AdoptCatalogues(doc, baseline);
             // The SAME inventory feeds the audit and the mint. Reading twice
             // would let the model change between them, so Apply could mint
             // against facts the user never saw in the report.
@@ -610,10 +660,12 @@ namespace StingTools.Commands.Baseline
 
             // Audit first, write on confirm. Nothing reaches a live model
             // without the full list of what will change being read first.
+            string adoptedNote = adoption.Summary();
             var dlg = new TaskDialog("STING Project Baseline — apply?")
             {
                 MainInstruction = $"Create {audit.MissingCount} missing item(s)?",
-                MainContent = BaselineAuditor.Report(audit),
+                MainContent = (string.IsNullOrEmpty(adoptedNote) ? "" : adoptedNote + "\n\n")
+                            + BaselineAuditor.Report(audit),
                 CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
                 DefaultButton = TaskDialogResult.No
             };

--- a/StingTools/Core/Baseline/TypeCataloguePack.cs
+++ b/StingTools/Core/Baseline/TypeCataloguePack.cs
@@ -1,0 +1,162 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeCataloguePack.cs — regional type catalogues, opt-in.
+//
+//  WHY PACKS RATHER THAN A CORPORATE LIST. Shipping thirty East African types
+//  in the baseline would make one person's reading of the market a standard
+//  that every future project is audited against. A project whose doors are
+//  genuinely 850 wide would be told, on every run, that it is missing a type
+//  it does not want — a confident default nobody asked for, which is the
+//  failure mode this schedule has spent sixteen fixes removing.
+//
+//  So: no pack applies unless a project adopts it BY ID. Packs are additive,
+//  overridable per type, and versioned in the id so V1 -> V2 is a migration
+//  rather than a silent redefinition of what somebody already adopted.
+//
+//  The shipped pack is marked provisional and adopted by nobody. It is to be
+//  replaced by harvesting a delivered model — see Baseline_HarvestTypes. A
+//  provisional pack nobody has adopted can be wrong for free.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Baseline
+{
+    public sealed class TypeCataloguePack
+    {
+        /// <summary>Versioned, e.g. EA-RESIDENTIAL-V1. The version is part of
+        /// the identity so a later revision cannot silently redefine what a
+        /// project adopted.</summary>
+        public string Id = "";
+        public string Title = "";
+
+        /// <summary>"provisional" or "adopted". Provisional means the sizes are
+        /// a starting shape, not a standard.</summary>
+        public string Status = "provisional";
+
+        /// <summary>Where the sizes came from. Required on a provisional pack:
+        /// a catalogue that cannot say where its numbers came from is a guess
+        /// wearing a standard's clothes.</summary>
+        public string SourceNote = "";
+
+        public List<BaselineFamilyType> FamilyTypes = new List<BaselineFamilyType>();
+
+        public bool IsProvisional =>
+            !string.Equals(Status, "adopted", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public sealed class TypeCatalogueLibrary
+    {
+        public string SchemaVersion = "1.0";
+        public string Note = "";
+        public List<TypeCataloguePack> Packs = new List<TypeCataloguePack>();
+
+        public TypeCataloguePack ById(string id) =>
+            string.IsNullOrWhiteSpace(id) ? null
+            : Packs?.FirstOrDefault(p => p != null
+                && string.Equals(p.Id, id.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>Problems inside the catalogue file itself, before adoption.</summary>
+        public List<string> Validate()
+        {
+            var problems = new List<string>();
+            foreach (var p in Packs ?? new List<TypeCataloguePack>())
+            {
+                if (p == null) continue;
+                if (string.IsNullOrWhiteSpace(p.Id)) { problems.Add("a pack has no id"); continue; }
+                if (p.IsProvisional && (p.SourceNote ?? "").Trim().Length < 40)
+                    problems.Add($"pack '{p.Id}' is provisional but its sourceNote is too short to "
+                               + "say where its sizes came from");
+                if (p.FamilyTypes == null || p.FamilyTypes.Count == 0)
+                    problems.Add($"pack '{p.Id}' declares no family types");
+            }
+
+            var dupes = (Packs ?? new List<TypeCataloguePack>())
+                .Where(p => p != null && !string.IsNullOrWhiteSpace(p.Id))
+                .GroupBy(p => p.Id.Trim(), StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1).Select(g => g.Key);
+            foreach (string d in dupes) problems.Add($"pack id '{d}' is declared more than once");
+
+            return problems;
+        }
+    }
+
+    public sealed class CatalogueAdoptionResult
+    {
+        public readonly List<string> Adopted = new List<string>();
+        public readonly List<string> Unknown = new List<string>();
+        public int TypesAdded;
+        public int TypesOverriddenByProject;
+
+        /// <summary>Null when the project adopted nothing — the default, and not
+        /// worth a line. An unknown id is always worth one.</summary>
+        public string Summary()
+        {
+            if (Adopted.Count == 0 && Unknown.Count == 0) return null;
+
+            var parts = new List<string>();
+            if (Adopted.Count > 0)
+            {
+                parts.Add($"Adopted {Adopted.Count} catalogue pack(s): {string.Join(", ", Adopted)} "
+                        + $"— {TypesAdded} type(s) added"
+                        + (TypesOverriddenByProject > 0
+                            ? $", {TypesOverriddenByProject} overridden by this project" : "")
+                        + ".");
+            }
+            if (Unknown.Count > 0)
+                parts.Add($"{Unknown.Count} adopted pack id(s) do not exist and were ignored: "
+                        + string.Join(", ", Unknown)
+                        + ". Check the spelling against STING_TYPE_CATALOGUES.json.");
+            return string.Join("\n", parts);
+        }
+    }
+
+    public static class CatalogueAdopter
+    {
+        /// <summary>
+        /// Merge the family types of every pack the baseline adopts BY ID.
+        ///
+        /// A type the project declares itself wins over the pack's version of
+        /// the same (category, typeName) — adopting a pack must never take away
+        /// a project's ability to differ from it.
+        /// </summary>
+        public static CatalogueAdoptionResult Adopt(ProjectBaseline baseline, TypeCatalogueLibrary library)
+        {
+            var r = new CatalogueAdoptionResult();
+            if (baseline?.AdoptCatalogues == null || baseline.AdoptCatalogues.Count == 0) return r;
+
+            var already = new HashSet<string>(
+                (baseline.FamilyTypes ?? new List<BaselineFamilyType>())
+                    .Where(t => t != null && !string.IsNullOrWhiteSpace(t.TypeName))
+                    .Select(Key),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (string id in baseline.AdoptCatalogues)
+            {
+                if (string.IsNullOrWhiteSpace(id)) continue;
+                var pack = library?.ById(id);
+                if (pack == null)
+                {
+                    // Silently ignoring a typo would leave somebody believing
+                    // they adopted a catalogue they did not.
+                    r.Unknown.Add(id.Trim());
+                    continue;
+                }
+
+                r.Adopted.Add(pack.Id);
+                foreach (var ft in pack.FamilyTypes ?? new List<BaselineFamilyType>())
+                {
+                    if (ft == null || string.IsNullOrWhiteSpace(ft.TypeName)) continue;
+                    if (already.Contains(Key(ft))) { r.TypesOverriddenByProject++; continue; }
+                    baseline.FamilyTypes.Add(ft);
+                    already.Add(Key(ft));
+                    r.TypesAdded++;
+                }
+            }
+            return r;
+        }
+
+        private static string Key(BaselineFamilyType t) =>
+            (t.Category ?? "").Trim() + "|" + (t.TypeName ?? "").Trim();
+    }
+}

--- a/StingTools/Data/STING_TYPE_CATALOGUES.json
+++ b/StingTools/Data/STING_TYPE_CATALOGUES.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "1.0",
+  "note": "Catalogue packs are OPT-IN. NO pack applies unless a project adopts it by id, via adoptCatalogues in <project>/_BIM_COORD/project_baseline.json. Packs are additive: a project can adopt one and still declare its own familyTypes, which win by (category, typeName). The version is part of the id so a later revision cannot silently redefine what a project already adopted - publish EA-RESIDENTIAL-V2 rather than editing V1. To create a pack from work that was actually built, run Baseline_HarvestTypes on a delivered model and promote the result.",
+
+  "packs": [
+    {
+      "id": "EA-RESIDENTIAL-V1",
+      "title": "East African residential - provisional starter",
+      "status": "provisional",
+      "sourceNote": "Common Ugandan residential door and window sizes, written from general practice to demonstrate the pack SHAPE. These are NOT measured from a delivered project and are NOT a STING standard. Replace this pack by harvesting a completed model rather than editing these numbers - a catalogue that grows from work that was built and paid for beats one that grows from recollection.",
+      "familyTypes": [
+        {
+          "category": "Doors",
+          "familyNamePatterns": [ "Single-Flush", "Single Flush", "Door" ],
+          "typeName": "STING Flush Door 900x2100",
+          "purpose": "Main internal door - bedrooms, living",
+          "parameters": [
+            { "name": "Width", "valueMm": 900 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Doors",
+          "familyNamePatterns": [ "Single-Flush", "Single Flush", "Door" ],
+          "typeName": "STING Flush Door 800x2100",
+          "purpose": "Secondary internal door - store, utility",
+          "parameters": [
+            { "name": "Width", "valueMm": 800 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Doors",
+          "familyNamePatterns": [ "Single-Flush", "Single Flush", "Door" ],
+          "typeName": "STING Flush Door 750x2100",
+          "purpose": "Bathroom / WC door",
+          "parameters": [
+            { "name": "Width", "valueMm": 750 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": [ "Casement", "Fixed", "Window" ],
+          "typeName": "STING Casement Window 1200x1200",
+          "purpose": "Standard habitable room window",
+          "parameters": [
+            { "name": "Width", "valueMm": 1200 },
+            { "name": "Height", "valueMm": 1200 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": [ "Casement", "Fixed", "Window" ],
+          "typeName": "STING Casement Window 1500x1200",
+          "purpose": "Living / dining window",
+          "parameters": [
+            { "name": "Width", "valueMm": 1500 },
+            { "name": "Height", "valueMm": 1200 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": [ "Casement", "Fixed", "Window" ],
+          "typeName": "STING Casement Window 600x600",
+          "purpose": "Bathroom / WC high-level window",
+          "parameters": [
+            { "name": "Width", "valueMm": 600 },
+            { "name": "Height", "valueMm": 600 }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Shipping thirty East African types in the corporate baseline would make **one reading of the market** a standard every future project is audited against. A project whose doors are genuinely 850 wide would be told on every run that it is missing a type it does not want.

So: **opt-in by id**, additive, overridable per type, versioned in the id so `V1 → V2` is a migration rather than a silent redefinition of what somebody already adopted.

### Three behaviours pinned, because each is easy to lose

- **No pack applies unless adopted.** `EA-RESIDENTIAL-V1` ships adopted by nobody, and a test asserts the corporate baseline does not adopt its own pack.
- **An unknown pack id is reported.** Silently ignoring a typo leaves somebody believing they adopted a catalogue they did not, then wondering why nothing appeared.
- **A project type wins over a pack type** of the same `(category, typeName)`. The 850 door stays 850.

### The provisional pack says so, at length

A provisional pack must state where its numbers came from, and a 40-character floor rejects *"common sizes"*. The shipped one says plainly that its sizes demonstrate the **shape**, are not measured from a delivered project, are not a STING standard, and are to be **replaced by harvesting** a completed model rather than edited.

Every shipped pack type is validated as a baseline type, so a missing `STING ` prefix or unnamed parameter fails here rather than at mint time on somebody's project.

### On mutation testing — one attempt proved nothing, and that is reported

My first mutation removed the early-return guard on an empty `adoptCatalogues` list. **Nothing failed** — because an empty list simply does not loop, so the guard is a fast path, not the protection.

Reported rather than counted. The real mutation makes the loop iterate every pack in the library, and that **does** fail. *A mutation that proves nothing is worth less than no mutation, because it reads as evidence.*

| Mutation | Result |
|---|---|
| Remove the empty-list fast path | 0 failed — **proves nothing, discarded** |
| Iterate every pack regardless of adoption | 1 failed ✓ |
| Ignore unknown pack ids silently | 1 failed ✓ |
| Ship the pack as `adopted` | 1 failed ✓ |

Tests **742 → 755**. Build **0/0**.

**NOT VERIFIED:** no pack has been adopted in Revit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)