### PR TITLE
B4 — harvest a catalogue pack from a delivered model

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\StingTools\Core\Baseline\BaselineAudit.cs" Link="Baseline\BaselineAudit.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAugmentReport.cs" Link="Baseline\BaselineAugmentReport.cs" />
     <Compile Include="..\StingTools\Core\Baseline\TypeCataloguePack.cs" Link="Baseline\TypeCataloguePack.cs" />
+    <Compile Include="..\StingTools\Core\Baseline\TypeHarvest.cs" Link="Baseline\TypeHarvest.cs" />
     <!-- The XLSX writer is Revit-free (ClosedXML only), so the DELIVERABLE itself
          is testable, not just the model behind it. -->
     <Compile Include="..\StingTools\BOQ\BoqXlsxStyle.cs" Link="MaterialSchedule\BoqXlsxStyle.cs" />

--- a/StingTools.Boq.Tests/TypeHarvestTests.cs
+++ b/StingTools.Boq.Tests/TypeHarvestTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Harvest — the mechanism that lets the catalogue grow from work that was
+    /// built rather than from anyone's recollection of the market.
+    ///
+    /// The rule that shapes it: PLACED types only. A type sitting in the
+    /// browser that nobody used is evidence that somebody loaded a family, not
+    /// evidence of practice, and counting it would let an unused vendor library
+    /// masquerade as a standard.
+    /// </summary>
+    public class TypeHarvestTests
+    {
+        private static HarvestedType Placed(string type, int count, string family = "M_Single-Flush") =>
+            new HarvestedType
+            {
+                Category = "Doors", FamilyName = family, TypeName = type, InstanceCount = count,
+                ParametersMm = new Dictionary<string, double> { { "Width", 900 }, { "Height", 2100 } }
+            };
+
+        private static TypeCataloguePack Pack(TypeCatalogueLibrary lib) => lib.Packs.Single();
+
+        [Fact]
+        public void A_Placed_Type_Is_Harvested()
+        {
+            var report = new TypeHarvestReport();
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("0900 x 2100mm", 14) }, "PRJ01", report);
+
+            Assert.Equal(1, report.TypesHarvested);
+            var ft = Pack(lib).FamilyTypes.Single();
+            Assert.Equal("STING 0900 x 2100mm", ft.TypeName);
+            Assert.Contains("14 instance(s)", ft.Purpose);
+            Assert.Equal(2, ft.Parameters.Count);
+        }
+
+        [Fact]
+        public void A_Type_Nobody_Placed_Is_Not_Harvested()
+        {
+            var report = new TypeHarvestReport();
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("Unused Type", 0) }, "PRJ01", report);
+
+            Assert.Empty(Pack(lib).FamilyTypes);
+            Assert.Equal(1, report.SkippedNotPlaced);
+            Assert.Contains("not evidence of practice", report.Summary());
+        }
+
+        [Fact]
+        public void Our_Own_Minted_Types_Are_Not_Harvested_Back()
+        {
+            // Otherwise the catalogue becomes a record of itself: mint from a
+            // pack, harvest, and the pack reappears as though the project chose
+            // those sizes.
+            var report = new TypeHarvestReport();
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("STING Flush Door 900x2100", 9) },
+                                               "PRJ01", report);
+
+            Assert.Empty(Pack(lib).FamilyTypes);
+            Assert.Equal(1, report.SkippedAlreadyPrefixed);
+            Assert.Contains("record of itself", report.Summary());
+        }
+
+        [Fact]
+        public void The_Harvested_Pack_Passes_Baseline_Validation()
+        {
+            // A pack that cannot be minted from is a pack that reads well and
+            // does nothing. Prefixing exists so the harvest is directly usable.
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("0900 x 2100mm", 3) },
+                                               "PRJ01", new TypeHarvestReport());
+
+            var b = new ProjectBaseline();
+            b.FamilyTypes.AddRange(Pack(lib).FamilyTypes);
+
+            Assert.Empty(b.Validate());
+            Assert.Empty(lib.Validate());
+        }
+
+        [Fact]
+        public void The_Family_Name_Is_The_Only_Pattern_Used()
+        {
+            // Inferring "Door" from "M_Single-Flush" would match families the
+            // observation never saw.
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("0900 x 2100mm", 3, "Vendor_ACME_Door_v4") },
+                                               "PRJ01", new TypeHarvestReport());
+
+            var ft = Pack(lib).FamilyTypes.Single();
+            Assert.Equal(new[] { "Vendor_ACME_Door_v4" }, ft.FamilyNamePatterns.ToArray());
+        }
+
+        [Fact]
+        public void The_Harvested_Pack_Is_Provisional_And_Adopted_By_Nobody()
+        {
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("0900 x 2100mm", 3) },
+                                               "PRJ01", new TypeHarvestReport());
+
+            Assert.True(Pack(lib).IsProvisional);
+            Assert.Contains("not a standard", Pack(lib).SourceNote);
+            Assert.Contains("nothing here applies", lib.Note.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void The_Pack_Id_Carries_The_Project_And_A_Version()
+        {
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("A", 1) }, "kut-01", new TypeHarvestReport());
+
+            Assert.Equal("HARVEST-KUT-01-V1", Pack(lib).Id);
+        }
+
+        [Fact]
+        public void An_Unnamed_Project_Still_Produces_A_Valid_Id()
+        {
+            var lib = TypeHarvestBuilder.Build(new[] { Placed("A", 1) }, null, new TypeHarvestReport());
+
+            Assert.Equal("HARVEST-PROJECT-V1", Pack(lib).Id);
+        }
+
+        [Fact]
+        public void Nothing_Observed_Says_So_Rather_Than_Producing_An_Empty_Pack()
+        {
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new HarvestedType[0], "PRJ01", report);
+
+            Assert.Equal(0, report.TypesObserved);
+            Assert.Contains("Nothing to harvest", report.Summary());
+        }
+
+        [Fact]
+        public void Zero_Valued_Parameters_Are_Dropped()
+        {
+            // A parameter that reads 0 was not set. Recording it would propose
+            // minting a door 0mm wide.
+            var h = Placed("0900 x 2100mm", 2);
+            h.ParametersMm["Depth"] = 0;
+
+            var lib = TypeHarvestBuilder.Build(new[] { h }, "PRJ01", new TypeHarvestReport());
+
+            Assert.DoesNotContain(Pack(lib).FamilyTypes.Single().Parameters, p => p.Name == "Depth");
+        }
+
+        [Fact]
+        public void Counts_Are_Reported_Per_Category()
+        {
+            var win = Placed("1200 x 1200mm", 6);
+            win.Category = "Windows";
+
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new[] { Placed("0900 x 2100mm", 4), win }, "PRJ01", report);
+
+            Assert.Equal(1, report.ByCategory["Doors"]);
+            Assert.Equal(1, report.ByCategory["Windows"]);
+            Assert.Contains("Doors 1", report.Summary());
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/HarvestTypesCommand.cs
+++ b/StingTools/Commands/Baseline/HarvestTypesCommand.cs
@@ -1,0 +1,156 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  HarvestTypesCommand.cs — read the types a delivered model actually uses
+//  and write them as a catalogue pack for review.
+//
+//  READ-ONLY on the model. It writes one JSON file and touches nothing else.
+//
+//  The categories are the ones layer 2 can mint into. Harvesting a category
+//  the baseline cannot create would produce a pack that reads well and does
+//  nothing.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+
+namespace StingTools.Commands.Baseline
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    public class BaselineHarvestTypesCommand : IExternalCommand
+    {
+        /// <summary>Family-backed categories layer 2 can mint types into.</summary>
+        private static readonly string[] Categories =
+        {
+            "Doors", "Windows",
+            "Structural Columns", "Structural Foundations", "Structural Framing"
+        };
+
+        /// <summary>
+        /// Dimension parameters worth recording. Deliberately a short list: a
+        /// pack carrying every parameter of every type would be unreviewable,
+        /// and the ones that define a type are its sizes.
+        /// </summary>
+        private static readonly string[] DimensionParams =
+        {
+            "Width", "Height", "Depth", "Thickness", "Diameter", "Length", "b", "h", "d"
+        };
+
+        public Result Execute(ExternalCommandData data, ref string message, ElementSet elements)
+        {
+            var doc = BaselineDoc.Resolve(data);
+            if (doc == null)
+            {
+                TaskDialog.Show("STING Harvest Types", "No active document.");
+                return Result.Cancelled;
+            }
+
+            var report = new TypeHarvestReport();
+            var library = TypeHarvestBuilder.Build(Observe(doc),
+                doc.ProjectInformation?.Number, report);
+
+            if (report.TypesHarvested == 0)
+            {
+                TaskDialog.Show("STING Harvest Types", report.Summary());
+                return Result.Succeeded;
+            }
+
+            string path;
+            try
+            {
+                path = StingPaths.MetaFile(doc, "_BIM_COORD", "harvested_catalogue.json");
+                File.WriteAllText(path, JsonConvert.SerializeObject(library, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("BaselineHarvestTypes write", ex);
+                TaskDialog.Show("STING Harvest Types",
+                    report.Summary() + "\n\nThe pack could not be written: " + ex.Message);
+                return Result.Failed;
+            }
+
+            StingLog.Info($"BaselineHarvestTypes: {report.TypesHarvested} type(s) -> {path}");
+            TaskDialog.Show("STING Harvest Types",
+                report.Summary()
+                + "\n\nWritten to:\n" + path
+                + "\n\nNothing is adopted by writing it. Review the sizes, rename the pack, "
+                + "then list its id in adoptCatalogues to use it.");
+            return Result.Succeeded;
+        }
+
+        /// <summary>
+        /// One pass over placed instances. Counting instances rather than
+        /// listing types is the whole point: a type nobody placed is not
+        /// evidence of practice.
+        /// </summary>
+        private static List<HarvestedType> Observe(Document doc)
+        {
+            var byKey = new Dictionary<string, HarvestedType>(StringComparer.OrdinalIgnoreCase);
+            var wanted = new HashSet<string>(Categories, StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                foreach (var inst in new FilteredElementCollector(doc)
+                             .OfClass(typeof(FamilyInstance))
+                             .WhereElementIsNotElementType()
+                             .Cast<FamilyInstance>())
+                {
+                    string cat = inst?.Category?.Name;
+                    if (string.IsNullOrWhiteSpace(cat) || !wanted.Contains(cat)) continue;
+
+                    var sym = inst.Symbol;
+                    if (sym == null) continue;
+
+                    string typeName = SafeName(() => sym.Name);
+                    string famName = SafeName(() => sym.Family?.Name);
+                    if (string.IsNullOrWhiteSpace(typeName)) continue;
+
+                    string key = cat + "|" + typeName;
+                    if (!byKey.TryGetValue(key, out var h))
+                    {
+                        h = new HarvestedType
+                        {
+                            Category = cat, FamilyName = famName ?? "", TypeName = typeName,
+                            ParametersMm = ReadDimensions(sym)
+                        };
+                        byKey[key] = h;
+                    }
+                    h.InstanceCount++;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("BaselineHarvestTypes.Observe: " + ex.Message);
+            }
+            return byKey.Values.ToList();
+        }
+
+        private static Dictionary<string, double> ReadDimensions(FamilySymbol sym)
+        {
+            var vals = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            foreach (string name in DimensionParams)
+            {
+                try
+                {
+                    var p = sym.LookupParameter(name);
+                    if (p == null || p.StorageType != StorageType.Double) continue;
+                    double mm = p.AsDouble() * 304.8;
+                    if (mm > 0) vals[name] = Math.Round(mm, 1);
+                }
+                catch (Exception ex) { StingLog.Warn("ReadDimensions [" + name + "]: " + ex.Message); }
+            }
+            return vals;
+        }
+
+        private static string SafeName(Func<string> f)
+        {
+            try { return f(); }
+            catch (Exception ex) { StingLog.Warn("SafeName: " + ex.Message); return null; }
+        }
+    }
+}

--- a/StingTools/Core/Baseline/TypeHarvest.cs
+++ b/StingTools/Core/Baseline/TypeHarvest.cs
@@ -1,0 +1,153 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeHarvest.cs — build a catalogue pack from what a delivered model
+//  actually contains.
+//
+//  This is what stops the catalogue ossifying. The shipped starter pack is
+//  one person's reading of the market; a harvested pack is a record of work
+//  that was built and paid for. After two or three delivered projects the
+//  starter should be replaced outright rather than edited.
+//
+//  PLACED types only. A type sitting in the browser that nobody ever used is
+//  not evidence of practice — it is evidence that somebody loaded a family.
+//  Counting it would let an unused vendor library masquerade as a standard.
+//
+//  Harvested names are PREFIXED, not renamed in place. The pack proposes
+//  "STING Flush Door 900x2100" and records the original name and instance
+//  count in its purpose, so a reviewer can see exactly what was observed
+//  before promoting anything to a corporate pack.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Baseline
+{
+    /// <summary>One placed type, as the Revit side observed it.</summary>
+    public sealed class HarvestedType
+    {
+        public string Category = "";
+        public string FamilyName = "";
+        public string TypeName = "";
+        /// <summary>How many instances are placed. Zero means it was not placed
+        /// and must never reach a pack.</summary>
+        public int InstanceCount;
+        /// <summary>Parameter name → value in mm, for the parameters that exist.</summary>
+        public Dictionary<string, double> ParametersMm =
+            new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class TypeHarvestReport
+    {
+        public int TypesObserved;
+        public int TypesHarvested;
+        public int SkippedNotPlaced;
+        public int SkippedAlreadyPrefixed;
+        public readonly Dictionary<string, int> ByCategory =
+            new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        public string Summary()
+        {
+            if (TypesObserved == 0)
+                return "Nothing to harvest: no placed instances were found in the "
+                     + "categories a catalogue pack can describe.";
+
+            string s = $"Harvested {TypesHarvested} placed type(s) from {TypesObserved} observed";
+            if (ByCategory.Count > 0)
+                s += " (" + string.Join(", ", ByCategory.OrderBy(k => k.Key)
+                        .Select(k => $"{k.Key} {k.Value}")) + ")";
+            s += ".";
+
+            if (SkippedNotPlaced > 0)
+                s += $" {SkippedNotPlaced} type(s) skipped as never placed — a type nobody used "
+                   + "is not evidence of practice.";
+            if (SkippedAlreadyPrefixed > 0)
+                s += $" {SkippedAlreadyPrefixed} skipped as already STING-minted: harvesting our "
+                   + "own types back would make the catalogue a record of itself.";
+            return s;
+        }
+    }
+
+    public static class TypeHarvestBuilder
+    {
+        /// <summary>
+        /// Turn observations into a pack. Never writes; the caller decides
+        /// whether the result is worth keeping.
+        /// </summary>
+        public static TypeCatalogueLibrary Build(IEnumerable<HarvestedType> observed,
+                                                 string projectCode,
+                                                 TypeHarvestReport report)
+        {
+            report = report ?? new TypeHarvestReport();
+            var pack = new TypeCataloguePack
+            {
+                Id = "HARVEST-" + Sanitise(projectCode) + "-V1",
+                Title = "Harvested from " + (string.IsNullOrWhiteSpace(projectCode)
+                                             ? "an unnamed project" : projectCode.Trim()),
+                Status = "provisional",
+                SourceNote = "Harvested from the types actually PLACED in "
+                    + (string.IsNullOrWhiteSpace(projectCode) ? "a delivered model" : projectCode.Trim())
+                    + " on " + DateTime.Now.ToString("yyyy-MM-dd")
+                    + ". These are observations of one project, not a standard: review the sizes, "
+                    + "rename the pack, and adopt it deliberately before relying on it. Type names "
+                    + "carry the STING prefix so they can be minted; the original name and instance "
+                    + "count are recorded against each one."
+            };
+
+            foreach (var h in observed ?? Enumerable.Empty<HarvestedType>())
+            {
+                if (h == null || string.IsNullOrWhiteSpace(h.TypeName)
+                    || string.IsNullOrWhiteSpace(h.Category)) continue;
+                report.TypesObserved++;
+
+                if (h.InstanceCount <= 0) { report.SkippedNotPlaced++; continue; }
+
+                // Harvesting our own minted types back would make the catalogue
+                // a record of itself rather than of the project.
+                if (h.TypeName.StartsWith(BaselineFamilyType.MintedPrefix, StringComparison.Ordinal))
+                { report.SkippedAlreadyPrefixed++; continue; }
+
+                var ft = new BaselineFamilyType
+                {
+                    Category = h.Category.Trim(),
+                    TypeName = BaselineFamilyType.MintedPrefix + h.TypeName.Trim(),
+                    FamilyNamePatterns = PatternsFor(h.FamilyName),
+                    Purpose = $"observed as [{h.TypeName.Trim()}] in family [{h.FamilyName}], "
+                            + $"{h.InstanceCount} instance(s) placed"
+                };
+                foreach (var kv in h.ParametersMm ?? new Dictionary<string, double>())
+                    if (!string.IsNullOrWhiteSpace(kv.Key) && kv.Value > 0)
+                        ft.Parameters.Add(new BaselineFamilyTypeParam { Name = kv.Key, ValueMm = kv.Value });
+
+                pack.FamilyTypes.Add(ft);
+                report.TypesHarvested++;
+                report.ByCategory.TryGetValue(ft.Category, out int n);
+                report.ByCategory[ft.Category] = n + 1;
+            }
+
+            return new TypeCatalogueLibrary
+            {
+                Note = "Harvested catalogue. Review before adopting: nothing here applies to any "
+                     + "project until its id is listed in adoptCatalogues.",
+                Packs = { pack }
+            };
+        }
+
+        /// <summary>
+        /// The family's own name is the only pattern that can be trusted to find
+        /// it again. A cleverer guess ("Door" from "M_Single-Flush") would match
+        /// families the observation never saw.
+        /// </summary>
+        private static List<string> PatternsFor(string familyName) =>
+            string.IsNullOrWhiteSpace(familyName)
+                ? new List<string>()
+                : new List<string> { familyName.Trim() };
+
+        private static string Sanitise(string code)
+        {
+            if (string.IsNullOrWhiteSpace(code)) return "PROJECT";
+            var kept = code.Trim().ToUpperInvariant()
+                .Where(c => char.IsLetterOrDigit(c) || c == '-').ToArray();
+            return kept.Length == 0 ? "PROJECT" : new string(kept);
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -782,6 +782,8 @@ namespace StingTools.UI
                     // would create and writes nothing until that is confirmed.
                     case "Baseline_Audit": RunCommand<Commands.Baseline.BaselineAuditCommand>(app); break;
                     case "Baseline_Apply": RunCommand<Commands.Baseline.BaselineApplyCommand>(app); break;
+                    // Read-only: writes a catalogue pack JSON, never the model.
+                    case "Baseline_HarvestTypes": RunCommand<Commands.Baseline.BaselineHarvestTypesCommand>(app); break;
 
                     // Live tick apply — same path, no report dialog.
                     case "Vis_ApplyLive": RunCommand<Commands.Visibility.ApplyVisibilityLiveCommand>(app); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1953,6 +1953,9 @@
                                 <Button Style="{StaticResource ActionBtn}" Content="Audit model baseline" Tag="Baseline_Audit" Click="Cmd_Click"
                                         ToolTip="READ-ONLY. Compares this project to the STING model-authoring baseline: which materials and wall/floor/roof/ceiling types are missing, which exist but differ, and which need families loaded by hand. Writes nothing."
                                         HorizontalAlignment="Stretch"/>
+                                <Button Style="{StaticResource ActionBtn}" Content="Harvest types from this model" Tag="Baseline_HarvestTypes" Click="Cmd_Click"
+                                        ToolTip="READ-ONLY. Records the door / window / structural types actually PLACED in this model as a catalogue pack, written to _BIM_COORD/harvested_catalogue.json for review. A type nobody placed is not harvested. Nothing is adopted by writing it."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
                                 <Button Style="{StaticResource OrangeBtn}" Content="Apply baseline (asks first)" Tag="Baseline_Apply" Click="Cmd_Click"
                                         ToolTip="Shows the full list of what it would create, then writes only after you confirm. Creates ONLY what is missing — an existing type is never edited, even when its build-up differs from the baseline. A material schedule can only measure finishes the model actually describes; this is what gives it something to read."
                                         HorizontalAlignment="Stretch" Margin="0,4,0,0"/>


### PR DESCRIPTION
The last piece, and the one that stops the catalogue ossifying. The shipped starter pack is one reading of the market; a **harvested** pack is a record of work that was built and paid for.

### Placed types only

A type sitting in the browser that nobody used is evidence that somebody loaded a family, **not evidence of practice** — counting it would let an unused vendor library masquerade as a standard. The pass counts *instances* rather than listing types, which is the whole difference.

### Two refusals worth their tests

- **Our own minted types are not harvested back.** Otherwise the catalogue becomes a record of *itself*: mint from a pack, harvest, and the pack reappears as though the project had chosen those sizes.
- **The family's own name is the only pattern used.** Inferring `"Door"` from `"M_Single-Flush"` would match families the observation never saw — the same inference-from-a-name that PR #710 withdrew.

### Transparent, and directly usable

Harvested names are **prefixed, not renamed in place**: the pack proposes `STING <original>` and records the original name and instance count in its `purpose`, so a reviewer sees exactly what was observed. The pack validates as a baseline pack, so it can be minted from without hand-editing — a harvest that reads well and cannot be used would be worth little.

**Nothing is adopted by writing it.** The pack is provisional, its `sourceNote` says it is one project's observations and not a standard, and the library note says nothing applies until an id appears in `adoptCatalogues`.

Read-only on the model: one JSON file, nothing else touched. Wired with a handler case **and a button** (#792).

### Verification

Tests **755 → 766**. Build **0/0**. All four gates PASS. Three mutations verified failing:

| Mutation | Result |
|---|---|
| Harvest unplaced types | 1 failed |
| Harvest our own minted types back | 1 failed |
| Infer a family pattern instead of using the observed name | 1 failed |

**NOT VERIFIED:** no model has been harvested in Revit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)