### PR TITLE
feat(matsched): show where every rate came from

### DIFF
--- a/StingTools.Boq.Tests/RateProvenanceLabelTests.cs
+++ b/StingTools.Boq.Tests/RateProvenanceLabelTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MaterialCommodity.RateSource has been populated since the first export
+    /// and written to no sheet, so 28,000 against cement printed identically
+    /// whether it came from the user's supplier quote or from the shipped
+    /// guess. Only one of those is safe to tender against.
+    /// </summary>
+    public class RateProvenanceLabelTests
+    {
+        private static MaterialCommodity C(double rate, string source, bool memo = false) =>
+            new MaterialCommodity
+            {
+                CommodityKey = "cement", Description = "Cement", SupplierUnit = "Bags",
+                OrderQuantity = 93, RateUGX = rate, RateSource = source, IsMemorandum = memo
+            };
+
+        [Fact]
+        public void A_Project_Rate_Says_Project()
+        {
+            Assert.Equal(RateProvenanceLabel.Project, RateProvenanceLabel.For(C(31000, "project")));
+        }
+
+        [Fact]
+        public void A_Baseline_Rate_Says_Indicative_Not_Baseline()
+        {
+            // The LITERAL, not the constant. "baseline" reads as authority and
+            // the file it comes from says the opposite in its own header —
+            // indicative Kampala prices, re-price before tender — so the word
+            // on the sheet is the whole point of this column. Asserting the
+            // constant would let somebody rename it back to "Baseline" without
+            // a single test moving; that mutation was run and passed, which is
+            // why this is written this way.
+            Assert.Equal("Indicative", RateProvenanceLabel.For(C(28000, "baseline")));
+            Assert.NotEqual("Baseline", RateProvenanceLabel.For(C(28000, "baseline")));
+        }
+
+        [Theory]
+        [InlineData("project", "Project")]
+        [InlineData("unpriced", "NOT PRICED")]
+        public void The_Other_Labels_Are_Pinned_To_Their_Words_Too(string source, string expected)
+        {
+            Assert.Equal(expected, RateProvenanceLabel.For(C(source == "unpriced" ? 0 : 1, source)));
+        }
+
+        [Fact]
+        public void An_Unpriced_Row_Says_So_Loudly()
+        {
+            Assert.Equal(RateProvenanceLabel.NotPriced, RateProvenanceLabel.For(C(0, "unpriced")));
+        }
+
+        [Fact]
+        public void A_Memorandum_Gets_The_Same_Dash_Its_Amount_Cell_Gets()
+        {
+            // Labelling it NOT PRICED would read as a defect to fix — the
+            // misreading that had four intermediate measures priced beside
+            // their own constituents.
+            Assert.Equal(RateProvenanceLabel.None, RateProvenanceLabel.For(C(0, "unpriced", memo: true)));
+        }
+
+        [Fact]
+        public void A_Rate_With_No_Recorded_Source_Is_Not_Quietly_Called_Baseline()
+        {
+            Assert.Equal("?", RateProvenanceLabel.For(C(5000, "")));
+        }
+
+        [Fact]
+        public void A_Null_Commodity_Does_Not_Throw()
+        {
+            Assert.Equal(RateProvenanceLabel.None, RateProvenanceLabel.For(null));
+        }
+
+        // ── the summary line ────────────────────────────────────────────────
+
+        [Fact]
+        public void The_Summary_Counts_Each_Provenance()
+        {
+            string s = RateProvenanceLabel.Summary(new List<MaterialCommodity>
+            {
+                C(31000, "project"), C(28000, "baseline"), C(0, "unpriced")
+            });
+
+            Assert.Contains("1 row(s) priced from THIS project's rates", s);
+            Assert.Contains("1 from the shipped indicative figures", s);
+            Assert.Contains("1 not priced", s);
+        }
+
+        [Fact]
+        public void Indicative_Rows_Carry_The_Re_Price_Warning()
+        {
+            string s = RateProvenanceLabel.Summary(new[] { C(28000, "baseline") });
+
+            Assert.Contains("must re-price before tender", s);
+            Assert.Contains("Price Commodities", s);
+        }
+
+        [Fact]
+        public void Unpriced_Rows_Say_The_Total_Is_An_Understatement()
+        {
+            // The grand total silently omits them. Saying "not priced" without
+            // saying what that does to the total is the half-truth.
+            string s = RateProvenanceLabel.Summary(new[] { C(0, "unpriced") });
+
+            Assert.Contains("UNDER-statement", s);
+        }
+
+        [Fact]
+        public void A_Fully_Project_Priced_Schedule_Carries_No_Warning_Tail()
+        {
+            string s = RateProvenanceLabel.Summary(new[] { C(31000, "project") });
+
+            Assert.DoesNotContain("re-price before tender", s);
+            Assert.DoesNotContain("UNDER-statement", s);
+        }
+
+        [Fact]
+        public void Memoranda_Are_Not_Counted_In_Any_Bucket()
+        {
+            // They have no rate by design, so counting them as "not priced"
+            // would report a problem that does not exist.
+            string s = RateProvenanceLabel.Summary(new[] { C(31000, "project"), C(0, "x", memo: true) });
+
+            Assert.Contains("1 row(s) priced from THIS project's rates", s);
+            Assert.Contains("0 not priced", s);
+        }
+
+        [Fact]
+        public void Nothing_To_Report_Returns_Null_Rather_Than_A_Line_Of_Zeroes()
+        {
+            Assert.Null(RateProvenanceLabel.Summary(new MaterialCommodity[0]));
+            Assert.Null(RateProvenanceLabel.Summary(null));
+            Assert.Null(RateProvenanceLabel.Summary(new[] { C(0, "x", memo: true) }));
+        }
+
+        [Fact]
+        public void An_Unknown_Source_Is_Reported_As_Something_That_Should_Not_Happen()
+        {
+            string s = RateProvenanceLabel.Summary(new[] { C(5000, "") });
+
+            Assert.Contains("should not", s);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\MembraneScanTally.cs" Link="MaterialSchedule\MembraneScanTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesCalculator.cs" Link="MaterialSchedule\ConsumablesCalculator.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RateEditorSeed.cs" Link="MaterialSchedule\RateEditorSeed.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\RateProvenanceLabel.cs" Link="MaterialSchedule\RateProvenanceLabel.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -132,6 +132,16 @@ namespace StingTools.BOQ.MaterialSchedule
             AppendSiteTools(doc, msDoc, lib, inputs.Rates, result);
             Reconciler.Check(msDoc);
 
+            // After every row exists and every rate is resolved, and after the
+            // site-tools and manual rows are appended so their rates count too.
+            // The column says it per row; this says it once.
+            if (msDoc.Options.ShowPrices)
+            {
+                string provenance = RateProvenanceLabel.Summary(
+                    msDoc.Stages.SelectMany(st => st.Commodities));
+                if (!string.IsNullOrEmpty(provenance)) msDoc.Warnings.Add(provenance);
+            }
+
             result.Document = msDoc;
             if (result.CompoundTakeoffWasOff)
                 result.Warnings.Add(

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
@@ -41,8 +41,14 @@ namespace StingTools.BOQ.MaterialSchedule
                 $"MATERIAL SCHEDULE — {doc.ProjectName}"
                 + (priced ? "" : "  (QUANTITIES ONLY — NO PRICES)"));
 
+            // "Rate source" is column 9, AFTER Amount, not between Rate and it.
+            // Amount is column 8 and is written by four separate paths (commodity,
+            // labour, provisional sum, sub-total); inserting mid-table would move
+            // every one of them and the F*G formula with them, to gain nothing a
+            // reader would notice.
             string[] cols = priced
-                ? new[] { "Item", "Description", "Unit", "Net Qty", "Waste %", "Order Qty", "Rate UGX", "Amount UGX" }
+                ? new[] { "Item", "Description", "Unit", "Net Qty", "Waste %", "Order Qty",
+                          "Rate UGX", "Amount UGX", "Rate source" }
                 : new[] { "Item", "Description", "Unit", "Net Qty", "Waste %", "Order Qty" };
 
             int row = 3;
@@ -87,6 +93,7 @@ namespace StingTools.BOQ.MaterialSchedule
                         // A memorandum row gets NO rate cell and NO formula. Its
                         // constituents carry the money; leaving an empty rate
                         // cell here is what invited pricing the same wall twice.
+                        ws.Cell(row, 9).Value = RateProvenanceLabel.For(c);
                         if (c.IsMemorandum)
                         {
                             ws.Cell(row, 8).Value = "—";

--- a/StingTools/Core/MaterialSchedule/RateProvenanceLabel.cs
+++ b/StingTools/Core/MaterialSchedule/RateProvenanceLabel.cs
@@ -1,0 +1,91 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RateProvenanceLabel.cs — turn a rate's internal source token into
+//  something a reader can act on.
+//
+//  MaterialCommodity.RateSource has always been populated ("baseline" /
+//  "project" / "unpriced") and written to no sheet at all, so a priced
+//  schedule showed 28,000 against cement without saying whether that was the
+//  user's supplier quote or the shipped guess. Both print identically, and
+//  only one of them is safe to tender against.
+//
+//  The labels are deliberately NOT the raw tokens. "baseline" reads as
+//  authority; the shipped file it comes from says the opposite of that in its
+//  own header — "indicative Kampala market prices; a live project MUST
+//  re-price before tender". So the label says Indicative.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public static class RateProvenanceLabel
+    {
+        public const string Project    = "Project";
+        public const string Indicative = "Indicative";
+        public const string NotPriced  = "NOT PRICED";
+        public const string None       = "—";
+
+        /// <summary>
+        /// The cell text for one commodity.
+        ///
+        /// A memorandum gets the same em dash its Amount cell gets: it carries
+        /// no rate by design, and labelling it "NOT PRICED" would read as a
+        /// defect to fix — which is exactly the misreading that had four
+        /// intermediate measures priced alongside their own constituents.
+        /// </summary>
+        public static string For(MaterialCommodity c)
+        {
+            if (c == null) return None;
+            if (c.IsMemorandum) return None;
+            if (c.IsUnpriced) return NotPriced;
+
+            switch ((c.RateSource ?? "").Trim().ToLowerInvariant())
+            {
+                case "project":  return Project;
+                case "baseline": return Indicative;
+                // A rate with no recorded source is not the same as no rate.
+                // Saying so beats inventing a provenance for it.
+                default:         return "?";
+            }
+        }
+
+        /// <summary>
+        /// One line for the export notes, so the column is a summary somebody
+        /// reads once rather than 58 cells they scan.
+        ///
+        /// Returns NULL when the schedule carries no priced rows at all — a
+        /// quantities-only export has no provenance to report, and a line of
+        /// zeroes there would read as a finding.
+        /// </summary>
+        public static string Summary(IEnumerable<MaterialCommodity> commodities)
+        {
+            var rows = (commodities ?? Enumerable.Empty<MaterialCommodity>())
+                       .Where(c => c != null && !c.IsMemorandum).ToList();
+            if (rows.Count == 0) return null;
+
+            int project    = rows.Count(c => For(c) == Project);
+            int indicative = rows.Count(c => For(c) == Indicative);
+            int unpriced   = rows.Count(c => For(c) == NotPriced);
+            int unknown    = rows.Count(c => For(c) == "?");
+
+            if (project == 0 && indicative == 0 && unpriced == 0 && unknown == 0) return null;
+
+            string s = $"Rate provenance: {project} row(s) priced from THIS project's rates, "
+                     + $"{indicative} from the shipped indicative figures, {unpriced} not priced.";
+
+            if (indicative > 0)
+                s += " The indicative rates are Kampala market figures shipped with the plugin and "
+                   + "the file that carries them says a live project must re-price before tender — "
+                   + "they are a starting point, not a quotation. Use Price Commodities to replace "
+                   + "them with your own.";
+            if (unpriced > 0)
+                s += $" The {unpriced} unpriced row(s) total zero in this schedule, so the grand "
+                   + "total is an UNDER-statement, not an estimate of them.";
+            if (unknown > 0)
+                s += $" {unknown} row(s) carry a rate with no recorded source, which should not "
+                   + "happen — report it rather than trusting the number.";
+            return s;
+        }
+    }
+}


### PR DESCRIPTION
## The gap

`MaterialCommodity.RateSource` has been populated since the first export and written to **no sheet at all**. So `28,000` against cement printed identically whether it was your supplier's quote or the figure shipped with the plugin — and only one of those is safe to tender against.

## What lands

A **Rate source** column, plus one aggregate line in the export notes so the column is a summary you read once rather than 58 cells you scan.

| Source | Cell reads |
|---|---|
| `project` | `Project` |
| `baseline` | `Indicative` |
| `unpriced` | `NOT PRICED` |
| memorandum | `—` |
| rate with no recorded source | `?` |

**The labels are deliberately not the internal tokens.** "baseline" reads as authority; the file it comes from says the opposite in its own header — *"indicative Kampala market prices; a live project MUST re-price before tender"*. So the sheet says **Indicative**, and the notes carry that warning in full with a pointer to Price Commodities.

A memorandum gets the same em dash its Amount cell gets. Labelling it `NOT PRICED` would read as a defect to fix, which is exactly the misreading that had four intermediate measures priced alongside their own constituents.

The unpriced count carries what it does to the bottom line: those rows total zero, so the grand total is an **under-statement**, not an estimate of them. Saying "not priced" without that is the half-truth.

## Placement

Column **9, after Amount** — not between Rate and Amount. Amount is column 8 and four separate paths write it (commodity, labour, provisional sum, sub-total), so inserting mid-table would move every one of them and the `F*G` formula with them, to gain nothing a reader would notice.

## Verified

- Boq tests **817 → 832**
- `dotnet build -c Release` **0 errors / 0 warnings**
- All four gates pass

**Five mutations, three failing:** a memorandum reading `NOT PRICED` (1), an unrecorded source silently becoming `Indicative` (2), dropping the under-statement warning (1).

## Two proved nothing and are reported rather than counted

**Renaming the label back to `"Baseline"` moved no test** — every assertion compared against the *constant* rather than the word. The word on the sheet is the entire point of this column. The test now pins the literal and that mutation fails. This was a real gap in the tests, and only mutating found it.

**Including memoranda in the summary's row list also moved nothing** — `For()` already returns the em dash for them, so they land in no bucket and the counts are identical. Genuinely redundant with the branch inside `For()`, kept for the idiom, recorded as redundant rather than presented as evidence.

## Not verified

No export has been produced with this column in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
