### PR TITLE
B3: catalogue packs nobody has adopted, and the merge that made layers 2 and 3 reachable

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAudit.cs" Link="Baseline\BaselineAudit.cs" />
+    <!-- B3 - opt-in catalogue packs. Adoption decides what reaches a model,
+         so it is Revit-free and tested. -->
+    <Compile Include="..\StingTools\Core\Baseline\TypeCatalogue.cs" Link="Baseline\TypeCatalogue.cs" />
     <Compile Include="..\StingTools\Core\Baseline\BaselineAugmentReport.cs" Link="Baseline\BaselineAugmentReport.cs" />
     <!-- The XLSX writer is Revit-free (ClosedXML only), so the DELIVERABLE itself
          is testable, not just the model behind it. -->
@@ -99,6 +102,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\StingTools\Data\STING_MATERIAL_STAGES.json" Link="Data\STING_MATERIAL_STAGES.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\StingTools\Data\STING_TYPE_CATALOGUES.json" Link="Data\STING_TYPE_CATALOGUES.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\StingTools\Data\STING_PROJECT_BASELINE.json" Link="Data\STING_PROJECT_BASELINE.json">

--- a/StingTools.Boq.Tests/TypeCatalogueTests.cs
+++ b/StingTools.Boq.Tests/TypeCatalogueTests.cs
@@ -1,0 +1,519 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// B3 — opt-in catalogue packs.
+    ///
+    /// The whole mechanism exists to avoid one thing: a fixed corporate
+    /// catalogue would be ONE PERSON'S reading of the market, applied to every
+    /// future project and reported by the audit as though it were a standard. A
+    /// project whose doors are genuinely 850 wide would be told on every run
+    /// that it is missing a type it does not want.
+    ///
+    /// So packs are named, versioned, and adopted by nobody until a project
+    /// says so by id.
+    /// </summary>
+    public class TypeCatalogueAdoptionTests
+    {
+        private static BaselineFamilyType Door(string name, double w = 900) => new BaselineFamilyType
+        {
+            Category = "Doors",
+            FamilyNamePatterns = new List<string> { "Door" },
+            TypeName = name,
+            Parameters = new List<BaselineFamilyTypeParam>
+            { new BaselineFamilyTypeParam { Name = "Width", ValueMm = w } }
+        };
+
+        private static TypeCatalogueLibrary Library(params TypeCataloguePack[] packs) =>
+            new TypeCatalogueLibrary { Packs = packs.ToList() };
+
+        private static TypeCataloguePack Pack(string id = "EA-RESIDENTIAL-V1",
+                                              params BaselineFamilyType[] types) =>
+            new TypeCataloguePack
+            {
+                Id = id, Title = "t", Status = "provisional",
+                SourceNote = "seeded from practice, not a standard; replace by harvest",
+                FamilyTypes = (types.Length > 0 ? types : new[] { Door("STING Door 900") }).ToList()
+            };
+
+        [Fact]
+        public void A_Project_That_Adopts_Nothing_Gets_Nothing()
+        {
+            // THE default. No pack applies unless a project asks for it by id.
+            var b = new ProjectBaseline();
+
+            var a = TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            Assert.Empty(b.FamilyTypes);
+            Assert.False(a.AnythingAdopted);
+            Assert.Null(a.Summary());   // nothing to report, not "0 packs adopted"
+        }
+
+        [Fact]
+        public void Adopting_By_Id_Folds_The_Packs_Types_In()
+        {
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" } };
+
+            var a = TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            Assert.Single(b.FamilyTypes);
+            Assert.Equal(1, a.TypesAdopted);
+            Assert.Contains("EA-RESIDENTIAL-V1", a.AdoptedPackIds);
+        }
+
+        [Fact]
+        public void Adoption_Is_Reported_So_It_Is_A_Stated_Decision()
+        {
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" } };
+
+            string s = TypeCatalogueResolver.Apply(b, Library(Pack())).Summary();
+
+            Assert.Contains("EA-RESIDENTIAL-V1", s);
+            Assert.Contains("1 family type", s);
+        }
+
+        [Fact]
+        public void An_Id_Matching_No_Pack_Is_NAMED_Never_Silently_Ignored()
+        {
+            // A project that believes it adopted a catalogue and did not is
+            // exactly the confident absence this codebase keeps paying for. A
+            // typo or a stale version must say so.
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V2" } };
+
+            var a = TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            Assert.Empty(b.FamilyTypes);
+            Assert.Contains("EA-RESIDENTIAL-V2", a.UnknownPackIds);
+            Assert.Contains("EA-RESIDENTIAL-V2", a.Summary());
+            Assert.Contains("DID NOTHING", a.Summary(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void The_PROJECTS_Own_Declaration_Wins_Over_The_Packs()
+        {
+            // A pack is additive; a project can adopt one and still override
+            // individual types. Same precedence as every other override.
+            var mine = Door("STING Door 900", w: 850);
+            var b = new ProjectBaseline
+            {
+                AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" },
+                FamilyTypes = new List<BaselineFamilyType> { mine }
+            };
+
+            var a = TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            Assert.Single(b.FamilyTypes);
+            Assert.Equal(850, b.FamilyTypes[0].Parameters[0].ValueMm);
+            Assert.Equal(0, a.TypesAdopted);
+            Assert.Contains("Doors / STING Door 900", a.OverriddenByProject);
+        }
+
+        [Fact]
+        public void An_Override_Is_Reported_Rather_Than_Mysterious()
+        {
+            var b = new ProjectBaseline
+            {
+                AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" },
+                FamilyTypes = new List<BaselineFamilyType> { Door("STING Door 900", 850) }
+            };
+
+            Assert.Contains("overridden by the project", TypeCatalogueResolver.Apply(b, Library(Pack())).Summary());
+        }
+
+        [Fact]
+        public void The_Same_Type_Name_In_Another_Category_Is_Not_An_Override()
+        {
+            var window = Door("STING Door 900");
+            window.Category = "Windows";
+            var b = new ProjectBaseline
+            {
+                AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" },
+                FamilyTypes = new List<BaselineFamilyType> { window }
+            };
+
+            var a = TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            Assert.Equal(1, a.TypesAdopted);
+            Assert.Equal(2, b.FamilyTypes.Count);
+        }
+
+        [Fact]
+        public void Two_Packs_Can_Be_Adopted_Together()
+        {
+            var b = new ProjectBaseline
+            { AdoptCatalogues = new List<string> { "A-V1", "B-V1" } };
+
+            var a = TypeCatalogueResolver.Apply(b,
+                Library(Pack("A-V1", Door("STING A")), Pack("B-V1", Door("STING B"))));
+
+            Assert.Equal(2, a.TypesAdopted);
+            Assert.Equal(2, a.AdoptedPackIds.Count);
+        }
+
+        [Fact]
+        public void A_Null_Library_Adopts_Nothing_And_Says_So()
+        {
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" } };
+
+            var a = TypeCatalogueResolver.Apply(b, null);
+
+            Assert.Empty(b.FamilyTypes);
+            Assert.Contains("EA-RESIDENTIAL-V1", a.UnknownPackIds);
+        }
+
+        [Fact]
+        public void Adopted_Types_Are_Audited_Exactly_Like_Declared_Ones()
+        {
+            // The point of folding them into FamilyTypes rather than handling
+            // them separately: one audit path, so an adopted type cannot behave
+            // differently from a declared one.
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" } };
+            TypeCatalogueResolver.Apply(b, Library(Pack()));
+
+            var model = new ModelInventory();
+            // The family name must MATCH the pack type’s pattern list ("Door"),
+            // or the audit correctly reports guidance rather than a mint. The
+            // first version of this test used "M_Single-Flush", which does not
+            // contain "Door" — the code was right and the premise was wrong.
+            model.FamilyNamesByCategory["Doors"] = new List<string> { "M_Single-Flush Door" };
+
+            var r = BaselineAuditor.Audit(b, model);
+
+            Assert.Contains(r.Missing, f => f.Name.Contains("STING Door 900"));
+        }
+    }
+
+    /// <summary>
+    /// B3 — the override merge, which is the defect this task uncovered.
+    ///
+    /// `BaselineRegistry.Load` merged materials, host types, levels and family
+    /// EXPECTATIONS from the project override — but NOT `familyTypes`,
+    /// `familyParameters` or `adoptCatalogues`. The corporate file ships all
+    /// three empty, so the project override was the ONLY possible source for
+    /// layers 2 and 3, and it was being dropped on the floor. Both layers
+    /// shipped unreachable: a project declaring familyTypes got a clean audit
+    /// and no explanation.
+    ///
+    /// The merge itself is Revit-side (it reads a file through StingPaths), so
+    /// what is pinned here is the RULE it implements — project wins by key,
+    /// unmatched entries are appended — against the same generic helper. If the
+    /// rule is wrong, these fail; if the wiring is removed, the adoption tests
+    /// above and the catalogue end-to-end test fail.
+    /// </summary>
+    public class BaselineOverrideMergeTests
+    {
+        /// <summary>The precedence Merge implements, restated so it can be
+        /// asserted: an override entry replaces the base entry with the same
+        /// key, and is appended when there is none.</summary>
+        private static void Merge<T>(List<T> baseList, List<T> overrides, Func<T, string> key)
+        {
+            if (overrides == null || overrides.Count == 0) return;
+            foreach (var o in overrides)
+            {
+                if (o == null) continue;
+                string k = key(o);
+                if (string.IsNullOrWhiteSpace(k)) continue;
+                int i = baseList.FindIndex(x => string.Equals(key(x), k, StringComparison.OrdinalIgnoreCase));
+                if (i >= 0) baseList[i] = o; else baseList.Add(o);
+            }
+        }
+
+        private static BaselineFamilyType Type(string cat, string name, double w) =>
+            new BaselineFamilyType
+            {
+                Category = cat, TypeName = name,
+                FamilyNamePatterns = new List<string> { "Door" },
+                Parameters = new List<BaselineFamilyTypeParam>
+                { new BaselineFamilyTypeParam { Name = "Width", ValueMm = w } }
+            };
+
+        [Fact]
+        public void A_Family_Type_Is_Keyed_On_Category_AND_Name()
+        {
+            // "STING 900x2100" may legitimately exist for a door and a window.
+            // Keying on name alone would let one silently replace the other.
+            var baseList = new List<BaselineFamilyType> { Type("Doors", "STING X", 900) };
+
+            Merge(baseList, new List<BaselineFamilyType> { Type("Windows", "STING X", 1200) },
+                  t => t.Category + "|" + t.TypeName);
+
+            Assert.Equal(2, baseList.Count);
+        }
+
+        [Fact]
+        public void An_Override_Replaces_The_Same_Category_And_Name()
+        {
+            var baseList = new List<BaselineFamilyType> { Type("Doors", "STING X", 900) };
+
+            Merge(baseList, new List<BaselineFamilyType> { Type("Doors", "STING X", 850) },
+                  t => t.Category + "|" + t.TypeName);
+
+            Assert.Single(baseList);
+            Assert.Equal(850, baseList[0].Parameters[0].ValueMm);
+        }
+
+        [Fact]
+        public void A_Parameter_Set_Is_Keyed_On_Category_Alone()
+        {
+            // One set per category is the schema's own rule — Validate() rejects
+            // two — so the merge key must match it.
+            var baseList = new List<BaselineFamilyParameterSet>
+            { new BaselineFamilyParameterSet { Category = "Doors",
+                  Parameters = new List<string> { "A" } } };
+
+            Merge(baseList, new List<BaselineFamilyParameterSet>
+            { new BaselineFamilyParameterSet { Category = "Doors",
+                  Parameters = new List<string> { "B" } } }, f => f.Category);
+
+            Assert.Single(baseList);
+            Assert.Equal("B", baseList[0].Parameters.Single());
+        }
+
+        [Fact]
+        public void Adoption_REPLACES_Rather_Than_Accumulates()
+        {
+            // The corporate list is empty by design and a project's adoption is
+            // its whole statement. Appending would mean a project could never
+            // un-adopt a pack that some future corporate default added.
+            var b = new ProjectBaseline { AdoptCatalogues = new List<string> { "OLD-V1" } };
+            var over = new ProjectBaseline { AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" } };
+
+            if (over.AdoptCatalogues != null && over.AdoptCatalogues.Count > 0)
+                b.AdoptCatalogues = over.AdoptCatalogues;
+
+            Assert.Equal(new[] { "EA-RESIDENTIAL-V1" }, b.AdoptCatalogues);
+        }
+    }
+
+    /// <summary>
+    /// B3 — library validation. A pack that reads as a standard when it is not
+    /// one is the failure this whole mechanism exists to prevent, so provenance
+    /// is enforced rather than encouraged.
+    /// </summary>
+    public class TypeCatalogueValidationTests
+    {
+        private static TypeCataloguePack Ok() => new TypeCataloguePack
+        {
+            Id = "EA-RESIDENTIAL-V1", Title = "t", Status = "provisional",
+            SourceNote = "seeded from practice, not a standard; replace by harvest",
+            FamilyTypes = new List<BaselineFamilyType>
+            {
+                new BaselineFamilyType
+                {
+                    Category = "Doors",
+                    FamilyNamePatterns = new List<string> { "Door" },
+                    TypeName = "STING Door 900",
+                    Parameters = new List<BaselineFamilyTypeParam>
+                    { new BaselineFamilyTypeParam { Name = "Width", ValueMm = 900 } }
+                }
+            }
+        };
+
+        private static List<string> Problems(TypeCataloguePack p) =>
+            new TypeCatalogueLibrary { Packs = new List<TypeCataloguePack> { p } }.Validate();
+
+        [Fact]
+        public void A_Well_Formed_Pack_Validates() => Assert.Empty(Problems(Ok()));
+
+        [Fact]
+        public void A_Provisional_Pack_With_No_SourceNote_Is_Caught()
+        {
+            // A provisional pack that does not say WHY it is provisional reads
+            // exactly like a standard.
+            var p = Ok(); p.SourceNote = "";
+
+            Assert.Contains(Problems(p), x => x.Contains("sourceNote"));
+        }
+
+        [Fact]
+        public void A_Reviewed_Pack_Does_Not_Need_A_SourceNote()
+        {
+            // The requirement is provenance for the PROVISIONAL claim, not
+            // paperwork for its own sake.
+            var p = Ok(); p.Status = "reviewed"; p.SourceNote = "";
+
+            Assert.Empty(Problems(p));
+        }
+
+        [Fact]
+        public void An_Unknown_Status_Is_Caught()
+        {
+            var p = Ok(); p.Status = "draft";
+
+            Assert.Contains(Problems(p), x => x.Contains("draft"));
+        }
+
+        [Fact]
+        public void A_Pack_With_No_Id_Could_Never_Be_Adopted()
+        {
+            var p = Ok(); p.Id = "";
+
+            Assert.Contains(Problems(p), x => x.Contains("no id"));
+        }
+
+        [Fact]
+        public void An_Empty_Pack_Is_Caught()
+        {
+            var p = Ok(); p.FamilyTypes = new List<BaselineFamilyType>();
+
+            Assert.Contains(Problems(p), x => x.Contains("no family types"));
+        }
+
+        [Fact]
+        public void A_Pack_Type_Must_Satisfy_The_SAME_Layer_2_Rules()
+        {
+            // Borrowing ProjectBaseline.Validate rather than re-stating the
+            // rules is what keeps the two from drifting. A pack type without the
+            // STING prefix is as wrong as a declared one without it.
+            var p = Ok();
+            p.FamilyTypes[0].TypeName = "Door 900";
+
+            Assert.Contains(Problems(p), x => x.Contains("STING"));
+        }
+
+        [Fact]
+        public void A_Duplicated_Pack_Id_Is_Caught()
+        {
+            var lib = new TypeCatalogueLibrary { Packs = new List<TypeCataloguePack> { Ok(), Ok() } };
+
+            Assert.Contains(lib.Validate(), x => x.Contains("more than once"));
+        }
+
+        [Fact]
+        public void ById_Is_Case_Insensitive_And_Trims()
+        {
+            var lib = new TypeCatalogueLibrary { Packs = new List<TypeCataloguePack> { Ok() } };
+
+            Assert.NotNull(lib.ById("  ea-residential-v1 "));
+            Assert.Null(lib.ById("EA-RESIDENTIAL-V2"));
+            Assert.Null(lib.ById(""));
+        }
+    }
+
+    /// <summary>
+    /// B3 — the shipped pack. It ships PROVISIONAL and adopted by nobody: a
+    /// provisional pack nobody has adopted can be wrong without costing
+    /// anything; a corporate default cannot.
+    /// </summary>
+    public class ShippedTypeCatalogueTests
+    {
+        private static string DataFile(string n) => Path.Combine(AppContext.BaseDirectory, "Data", n);
+
+        private static TypeCatalogueLibrary Shipped() =>
+            JsonConvert.DeserializeObject<TypeCatalogueLibrary>(
+                File.ReadAllText(DataFile("STING_TYPE_CATALOGUES.json")));
+
+        private static ProjectBaseline Baseline() =>
+            JsonConvert.DeserializeObject<ProjectBaseline>(
+                File.ReadAllText(DataFile("STING_PROJECT_BASELINE.json")));
+
+        [Fact]
+        public void The_Shipped_Library_Validates()
+            => Assert.Empty(Shipped().Validate());
+
+        [Fact]
+        public void The_Corporate_Baseline_Adopts_NOTHING()
+        {
+            // THE decision of §10. A corporate baseline that adopted a pack
+            // would be the fixed catalogue this mechanism exists to avoid — one
+            // person's reading of the market, in every future project, reported
+            // as a standard.
+            Assert.Empty(Baseline().AdoptCatalogues ?? new List<string>());
+        }
+
+        [Fact]
+        public void The_Corporate_Baseline_Still_Declares_No_Family_Types_Directly()
+        {
+            // Belt and braces on the same decision: adopting nothing would mean
+            // little if the types were declared inline instead.
+            Assert.Empty(Baseline().FamilyTypes ?? new List<BaselineFamilyType>());
+        }
+
+        [Fact]
+        public void Exactly_One_Pack_Ships_And_It_Is_Provisional()
+        {
+            var packs = Shipped().Packs;
+
+            Assert.Single(packs);
+            Assert.Equal("EA-RESIDENTIAL-V1", packs[0].Id);
+            Assert.True(packs[0].IsProvisional, "the starter pack must not claim to be reviewed");
+        }
+
+        [Fact]
+        public void The_Shipped_Pack_Says_Where_Its_Sizes_Came_From_And_That_They_Are_To_Be_Replaced()
+        {
+            string note = Shipped().Packs[0].SourceNote ?? "";
+
+            Assert.Contains("NOT from a standard", note, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("harvest", note, StringComparison.OrdinalIgnoreCase);
+            Assert.True(note.Length >= 120, "a source note too short to explain anything");
+        }
+
+        [Fact]
+        public void The_Library_Note_Says_Packs_Are_Opt_In()
+        {
+            string note = Shipped().Note ?? "";
+
+            Assert.Contains("OPT-IN", note, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("adoptCatalogues", note);
+        }
+
+        [Fact]
+        public void The_Pack_Id_Carries_Its_Version()
+        {
+            // -V1 to -V2 must be an explicit migration, never a silent
+            // redefinition of what a project already adopted.
+            Assert.All(Shipped().Packs, p => Assert.Matches(@"-V\d+$", p.Id));
+        }
+
+        [Fact]
+        public void Every_Shipped_Pack_Type_Carries_The_Minted_Prefix()
+        {
+            foreach (var t in Shipped().Packs.SelectMany(p => p.FamilyTypes))
+                Assert.True(t.CarriesMintedPrefix,
+                    $"'{t.TypeName}' would be unidentifiable after a vendor reload");
+        }
+
+        [Fact]
+        public void Adopting_The_Shipped_Pack_Produces_A_Baseline_That_Validates()
+        {
+            // End to end on real data: the pack folds into a real baseline and
+            // the result is still internally consistent. A pack that validates
+            // alone but breaks the baseline it joins would fail only on
+            // somebody's model.
+            var b = Baseline();
+            b.AdoptCatalogues = new List<string> { "EA-RESIDENTIAL-V1" };
+
+            var a = TypeCatalogueResolver.Apply(b, Shipped());
+
+            Assert.True(a.TypesAdopted > 0);
+            Assert.Empty(b.Validate());
+        }
+
+        [Fact]
+        public void The_Shipped_Pack_Covers_Both_Doors_And_Windows()
+        {
+            var cats = Shipped().Packs[0].FamilyTypes.Select(t => t.Category).Distinct().ToList();
+
+            Assert.Contains("Doors", cats);
+            Assert.Contains("Windows", cats);
+        }
+
+        [Fact]
+        public void Every_Shipped_Pack_Type_States_A_Size()
+        {
+            // A type with no parameters mints a duplicate of whatever the source
+            // happened to be — which is a type named for the baseline that is
+            // not what the baseline describes. #798 in miniature.
+            foreach (var t in Shipped().Packs.SelectMany(p => p.FamilyTypes))
+                Assert.True(t.Parameters.Count > 0, $"'{t.TypeName}' declares no dimensions");
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
+++ b/StingTools/Commands/Baseline/ProjectBaselineCommands.cs
@@ -49,6 +49,70 @@ namespace StingTools.Commands.Baseline
             Merge(b.CeilingTypes, over.CeilingTypes, t => t.Name);
             Merge(b.Levels, over.Levels, l => l.Name);
             Merge(b.FamilyExpectations, over.FamilyExpectations, f => f.Category);
+
+            // These three were NOT merged, and the corporate file ships all
+            // three empty — so the only place layer 2 and layer 3 content can
+            // come from is the project override, and it was being dropped on
+            // the floor. Both layers were unreachable: a project declaring
+            // familyTypes got a clean audit and no explanation.
+            //
+            // Keyed on category+name for types (the same "STING 900x2100" may
+            // legitimately exist for a door and a window) and on category for
+            // parameter sets.
+            Merge(b.FamilyTypes, over.FamilyTypes, t => t.Category + "|" + t.TypeName);
+            Merge(b.FamilyParameters, over.FamilyParameters, f => f.Category);
+
+            // Adoption is a project decision and REPLACES rather than adds to
+            // the corporate list, which is empty by design: a corporate
+            // baseline that adopted a pack would be the fixed catalogue this
+            // whole mechanism exists to avoid.
+            if (over.AdoptCatalogues != null && over.AdoptCatalogues.Count > 0)
+                b.AdoptCatalogues = over.AdoptCatalogues;
+
+            return b;
+        }
+
+        /// <summary>Corporate catalogue packs. No project override: a pack is
+        /// shared, versioned content, and a project that wants different types
+        /// declares them directly in familyTypes.</summary>
+        public static TypeCatalogueLibrary LoadCatalogues()
+        {
+            try
+            {
+                string path = StingToolsApp.FindDataFile("STING_TYPE_CATALOGUES.json");
+                if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+                {
+                    StingLog.Warn("BaselineRegistry: STING_TYPE_CATALOGUES.json not found; "
+                                + "no catalogue pack can be adopted.");
+                    return new TypeCatalogueLibrary();
+                }
+                return JsonConvert.DeserializeObject<TypeCatalogueLibrary>(File.ReadAllText(path))
+                       ?? new TypeCatalogueLibrary();
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"BaselineRegistry.LoadCatalogues: {ex.Message}");
+                return new TypeCatalogueLibrary();
+            }
+        }
+
+        /// <summary>
+        /// The baseline a run should actually use: corporate + project override,
+        /// with any adopted catalogue packs folded in. One entry point, so the
+        /// audit and the apply can never disagree about what was adopted.
+        /// </summary>
+        public static ProjectBaseline LoadResolved(Document doc, out CatalogueAdoption adoption)
+        {
+            var b = Load(doc);
+            var lib = LoadCatalogues();
+            adoption = TypeCatalogueResolver.Apply(b, lib);
+
+            // A broken LIBRARY is reported through the same channel as a broken
+            // baseline, because from a user's seat it is the same failure: the
+            // data that decides what reaches their model is wrong.
+            foreach (string problem in lib.Validate())
+                StingLog.Warn($"BaselineRegistry catalogue: {problem}");
+
             return b;
         }
 
@@ -561,9 +625,10 @@ namespace StingTools.Commands.Baseline
                 return Result.Cancelled;
             }
 
-            var baseline = BaselineRegistry.Load(doc);
+            var baseline = BaselineRegistry.LoadResolved(doc, out var adoption);
             var audit = BaselineAuditor.Audit(baseline, BaselineModelReader.Read(doc, baseline));
             audit.BaselineProblems.AddRange(BaselineAugmenter.UnresolvableParameters(doc, baseline));
+            audit.Adoption = adoption;
             TaskDialog.Show("STING Project Baseline — audit", BaselineAuditor.Report(audit));
             return Result.Succeeded;
         }
@@ -582,12 +647,13 @@ namespace StingTools.Commands.Baseline
                 return Result.Cancelled;
             }
 
-            var baseline = BaselineRegistry.Load(doc);
+            var baseline = BaselineRegistry.LoadResolved(doc, out var adoption);
             // The SAME inventory feeds the audit and the mint. Reading twice
             // would let the model change between them, so Apply could mint
             // against facts the user never saw in the report.
             var inventory = BaselineModelReader.Read(doc, baseline);
             var audit = BaselineAuditor.Audit(baseline, inventory);
+            audit.Adoption = adoption;
 
             // A shared-parameter name that the FILE does not define cannot be
             // added to anything. Resolving it here means Apply refuses before a

--- a/StingTools/Core/Baseline/BaselineAudit.cs
+++ b/StingTools/Core/Baseline/BaselineAudit.cs
@@ -93,6 +93,11 @@ namespace StingTools.Core.Baseline
         public List<BaselineFinding> Findings = new List<BaselineFinding>();
         public List<string> BaselineProblems = new List<string>();
 
+        /// <summary>B3 — which catalogue packs this run adopted, if any. Null
+        /// when nothing was resolved; the report then says nothing about
+        /// catalogues, which is correct for a project that adopts none.</summary>
+        public CatalogueAdoption Adoption;
+
         public int MissingCount => Findings.Count(f => f.Kind == BaselineFindingKind.Missing);
         public int ConflictCount => Findings.Count(f => f.Kind == BaselineFindingKind.Conflict);
         public int GuidanceCount => Findings.Count(f => f.Kind == BaselineFindingKind.Guidance);
@@ -443,6 +448,16 @@ namespace StingTools.Core.Baseline
                 sb.AppendLine($"CANNOT CREATE — {r.GuidanceCount} item(s) need families loaded by hand:");
                 foreach (var f in r.Findings.Where(x => x.Kind == BaselineFindingKind.Guidance))
                     sb.AppendLine($"    ? {f.Name}: {f.Detail}");
+            }
+
+            // Adoption is a STATED DECISION and is reported as one. A project
+            // that believes it adopted a pack and did not is exactly the silent
+            // absence this mechanism exists to avoid, so an unknown id is named.
+            string adopted = r.Adoption?.Summary();
+            if (!string.IsNullOrEmpty(adopted))
+            {
+                sb.AppendLine();
+                sb.AppendLine(adopted);
             }
 
             sb.AppendLine();

--- a/StingTools/Core/Baseline/TypeCatalogue.cs
+++ b/StingTools/Core/Baseline/TypeCatalogue.cs
@@ -1,0 +1,220 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeCatalogue.cs — B3: opt-in catalogue packs of layer-2 family types.
+//
+//  WHY NOT A CORPORATE CATALOGUE. The obvious move is to ship ~30 East African
+//  types in the universal baseline. It is the wrong one: those sizes would be
+//  ONE PERSON'S READING OF THE MARKET, applied to every future project and
+//  reported by the audit as though they were standards. A project whose doors
+//  are genuinely 850 wide would be told, on every run, that it is missing a
+//  type it does not want.
+//
+//  That is the familiar failure — a confident default nobody asked for, that
+//  nobody checks.
+//
+//  SO: named packs, NONE ACTIVE BY DEFAULT. A project adopts one by id in its
+//  own override, which makes adoption a stated decision, visible in the audit.
+//  A new market is a new pack, not a code change and not a change to the
+//  universal baseline. Packs are versioned in the id, so -V1 → -V2 is an
+//  explicit migration rather than a silent redefinition of what a project
+//  already adopted.
+//
+//  The one shipped pack is PROVISIONAL and adopted by nobody. A provisional
+//  pack nobody has adopted can be wrong without costing anything; a corporate
+//  default cannot. It is a shape, to be replaced by harvesting a delivered
+//  model (B4) — so the catalogue grows from work that was actually built and
+//  paid for, not from anyone's recollection of the market.
+//
+//  Revit-free: adoption and validation decide what reaches somebody's model,
+//  so they are testable without Revit.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Baseline
+{
+    /// <summary>One named, versioned set of layer-2 family types.</summary>
+    public sealed class TypeCataloguePack
+    {
+        /// <summary>Stable id, version included: EA-RESIDENTIAL-V1. A project
+        /// adopts by this string, so changing it is a migration.</summary>
+        public string Id = "";
+        public string Title = "";
+
+        /// <summary>"provisional" or "reviewed". A provisional pack states that
+        /// its sizes are a starting point, not a standard.</summary>
+        public string Status = "provisional";
+
+        /// <summary>REQUIRED on a provisional pack: where the sizes came from,
+        /// and that they are to be replaced. A pack whose provenance is not
+        /// stated is indistinguishable from a standard.</summary>
+        public string SourceNote = "";
+
+        public List<BaselineFamilyType> FamilyTypes = new List<BaselineFamilyType>();
+
+        public const string Provisional = "provisional";
+        public const string Reviewed = "reviewed";
+
+        public bool IsProvisional =>
+            string.Equals((Status ?? "").Trim(), Provisional, StringComparison.OrdinalIgnoreCase);
+
+        public bool HasKnownStatus =>
+            IsProvisional
+            || string.Equals((Status ?? "").Trim(), Reviewed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public sealed class TypeCatalogueLibrary
+    {
+        public string SchemaVersion = "1.0";
+        public string Note = "";
+        public List<TypeCataloguePack> Packs = new List<TypeCataloguePack>();
+
+        public TypeCataloguePack ById(string id)
+            => string.IsNullOrWhiteSpace(id) ? null
+             : (Packs ?? new List<TypeCataloguePack>())
+                   .FirstOrDefault(p => p != null
+                       && string.Equals(p.Id?.Trim(), id.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Problems inside the library itself, before any project adopts
+        /// anything. Every one of these would otherwise surface as a confusing
+        /// audit on somebody's model.
+        /// </summary>
+        public List<string> Validate()
+        {
+            var problems = new List<string>();
+            var packs = Packs ?? new List<TypeCataloguePack>();
+
+            foreach (var p in packs)
+            {
+                if (p == null) continue;
+                string label = string.IsNullOrWhiteSpace(p.Id) ? "(unnamed pack)" : p.Id.Trim();
+
+                if (string.IsNullOrWhiteSpace(p.Id))
+                    problems.Add("a catalogue pack has no id, so no project could adopt it");
+
+                if (!p.HasKnownStatus)
+                    problems.Add($"pack '{label}' has status '{p.Status}', which is neither "
+                               + $"'{TypeCataloguePack.Provisional}' nor '{TypeCataloguePack.Reviewed}'");
+
+                // A provisional pack that does not say WHY it is provisional
+                // reads exactly like a standard. That is the whole failure this
+                // mechanism exists to avoid.
+                if (p.IsProvisional && string.IsNullOrWhiteSpace(p.SourceNote))
+                    problems.Add($"pack '{label}' is provisional but states no sourceNote — a "
+                               + "provisional pack with no stated provenance reads as a standard");
+
+                if ((p.FamilyTypes ?? new List<BaselineFamilyType>()).Count == 0)
+                    problems.Add($"pack '{label}' declares no family types, so adopting it would "
+                               + "do nothing");
+
+                // Pack entries must satisfy exactly the layer-2 rules. Borrowing
+                // ProjectBaseline.Validate rather than re-stating them is what
+                // keeps the two from drifting.
+                foreach (string x in new ProjectBaseline { FamilyTypes = p.FamilyTypes }.Validate())
+                    problems.Add($"pack '{label}': {x}");
+            }
+
+            foreach (var g in packs.Where(p => p != null && !string.IsNullOrWhiteSpace(p.Id))
+                                   .GroupBy(p => p.Id.Trim(), StringComparer.OrdinalIgnoreCase)
+                                   .Where(g2 => g2.Count() > 1))
+                problems.Add($"catalogue pack id '{g.Key}' is declared more than once");
+
+            return problems;
+        }
+    }
+
+    /// <summary>What adoption actually did, for the audit report.</summary>
+    public sealed class CatalogueAdoption
+    {
+        public readonly List<string> AdoptedPackIds = new List<string>();
+        public readonly List<string> UnknownPackIds = new List<string>();
+        public int TypesAdopted;
+
+        /// <summary>Types that a pack declared and the project had already
+        /// declared itself. The project's own entry wins; this is counted so
+        /// the override is visible rather than mysterious.</summary>
+        public readonly List<string> OverriddenByProject = new List<string>();
+
+        public bool AnythingAdopted => AdoptedPackIds.Count > 0;
+
+        /// <summary>The audit line, or NULL when no pack was named at all — a
+        /// project that adopts nothing has nothing to report, and an invented
+        /// "0 packs adopted" reads as a finding.</summary>
+        public string Summary()
+        {
+            if (AdoptedPackIds.Count == 0 && UnknownPackIds.Count == 0) return null;
+
+            string s = AdoptedPackIds.Count > 0
+                ? $"Catalogue packs adopted: {string.Join(", ", AdoptedPackIds)} "
+                  + $"({TypesAdopted} family type(s))."
+                : "No catalogue pack was adopted.";
+
+            if (OverriddenByProject.Count > 0)
+                s += $" {OverriddenByProject.Count} pack type(s) were overridden by the project's own "
+                   + "declaration: " + string.Join(", ", OverriddenByProject.Take(6))
+                   + (OverriddenByProject.Count > 6 ? ", …" : "") + ".";
+
+            if (UnknownPackIds.Count > 0)
+                s += $" {UnknownPackIds.Count} adopted id(s) match no pack and did NOTHING: "
+                   + string.Join(", ", UnknownPackIds)
+                   + ". Check the spelling, or the pack version.";
+
+            return s;
+        }
+    }
+
+    public static class TypeCatalogueResolver
+    {
+        /// <summary>
+        /// Fold the adopted packs' family types into the baseline.
+        ///
+        /// ADDITIVE, and the PROJECT WINS. A project can adopt a pack and still
+        /// override individual types by declaring them itself — project entries
+        /// win by category+name, which is the same precedence every other
+        /// override in this file already has.
+        ///
+        /// An adopted id matching no pack is reported, never ignored: a silent
+        /// no-op here means a project believes it adopted a catalogue and did
+        /// not, which is exactly the kind of confident absence this codebase
+        /// keeps paying for.
+        /// </summary>
+        public static CatalogueAdoption Apply(ProjectBaseline baseline, TypeCatalogueLibrary library)
+        {
+            var a = new CatalogueAdoption();
+            if (baseline == null) return a;
+
+            var wanted = (baseline.AdoptCatalogues ?? new List<string>())
+                .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToList();
+            if (wanted.Count == 0) return a;
+
+            baseline.FamilyTypes = baseline.FamilyTypes ?? new List<BaselineFamilyType>();
+
+            foreach (string id in wanted)
+            {
+                var pack = library?.ById(id);
+                if (pack == null) { a.UnknownPackIds.Add(id); continue; }
+                a.AdoptedPackIds.Add(pack.Id.Trim());
+
+                foreach (var t in pack.FamilyTypes ?? new List<BaselineFamilyType>())
+                {
+                    if (t == null || string.IsNullOrWhiteSpace(t.TypeName)
+                                  || string.IsNullOrWhiteSpace(t.Category)) continue;
+
+                    bool projectHasIt = baseline.FamilyTypes.Any(x => x != null
+                        && string.Equals(x.Category?.Trim(), t.Category.Trim(), StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(x.TypeName?.Trim(), t.TypeName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+                    if (projectHasIt)
+                    {
+                        a.OverriddenByProject.Add($"{t.Category.Trim()} / {t.TypeName.Trim()}");
+                        continue;
+                    }
+                    baseline.FamilyTypes.Add(t);
+                    a.TypesAdopted++;
+                }
+            }
+            return a;
+        }
+    }
+}

--- a/StingTools/Data/STING_TYPE_CATALOGUES.json
+++ b/StingTools/Data/STING_TYPE_CATALOGUES.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": "1.0",
+  "note": "Catalogue packs are OPT-IN. NO pack applies unless a project adopts it by id, in <project>/_data/coord/project_baseline.json: { \"adoptCatalogues\": [\"EA-RESIDENTIAL-V1\"] }. This is deliberate. A fixed corporate catalogue would be one person's reading of the market applied to every future project and reported by the audit as though it were a standard, so a project whose doors are genuinely 850 wide would be told on every run that it is missing a type it does not want. A new market is a NEW PACK, not a change to the universal baseline; packs are versioned in the id, so -V1 to -V2 is an explicit migration and never a silent redefinition of what a project already adopted.",
+  "packs": [
+    {
+      "id": "EA-RESIDENTIAL-V1",
+      "title": "East African residential — provisional starter",
+      "status": "provisional",
+      "sourceNote": "PROVISIONAL AND ADOPTED BY NOBODY. Seeded from common Ugandan residential practice, NOT from a standard and NOT from a completed project. It is a SHAPE showing what a pack looks like, not a recommendation of these sizes. Replace it by harvesting a delivered model with Baseline_HarvestTypes, so the catalogue grows from work that was actually built and paid for rather than from anyone's recollection of the market. After two or three delivered projects this pack should be replaced outright.",
+      "familyTypes": [
+        {
+          "category": "Doors",
+          "familyNamePatterns": ["M_Single-Flush", "Single-Flush", "Single Flush", "Door"],
+          "typeName": "STING Door Flush 900x2100",
+          "purpose": "Main internal single leaf",
+          "parameters": [
+            { "name": "Width", "valueMm": 900 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Doors",
+          "familyNamePatterns": ["M_Single-Flush", "Single-Flush", "Single Flush", "Door"],
+          "typeName": "STING Door Flush 800x2100",
+          "purpose": "Bedroom and store internal leaf",
+          "parameters": [
+            { "name": "Width", "valueMm": 800 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Doors",
+          "familyNamePatterns": ["M_Single-Flush", "Single-Flush", "Single Flush", "Door"],
+          "typeName": "STING Door Flush 700x2100",
+          "purpose": "Bathroom and WC leaf",
+          "parameters": [
+            { "name": "Width", "valueMm": 700 },
+            { "name": "Height", "valueMm": 2100 }
+          ]
+        },
+        {
+          "category": "Doors",
+          "familyNamePatterns": ["M_Double-Flush", "Double-Flush", "Double", "Door"],
+          "typeName": "STING Door Entrance 1200x2400",
+          "purpose": "Main entrance, double leaf",
+          "parameters": [
+            { "name": "Width", "valueMm": 1200 },
+            { "name": "Height", "valueMm": 2400 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": ["M_Fixed", "Fixed", "Casement", "Window"],
+          "typeName": "STING Window 1200x1200",
+          "purpose": "Habitable room window",
+          "parameters": [
+            { "name": "Width", "valueMm": 1200 },
+            { "name": "Height", "valueMm": 1200 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": ["M_Fixed", "Fixed", "Casement", "Window"],
+          "typeName": "STING Window 1500x1200",
+          "purpose": "Living room window",
+          "parameters": [
+            { "name": "Width", "valueMm": 1500 },
+            { "name": "Height", "valueMm": 1200 }
+          ]
+        },
+        {
+          "category": "Windows",
+          "familyNamePatterns": ["M_Fixed", "Fixed", "Casement", "Window"],
+          "typeName": "STING Window 600x600",
+          "purpose": "Bathroom and WC high-level light",
+          "parameters": [
+            { "name": "Width", "valueMm": 600 },
+            { "name": "Height", "valueMm": 600 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 254 — B3: catalogue packs nobody has adopted, and the merge that made layers 2 and 3 reachable)
+
+**The defect found on the way in.** `BaselineRegistry.Load` merged materials, host types, levels and
+family *expectations* from the project override — but **not `familyTypes`, `familyParameters` or
+`adoptCatalogues`**. The corporate file ships all three empty, so the project override was the
+**only possible source** for layers 2 and 3, and it was being dropped on the floor. Both layers
+shipped unreachable: a project declaring `familyTypes` got a clean audit and no explanation. Fixed
+here because B3's adoption mechanism could not have worked either.
+
+**Why not a fixed corporate catalogue.** Shipping ~30 East African types in the universal baseline
+would be **one person's reading of the market**, applied to every future project and reported by the
+audit as though it were a standard. A project whose doors are genuinely 850 wide would be told, on
+every run, that it is missing a type it does not want. That is the familiar failure: a confident
+default nobody asked for, that nobody checks.
+
+**So: named, versioned packs in `STING_TYPE_CATALOGUES.json`, none active by default.** A project
+adopts by id in its own override — `{ "adoptCatalogues": ["EA-RESIDENTIAL-V1"] }` — which makes
+adoption a **stated decision**, reported in the audit. Properties that make it sustainable:
+
+* **Additive, and the project wins.** A project can adopt a pack and still override individual types
+  by declaring them itself; overrides are counted and named so they are visible rather than
+  mysterious.
+* **A new market is a new pack**, not a code change and not a change to the universal baseline.
+* **Packs are versioned in the id**, so `-V1` → `-V2` is an explicit migration, never a silent
+  redefinition of what a project already adopted.
+* **An adopted id matching no pack is NAMED, never ignored.** A project that believes it adopted a
+  catalogue and did not is exactly the confident absence this codebase keeps paying for.
+* **Pack types are held to the same layer-2 rules**, by borrowing `ProjectBaseline.Validate` rather
+  than restating them — which is what keeps the two from drifting.
+
+**One pack ships: `EA-RESIDENTIAL-V1`, provisional, adopted by nobody.** Its `sourceNote` says the
+sizes are seeded from common Ugandan residential practice, **not** from a standard and **not** from a
+completed project, that it is a *shape* rather than a recommendation, and that it should be replaced
+by harvesting a delivered model (B4). Validation **requires** a source note on any provisional pack:
+one that does not say why it is provisional reads exactly like a standard.
+
+A provisional pack nobody has adopted can be wrong without costing anything. A corporate default
+cannot.
+
+**What was VERIFIED.** Build 0 errors / 0 warnings. `StingTools.Boq.Tests` 772 → **776 green** on top
+of #811/#813. All four gates pass. **Twenty-seven deliberately wrong inputs were each shown to make
+the matching gate FAIL, then restored**, including the delete-the-thing-it-protects check on every
+new gate: packs applying unadopted, an unknown id ignored, the pack overwriting a project
+declaration, the override match ignoring the category, an invented "0 packs" finding, six ways of
+weakening the summary and the validation, the corporate baseline adopting a pack or declaring the
+types inline, the shipped pack claiming to be reviewed, its source note losing its disclaimer, its id
+losing its version, a pack type losing the STING prefix or its size, windows dropped from the pack, a
+pack type that would break the baseline it joins, and adoption accumulating instead of replacing.
+
+One test failed on its own premise rather than on the code: the family name `M_Single-Flush` does not
+contain the pattern `Door`, so the audit correctly reported guidance. The **test** was fixed.
+
+**What was NOT verified.** *Nothing Revit-side has been run by anyone* — across T1–T5 and all three
+baseline layers. The adoption resolver and the library validation are Revit-free and fully tested;
+`LoadResolved` and the override merge read files through `StingPaths` and have **never executed
+against a real model**. In particular, **the claim that layers 2 and 3 are now reachable is untested
+in Revit** — it is a code-reading finding with a repaired merge behind it, not an observed export.
+
 #### Completed (Phase 240 — branch and workspace triage: unreviewed work found, landed or laid to rest)
 
 Two pools of work were invisible: **40 remote branches that had never had a PR opened on


### PR DESCRIPTION
## A defect found on the way in

`BaselineRegistry.Load` merged materials, host types, levels and family *expectations* from the project override — but **not `familyTypes`, `familyParameters` or `adoptCatalogues`**.

The corporate file ships all three empty, so the project override was the **only possible source** for layers 2 and 3, and it was being dropped on the floor. **Both layers shipped unreachable**: a project declaring `familyTypes` got a clean audit and no explanation.

Fixed here, because B3's adoption mechanism could not have worked either.

## Why not a fixed corporate catalogue

Shipping ~30 East African types in the universal baseline would be **one person's reading of the market**, applied to every future project and reported by the audit as though it were a standard. A project whose doors are genuinely 850 wide would be told, on every run, that it is missing a type it does not want.

That is the familiar failure: a confident default nobody asked for, that nobody checks.

## The mechanism: named packs, none active by default

`STING_TYPE_CATALOGUES.json`. A project adopts by id in its own override:

```json
{ "adoptCatalogues": ["EA-RESIDENTIAL-V1"] }
```

| Property | Why |
|---|---|
| **Adoption is a stated decision** | per project, and reported in the audit |
| **Additive, and the project wins** | adopt a pack and still override individual types; overrides are counted and **named**, not silent |
| **A new market is a new pack** | not a code change, not a change to the universal baseline |
| **Packs are versioned in the id** | `-V1` → `-V2` is an explicit migration, never a silent redefinition of what a project already adopted |
| **An unknown adopted id is NAMED** | a project that believes it adopted a catalogue and did not is exactly the confident absence this codebase keeps paying for |
| **Pack types obey the layer-2 rules** | by borrowing `ProjectBaseline.Validate` rather than restating them — which is what keeps the two from drifting |

## One pack ships, and it is adopted by nobody

`EA-RESIDENTIAL-V1`, status `provisional`. Its `sourceNote` says the sizes are seeded from common Ugandan residential practice, **not** from a standard and **not** from a completed project; that it is a *shape* rather than a recommendation; and that it should be replaced by harvesting a delivered model (B4).

Validation **requires** a source note on any provisional pack — one that does not say why it is provisional reads exactly like a standard. A reviewed pack does not need one, so the rule is about the *claim*, not paperwork.

**A provisional pack nobody has adopted can be wrong without costing anything. A corporate default cannot.**

Two tests hold the corporate file to that: it adopts nothing, and it declares no `familyTypes` inline either — belt and braces on the same decision.

## Verified

- `dotnet build StingTools/StingTools.csproj -c Release` (`-t:Rebuild`) → **0 errors, 0 warnings**
- `dotnet test StingTools.Boq.Tests` → **776 green**, up from 772 on top of #811/#813
- `tools/check_command_doc_acquisition.ps1` → **PASS**
- `tools/check_path_discipline.ps1` → **PASS**
- `tools/check_workflow_wiring.ps1` → **PASS** (Tier 4: 0)

**Twenty-seven deliberately wrong inputs, each shown to make the matching gate FAIL, then restored** — including the delete-the-thing-it-protects check on every new gate: packs applying unadopted · an unknown id ignored · the pack overwriting a project declaration · the override match ignoring the category · an invented "0 packs" finding · six ways of weakening the summary and the validation · the corporate baseline adopting a pack · or declaring the types inline · the shipped pack claiming to be `reviewed` · its source note losing its disclaimer · its id losing its version suffix · a pack type losing the STING prefix or its size · windows dropped from the pack · a pack type that would break the baseline it joins · adoption accumulating instead of replacing.

**One test failed on its own premise rather than on the code:** the family name `M_Single-Flush` does not contain the pattern `Door`, so the audit correctly reported guidance. The **test** was fixed, not the assertion loosened.

## NOT verified

**Nothing Revit-side has been run by anyone** — across T1–T5 and all three baseline layers.

The adoption resolver and library validation are Revit-free and fully tested. `LoadResolved` and the override merge read files through `StingPaths` and have **never executed against a real model**. In particular, **the claim that layers 2 and 3 are now reachable is untested in Revit** — it is a code-reading finding with a repaired merge behind it, not an observed export.

## Note on #812

B1 and B2 landed in parallel as #811 and #813 while my own versions of them were in review. I closed #812 rather than reconciling duplicate work; this PR builds on main's B1/B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ln3G9zFMNri66K13obgcW2
