### PR TITLE
feat(classification): OmniClass assign/audit, table selector, and classification-on-tags

### DIFF
--- a/StingTools.Boq.Tests/ClassificationPolicyTests.cs
+++ b/StingTools.Boq.Tests/ClassificationPolicyTests.cs
@@ -1,0 +1,143 @@
+using System.Linq;
+using StingTools.Core.Classification;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase 196 — host-free classification-order overlay (classification_policy.json).
+    public class ClassificationPolicyTests
+    {
+        [Fact]
+        public void Default_Reproduces_Historic_Order()
+        {
+            var p = ClassificationPolicy.Default;
+            var ids = p.Order.Select(s => s.Id).ToArray();
+            Assert.Equal(new[] { "uniclass.pr", "uniclass.ss", "uniclass.ef", "omniclass23", "native" }, ids);
+            Assert.True(p.Order.Last().IsNative);
+            // The Pr rung carries the historic param + key prefix.
+            var pr = p.Order[0];
+            Assert.Equal("UNICLASS_PR_TXT", pr.Param);
+            Assert.Equal("PR", pr.Prefix);
+            Assert.Equal("Uniclass.Pr", pr.Label);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("{ not json")]
+        [InlineData("{ \"order\": [] }")]
+        public void Blank_Malformed_Or_Empty_Falls_Back_To_Default(string raw)
+        {
+            var p = ClassificationPolicy.Parse(raw);
+            var ids = p.Order.Select(s => s.Id).ToArray();
+            Assert.Equal(new[] { "uniclass.pr", "uniclass.ss", "uniclass.ef", "omniclass23", "native" }, ids);
+        }
+
+        [Fact]
+        public void American_Overlay_Puts_Csi_First()
+        {
+            string json = @"{
+              ""order"": [
+                { ""id"": ""csi"",         ""param"": ""CSI_SECTION_TXT"",    ""prefix"": ""CSI"",  ""label"": ""CSI.MasterFormat"" },
+                { ""id"": ""omniclass23"", ""param"": ""STING_OMNICLASS_23"", ""prefix"": ""OMNI"", ""label"": ""OmniClass23"" },
+                { ""id"": ""uniclass.pr"", ""param"": ""UNICLASS_PR_TXT"",    ""prefix"": ""PR"",   ""label"": ""Uniclass.Pr"" },
+                { ""id"": ""native"" }
+              ]
+            }";
+            var p = ClassificationPolicy.Parse(json);
+            Assert.Equal("csi", p.Order[0].Id);
+            Assert.Equal("CSI_SECTION_TXT", p.Order[0].Param);
+            Assert.Equal("CSI", p.Order[0].Prefix);
+            Assert.True(p.Order.Last().IsNative);
+        }
+
+        [Fact]
+        public void Prefix_And_Label_Are_Synthesised_When_Omitted()
+        {
+            // A bespoke owner table named only by id + param — prefix/label derived.
+            string json = @"{ ""order"": [ { ""id"": ""church.fcs"", ""param"": ""OWNER_FCS_CODE_TXT"" }, { ""id"": ""native"" } ] }";
+            var p = ClassificationPolicy.Parse(json);
+            var s = p.Order[0];
+            Assert.Equal("OWNER_FCS_CODE_TXT", s.Param);
+            Assert.Equal("FCS", s.Prefix);          // tail after the dot, upper-cased
+            Assert.Equal("church.fcs", s.Label);    // falls back to the id
+        }
+
+        [Fact]
+        public void Missing_Native_Rung_Is_Appended()
+        {
+            string json = @"{ ""order"": [ { ""id"": ""csi"", ""param"": ""CSI_SECTION_TXT"" } ] }";
+            var p = ClassificationPolicy.Parse(json);
+            Assert.Equal(2, p.Order.Count);
+            Assert.True(p.Order.Last().IsNative);
+        }
+
+        [Fact]
+        public void Rungs_After_Native_Are_Dropped_And_Duplicates_Collapsed()
+        {
+            string json = @"{
+              ""order"": [
+                { ""id"": ""csi"", ""param"": ""CSI_SECTION_TXT"" },
+                { ""id"": ""native"" },
+                { ""id"": ""native"" },
+                { ""id"": ""uniclass.pr"", ""param"": ""UNICLASS_PR_TXT"" }
+              ]
+            }";
+            var p = ClassificationPolicy.Parse(json);
+            Assert.Equal(2, p.Order.Count);          // csi + single native; trailing rungs dropped
+            Assert.Equal("csi", p.Order[0].Id);
+            Assert.True(p.Order[1].IsNative);
+        }
+
+        // ---- the SHIPPED KUT overlay --------------------------------------------
+        // Newtonsoft leaves an unrecognised or wrongly-typed field at its default, so a
+        // typo in this file is a silent no-op in Revit rather than an error. Parsing the
+        // real shipped overlay with the real parser is the only thing that catches it.
+        [Fact]
+        public void ShippedKutOverlay_ParsesToTheValuesItClaims()
+        {
+            string path = System.IO.Path.Combine(System.AppContext.BaseDirectory, "Data", "kut_classification_policy.json");
+            Assert.True(System.IO.File.Exists(path), $"Shipped KUT classification overlay not found at {path}");
+
+            var p = ClassificationPolicy.Parse(System.IO.File.ReadAllText(path));
+
+            // An explicit order - so it overrides the Classification Standard picker.
+            Assert.True(p.HasExplicitOrder);
+            Assert.Equal("csi", p.Order[0].Id);
+            Assert.Equal("CSI_SECTION_TXT", p.Order[0].Param);
+            Assert.Equal("CSI", p.Order[0].Prefix);
+            Assert.True(p.Order.Last().IsNative);
+
+            // omniClassTable is a STRING; a numeric 21 would deserialise fine but a typo
+            // would silently fall back to "21" too, so assert the parsed value.
+            Assert.Equal("21", p.OmniClassTableNumber);
+
+            // tagClassifications is a string ARRAY; a bare string would leave it empty.
+            Assert.Equal(new[] { "CSI_SECTION_TXT" }, p.TagClassifications.ToArray());
+        }
+
+        [Fact]
+        public void Default_And_TableOnly_Policies_Do_Not_Claim_An_Explicit_Order()
+        {
+            // Only an authored, non-empty order overrides ClassificationStandard. Opting
+            // into an OmniClass table must not silently re-order a project's BOQ grouping.
+            Assert.False(ClassificationPolicy.Default.HasExplicitOrder);
+            Assert.False(ClassificationPolicy.Parse("{ \"omniClassTable\": \"13\" }").HasExplicitOrder);
+            Assert.False(ClassificationPolicy.Parse("{ \"order\": [] }").HasExplicitOrder);
+            Assert.False(ClassificationPolicy.Parse("{ not json").HasExplicitOrder);
+            Assert.True(ClassificationPolicy.Parse(
+                "{ \"order\": [ { \"id\": \"csi\", \"param\": \"CSI_SECTION_TXT\" } ] }").HasExplicitOrder);
+        }
+
+        [Fact]
+        public void Entry_Without_Param_Is_Treated_As_Native_Terminal()
+        {
+            string json = @"{ ""order"": [ { ""id"": ""uniclass.pr"", ""param"": ""UNICLASS_PR_TXT"" }, { ""id"": ""fallback"" } ] }";
+            var p = ClassificationPolicy.Parse(json);
+            Assert.Equal(2, p.Order.Count);
+            Assert.False(p.Order[0].IsNative);
+            Assert.True(p.Order[1].IsNative);        // no param → terminal native
+        }
+    }
+}

--- a/StingTools.Boq.Tests/OmniClassMapTests.cs
+++ b/StingTools.Boq.Tests/OmniClassMapTests.cs
@@ -1,0 +1,253 @@
+using System.IO;
+using System.Linq;
+using StingTools.Core.Classification;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase 198 — OmniClass Table 21 (Elements) map. Pure logic; no Revit.
+    // Reuses the CsiMasterFormat parser/resolver (same CSV grammar) — the
+    // "Section" column carries the OmniClass number.
+    public class OmniClassMapTests
+    {
+        private static System.Collections.Generic.List<CsiRule> LoadShipped(string file = "STING_OMNICLASS_21_MAP.csv")
+        {
+            string path = Path.Combine(System.AppContext.BaseDirectory, "Data", file);
+            Assert.True(File.Exists(path), $"Shipped OmniClass map not found at {path}");
+            return CsiMasterFormat.ParseCsvLines(File.ReadAllLines(path));
+        }
+
+        [Fact]
+        public void ShippedMap_Loads_And_Every_Row_Has_Code_And_Title()
+        {
+            var rules = LoadShipped();
+            Assert.NotEmpty(rules);
+            // Section (OmniClass code) + Title must be present, and the comma-split
+            // parser must not have leaked the title into the Nrm2/Unit columns.
+            Assert.All(rules, r =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(r.Section), $"{r.Category} missing OmniClass code");
+                Assert.False(string.IsNullOrWhiteSpace(r.Title), $"{r.Category}/{r.Section} missing title");
+                Assert.True(string.IsNullOrEmpty(r.Nrm2), $"{r.Category}/{r.Section} leaked into Nrm2 — a comma in the Title?");
+                Assert.StartsWith("21-", r.Section);   // Table 21 (Elements)
+            });
+        }
+
+        [Fact]
+        public void Resolves_Services_To_The_Right_Element_Group()
+        {
+            var rules = LoadShipped();
+            // HVAC ducts → 21-04 30 00; sanitary pipes → plumbing 21-04 20 00;
+            // sprinklers → fire protection 21-04 40 00.
+            Assert.Equal("21-04 30 00", CsiMasterFormat.Resolve(rules, "Ducts", "", "", "").Section);
+            Assert.Equal("21-04 20 00", CsiMasterFormat.Resolve(rules, "Pipes", "", "", "SAN").Section);
+            Assert.Equal("21-04 30 00", CsiMasterFormat.Resolve(rules, "Pipes", "", "", "CHW").Section);
+            Assert.Equal("21-04 40 00", CsiMasterFormat.Resolve(rules, "Sprinklers", "", "", "").Section);
+        }
+
+        [Fact]
+        public void Specific_Family_Beats_Generic_For_Mechanical_Equipment()
+        {
+            var rules = LoadShipped();
+            // An elevator on Mechanical Equipment → Conveying; a generic AHU → HVAC.
+            Assert.Equal("21-04 10 00", CsiMasterFormat.Resolve(rules, "Mechanical Equipment", "Passenger Elevator", "", "").Section);
+            Assert.Equal("21-04 30 00", CsiMasterFormat.Resolve(rules, "Mechanical Equipment", "Generic AHU", "", "").Section);
+        }
+
+        [Fact]
+        public void Structure_And_Site_Resolve()
+        {
+            var rules = LoadShipped();
+            Assert.Equal("21-02 10 00", CsiMasterFormat.Resolve(rules, "Structural Framing", "", "", "").Section);  // Superstructure
+            Assert.Equal("21-01 10 00", CsiMasterFormat.Resolve(rules, "Structural Foundations", "", "", "").Section); // Foundations
+            Assert.Equal("21-07 20 00", CsiMasterFormat.Resolve(rules, "Planting", "", "", "").Section);            // Site Improvements
+        }
+
+        // ── Phase 199 — table switching ─────────────────────────────────────
+
+        [Fact]
+        public void Table13_SpacesMap_ResolvesByRoomName()
+        {
+            // Table 13 keys on the host-room name fed into FamilyRegex (Category "*").
+            var rules = LoadShipped("STING_OMNICLASS_13_MAP.csv");
+            Assert.All(rules, r =>
+            {
+                Assert.StartsWith("13-", r.Section);
+                Assert.False(string.IsNullOrWhiteSpace(r.Title));
+                Assert.True(string.IsNullOrEmpty(r.Nrm2), "comma leaked into Title?");
+            });
+            Assert.Equal("13-25 00 00", CsiMasterFormat.Resolve(rules, "*", "Male WC", "Male WC", "").Section);     // Sanitary
+            Assert.Equal("13-15 00 00", CsiMasterFormat.Resolve(rules, "*", "Bishop Office", "Bishop Office", "").Section); // Office
+            Assert.Equal("13-21 00 00", CsiMasterFormat.Resolve(rules, "*", "Main Corridor", "Main Corridor", "").Section); // Circulation
+            Assert.Equal("13-61 00 00", CsiMasterFormat.Resolve(rules, "*", "Sealing Room", "Sealing Room", "").Section);   // Religious
+            Assert.Null(CsiMasterFormat.Resolve(rules, "*", "", "", ""));   // no room → unresolved
+        }
+
+        [Fact]
+        public void TableRegistry_KnowsElementVsSpatial()
+        {
+            Assert.False(OmniClassTables.Resolve("21").IsSpatial);
+            Assert.Equal("STING_OMNICLASS_21_MAP.csv", OmniClassTables.Resolve("21").MapFile);
+            // Both Spaces tables (13, 14) are spatial — they classify the host room.
+            Assert.True(OmniClassTables.Resolve("13").IsSpatial);
+            Assert.True(OmniClassTables.Resolve("14").IsSpatial);
+            Assert.Equal("Table 13 — Spaces by Function", OmniClassTables.Resolve("13").Label);
+            // The other BOQ-relevant element axes are registered + non-spatial.
+            Assert.False(OmniClassTables.Resolve("23").IsSpatial);
+            Assert.Equal("Products", OmniClassTables.Resolve("23").Name);
+            Assert.Equal("Work Results", OmniClassTables.Resolve("22").Name);
+            Assert.Equal("Materials", OmniClassTables.Resolve("41").Name);
+            Assert.False(OmniClassTables.Resolve("11").IsSpatial);
+            // A truly-unknown number → generic non-spatial info (so an overlay table still works).
+            Assert.Equal("STING_OMNICLASS_99_MAP.csv", OmniClassTables.Resolve("99").MapFile);
+            Assert.False(OmniClassTables.Resolve("99").IsSpatial);
+            // Blank → default Table 21.
+            Assert.Equal("21", OmniClassTables.Resolve("").Number);
+        }
+
+        [Fact]
+        public void TableRegistry_TableOf_ReadsPrefix()
+        {
+            Assert.Equal("21", OmniClassTables.TableOf("21-04 30 00"));
+            Assert.Equal("13", OmniClassTables.TableOf("13-25 00 00"));
+            Assert.Equal("", OmniClassTables.TableOf(""));
+        }
+
+        [Fact]
+        public void Policy_OmniClassTable_ParsesAndNormalises()
+        {
+            // Default policy → Table 21.
+            Assert.Equal("21", ClassificationPolicy.Default.OmniClassTableNumber);
+            // A policy that sets ONLY the table (no order) keeps it + uses the default order.
+            var p = ClassificationPolicy.Parse("{ \"omniClassTable\": \"Table 13\" }");
+            Assert.Equal("13", p.OmniClassTableNumber);
+            Assert.NotEmpty(p.Order);
+            // Normalises "T23" / whitespace → "23".
+            Assert.Equal("23", ClassificationPolicy.Parse("{ \"omniClassTable\": \"T23\" }").OmniClassTableNumber);
+        }
+
+        [Fact]
+        public void Policy_TagClassifications_ParsesAndDefaultsEmpty()
+        {
+            // Default + a table-only policy ⇒ no tag classifications (opt-in).
+            Assert.Empty(ClassificationPolicy.Default.TagClassifications);
+            Assert.Empty(ClassificationPolicy.Parse("{ \"omniClassTable\": \"23\" }").TagClassifications);
+            // Explicit list survives parse + normalise; coexists with the BOQ order.
+            var p = ClassificationPolicy.Parse(
+                "{ \"tagClassifications\": [\"CSI_SECTION_TXT\", \"ASS_OMNICLASS_TXT\"], " +
+                "\"order\": [ { \"id\": \"csi\", \"param\": \"CSI_SECTION_TXT\" }, { \"id\": \"native\" } ] }");
+            Assert.Equal(new[] { "CSI_SECTION_TXT", "ASS_OMNICLASS_TXT" }, p.TagClassifications.ToArray());
+            Assert.NotEmpty(p.Order);
+        }
+
+        // ── Phase 199c — Table 23 (Products) + Table 41 (Materials) maps ────
+
+        [Fact]
+        public void Table23_ProductsMap_ResolvesFromAutodeskCodes()
+        {
+            var rules = LoadShipped("STING_OMNICLASS_23_MAP.csv");
+            Assert.All(rules, r =>
+            {
+                Assert.StartsWith("23-", r.Section);
+                Assert.False(string.IsNullOrWhiteSpace(r.Title));
+                Assert.True(string.IsNullOrEmpty(r.Nrm2), "comma leaked into Title?");
+            });
+            Assert.Equal("23-17 11 00", CsiMasterFormat.Resolve(rules, "Doors", "", "", "").Section);
+            Assert.Equal("23-17 13 00", CsiMasterFormat.Resolve(rules, "Windows", "", "", "").Section);
+            Assert.Equal("23-33 49 00", CsiMasterFormat.Resolve(rules, "Ducts", "", "", "").Section);          // HVAC Ductwork
+            Assert.Equal("23-27 39 00", CsiMasterFormat.Resolve(rules, "Pipes", "", "", "DCW").Section);        // Piping
+            Assert.Equal("23-29 33 00", CsiMasterFormat.Resolve(rules, "Pipes", "", "", "FP").Section);         // Fire suppression
+            Assert.Equal("23-35 47 00", CsiMasterFormat.Resolve(rules, "Lighting Fixtures", "", "", "").Section);
+            // Family-specific refinement beats the Mechanical Equipment family default.
+            Assert.Equal("23-33 25 00", CsiMasterFormat.Resolve(rules, "Mechanical Equipment", "Generic AHU", "", "").Section);
+            Assert.Equal("23-33 00 00", CsiMasterFormat.Resolve(rules, "Mechanical Equipment", "Misc Unit", "", "").Section);
+            Assert.Equal("23-31 19 00", CsiMasterFormat.Resolve(rules, "Plumbing Fixtures", "Wall Hung WC", "", "").Section); // Toilets
+        }
+
+        [Fact]
+        public void Table41_MaterialsMap_ResolvesByTypeNameKeyword()
+        {
+            var rules = LoadShipped("STING_OMNICLASS_41_MAP.csv");
+            Assert.All(rules, r =>
+            {
+                Assert.StartsWith("41-", r.Section);
+                Assert.False(string.IsNullOrWhiteSpace(r.Title));
+                Assert.True(string.IsNullOrEmpty(r.Nrm2), "comma leaked into Title?");
+            });
+            // Material keyword lives in the type name (3rd arg = type).
+            Assert.Equal("41-30 10 25 19 15", CsiMasterFormat.Resolve(rules, "Floors", "Floor", "Concrete - 200mm", "").Section); // Cement
+            Assert.Equal("41-30 20 11 11", CsiMasterFormat.Resolve(rules, "Structural Framing", "UB", "Steel UB 305x165", "").Section); // Carbon Steel
+            Assert.Equal("41-30 20 11 14", CsiMasterFormat.Resolve(rules, "Pipes", "Pipe", "Stainless Steel DN50", "").Section); // Stainless beats steel
+            Assert.Equal("41-30 10 27 17 13", CsiMasterFormat.Resolve(rules, "Walls", "Curtain", "Glazed Curtain Wall", "").Section); // Glass
+            Assert.Equal("41-30 30 11 19 13", CsiMasterFormat.Resolve(rules, "Casework", "Unit", "White Oak Veneer", "").Section); // Hardwood
+            // Category fallback when the type name has no material keyword.
+            Assert.Equal("41-30 20 11 11", CsiMasterFormat.Resolve(rules, "Structural Rebar", "Rebar", "16mm", "").Section); // Carbon Steel
+        }
+
+        // ── Phase 199d — resolver robustness + match modes ──────────────────
+
+        [Fact]
+        public void Resolver_IsCaseInsensitive_WithoutInlineFlag()
+        {
+            // A hand-authored overlay row with no "(?i)" must still match regardless of case.
+            var rules = new System.Collections.Generic.List<CsiRule>
+            {
+                new CsiRule { Category = "Walls", FamilyRegex = "concrete", Section = "21-02 20 00", Title = "X" },
+            };
+            Assert.NotNull(CsiMasterFormat.Resolve(rules, "Walls", "CONCRETE Cavity", "", ""));
+            Assert.NotNull(CsiMasterFormat.Resolve(rules, "Walls", "Precast Concrete", "", ""));
+        }
+
+        [Fact]
+        public void Resolver_ReportsAmbiguity_WhenTwoRulesTieOnDifferentCodes()
+        {
+            var rules = new System.Collections.Generic.List<CsiRule>
+            {
+                new CsiRule { Category = "Specialty Equipment", Section = "23-19 00 00", Title = "A" },
+                new CsiRule { Category = "Specialty Equipment", Section = "23-21 00 00", Title = "B" },
+            };
+            var best = CsiMasterFormat.Resolve(rules, "Specialty Equipment", "", "", "", out int score, out int tie);
+            Assert.Equal("23-19 00 00", best.Section);  // first wins
+            Assert.Equal(1, score);
+            Assert.Equal(2, tie);                        // ambiguous — two distinct codes tie
+            // Two rules that tie but AGREE on the code are not flagged.
+            var agree = new System.Collections.Generic.List<CsiRule>
+            {
+                new CsiRule { Category = "Doors", Section = "23-17 11 00" },
+                new CsiRule { Category = "Doors", Section = "23-17 11 00" },
+            };
+            CsiMasterFormat.Resolve(agree, "Doors", "", "", "", out _, out int tie2);
+            Assert.Equal(1, tie2);
+        }
+
+        [Fact]
+        public void TableRegistry_MatchModes()
+        {
+            Assert.Equal("element",  OmniClassTables.Resolve("21").MatchMode);
+            Assert.Equal("element",  OmniClassTables.Resolve("23").MatchMode);
+            Assert.Equal("room",     OmniClassTables.Resolve("13").MatchMode);
+            Assert.Equal("room",     OmniClassTables.Resolve("14").MatchMode);
+            Assert.Equal("material", OmniClassTables.Resolve("41").MatchMode);
+            Assert.Equal("element",  OmniClassTables.Resolve("99").MatchMode);   // generic fallback
+            Assert.True(OmniClassTables.Resolve("13").IsSpatial);
+            Assert.False(OmniClassTables.Resolve("41").IsSpatial);               // material ≠ spatial
+        }
+
+        [Fact]
+        public void TableRegistry_All_ListsEveryTable_FlagsMappedOnes()
+        {
+            var all = OmniClassTables.All;
+            Assert.Equal(15, all.Count);                              // the real OmniClass tables
+            Assert.Equal(new[] { "11", "12", "13", "14", "21" },     // ordered by number
+                all.Take(5).Select(t => t.Number).ToArray());
+            // Only 21/23/41/13 ship a corporate map out of the box.
+            Assert.True(OmniClassTables.ShipsMap("21"));
+            Assert.True(OmniClassTables.ShipsMap("23"));
+            Assert.True(OmniClassTables.ShipsMap("41"));
+            Assert.True(OmniClassTables.ShipsMap("13"));
+            Assert.False(OmniClassTables.ShipsMap("32"));
+            Assert.False(OmniClassTables.ShipsMap("99"));
+            Assert.Equal(4, OmniClassTables.MappedTableNumbers.Count);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -69,6 +69,12 @@
     <Compile Include="..\StingTools\BOQ\BoqXlsxStyle.cs" Link="MaterialSchedule\BoqXlsxStyle.cs" />
     <Compile Include="..\StingTools\BOQ\MaterialSchedule\MaterialScheduleXlsxWriter.cs" Link="MaterialSchedule\MaterialScheduleXlsxWriter.cs" />
     <Compile Include="..\StingTools\Core\ExportRouteMerge.cs" Link="ExportRouteMerge.cs" />
+    <!-- OmniClass / classification - the three Revit-free halves of the classification
+         layer: the CSI-grammar rule parser + resolver, the OmniClass table registry, and
+         the per-project policy POCO. The commands that walk the model stay out. -->
+    <Compile Include="..\StingTools\Core\Classification\CsiMasterFormat.cs" Link="Classification\CsiMasterFormat.cs" />
+    <Compile Include="..\StingTools\Core\Classification\OmniClassTables.cs" Link="Classification\OmniClassTables.cs" />
+    <Compile Include="..\StingTools\Core\Classification\ClassificationPolicy.cs" Link="Classification\ClassificationPolicy.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -108,6 +114,26 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\StingTools\Data\STING_TYPE_CATALOGUES.json" Link="Data\STING_TYPE_CATALOGUES.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- OmniClass - the SHIPPED maps, so the tests assert against the codes that
+         actually reach a project rather than against a fixture that restates them. -->
+    <None Include="..\StingTools\Data\STING_OMNICLASS_13_MAP.csv" Link="Data\STING_OMNICLASS_13_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\StingTools\Data\STING_OMNICLASS_21_MAP.csv" Link="Data\STING_OMNICLASS_21_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\StingTools\Data\STING_OMNICLASS_23_MAP.csv" Link="Data\STING_OMNICLASS_23_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\StingTools\Data\STING_OMNICLASS_41_MAP.csv" Link="Data\STING_OMNICLASS_41_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- The SHIPPED KUT classification overlay. Data-file JSON is not compile-checked:
+         a mistyped field leaves the POCO at its default and goes runtime-dead. Parsing
+         the real file with the real parser is what catches that. -->
+    <None Include="..\project-templates\KUT\_BIM_COORD\classification_policy.json" Link="Data\kut_classification_policy.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/StingTools/Commands/Classification/ClassificationStandardCommand.cs
+++ b/StingTools/Commands/Classification/ClassificationStandardCommand.cs
@@ -28,12 +28,23 @@ namespace StingTools.Commands.Classification
 
                 var current = ClassificationStandard.Active(doc);
 
+                // A project that authored its own classification_policy.json "order" has
+                // already overridden this selector. Saying so beats letting the dialog
+                // report success while the ladder it set is ignored.
+                bool overridden = ClassificationReader.HasExplicitPolicyOrder(doc);
+
                 var td = new TaskDialog("STING — Classification Standard")
                 {
                     MainInstruction = "Choose the authoritative classification standard",
                     MainContent = $"Current: {ClassificationStandard.Label(current)}.\n\n" +
                                   "This leads the BOQ / COBie / handover / IFC grouping cascade. " +
-                                  "Uniclass is the default; the others promote their codes to the front.",
+                                  "Uniclass is the default; the others promote their codes to the front." +
+                                  (overridden
+                                      ? "\n\n\u26A0 This project defines its own classification ladder in " +
+                                        "_BIM_COORD/classification_policy.json (\"order\"), which takes precedence. " +
+                                        "Your choice here will be recorded but will NOT change grouping until that " +
+                                        "\"order\" is removed."
+                                      : ""),
                     AllowCancellation = true
                 };
                 td.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Uniclass 2015", "Uniclass Pr → Ss → Ef (STING default)");

--- a/StingTools/Commands/Classification/OmniClassCommands.cs
+++ b/StingTools/Commands/Classification/OmniClassCommands.cs
@@ -1,0 +1,600 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  OmniClassCommands.cs — Phase 198/199 (KUT dual classification).
+//
+//  OmniClass is the element/product/material/space axis that rides alongside
+//  MasterFormat (work results) on the BOQ. CSI_Assign stamps the MasterFormat
+//  section; this is its OmniClass twin — a rule-driven assigner + audit that
+//  resolves each element to an OmniClass code + title and writes ASS_OMNICLASS_TXT
+//  (+ the ArchiCAD-compatible CLS_OMNICLASS_TITLE_TXT when bound).
+//
+//  Phase 199d (robustness/accuracy sweep):
+//   • 3-TIER resolution — (1) an authored native OmniClass Number on the type
+//     (Revit's built-in, Table 23) wins; (2) the map heuristic; the audit then
+//     measures the residual so a project closes it deliberately.
+//   • Per-map "# matchOn: element|room|material" directive (defaults: 13/14→room,
+//     41→material, else element) decides what each element is matched on:
+//     the element's own category/family/type/sys, its host ROOM name, or its
+//     MATERIAL name (with type-name fallback).
+//   • Switch-table hygiene — a stamped code from a DIFFERENT table is treated as
+//     empty in "fill empty" mode, so switching tables re-classifies cleanly.
+//   • Code validation — rows whose Section doesn't start with the active table
+//     number are warned (typo / wrong-table overlay row) and skipped.
+//   • OmniClass_Audit — read-only dry-run: % classified, unmapped keys, and
+//     AMBIGUOUS elements (≥2 rules tie at the top score) → CSV + summary.
+//
+//  Corporate maps STING_OMNICLASS_<table>_MAP.csv; project overlay
+//  <project>/_BIM_COORD/omniclass_map.csv (loaded first so it wins ties).
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Classification;
+
+namespace StingTools.Commands.Classification
+{
+    /// <summary>Reads / writes &lt;project&gt;/_BIM_COORD/classification_policy.json.
+    /// The path is resolved by <see cref="StingPaths"/> so the setting lands in whichever
+    /// coordination folder the project actually uses, and writes MERGE into the existing
+    /// JObject so setting one key never drops another - order / tagClassifications /
+    /// omniClassTable are independent switches that share one file.</summary>
+    internal static class PolicyFile
+    {
+        /// <summary>The policy file path, or null when the project is unsaved.</summary>
+        public static string Resolve(Document doc)
+            => StingPaths.MetaFile(doc, "_BIM_COORD", "classification_policy.json");
+
+        /// <summary>Apply <paramref name="mutate"/> to the existing (or a new) policy JObject
+        /// and write it back. An unparseable file is rewritten rather than silently extended -
+        /// merging into a half-read object would lose the keys we could not read anyway, and
+        /// the log line says so.</summary>
+        public static void Merge(string path, Action<Newtonsoft.Json.Linq.JObject> mutate)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            Newtonsoft.Json.Linq.JObject root;
+            if (File.Exists(path))
+            {
+                try { root = Newtonsoft.Json.Linq.JObject.Parse(File.ReadAllText(path)); }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"classification_policy.json unparseable ({ex.Message}) - rewriting.");
+                    root = new Newtonsoft.Json.Linq.JObject();
+                }
+            }
+            else root = new Newtonsoft.Json.Linq.JObject();
+            mutate(root);
+            File.WriteAllText(path, root.ToString(Newtonsoft.Json.Formatting.Indented));
+        }
+    }
+
+    internal static class OmniClassMap
+    {
+        private static readonly Regex MatchOnRx =
+            new Regex(@"^\s*#\s*matchOn\s*:\s*(element|room|material)\b", RegexOptions.IgnoreCase);
+
+        /// <summary>Load the rules for the active OmniClass table: corporate
+        /// STING_OMNICLASS_&lt;table&gt;_MAP.csv + the table-agnostic project overlay
+        /// _BIM_COORD/omniclass_map.csv (loaded first so it wins ties). Also extracts
+        /// the optional "# matchOn:" directive (overlay wins, else corporate, else null).</summary>
+        public static List<CsiRule> Load(Document doc, OmniClassTableInfo table, out int corp, out int overlay, out string matchOn)
+        {
+            corp = 0; overlay = 0; matchOn = null;
+            var rules = new List<CsiRule>();
+            // Project overlay first so it wins ties (Resolve takes the earliest on a tie).
+            try
+            {
+                string p = StingPaths.MetaFile(doc, "_BIM_COORD", "omniclass_map.csv");
+                if (!string.IsNullOrEmpty(p) && File.Exists(p))
+                {
+                    var lines = File.ReadAllLines(p);
+                    var r = CsiMasterFormat.ParseCsvLines(lines);
+                    overlay = r.Count; rules.AddRange(r);
+                    matchOn = ReadMatchOn(lines) ?? matchOn;   // overlay directive wins
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"OmniClass overlay load: {ex.Message}"); }
+
+            try
+            {
+                string c = StingToolsApp.FindDataFile(table.MapFile);
+                if (!string.IsNullOrEmpty(c) && File.Exists(c))
+                {
+                    var lines = File.ReadAllLines(c);
+                    var r = CsiMasterFormat.ParseCsvLines(lines);
+                    corp = r.Count; rules.AddRange(r);
+                    if (matchOn == null) matchOn = ReadMatchOn(lines);   // corporate directive as fallback
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"OmniClass corporate load ({table.MapFile}): {ex.Message}"); }
+
+            return rules;
+        }
+
+        private static string ReadMatchOn(IEnumerable<string> lines)
+        {
+            foreach (var l in lines ?? Enumerable.Empty<string>())
+            {
+                var m = MatchOnRx.Match(l ?? "");
+                if (m.Success) return m.Groups[1].Value.ToLowerInvariant();
+            }
+            return null;
+        }
+
+        /// <summary>The match mode in effect: map directive &gt; table default &gt; "element".</summary>
+        public static string EffectiveMatchMode(OmniClassTableInfo table, string directive)
+            => !string.IsNullOrEmpty(directive) ? directive
+             : !string.IsNullOrEmpty(table.MatchMode) ? table.MatchMode : "element";
+
+        /// <summary>Warn (log) on shipped/overlay rows whose Section doesn't belong to the
+        /// active table (typo or wrong-table overlay row). Returns the count of bad rows.</summary>
+        public static int CountMisfiledRows(IReadOnlyList<CsiRule> rules, string tableNumber)
+        {
+            int bad = 0;
+            string prefix = tableNumber + "-";
+            foreach (var r in rules)
+            {
+                string s = (r.Section ?? "").Trim();
+                if (s.Length == 0) continue;
+                if (!s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    bad++;
+                    StingLog.Warn($"OmniClass map: code '{s}' ({r.Category}) is not a Table {tableNumber} code — check the active table / overlay.");
+                }
+            }
+            return bad;
+        }
+
+        /// <summary>Normalise an OmniClass code to canonical single-spaced form so a
+        /// hand-typed "23-17  11 00" can't create a phantom distinct BOQ group.</summary>
+        public static string Normalize(string code) =>
+            string.IsNullOrWhiteSpace(code) ? "" : Regex.Replace(code.Trim(), "\\s+", " ");
+
+        /// <summary>Tier-1 — the element type's authored native OmniClass Number (Revit's
+        /// built-in param IS Table 23). Returned only when it matches the active table.</summary>
+        public static string AuthoredNative(Document doc, Element el, string tableNumber)
+        {
+            if (tableNumber != "23") return null;   // the built-in param is Table 23 only
+            try
+            {
+                Element type = doc.GetElement(el.GetTypeId());
+                Parameter p = type?.get_Parameter(BuiltInParameter.OMNICLASS_CODE)
+                              ?? el.get_Parameter(BuiltInParameter.OMNICLASS_CODE);
+                string v = p?.AsString();
+                if (!string.IsNullOrWhiteSpace(v) && v.Trim().StartsWith("23-")) return Normalize(v);
+            }
+            catch { }
+            return null;
+        }
+
+        /// <summary>The element's primary material name (structural material first, then the
+        /// first compound-structure material), for material-axis classification. Empty when
+        /// the element carries no material — the caller falls back to the type name.</summary>
+        public static string PrimaryMaterialName(Document doc, Element el)
+        {
+            try
+            {
+                ElementId mid = ElementId.InvalidElementId;
+                var sp = el.get_Parameter(BuiltInParameter.STRUCTURAL_MATERIAL_PARAM);
+                if (sp != null && sp.StorageType == StorageType.ElementId) mid = sp.AsElementId();
+                if (mid == null || mid == ElementId.InvalidElementId)
+                {
+                    var ids = el.GetMaterialIds(false);
+                    if (ids != null && ids.Count > 0) mid = ids.First();
+                }
+                if (mid != null && mid != ElementId.InvalidElementId)
+                    return (doc.GetElement(mid) as Material)?.Name ?? "";
+            }
+            catch { }
+            return "";
+        }
+    }
+
+    // ── result of resolving one element (shared by Assign + Audit) ──────────
+    internal sealed class OmniResolveResult
+    {
+        public string Code;        // null ⇒ unresolved
+        public string Title;
+        public string Source;      // "native" | "map"
+        public string UnmappedKey; // category / room / material — for the unmapped report
+        public int TieCount;       // >1 ⇒ ambiguous (map only)
+    }
+
+    internal static class OmniResolver
+    {
+        /// <summary>Resolve one element for the active table + match mode. Tier-1 native first
+        /// (table 23), then the map heuristic on element / room / material input.</summary>
+        public static OmniResolveResult Resolve(Document doc, Element el, OmniClassTableInfo table,
+            string matchMode, IReadOnlyList<CsiRule> rules)
+        {
+            var res = new OmniResolveResult();
+
+            // Tier-1 — authored native code wins (author-on-type → 100%).
+            string native = OmniClassMap.AuthoredNative(doc, el, table.Number);
+            if (native != null) { res.Code = native; res.Title = ""; res.Source = "native"; res.UnmappedKey = ""; return res; }
+
+            string cat = ParameterHelpers.GetCategoryName(el);
+            CsiRule rule = null; int tie = 0;
+            if (string.Equals(matchMode, "room", StringComparison.OrdinalIgnoreCase))
+            {
+                // Classify the host ROOM by name (fed into family+type; the real category
+                // is passed too so a future category-specific spatial row could match).
+                var room = ParameterHelpers.GetRoomAtElement(doc, el);
+                string roomName = room?.Name ?? "";
+                res.UnmappedKey = string.IsNullOrEmpty(roomName) ? "(no room)" : roomName;
+                if (!string.IsNullOrEmpty(roomName))
+                    rule = CsiMasterFormat.Resolve(rules, cat, roomName, roomName, "", out _, out tie);
+            }
+            else if (string.Equals(matchMode, "material", StringComparison.OrdinalIgnoreCase))
+            {
+                // Prefer the element's actual MATERIAL name; fall back to the type name
+                // (legacy keyword path). The real category is passed so the map's
+                // near-certain category fallbacks (rebar→steel, curtain panel→glass) fire.
+                string mat = OmniClassMap.PrimaryMaterialName(doc, el);
+                string typeName = ParameterHelpers.GetFamilySymbolName(el);
+                string input = !string.IsNullOrEmpty(mat) ? mat : typeName;
+                res.UnmappedKey = !string.IsNullOrEmpty(mat) ? mat
+                    : (string.IsNullOrEmpty(typeName) ? "(no material)" : "type:" + typeName);
+                if (!string.IsNullOrEmpty(input))
+                    rule = CsiMasterFormat.Resolve(rules, cat, input, input, "", out _, out tie);
+                else  // no name at all → category fallback still has a chance
+                    rule = CsiMasterFormat.Resolve(rules, cat, "", "", "", out _, out tie);
+            }
+            else // element
+            {
+                string fam = ParameterHelpers.GetFamilyName(el);
+                string type = ParameterHelpers.GetFamilySymbolName(el);
+                string sys = ParameterHelpers.GetString(el, ParamRegistry.SYS);
+                res.UnmappedKey = cat;
+                rule = CsiMasterFormat.Resolve(rules, cat, fam, type, sys, out _, out tie);
+            }
+
+            if (rule != null) { res.Code = OmniClassMap.Normalize(rule.Section); res.Title = rule.Title; res.Source = "map"; res.TieCount = tie; }
+            return res;
+        }
+    }
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class OmniClassAssignCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            var table = OmniClassTables.Resolve(ClassificationReader.OmniClassTable(doc));
+            var rules = OmniClassMap.Load(doc, table, out int corp, out int overlay, out string directive);
+            if (rules.Count == 0)
+            {
+                TaskDialog.Show("OmniClass Assign", $"No OmniClass map found for {table.Label}. Ship " +
+                    $"{table.MapFile} in data/ or add _BIM_COORD/omniclass_map.csv.");
+                return Result.Succeeded;
+            }
+            string mode = OmniClassMap.EffectiveMatchMode(table, directive);
+            int misfiled = OmniClassMap.CountMisfiledRows(rules, table.Number);
+
+            var picker = new TaskDialog("OmniClass Assign")
+            {
+                MainInstruction = $"Write OmniClass {table.Label} code to elements",
+                MainContent = $"{rules.Count} rules ({corp} corporate + {overlay} project). Match on: {mode}. " +
+                    (misfiled > 0 ? $"⚠ {misfiled} map row(s) are not Table {table.Number} codes (see log). " : "") +
+                    "Choose write mode:",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+                AllowCancellation = true
+            };
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Fill empty only",
+                "Write where ASS_OMNICLASS_TXT is blank OR holds a code from a different table");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Overwrite all", "Re-resolve and overwrite existing values");
+            var choice = picker.Show();
+            if (choice == TaskDialogResult.Cancel) return Result.Cancelled;
+            bool overwrite = choice == TaskDialogResult.CommandLink2;
+
+            var scope = CsiMap.Scope(ctx.UIDoc, doc, out string scopeLabel);
+            int assigned = 0, skippedSet = 0, unresolved = 0, native = 0, restamped = 0;
+            var unmapped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            using (var t = new Transaction(doc, "STING OmniClass Assign"))
+            {
+                t.Start();
+                foreach (var el in scope)
+                {
+                    var r = OmniResolver.Resolve(doc, el, table, mode, rules);
+                    if (r.Code == null)
+                    {
+                        unresolved++;
+                        unmapped.TryGetValue(r.UnmappedKey, out int c); unmapped[r.UnmappedKey] = c + 1;
+                        continue;
+                    }
+                    // Switch-table hygiene: a stamped code from a DIFFERENT table counts as
+                    // empty in fill-mode, so switching tables re-classifies it instead of leaving
+                    // a mixed-table column.
+                    string existing = ParameterHelpers.GetString(el, ParamRegistry.OMNICLASS);
+                    bool hasSet = !string.IsNullOrEmpty(existing);
+                    bool otherTable = hasSet && !string.Equals(OmniClassTables.TableOf(existing), table.Number, StringComparison.OrdinalIgnoreCase);
+                    if (!overwrite && hasSet && !otherTable) { skippedSet++; continue; }
+                    if (!TagPipelineHelper.IsEditableInWorksharing(doc, el)) continue;
+                    if (otherTable) restamped++;
+
+                    bool w1 = ParameterHelpers.SetString(el, ParamRegistry.OMNICLASS, r.Code, overwrite: true);
+                    if (!string.IsNullOrEmpty(r.Title))
+                        ParameterHelpers.SetString(el, "CLS_OMNICLASS_TITLE_TXT", r.Title, overwrite: true);
+                    if (w1) { assigned++; if (r.Source == "native") native++; }
+                }
+                t.Commit();
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"OmniClass {table.Label}   (match on: {mode})");
+            sb.AppendLine($"Scope: {scopeLabel}   Mode: {(overwrite ? "overwrite" : "fill empty")}");
+            sb.AppendLine($"Assigned:        {assigned}   (of which native-authored: {native})");
+            sb.AppendLine($"Re-stamped from another table: {restamped}");
+            sb.AppendLine($"Skipped (set):   {skippedSet}");
+            sb.AppendLine($"Unresolved:      {unresolved}");
+            if (unmapped.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine(mode == "room" ? "Unmapped rooms (add rows to _BIM_COORD/omniclass_map.csv):"
+                    : mode == "material" ? "Unmapped materials (add rows to _BIM_COORD/omniclass_map.csv):"
+                    : "Unmapped categories (add rows to _BIM_COORD/omniclass_map.csv):");
+                foreach (var kv in unmapped.OrderByDescending(k => k.Value).Take(15))
+                    sb.AppendLine($"   {kv.Value,5}  {kv.Key}");
+            }
+            new TaskDialog("OmniClass Assign")
+            {
+                MainInstruction = $"{assigned} element(s) assigned an OmniClass {table.Label} code",
+                MainContent = sb.ToString()
+            }.Show();
+            StingLog.Info($"OmniClass_Assign ({table.Label}, {mode}): {assigned} assigned ({native} native), {unresolved} unresolved ({scopeLabel})");
+            return Result.Succeeded;
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class OmniClassAuditCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            var table = OmniClassTables.Resolve(ClassificationReader.OmniClassTable(doc));
+            var rules = OmniClassMap.Load(doc, table, out int corp, out int overlay, out string directive);
+            if (rules.Count == 0)
+            {
+                TaskDialog.Show("OmniClass Audit", $"No OmniClass map found for {table.Label}.");
+                return Result.Succeeded;
+            }
+            string mode = OmniClassMap.EffectiveMatchMode(table, directive);
+            int misfiled = OmniClassMap.CountMisfiledRows(rules, table.Number);
+
+            var scope = CsiMap.Scope(ctx.UIDoc, doc, out string scopeLabel);
+            int total = 0, classified = 0, nativeCount = 0, ambiguous = 0;
+            var unmapped = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var ambig = new List<string>();
+
+            foreach (var el in scope)
+            {
+                total++;
+                var r = OmniResolver.Resolve(doc, el, table, mode, rules);
+                if (r.Code == null) { unmapped.TryGetValue(r.UnmappedKey, out int c); unmapped[r.UnmappedKey] = c + 1; continue; }
+                classified++;
+                if (r.Source == "native") nativeCount++;
+                else if (r.TieCount > 1) { ambiguous++; if (ambig.Count < 200) ambig.Add($"{el.Id.Value}\t{ParameterHelpers.GetCategoryName(el)}\t{r.UnmappedKey}\t{r.Code}\ttied={r.TieCount}"); }
+            }
+
+            double pct = total == 0 ? 0 : 100.0 * classified / total;
+            string csv = null;
+            try
+            {
+                string dir = OutputLocationHelper.GetOutputDirectory(doc);
+                csv = Path.Combine(dir, $"omniclass_audit_T{table.Number}.csv");
+                var lines = new List<string> { "Section,Kind,Count" };
+                lines.Add($",Total,{total}");
+                lines.Add($",Classified,{classified}");
+                lines.Add($",Native,{nativeCount}");
+                lines.Add($",Ambiguous,{ambiguous}");
+                lines.Add($",Misfiled rows,{misfiled}");
+                lines.Add("");
+                lines.Add("UNMAPPED,Key,Count");
+                foreach (var kv in unmapped.OrderByDescending(k => k.Value)) lines.Add($"unmapped,\"{kv.Key}\",{kv.Value}");
+                lines.Add("");
+                lines.Add("AMBIGUOUS,ElementId\tCategory\tKey\tCode\tTie");
+                lines.AddRange(ambig.Select(a => "ambiguous," + a.Replace(",", " ")));
+                File.WriteAllLines(csv, lines);
+            }
+            catch (Exception ex) { StingLog.Warn($"OmniClass audit CSV: {ex.Message}"); csv = null; }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"OmniClass {table.Label}   (match on: {mode})");
+            sb.AppendLine($"Scope: {scopeLabel}");
+            sb.AppendLine($"Classified:  {classified} / {total}   ({pct:F1} %)");
+            sb.AppendLine($"  native-authored: {nativeCount}   map: {classified - nativeCount}");
+            sb.AppendLine($"Unmapped:    {total - classified}");
+            sb.AppendLine($"Ambiguous (≥2 rules tie — needs a more-specific rule): {ambiguous}");
+            if (misfiled > 0) sb.AppendLine($"⚠ Map rows not in Table {table.Number}: {misfiled} (see log)");
+            if (unmapped.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Top unmapped keys:");
+                foreach (var kv in unmapped.OrderByDescending(k => k.Value).Take(12))
+                    sb.AppendLine($"   {kv.Value,5}  {kv.Key}");
+            }
+            if (csv != null) sb.AppendLine($"\nFull report: {csv}");
+
+            new TaskDialog("OmniClass Audit")
+            {
+                MainInstruction = $"{pct:F0}% of {total} element(s) classified for {table.Label}",
+                MainContent = sb.ToString()
+            }.Show();
+            StingLog.Info($"OmniClass_Audit ({table.Label}): {classified}/{total} classified, {ambiguous} ambiguous ({scopeLabel})");
+            return Result.Succeeded;
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class OmniClassSetTableCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            string policyPath = PolicyFile.Resolve(doc);
+            if (string.IsNullOrEmpty(policyPath))
+            {
+                TaskDialog.Show("OmniClass Table", "Save the project first — the active table is stored in " +
+                    "<project>/_BIM_COORD/classification_policy.json.");
+                return Result.Cancelled;
+            }
+
+            string current = ClassificationReader.OmniClassTable(doc);
+
+            // The four tables that ship a corporate map are the meaningful out-of-the-box
+            // choices (CommandLinks 1-4). The other 11 OmniClass tables resolve too but need
+            // a project map — set those by editing classification_policy.json directly.
+            string[] choices = { "21", "23", "41", "13" };   // Elements / Products / Materials / Spaces
+            var picker = new TaskDialog("OmniClass Table")
+            {
+                MainInstruction = "Choose the active OmniClass table",
+                MainContent = $"Drives OmniClass Assign / Audit + the BOQ OmniClass column. " +
+                    $"Current: {OmniClassTables.Resolve(current).Label}.\n\n" +
+                    "These four ship corporate maps. The other 11 tables resolve via a project " +
+                    "map (_BIM_COORD/omniclass_map.csv) — set those in classification_policy.json.",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+                AllowCancellation = true
+            };
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Table 21 — Elements" + (current == "21" ? "   (current)" : ""), "Classify each element by its own category / family / type / system");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Table 23 — Products" + (current == "23" ? "   (current)" : ""), "Classify by product type; honours a native OmniClass code authored on the type");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink3, "Table 41 — Materials" + (current == "41" ? "   (current)" : ""), "Classify by the element's actual material name");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink4, "Table 13 — Spaces by Function" + (current == "13" ? "   (current)" : ""), "Classify the element's HOST ROOM by function (spatial axis)");
+            var res = picker.Show();
+            int idx = res - TaskDialogResult.CommandLink1;
+            if (idx < 0 || idx >= choices.Length) return Result.Cancelled;
+            string number = choices[idx];
+            if (number == current)
+            {
+                TaskDialog.Show("OmniClass Table", $"Already set to {OmniClassTables.Resolve(number).Label}.");
+                return Result.Succeeded;
+            }
+
+            // Write omniClassTable into the project policy, PRESERVING any existing
+            // classification order. JObject merge keeps unknown keys intact.
+            try
+            {
+                PolicyFile.Merge(policyPath, root => root["omniClassTable"] = number);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("OmniClass_SetTable write", ex);
+                TaskDialog.Show("OmniClass Table", "Could not write classification_policy.json: " + ex.Message);
+                return Result.Failed;
+            }
+
+            ClassificationReader.InvalidatePolicy();   // next Assign/Audit/BOQ re-reads the file
+
+            var info = OmniClassTables.Resolve(number);
+            new TaskDialog("OmniClass Table")
+            {
+                MainInstruction = $"Active OmniClass table → {info.Label}",
+                MainContent = (OmniClassTables.ShipsMap(number)
+                        ? "This table ships a corporate map — run OmniClass Audit to see coverage, then OmniClass Assign."
+                        : $"⚠ Table {number} has no corporate map. Add rows to _BIM_COORD/omniclass_map.csv " +
+                          "(matchOn directive optional) or nothing will classify.") +
+                    "\n\nStored in _BIM_COORD/classification_policy.json. The BOQ OmniClass column + " +
+                    "OmniClass Assign/Audit now use this table."
+            }.Show();
+            StingLog.Info($"OmniClass_SetTable: {current} → {number} ({info.Label})");
+            return Result.Succeeded;
+        }
+    }
+
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class ClassificationTagsSetCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            string policyPath = PolicyFile.Resolve(doc);
+            if (string.IsNullOrEmpty(policyPath))
+            {
+                TaskDialog.Show("Classification on Tags", "Save the project first — the setting lives in " +
+                    "<project>/_BIM_COORD/classification_policy.json.");
+                return Result.Cancelled;
+            }
+
+            var current = ClassificationReader.TagClassifications(doc);
+            string curLabel = current.Count == 0 ? "none"
+                : string.Join(" + ", current.Select(p => ClassificationReader.ClassificationLabel(p)));
+
+            var picker = new TaskDialog("Classification on Tags")
+            {
+                MainInstruction = "Stamp classification code(s) on the tag narrative",
+                MainContent = $"Adds the chosen classification code into each element's rich TAG7 " +
+                    $"narrative, so it shows on drawings. Currently: {curLabel}.\n\n" +
+                    "Pick the common presets below, or list any classification parameter(s) in " +
+                    "classification_policy.json \"tagClassifications\" for full flexibility " +
+                    "(e.g. Uniclass). Re-run Auto Tag / Build Tags afterwards to refresh the narrative.",
+                CommonButtons = TaskDialogCommonButtons.Cancel,
+                AllowCancellation = true
+            };
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "MasterFormat (CSI)", "Stamp CSI_SECTION_TXT");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "OmniClass", "Stamp ASS_OMNICLASS_TXT");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink3, "MasterFormat + OmniClass", "Stamp both codes");
+            picker.AddCommandLink(TaskDialogCommandLinkId.CommandLink4, "None (off)", "Don't stamp any classification on tags");
+            var res = picker.Show();
+
+            List<string> chosen;
+            switch (res)
+            {
+                case TaskDialogResult.CommandLink1: chosen = new List<string> { "CSI_SECTION_TXT" }; break;
+                case TaskDialogResult.CommandLink2: chosen = new List<string> { "ASS_OMNICLASS_TXT" }; break;
+                case TaskDialogResult.CommandLink3: chosen = new List<string> { "CSI_SECTION_TXT", "ASS_OMNICLASS_TXT" }; break;
+                case TaskDialogResult.CommandLink4: chosen = new List<string>(); break;
+                default: return Result.Cancelled;
+            }
+
+            try
+            {
+                PolicyFile.Merge(policyPath, root => root["tagClassifications"] = new Newtonsoft.Json.Linq.JArray(chosen));
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("ClassificationTags_Set write", ex);
+                TaskDialog.Show("Classification on Tags", "Could not write classification_policy.json: " + ex.Message);
+                return Result.Failed;
+            }
+
+            ClassificationReader.InvalidatePolicy();
+
+            string newLabel = chosen.Count == 0 ? "none (off)"
+                : string.Join(" + ", chosen.Select(p => ClassificationReader.ClassificationLabel(p)));
+            new TaskDialog("Classification on Tags")
+            {
+                MainInstruction = $"Tag classification → {newLabel}",
+                MainContent = (chosen.Count == 0
+                        ? "No classification will be stamped on tags."
+                        : "The code(s) will appear in the element's rich TAG7 narrative (Section A) — " +
+                          "make sure you've run the matching assign (CSI Assign / OmniClass Assign) so the " +
+                          "values exist.") +
+                    "\n\nRe-run Auto Tag / Build Tags to refresh the narrative on existing elements."
+            }.Show();
+            StingLog.Info($"ClassificationTags_Set: [{string.Join(",", chosen)}]");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/Core/Classification/ClassificationPolicy.cs
+++ b/StingTools/Core/Classification/ClassificationPolicy.cs
@@ -1,0 +1,205 @@
+// ==========================================================================
+//  ClassificationPolicy.cs - per-project classification overlay.
+//
+//  <project>/_BIM_COORD/classification_policy.json carries three independent
+//  per-project switches, all optional and all defaulting to today's behaviour:
+//
+//    {
+//      "omniClassTable": "21",
+//      "tagClassifications": ["CSI_SECTION_TXT"],
+//      "order": [
+//        { "id": "csi",         "param": "CSI_SECTION_TXT",    "prefix": "CSI",  "label": "CSI.MasterFormat" },
+//        { "id": "omniclass23", "param": "STING_OMNICLASS_23", "prefix": "OMNI", "label": "OmniClass23" },
+//        { "id": "native" }
+//      ]
+//    }
+//
+//  omniClassTable      which OmniClass table OmniClass_Assign / _Audit and the
+//                      BOQ OmniClass column classify by (see OmniClassTables).
+//  tagClassifications  which classification parameter(s) get stamped into the
+//                      element's rich TAG7 narrative. Empty => none.
+//  order               an EXPLICIT classification fallback ladder for BOQ
+//                      grouping / COBie / IFC.
+//
+//  On `order` and ClassificationStandard
+//  ------------------------------------
+//  ClassificationReader.ResolveFallback already lets a project choose which
+//  standard leads, through ClassificationStandard (sting_classification.json:
+//  Uniclass | CSI | OmniClass | Native). That covers the four common answers and
+//  stays the default. What it cannot express is a bespoke ladder over a
+//  parameter the code has never heard of - an owner classification table, say.
+//  `order` is that escape hatch: name ANY text parameter, in any sequence, and
+//  the ladder is data, not a recompile.
+//
+//  The two do not fight. `order` is honoured ONLY when the project authored a
+//  non-empty one (HasExplicitOrder); otherwise ResolveFallback keeps using
+//  ClassificationStandard exactly as before. A project with no policy file, or
+//  one that sets only omniClassTable, sees no change at all.
+//
+//  HOST-FREE (no Autodesk.Revit references) so it unit-tests independently of
+//  Revit. Reading the file is ClassificationReader's job - it holds the Document
+//  the path resolver needs.
+// ==========================================================================
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace StingTools.Core.Classification
+{
+    /// <summary>One rung of the classification fallback ladder.</summary>
+    public sealed class ClassificationSource
+    {
+        [JsonProperty("id")]    public string Id { get; set; } = "";
+        [JsonProperty("param")] public string Param { get; set; } = "";
+        [JsonProperty("prefix")] public string Prefix { get; set; } = "";
+        [JsonProperty("label")] public string Label { get; set; } = "";
+
+        /// <summary>Terminal native family/type fallback (no parameter to read).</summary>
+        [JsonIgnore]
+        public bool IsNative =>
+            string.IsNullOrWhiteSpace(Param) ||
+            string.Equals(Id, "native", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public sealed class ClassificationPolicy
+    {
+        [JsonProperty("order")]
+        public List<ClassificationSource> Order { get; set; } = new List<ClassificationSource>();
+
+        /// <summary>
+        /// Phase 199 — the active OmniClass TABLE the OmniClass column / OmniClass_Assign
+        /// classifies by. Any real OmniClass table number works (11/12/13/14/21/22/23/31/
+        /// 32/33/34/35/36/41/49 — there is NO table 24-28); the BOQ-relevant ones are
+        /// "21" = Elements (default), "23" = Products, "41" = Materials (element axes) and
+        /// "13"/"14" = Spaces (host-room axis). Accepts "Table 21" / "T21" / "21"
+        /// (normalised by <see cref="OmniClassTableNumber"/>). Switching is this one line;
+        /// the assigner loads STING_OMNICLASS_&lt;table&gt;_MAP.csv (corporate) +
+        /// _BIM_COORD/omniclass_map.csv (overlay) and the BOQ column names the table.
+        /// Tables 21 (Elements), 23 (Products), 41 (Materials) + 13 (Spaces) ship corporate
+        /// maps; any other table needs its map shipped or supplied via the overlay.
+        /// </summary>
+        [JsonProperty("omniClassTable")]
+        public string OmniClassTable { get; set; } = "21";
+
+        /// <summary>
+        /// Phase 199f — which classification code(s) get stamped into the element's
+        /// TAG7 rich narrative (so they appear on drawings). A flat list of shared-parameter
+        /// names, e.g. ["CSI_SECTION_TXT"] for MasterFormat, ["ASS_OMNICLASS_TXT"] for
+        /// OmniClass, or both. EMPTY by default ⇒ nothing stamped (no change for existing
+        /// projects). Data-driven + sustainable: name ANY classification text parameter and
+        /// it stamps with a sensible label — no recompile, no tag-family rebuild. Decoupled
+        /// from the BOQ `order`, so a project can bill by one axis but annotate by another
+        /// (or none). Set via the "Classification on Tags…" command or this file.
+        /// </summary>
+        [JsonProperty("tagClassifications")]
+        public List<string> TagClassifications { get; set; } = new List<string>();
+
+        /// <summary>
+        /// True when the project authored its own non-empty <see cref="Order"/>. Only then
+        /// does the ladder override <c>ClassificationStandard</c>; the default policy and a
+        /// policy that sets only <c>omniClassTable</c> / <c>tagClassifications</c> leave the
+        /// existing standard selector in charge, so opting into an OmniClass table cannot
+        /// silently re-order a project's BOQ grouping.
+        /// </summary>
+        [JsonIgnore]
+        public bool HasExplicitOrder { get; private set; }
+
+        /// <summary>Normalised active table number — "Table 21"/"T21"/"21" → "21". Default "21".</summary>
+        [JsonIgnore]
+        public string OmniClassTableNumber => NormalizeTable(OmniClassTable);
+
+        private static string NormalizeTable(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return "21";
+            var digits = new string(raw.Where(char.IsDigit).ToArray());
+            return digits.Length > 0 ? digits : "21";
+        }
+
+        /// <summary>
+        /// The compiled-in default: the exact order ResolveFallback used before
+        /// Phase 196 (Uniclass.Pr → Ss → Ef → OmniClass23 → native). Returned
+        /// whenever no project policy is present, so existing projects are
+        /// untouched.
+        /// </summary>
+        public static ClassificationPolicy Default => new ClassificationPolicy
+        {
+            Order = new List<ClassificationSource>
+            {
+                new ClassificationSource { Id = "uniclass.pr", Param = "UNICLASS_PR_TXT",    Prefix = "PR",   Label = "Uniclass.Pr" },
+                new ClassificationSource { Id = "uniclass.ss", Param = "UNICLASS_SS_TXT",    Prefix = "SS",   Label = "Uniclass.Ss" },
+                new ClassificationSource { Id = "uniclass.ef", Param = "UNICLASS_EF_TXT",    Prefix = "EF",   Label = "Uniclass.Ef" },
+                new ClassificationSource { Id = "omniclass23", Param = "STING_OMNICLASS_23", Prefix = "OMNI", Label = "OmniClass23" },
+                new ClassificationSource { Id = "native" }
+            }
+        };
+
+        /// <summary>
+        /// Parse a policy from raw JSON. Returns the Default policy on null/blank
+        /// input, malformed JSON, or an empty order — a broken policy file must
+        /// never break classification, it just falls back to the baseline order.
+        /// Always normalised so a terminal native rung exists and every rung
+        /// carries a prefix + label (synthesised from the id when omitted).
+        /// </summary>
+        public static ClassificationPolicy Parse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return Default;
+            try
+            {
+                var p = JsonConvert.DeserializeObject<ClassificationPolicy>(json);
+                if (p == null) return Default;
+                // A policy may set only omniClassTable / tagClassifications (no order) -
+                // keep those, use the default classification order, and leave
+                // HasExplicitOrder false so ClassificationStandard stays in charge.
+                if (p.Order == null || p.Order.Count == 0) { p.Order = Default.Order; return p; }
+                return Normalize(p);
+            }
+            catch
+            {
+                return Default;
+            }
+        }
+
+        private static ClassificationPolicy Normalize(ClassificationPolicy p)
+        {
+            var cleaned = new List<ClassificationSource>();
+            bool hasNative = false;
+            foreach (var s in p.Order)
+            {
+                if (s == null) continue;
+                if (hasNative) break;              // native is terminal — ignore any trailing rungs
+                if (s.IsNative)
+                {
+                    hasNative = true;
+                    cleaned.Add(new ClassificationSource { Id = "native" });
+                    continue;
+                }
+                cleaned.Add(new ClassificationSource
+                {
+                    Id = string.IsNullOrWhiteSpace(s.Id) ? s.Param : s.Id.Trim(),
+                    Param = s.Param.Trim(),
+                    Prefix = string.IsNullOrWhiteSpace(s.Prefix) ? PrefixFromId(s) : s.Prefix.Trim(),
+                    Label = string.IsNullOrWhiteSpace(s.Label) ? (string.IsNullOrWhiteSpace(s.Id) ? s.Param : s.Id.Trim()) : s.Label.Trim()
+                });
+            }
+            // Guarantee a terminal native rung so ResolveFallback always yields a key.
+            if (!hasNative) cleaned.Add(new ClassificationSource { Id = "native" });
+            return new ClassificationPolicy
+            {
+                Order = cleaned,
+                OmniClassTable = p.OmniClassTable,
+                TagClassifications = p.TagClassifications ?? new List<string>(),
+                HasExplicitOrder = true
+            };
+        }
+
+        private static string PrefixFromId(ClassificationSource s)
+        {
+            string baseId = string.IsNullOrWhiteSpace(s.Id) ? s.Param : s.Id;
+            baseId = (baseId ?? "").Trim();
+            int dot = baseId.IndexOf('.');
+            string seg = dot > 0 ? baseId.Substring(dot + 1) : baseId;
+            return string.IsNullOrEmpty(seg) ? "CLS" : seg.ToUpperInvariant();
+        }
+    }
+}

--- a/StingTools/Core/Classification/ClassificationReader.cs
+++ b/StingTools/Core/Classification/ClassificationReader.cs
@@ -5,7 +5,12 @@
 // (already injected by InjectAutomationPresentationPack) so hybrid projects
 // that only populated OmniClass remain fully functional.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
 using Autodesk.Revit.DB;
+using StingTools.Core;
 
 namespace StingTools.Core.Classification
 {
@@ -45,6 +50,95 @@ namespace StingTools.Core.Classification
             return c;
         }
 
+        // ---- per-project classification policy (classification_policy.json) --------
+        // Cached per open document. A missing / malformed file yields the DEFAULT
+        // policy, whose Order is the historic ladder and whose HasExplicitOrder is false,
+        // so nothing below changes behaviour until a project opts in.
+        private static readonly ConcurrentDictionary<string, ClassificationPolicy> _policyCache
+            = new ConcurrentDictionary<string, ClassificationPolicy>(StringComparer.OrdinalIgnoreCase);
+
+        private static ClassificationPolicy PolicyFor(Document doc)
+        {
+            // Key on the MODEL PATH, not the resolved policy path. ResolveFallback runs
+            // per element across a whole-project BOQ, and StingPaths.MetaFile probes the
+            // consolidated and legacy locations on every call - doing that per element
+            // would put thousands of File.Exists calls in the take-off loop. The model
+            // path is free, and InvalidatePolicy() is what makes an edit visible.
+            string key = string.IsNullOrEmpty(doc?.PathName) ? "<unsaved>" : doc.PathName;
+            return _policyCache.GetOrAdd(key, _ =>
+            {
+                string path = null;
+                try { path = StingPaths.MetaFile(doc, "_BIM_COORD", "classification_policy.json"); }
+                catch (Exception ex) { StingLog.Warn($"ClassificationReader policy path: {ex.Message}"); }
+                if (string.IsNullOrEmpty(path)) return ClassificationPolicy.Default;
+                try
+                {
+                    if (!File.Exists(path)) return ClassificationPolicy.Default;
+                    var p = ClassificationPolicy.Parse(File.ReadAllText(path));
+                    StingLog.Info($"ClassificationReader: applied classification_policy.json " +
+                                  $"(table {p.OmniClassTableNumber}, explicit order: {p.HasExplicitOrder}).");
+                    return p;
+                }
+                catch (Exception ex)
+                {
+                    StingLog.Warn($"ClassificationReader: classification_policy.json unreadable ({ex.Message}) - using defaults.");
+                    return ClassificationPolicy.Default;
+                }
+            });
+        }
+
+        /// <summary>Drop the cached policy so an edited classification_policy.json is re-read.</summary>
+        public static void InvalidatePolicy() => _policyCache.Clear();
+
+        /// <summary>True when the project authored an explicit <c>order</c> in
+        /// classification_policy.json, which takes precedence over
+        /// <see cref="ClassificationStandard"/>. Surfaced so the standard picker can say
+        /// its choice will be overridden instead of appearing to work and doing nothing.</summary>
+        public static bool HasExplicitPolicyOrder(Document doc) => PolicyFor(doc).HasExplicitOrder;
+
+        /// <summary>The project's active OmniClass table number ("21" / "13" / ...), from
+        /// classification_policy.json (default "21"). Read by OmniClass_Assign / _Audit.</summary>
+        public static string OmniClassTable(Document doc) => PolicyFor(doc).OmniClassTableNumber;
+
+        /// <summary>The classification parameter(s) the project stamps into the TAG7
+        /// narrative (so they show on drawings). Empty list =&gt; none. Read by the tag
+        /// narrative builder.</summary>
+        public static IReadOnlyList<string> TagClassifications(Document doc)
+            => PolicyFor(doc).TagClassifications ?? new List<string>();
+
+        /// <summary>Human label for a classification parameter, for the tag narrative
+        /// ("CSI_SECTION_TXT" -&gt; "MasterFormat"). Unknown params fall back to a tidied
+        /// name so a new axis still stamps with something readable.</summary>
+        public static string ClassificationLabel(string paramName)
+        {
+            switch ((paramName ?? "").ToUpperInvariant())
+            {
+                case "CSI_SECTION_TXT":
+                case "CSI_TITLE_TXT":           return "MasterFormat";
+                case "ASS_OMNICLASS_TXT":
+                case "CLS_OMNICLASS_TITLE_TXT": return "OmniClass";
+                case "ASS_UNIFORMAT_TXT":
+                case "ASS_UNIFORMAT_DESC_TXT":  return "Uniformat";
+                case "UNICLASS_PR_TXT":         return "Uniclass Pr";
+                case "UNICLASS_SS_TXT":         return "Uniclass Ss";
+                case "UNICLASS_EF_TXT":         return "Uniclass EF";
+                default:
+                    string n = (paramName ?? "").Trim();
+                    if (n.EndsWith("_TXT", StringComparison.OrdinalIgnoreCase)) n = n.Substring(0, n.Length - 4);
+                    return n.Replace('_', ' ');
+            }
+        }
+
+        /// <summary>Read a classification value type-first (classification is usually authored
+        /// on the type) then instance - used by the tag narrative stamp.</summary>
+        public static string ReadClassificationValue(Element el, string paramName)
+        {
+            if (el == null || string.IsNullOrEmpty(paramName)) return "";
+            Element type = null;
+            try { type = el.Document.GetElement(el.GetTypeId()); } catch { }
+            return TypeFirst(el, type, paramName);
+        }
+
         /// <summary>
         /// Pack 126 / Gap J — single canonical fallback chain used by BOQ /
         /// COBie / handover / IFC export. Ordered by specificity:
@@ -77,6 +171,22 @@ namespace StingTools.Core.Classification
             var csiB  = ("CSI:" + csi,   "CSI.MasterFormat", csi);
             var omniB = ("OMNI:" + omni, "OmniClass23", omni);
             var natB  = ("NATIVE:" + famTypeKey, "Native.Family", famTypeKey);
+
+            // An EXPLICIT classification_policy.json "order" wins: it can name parameters
+            // (a bespoke owner table) that the four-way standard selector cannot express.
+            // Absent one - the overwhelmingly common case - fall through to the standard
+            // selector below, unchanged.
+            var policy = PolicyFor(el?.Document);
+            if (policy.HasExplicitOrder)
+            {
+                foreach (var src in policy.Order)
+                {
+                    if (src.IsNative) return natB;
+                    string pv = TypeFirst(el, type, src.Param);
+                    if (!string.IsNullOrEmpty(pv)) return (src.Prefix + ":" + pv, src.Label, pv);
+                }
+                return natB;   // policy with no terminal native rung - guarantee a key
+            }
 
             // Order the cascade by the project's chosen standard (Phase G). Uniclass
             // is the default and preserves the historic order exactly; the others

--- a/StingTools/Core/Classification/CsiMasterFormat.cs
+++ b/StingTools/Core/Classification/CsiMasterFormat.cs
@@ -22,6 +22,13 @@ namespace StingTools.Core.Classification
         public string Sys { get; set; } = "";
         public string Section { get; set; } = "";
         public string Title { get; set; } = "";
+        /// <summary>Optional NRM2 work-section code, so a single rule resolves both the
+        /// CSI MasterFormat section AND the NRM2 section a BOQ line is billed under.
+        /// Blank = let the BOQ engine derive the NRM2 section from the category.</summary>
+        public string Nrm2 { get; set; } = "";
+        /// <summary>Optional spec measurement basis (m2/m3/m/kg/each) for the section, so a
+        /// spec can drive the BOQ measurement-basis advisory. Blank = no opinion.</summary>
+        public string Unit { get; set; } = "";
 
         private Regex _famRx, _typeRx;
         private bool _compiled;
@@ -30,8 +37,12 @@ namespace StingTools.Core.Classification
         {
             if (_compiled) return;
             _compiled = true;
-            if (!string.IsNullOrEmpty(FamilyRegex)) { try { _famRx = new Regex(FamilyRegex); } catch { } }
-            if (!string.IsNullOrEmpty(TypeRegex)) { try { _typeRx = new Regex(TypeRegex); } catch { } }
+            // Always case-insensitive - authors (project-overlay rows especially) need not
+            // remember the inline "(?i)" prefix. The shipped maps already carry it, so this
+            // only rescues rows that would otherwise have silently matched nothing.
+            const RegexOptions opt = RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+            if (!string.IsNullOrEmpty(FamilyRegex)) { try { _famRx = new Regex(FamilyRegex, opt); } catch { } }
+            if (!string.IsNullOrEmpty(TypeRegex)) { try { _typeRx = new Regex(TypeRegex, opt); } catch { } }
         }
 
         /// <summary>Match score, or -1 when the rule does not apply. Higher = more specific.</summary>
@@ -76,7 +87,10 @@ namespace StingTools.Core.Classification
                 if (string.IsNullOrWhiteSpace(raw)) continue;
                 string line = raw.TrimEnd('\r');
                 if (line.TrimStart().StartsWith("#")) continue;
-                var f = line.Split(new[] { ',' }, 6);
+                // Split into 8 so the optional 7th "Nrm2" + 8th "Unit" columns are read while
+                // 6-column legacy rows keep working. The shipped Titles carry no commas, so
+                // Title stays whole on the shorter rows.
+                var f = line.Split(new[] { ',' }, 8);
                 if (f.Length < 6) continue;
                 string cat = f[0].Trim();
                 if (cat.Length == 0) continue;
@@ -90,6 +104,8 @@ namespace StingTools.Core.Classification
                     Sys = f[3].Trim(),
                     Section = f[4].Trim(),
                     Title = f[5].Trim(),
+                    Nrm2 = f.Length >= 7 ? f[6].Trim() : "",
+                    Unit = f.Length >= 8 ? f[7].Trim() : "",
                 });
             }
             return rules;
@@ -98,16 +114,32 @@ namespace StingTools.Core.Classification
         /// <summary>Best-matching rule for the element context, or null when none apply.
         /// Highest score wins; ties resolve to the earliest rule in the list.</summary>
         public static CsiRule Resolve(IReadOnlyList<CsiRule> rules, string category, string family, string type, string sys)
+            => Resolve(rules, category, family, type, sys, out _, out _);
+
+        /// <summary>Resolve + report the winning <paramref name="score"/> and how many rules
+        /// tied at that top score (<paramref name="tieCount"/>). tieCount &gt; 1 means the match
+        /// is AMBIGUOUS - row order silently decided it - so an audit can surface it and a
+        /// more-specific rule be authored. Ties are counted by DISTINCT Section, so two rules
+        /// that tie but agree on the code are not flagged.</summary>
+        public static CsiRule Resolve(IReadOnlyList<CsiRule> rules, string category, string family, string type, string sys,
+            out int score, out int tieCount)
         {
             CsiRule best = null;
             int bestScore = -1;
+            score = -1; tieCount = 0;
             if (rules == null) return null;
             for (int i = 0; i < rules.Count; i++)
             {
                 int s = rules[i].Score(category, family, type, sys);
                 if (s > bestScore) { bestScore = s; best = rules[i]; }
             }
-            return bestScore >= 0 ? best : null;
+            if (bestScore < 0) return null;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < rules.Count; i++)
+                if (rules[i].Score(category, family, type, sys) == bestScore)
+                    seen.Add(NormalizeSection(rules[i].Section));
+            score = bestScore; tieCount = seen.Count;
+            return best;
         }
 
         /// <summary>Canonical key for a CSI section number. Removes ALL whitespace (and

--- a/StingTools/Core/Classification/OmniClassTables.cs
+++ b/StingTools/Core/Classification/OmniClassTables.cs
@@ -1,0 +1,110 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  OmniClassTables.cs — Phase 199. OmniClass table metadata (host-free).
+//
+//  OmniClass has 15 tables; the BOQ-relevant ones are Table 21 (Elements),
+//  Table 23 (Products) and Table 13 (Spaces by Function). This registry tells
+//  the assigner + BOQ each table's human name, the corporate map file to load,
+//  and — critically — whether the table classifies ELEMENTS or SPACES.
+//
+//  Element tables (21 / 23) resolve from the element's own category/family/type/
+//  sys. Spatial tables (13) classify the element's HOST ROOM by function, so the
+//  assigner feeds the room name into the resolver instead. Either way the result
+//  is written to ASS_OMNICLASS_TXT and the code self-describes its table by its
+//  numeric prefix ("21-…", "13-…", "23-…").
+//
+//  No Autodesk.Revit references — unit-testable.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Classification
+{
+    public sealed class OmniClassTableInfo
+    {
+        public string Number;     // "21"
+        public string Name;       // "Elements"
+        public string MapFile;    // "STING_OMNICLASS_21_MAP.csv"
+
+        /// <summary>What the assigner matches on for this table: "element" (the element's
+        /// own category/family/type/sys — default), "room" (the host room name, for Spaces
+        /// tables) or "material" (the element's material name, for the Materials table). A
+        /// map may override this with a "# matchOn:" header directive.</summary>
+        public string MatchMode = "element";
+
+        /// <summary>true ⇒ classify the host room, not the element (Spaces tables 13/14).</summary>
+        public bool IsSpatial => string.Equals(MatchMode, "room", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>e.g. "Table 21 — Elements".</summary>
+        public string Label => $"Table {Number} — {Name}";
+    }
+
+    public static class OmniClassTables
+    {
+        // The full OmniClass table set (there is NO table 24-28; the BOQ-relevant
+        // ones are 21/23/41 — element/material axes — and 13/14 — spatial axes).
+        // Only Spaces tables (13, 14) classify the host ROOM; every other table
+        // classifies the element itself. Any number not listed here still resolves
+        // (Resolve synthesises a generic non-spatial entry) so an overlay table works.
+        private static readonly Dictionary<string, OmniClassTableInfo> Known =
+            new Dictionary<string, OmniClassTableInfo>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["11"] = new OmniClassTableInfo { Number = "11", Name = "Construction Entities by Function", MapFile = "STING_OMNICLASS_11_MAP.csv" },
+            ["12"] = new OmniClassTableInfo { Number = "12", Name = "Construction Entities by Form",     MapFile = "STING_OMNICLASS_12_MAP.csv" },
+            ["13"] = new OmniClassTableInfo { Number = "13", Name = "Spaces by Function",  MatchMode = "room",     MapFile = "STING_OMNICLASS_13_MAP.csv" },
+            ["14"] = new OmniClassTableInfo { Number = "14", Name = "Spaces by Form",      MatchMode = "room",     MapFile = "STING_OMNICLASS_14_MAP.csv" },
+            ["21"] = new OmniClassTableInfo { Number = "21", Name = "Elements",            MapFile = "STING_OMNICLASS_21_MAP.csv" },
+            ["22"] = new OmniClassTableInfo { Number = "22", Name = "Work Results",        MapFile = "STING_OMNICLASS_22_MAP.csv" },
+            ["23"] = new OmniClassTableInfo { Number = "23", Name = "Products",            MapFile = "STING_OMNICLASS_23_MAP.csv" },
+            ["31"] = new OmniClassTableInfo { Number = "31", Name = "Phases",              MapFile = "STING_OMNICLASS_31_MAP.csv" },
+            ["32"] = new OmniClassTableInfo { Number = "32", Name = "Services",            MapFile = "STING_OMNICLASS_32_MAP.csv" },
+            ["33"] = new OmniClassTableInfo { Number = "33", Name = "Disciplines",         MapFile = "STING_OMNICLASS_33_MAP.csv" },
+            ["34"] = new OmniClassTableInfo { Number = "34", Name = "Organizational Roles",MapFile = "STING_OMNICLASS_34_MAP.csv" },
+            ["35"] = new OmniClassTableInfo { Number = "35", Name = "Tools",               MapFile = "STING_OMNICLASS_35_MAP.csv" },
+            ["36"] = new OmniClassTableInfo { Number = "36", Name = "Information",         MapFile = "STING_OMNICLASS_36_MAP.csv" },
+            ["41"] = new OmniClassTableInfo { Number = "41", Name = "Materials",           MatchMode = "material", MapFile = "STING_OMNICLASS_41_MAP.csv" },
+            ["49"] = new OmniClassTableInfo { Number = "49", Name = "Properties",          MapFile = "STING_OMNICLASS_49_MAP.csv" },
+        };
+
+        /// <summary>Resolve a table number ("13"/"21"/…) to its metadata, defaulting
+        /// to Table 21 (Elements) for an unknown number — and synthesising a generic
+        /// (non-spatial) info for any other numeric table so an overlay table still
+        /// works.</summary>
+        public static OmniClassTableInfo Resolve(string tableNumber)
+        {
+            string n = (tableNumber ?? "").Trim();
+            if (string.IsNullOrEmpty(n)) n = "21";
+            if (Known.TryGetValue(n, out var info)) return info;
+            return new OmniClassTableInfo
+            {
+                Number = n,
+                Name = $"Table {n}",
+                MapFile = $"STING_OMNICLASS_{n}_MAP.csv"
+            };
+        }
+
+        /// <summary>The tables that ship a corporate STING_OMNICLASS_&lt;n&gt;_MAP.csv out of
+        /// the box (so OmniClass_Assign / Audit work with no project overlay). Other tables
+        /// resolve but need their map supplied via _BIM_COORD/omniclass_map.csv.</summary>
+        public static readonly HashSet<string> MappedTableNumbers =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "21", "23", "41", "13" };
+
+        /// <summary>All known OmniClass tables, ordered by number, for a UI selector.</summary>
+        public static IReadOnlyList<OmniClassTableInfo> All =>
+            Known.Values.OrderBy(t => int.TryParse(t.Number, out int n) ? n : 999).ToList();
+
+        /// <summary>True if the table ships a corporate map.</summary>
+        public static bool ShipsMap(string number) => MappedTableNumbers.Contains((number ?? "").Trim());
+
+        /// <summary>The table number a code belongs to, read from its numeric prefix
+        /// ("21-04 30 00" → "21"). Empty when the code has no leading number.</summary>
+        public static string TableOf(string omniClassCode)
+        {
+            if (string.IsNullOrWhiteSpace(omniClassCode)) return "";
+            string s = omniClassCode.Trim();
+            int i = 0;
+            while (i < s.Length && char.IsDigit(s[i])) i++;
+            return i > 0 ? s.Substring(0, i) : "";
+        }
+    }
+}

--- a/StingTools/Core/TagConfig.Tag7.cs
+++ b/StingTools/Core/TagConfig.Tag7.cs
@@ -902,6 +902,33 @@ namespace StingTools.Core
                 identityMarked.Append($" \u00ABL\u00BBsized at\u00AB/L\u00BB \u00ABV\u00BB{size}\u00AB/V\u00BB");
             }
 
+            // Policy-driven classification stamp. classification_policy.json
+            // "tagClassifications" lists which classification axes (parameter names) to
+            // annotate on the tag, e.g. ["CSI_SECTION_TXT"] for MasterFormat. Empty list
+            // (the default) adds nothing, so no existing project's narrative changes.
+            // Any text parameter works - a new axis needs no code and no family rebuild.
+            try
+            {
+                var clsParams = StingTools.Core.Classification.ClassificationReader.TagClassifications(doc);
+                if (clsParams != null && clsParams.Count > 0)
+                {
+                    var clsParts = new System.Collections.Generic.List<string>();
+                    foreach (var pn in clsParams)
+                    {
+                        string cv = StingTools.Core.Classification.ClassificationReader.ReadClassificationValue(el, pn);
+                        if (string.IsNullOrWhiteSpace(cv)) continue;
+                        clsParts.Add($"{StingTools.Core.Classification.ClassificationReader.ClassificationLabel(pn)} {cv}");
+                    }
+                    if (clsParts.Count > 0)
+                    {
+                        string clsText = string.Join("; ", clsParts);
+                        identityPlain.Append($" classified as {clsText}");
+                        identityMarked.Append($" \u00ABL\u00BBclassified as\u00AB/L\u00BB \u00ABV\u00BB{clsText}\u00AB/V\u00BB");
+                    }
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"Tag7 classification stamp: {ex.Message}"); }
+
             result.SectionA = identityPlain.ToString().Trim();
             markedSections.Add(identityMarked.ToString().Trim());
 

--- a/StingTools/Data/STING_OMNICLASS_13_MAP.csv
+++ b/StingTools/Data/STING_OMNICLASS_13_MAP.csv
@@ -1,0 +1,33 @@
+# STING OmniClass Table 13 (Spaces by Function) map (Phase 199). Active when
+# classification_policy.json sets "omniClassTable": "13". Unlike the element
+# tables (21 / 23), this is a SPATIAL table: OmniClass_Assign classifies each
+# element's HOST ROOM by function and stamps the room's space code onto the
+# element — giving a "cost by space function" cut on the BOQ.
+#
+# Because the match is on the room, the grammar is reused with the ROOM NAME fed
+# into the FamilyRegex column and Category left as "*" (any):
+#   Category    "*" (the element's own category is irrelevant for a spatial table)
+#   FamilyRegex regex tested against the HOST ROOM NAME (case-insensitive)
+#   TypeRegex   also tested against the room name (redundant; leave blank)
+#   Sys         leave blank
+#   Section     OmniClass Table 13 number (e.g. 13-25 00 00)
+#   Title       OmniClass space title (NO commas)
+# Most-specific row wins (more matched qualifiers = higher score; ties: first).
+# Starter baseline — codes are common approximations to be confirmed against the
+# published OmniClass Table 13. Projects extend/override via
+# _BIM_COORD/omniclass_map.csv (loaded first so it wins ties); a temple/owner
+# can add ordinance/sealing/baptistry rooms there.
+# matchOn: room
+Category,FamilyRegex,TypeRegex,Sys,Section,Title
+*,(?i)hall|auditorium|assembly|multipurpose|gather,,,13-11 00 00,Assembly Space
+*,(?i)chapel|ordinance|sealing|baptistry|endowment|celestial|worship|prayer|temple,,,13-61 00 00,Religious Space
+*,(?i)office|admin|reception|registry|workstation,,,13-15 00 00,Office Space
+*,(?i)meeting|conference|board\s*room|seminar,,,13-15 00 00,Office Space
+*,(?i)corridor|lobby|foyer|stair|circulation|vestibule|hallway|atrium,,,13-21 00 00,Circulation Space
+*,(?i)toilet|\bwc\b|restroom|washroom|bathroom|lavatory|shower|changing,,,13-25 00 00,Sanitary Space
+*,(?i)store|storage|closet|cupboard|archive,,,13-31 00 00,Storage Space
+*,(?i)plant|mechanical|electrical\s*room|elec\s*room|riser|switch|comms|server|boiler,,,13-41 00 00,Mechanical Space
+*,(?i)kitchen|pantry|dining|cafe|canteen|servery,,,13-45 00 00,Food Service Space
+*,(?i)classroom|training|learning|nursery|library|study,,,13-51 00 00,Educational Space
+*,(?i)patient|exam|treatment|consult|ward|clinic|surgery,,,13-55 00 00,Healthcare Space
+*,(?i)parking|garage|car\s*park|loading,,,13-71 00 00,Parking Space

--- a/StingTools/Data/STING_OMNICLASS_21_MAP.csv
+++ b/StingTools/Data/STING_OMNICLASS_21_MAP.csv
@@ -1,0 +1,88 @@
+# STING OmniClass map (Phase 198). Resolves a Revit element to an OmniClass
+# Table 21 (Elements) number + title, written to ASS_OMNICLASS_TXT by
+# OmniClass_Assign. OmniClass Table 21 is the ELEMENTAL breakdown (UniFormat-
+# aligned) that complements MasterFormat work-results on the BOQ. Same grammar
+# as the CSI MasterFormat map:
+#   Category    Revit category name (exact, case-insensitive). "*" = any.
+#   FamilyRegex optional regex tested against the family name (case-insensitive).
+#   TypeRegex   optional regex tested against the type/symbol name.
+#   Sys         optional SYS token (ASS_SYSTEM_TYPE_TXT) exact match.
+#   Section     OmniClass Table 21 number (e.g. 21-04 30 00).
+#   Title       OmniClass element title (NO commas — the parser is comma-split).
+# Most-specific row wins (more matched qualifiers = higher score; ties: first).
+# Starter baseline — codes are common approximations to be confirmed against the
+# published OmniClass Table 21. Projects extend/override via
+# _BIM_COORD/omniclass_map.csv (loaded first so it wins ties). To classify by
+# Table 23 (Products) or Table 22 (Work Results) instead, replace the Section
+# codes in a project overlay.
+Category,FamilyRegex,TypeRegex,Sys,Section,Title
+Doors,,,,21-02 20 00,Exterior Vertical Enclosures
+Doors,(?i)interior,,,21-03 10 00,Interior Construction
+Windows,,,,21-02 20 00,Exterior Vertical Enclosures
+Curtain Panels,,,,21-02 20 00,Exterior Vertical Enclosures
+Curtain Wall Mullions,,,,21-02 20 00,Exterior Vertical Enclosures
+Walls,,,,21-02 20 00,Exterior Vertical Enclosures
+Walls,(?i)partition|interior,,,21-03 10 00,Interior Construction
+Floors,,,,21-03 20 00,Interior Finishes
+Floors,(?i)\bslab\b|structural,,,21-02 10 00,Superstructure
+Ceilings,,,,21-03 20 00,Interior Finishes
+Roofs,,,,21-02 30 00,Exterior Horizontal Enclosures
+Structural Framing,,,,21-02 10 00,Superstructure
+Structural Columns,,,,21-02 10 00,Superstructure
+Structural Trusses,,,,21-02 10 00,Superstructure
+Structural Foundations,,,,21-01 10 00,Foundations
+Structural Rebar,,,,21-02 10 00,Superstructure
+Stairs,,,,21-03 30 00,Stairs
+Railings,,,,21-03 30 00,Stairs
+Ramps,,,,21-02 10 00,Superstructure
+Specialty Equipment,,,,21-05 10 00,Equipment
+Specialty Equipment,(?i)bench|pew|seating,,,21-05 20 00,Furnishings
+Specialty Equipment,(?i)elevator|lift|escalator,,,21-04 10 00,Conveying
+Furniture,,,,21-05 20 00,Furnishings
+Furniture Systems,,,,21-05 20 00,Furnishings
+Casework,,,,21-05 20 00,Furnishings
+Sprinklers,,,,21-04 40 00,Fire Protection
+Pipes,,,FP,21-04 40 00,Fire Protection
+Mechanical Equipment,(?i)fire pump,,,21-04 40 00,Fire Protection
+Plumbing Fixtures,,,,21-04 20 00,Plumbing
+Pipes,,,DCW,21-04 20 00,Plumbing
+Pipes,,,DHW,21-04 20 00,Plumbing
+Pipes,,,HWS,21-04 20 00,Plumbing
+Pipes,,,SAN,21-04 20 00,Plumbing
+Pipes,,,RWD,21-04 20 00,Plumbing
+Pipes,,,GAS,21-04 20 00,Plumbing
+Mechanical Equipment,(?i)water heater|calorifier|cylinder|dhw,,,21-04 20 00,Plumbing
+Mechanical Equipment,(?i)booster|pump set,,,21-04 20 00,Plumbing
+Mechanical Equipment,(?i)elevator|lift|escalator,,,21-04 10 00,Conveying
+Ducts,,,,21-04 30 00,HVAC
+Duct Fittings,,,,21-04 30 00,HVAC
+Flex Ducts,,,,21-04 30 00,HVAC
+Duct Accessory,,,,21-04 30 00,HVAC
+Air Terminals,,,,21-04 30 00,HVAC
+Pipes,,,CHW,21-04 30 00,HVAC
+Pipes,,,HHW,21-04 30 00,HVAC
+Pipes,,,LHW,21-04 30 00,HVAC
+Pipes,,,CWS,21-04 30 00,HVAC
+Pipes,,,REFRIG,21-04 30 00,HVAC
+Pipe Fittings,,,,21-04 30 00,HVAC
+Mechanical Equipment,,,,21-04 30 00,HVAC
+Electrical Equipment,,,,21-04 50 00,Electrical
+Electrical Fixtures,,,,21-04 50 00,Electrical
+Lighting Fixtures,,,,21-04 50 00,Electrical
+Lighting Devices,,,,21-04 50 00,Electrical
+Conduits,,,,21-04 50 00,Electrical
+Conduit Fittings,,,,21-04 50 00,Electrical
+Cable Trays,,,,21-04 50 00,Electrical
+Cable Tray Fittings,,,,21-04 50 00,Electrical
+Communication Devices,,,,21-04 60 00,Communications
+Data Devices,,,,21-04 60 00,Communications
+Telephone Devices,,,,21-04 60 00,Communications
+Fire Alarm Devices,,,,21-04 70 00,Electronic Safety and Security
+Security Devices,,,,21-04 70 00,Electronic Safety and Security
+Nurse Call Devices,,,,21-04 70 00,Electronic Safety and Security
+Topography,,,,21-07 10 00,Site Preparation
+Pads,,,,21-07 10 00,Site Preparation
+Roads,,,,21-07 20 00,Site Improvements
+Parking,,,,21-07 20 00,Site Improvements
+Planting,,,,21-07 20 00,Site Improvements
+Site,,,,21-07 20 00,Site Improvements

--- a/StingTools/Data/STING_OMNICLASS_23_MAP.csv
+++ b/StingTools/Data/STING_OMNICLASS_23_MAP.csv
@@ -1,0 +1,91 @@
+# STING OmniClass Table 23 (Products) map (Phase 199c). Active when
+# classification_policy.json sets "omniClassTable": "23". Classifies each element
+# by product TYPE and stamps ASS_OMNICLASS_TXT. Table 23 is the axis Revit itself
+# uses (the "OmniClass Number" family property) — these codes are taken from
+# Autodesk's Classification Manager database "US-WITH CATEGORIES.xlsx" (OmniClass
+# Table 23, May 2012), i.e. the exact OmniClass-number ↔ Revit-category mapping
+# Revit ships. Grammar matches the other maps:
+#   Category   Revit category name (exact, case-insensitive). "*" = any.
+#   FamilyRegex optional regex on the family name (case-insensitive).
+#   TypeRegex  optional regex on the type/symbol name.
+#   Sys        optional SYS token (ASS_SYSTEM_TYPE_TXT) exact match.
+#   Section    OmniClass Table 23 number.
+#   Title      OmniClass product title (NO commas — the parser is comma-split).
+# Most-specific row wins (more matched qualifiers = higher score; ties: first).
+# Source: Autodesk Classification Manager (OmniClass Table 23, May 2012). Projects
+# refine via _BIM_COORD/omniclass_map.csv (loaded first so it wins ties).
+Category,FamilyRegex,TypeRegex,Sys,Section,Title
+Doors,,,,23-17 11 00,Doors
+Windows,,,,23-17 13 00,Windows
+Curtain Panels,,,,23-17 13 00,Windows
+Curtain Wall Mullions,,,,23-17 13 00,Windows
+Walls,,,,23-15 15 00,Wall Coverings Claddings and Linings
+Floors,,,,23-15 17 00,Floor Coverings
+Ceilings,,,,23-15 19 00,Ceiling Coverings Claddings and Linings
+Roofs,,,,23-13 41 00,Roof Specialties and Accessories
+Stairs,,,,23-17 23 17,Stairs
+Railings,,,,23-17 23 17,Stairs
+Ramps,,,,23-17 23 17,Stairs
+Structural Framing,,,,23-13 35 11,Structural Frames
+Structural Columns,,,,23-13 35 11,Structural Frames
+Structural Trusses,,,,23-13 35 19,Trusses
+Structural Foundations,,,,23-13 29 00,Foundations
+Structural Rebar,,,,23-13 35 11,Structural Frames
+Plumbing Fixtures,,,,23-31 00 00,Plumbing Specific Products and Equipment
+Plumbing Fixtures,(?i)basin|lavatory|sink,,,23-31 13 00,Sinks
+Plumbing Fixtures,(?i)\bwc\b|toilet|water closet|cistern,,,23-31 19 00,Toilets
+Plumbing Fixtures,(?i)urinal,,,23-31 21 00,Urinals
+Plumbing Fixtures,(?i)shower,,,23-31 17 00,Showers
+Plumbing Fixtures,(?i)\bbath\b|bathtub,,,23-31 15 00,Bathtubs
+Plumbing Fixtures,(?i)tap|faucet|mixer,,,23-31 11 00,Faucets
+Plumbing Fixtures,(?i)drinking|water fountain,,,23-31 31 00,Drinking Fountains
+Pipes,,,,23-27 39 00,Piping
+Pipes,,,FP,23-29 33 00,Fire Suppression System Components
+Pipe Fittings,,,,23-27 39 00,Piping
+Ducts,,,,23-33 49 00,HVAC Ductwork
+Duct Fittings,,,,23-33 49 00,HVAC Ductwork
+Flex Ducts,,,,23-33 49 00,HVAC Ductwork
+Duct Accessory,,,,23-33 29 00,HVAC Dampers
+Air Terminals,,,,23-33 41 00,HVAC Air Terminals
+Mechanical Equipment,,,,23-33 00 00,HVAC Specific Products and Equipment
+Mechanical Equipment,(?i)ahu|air handling,,,23-33 25 00,Air Handling Units
+Mechanical Equipment,(?i)\bfcu\b|fan coil,,,23-33 33 00,HVAC Fan Coil Units
+Mechanical Equipment,(?i)boiler,,,23-33 11 00,Commercial Boilers
+Mechanical Equipment,(?i)chiller,,,23-33 21 00,Chillers
+Mechanical Equipment,(?i)cooling tower,,,23-33 23 00,Cooling Towers
+Mechanical Equipment,(?i)heat pump,,,23-33 17 00,Heat Pumps
+Mechanical Equipment,(?i)furnace,,,23-33 13 00,Furnaces
+Mechanical Equipment,(?i)condens,,,23-33 37 00,Refrigerant Condensing Units
+Mechanical Equipment,(?i)water heater|calorifier|cylinder|dhw,,,23-31 29 00,Hot Water Heaters
+Mechanical Equipment,(?i)pump,,,23-27 17 00,Pumps
+Mechanical Equipment,(?i)elevator|lift|escalator,,,23-23 00 00,Conveying Systems and Material Handling Products
+Electrical Equipment,,,,23-35 00 00,Electrical and Lighting Specific Products and Equipment
+Electrical Equipment,(?i)transformer,,,23-35 13 00,Transformers
+Electrical Equipment,(?i)generator,,,23-35 11 00,Electrical Generators
+Electrical Equipment,(?i)switchgear|switchboard|distribution board|panel|\bdb\b|\bmdb\b,,,23-35 31 00,Electrical Power Distribution Devices
+Electrical Equipment,(?i)\bups\b|inverter,,,23-35 23 00,Power Conditioning Equipment
+Electrical Fixtures,,,,23-35 37 00,Electrical Switches
+Lighting Fixtures,,,,23-35 47 00,Electrical Lighting
+Lighting Devices,,,,23-35 47 00,Electrical Lighting
+Conduits,,,,23-35 33 00,Electrical Ducting Wireways Components
+Conduit Fittings,,,,23-35 33 00,Electrical Ducting Wireways Components
+Cable Trays,,,,23-35 33 00,Electrical Ducting Wireways Components
+Cable Tray Fittings,,,,23-35 33 00,Electrical Ducting Wireways Components
+Sprinklers,,,,23-29 33 00,Fire Suppression System Components
+Fire Alarm Devices,,,,23-29 29 00,Fire Detection Devices
+Communication Devices,,,,23-37 00 00,Information and Communication Specific Products and Equipment
+Data Devices,,,,23-37 13 00,Information Technology Equipment
+Telephone Devices,,,,23-37 00 00,Information and Communication Specific Products and Equipment
+Security Devices,,,,23-29 11 00,Security Detection and Monitoring
+Nurse Call Devices,,,,23-37 00 00,Information and Communication Specific Products and Equipment
+Specialty Equipment,,,,23-19 00 00,Specialty Products
+Specialty Equipment,(?i)elevator|lift|escalator,,,23-23 00 00,Conveying Systems and Material Handling Products
+Furniture,,,,23-21 11 00,Commercial Furniture
+Furniture Systems,,,,23-21 11 00,Commercial Furniture
+Casework,,,,23-21 19 00,Casework
+Topography,,,,23-11 00 00,Site Products
+Pads,,,,23-11 00 00,Site Products
+Roads,,,,23-11 21 00,Pavements
+Parking,,,,23-11 21 00,Pavements
+Planting,,,,23-11 27 00,Landscaping
+Site,,,,23-11 00 00,Site Products

--- a/StingTools/Data/STING_OMNICLASS_41_MAP.csv
+++ b/StingTools/Data/STING_OMNICLASS_41_MAP.csv
@@ -1,0 +1,62 @@
+# STING OmniClass Table 41 (Materials) map (Phase 199c). Active when
+# classification_policy.json sets "omniClassTable": "41". Classifies each element
+# by the MATERIAL it is made of and stamps ASS_OMNICLASS_TXT.
+#
+# IMPORTANT — Table 41 is a chemistry taxonomy (Chemical Elements 41-10 / Solid
+# Compounds 41-30 / Liquids 41-50 / Gases 41-70); construction materials live
+# under 41-30 Solid Compounds. Revit carries an element's material SEPARATELY from
+# its name, so this map keys on MATERIAL KEYWORDS in the type name (TypeRegex) +
+# a few near-certain category fallbacks. It is therefore best-effort: a steel beam
+# whose type name is "305x165x40" (no "steel") won't match. Refine per project via
+# _BIM_COORD/omniclass_map.csv, or drive it from the element material in a custom
+# pass. Codes are from the official NBIMS-US v3 OmniClass Table 41 (Materials).
+#
+# Grammar: Category, FamilyRegex, TypeRegex, Sys, Section, Title (Title NO commas).
+# Most-specific row wins (more matched qualifiers = higher score; ties: first) —
+# so specific keywords (stainless, hardwood, PVC) are listed before generic ones.
+# matchOn: material  (the assigner reads the element's actual material name, then
+# falls back to the type name; the keyword regex below matches either)
+Category,FamilyRegex,TypeRegex,Sys,Section,Title
+*,,(?i)stainless,,41-30 20 11 14,Stainless Steel
+*,,(?i)\bsteel\b|\brsj\b|\bub\b|\buc\b|\bshs\b|\brhs\b|\bchs\b|rebar|reinforc,,41-30 20 11 11,Carbon Steel
+*,,(?i)cast iron,,41-30 20 11 17,Cast Iron
+*,,(?i)alumin,,41-30 20 14,Aluminum Alloys
+*,,(?i)brass,,41-30 20 17 11,Brass
+*,,(?i)bronze,,41-30 20 17 14,Bronze
+*,,(?i)\bcopper\b,,41-30 20 17,Copper Alloys
+*,,(?i)\bzinc\b|galvani,,41-30 20 21,Zinc Alloys
+*,,(?i)\blead\b,,41-30 20 24,Lead Alloys
+*,,(?i)portland,,41-30 10 25 19 15 11,Portland Cement
+*,,(?i)concrete|\brc\b|screed|blinding|cement|grout,,41-30 10 25 19 15,Cement
+*,,(?i)brick|brickwork,,41-30 10 25 13 11,Brick
+*,,(?i)\bblock\b|blockwork|\bcmu\b|masonry|mortar,,41-30 10 25 19 15,Cement
+*,,(?i)porcelain,,41-30 10 25 13 19,Porcelain
+*,,(?i)ceramic|terracotta|earthenware|\btile\b,,41-30 10 25 13,Ceramic
+*,,(?i)granite,,41-30 10 11 11,Granite
+*,,(?i)marble,,41-30 10 15 13,Marble
+*,,(?i)limestone,,41-30 10 13 11,Limestone
+*,,(?i)sandstone,,41-30 10 13 13,Sandstone
+*,,(?i)slate,,41-30 10 15 17,Slate
+*,,(?i)\bstone\b,,41-30 10 00,Mineral Compounds
+*,,(?i)glass|glazing|glazed,,41-30 10 27 17 13,Glass
+*,,(?i)gypsum|plaster|plasterboard|drywall|gyp ?board,,41-30 10 25 17,Gypsum
+*,,(?i)softwood|\bpine\b|\bfir\b|spruce|cedar|redwood,,41-30 30 11 19 11,Softwood Timber
+*,,(?i)hardwood|\boak\b|\bmaple\b|cherry|mahogany|walnut,,41-30 30 11 19 13,Hardwood Timber
+*,,(?i)timber|\bwood\b|lumber|plywood|\bmdf\b|chipboard|\bosb\b|joinery,,41-30 30 11 19,Timber
+*,,(?i)bamboo,,41-30 30 11 17 13 11,Bamboo
+*,,(?i)\bcork\b,,41-30 30 11 17 11,Cork
+*,,(?i)\bpvc\b|polyvinyl|\bupvc\b,,41-30 50 21 71,Polyvinyl Chloride
+*,,(?i)polyethylene|\bhdpe\b|\bmdpe\b|\bldpe\b,,41-30 50 21 37,Polyethylene
+*,,(?i)polycarbonate,,41-30 50 21 31,Polycarbonate
+*,,(?i)polystyrene|\beps\b|\bxps\b,,41-30 50 21 54,Polystyrene
+*,,(?i)polyurethane|\bpur\b|\bpir\b|polyiso,,41-30 50 21 61,Polyurethane
+*,,(?i)\bplastic\b|acrylic|\bhpl\b|laminate|composite,,41-30 50 21,Plastics
+*,,(?i)silicone|sealant,,41-30 50 24 17,Silicone
+*,,(?i)rubber|\bepdm\b|neoprene,,41-30 50 24,Rubbers
+*,,(?i)mineral ?wool|rock ?wool|rock fib|glass ?wool|insulation,,41-30 10 27 19,Rock Fibers
+*,,(?i)\bwool\b|acoustic,,41-30 30 21 11 15,Wool
+*,,(?i)leather,,41-30 30 21 11 11,Leather
+Curtain Panels,,,,41-30 10 27 17 13,Glass
+Curtain Wall Mullions,,,,41-30 20 14,Aluminum Alloys
+Structural Rebar,,,,41-30 20 11 11,Carbon Steel
+Structural Foundations,,,,41-30 10 25 19 15,Cement

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -253,6 +253,10 @@ namespace StingTools.UI
 
                     // ── Phase 192 (C2): CSI MasterFormat / SpecLink ──
                     case "CSI_Assign":               RunCommand<Commands.Classification.CsiAssignCommand>(app); break;
+                    case "OmniClass_Assign":         RunCommand<Commands.Classification.OmniClassAssignCommand>(app); break;
+                    case "OmniClass_Audit":          RunCommand<Commands.Classification.OmniClassAuditCommand>(app); break;
+                    case "OmniClass_SetTable":       RunCommand<Commands.Classification.OmniClassSetTableCommand>(app); break;
+                    case "ClassificationTags_Set":   RunCommand<Commands.Classification.ClassificationTagsSetCommand>(app); break;
                     case "SpecLink_Reconcile":       RunCommand<Commands.Classification.SpecLinkReconcileCommand>(app); break;
                     case "Prod_GenerateRules":       RunCommand<Commands.Classification.GenerateProdCodeRulesCommand>(app); break;
                     case "Prod_CoverageAudit":       RunCommand<Commands.Classification.ProdCoverageAuditCommand>(app); break;

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -3745,10 +3745,18 @@
                         <TextBlock Style="{StaticResource SectionLabel}" Text="CSI / SPECLINK"/>
                         <Border Style="{StaticResource GroupBorder}" BorderBrush="#00897B">
                             <StackPanel>
-                                <TextBlock Text="CSI MasterFormat classification + RIB SpecLink TOC reconciliation" FontSize="9" Foreground="#888" Margin="0,0,0,4"/>
+                                <TextBlock Text="MasterFormat (work results) + OmniClass (elements) classification + RIB SpecLink TOC reconciliation" FontSize="9" Foreground="#888" Margin="0,0,0,4"/>
                                 <WrapPanel>
                                     <Button Style="{StaticResource GreenBtn}" Content="CSI Assign" Tag="CSI_Assign" Click="Cmd_Click"
-                                            ToolTip="Resolve + write CSI_SECTION_TXT / CSI_TITLE_TXT from STING_CSI_MASTERFORMAT_MAP.csv (category → family → SYS)"/>
+                                            ToolTip="Resolve + write CSI_SECTION_TXT / CSI_TITLE_TXT (MasterFormat) from STING_CSI_MASTERFORMAT_MAP.csv (category → family → SYS)"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="OmniClass Table…" Tag="OmniClass_SetTable" Click="Cmd_Click"
+                                            ToolTip="Pick the active OmniClass table (21 Elements / 23 Products / 41 Materials / 13 Spaces ship maps; the other 11 tables resolve via _BIM_COORD/omniclass_map.csv). Sets classification_policy.json — drives OmniClass Assign / Audit"/>
+                                    <Button Style="{StaticResource GreenBtn}" Content="OmniClass Assign" Tag="OmniClass_Assign" Click="Cmd_Click"
+                                            ToolTip="Resolve + write ASS_OMNICLASS_TXT for the active OmniClass table (per classification_policy.json). A native-authored OmniClass Number on the type wins; the map is the bootstrap"/>
+                                    <Button Style="{StaticResource BlueBtn}" Content="OmniClass Audit" Tag="OmniClass_Audit" Click="Cmd_Click"
+                                            ToolTip="Read-only dry-run: % classified, unmapped keys, and ambiguous (tied-rule) elements for the active OmniClass table — CSV + summary. Run before Assign to see the holes"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="Classification on Tags…" Tag="ClassificationTags_Set" Click="Cmd_Click"
+                                            ToolTip="Optionally stamp a classification code (MasterFormat / OmniClass / both / none) into each element's rich TAG7 narrative so it shows on drawings. Per-project, data-driven (classification_policy.json), off by default. Re-run Auto Tag / Build Tags to refresh"/>
                                     <Button Style="{StaticResource BlueBtn}" Content="SpecLink Reconcile" Tag="SpecLink_Reconcile" Click="Cmd_Click"
                                             ToolTip="Compare model CSI sections against the SpecLink spec TOC — spec gaps / over-spec / title mismatches; XLSX report"/>
                                 </WrapPanel>

--- a/project-templates/KUT/_BIM_COORD/classification_policy.json
+++ b/project-templates/KUT/_BIM_COORD/classification_policy.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "KUT (Kampala Uganda Temple) classification policy overlay. Phase 196. KUT follows the American convention: CSI MasterFormat is the authoritative classification for work-results / BOQ structure (auto-assigned by CSI_Assign from STING_CSI_MASTERFORMAT_MAP.csv + project csi_map.csv overlay), with OmniClass Table 23 next and Uniclass 2015 as the final coded fallback before the native family/type bucket. To switch a project to Uniclass-first (UK) simply reorder the rungs, or delete this file to use the corporate default (Uniclass.Pr -> Ss -> Ef -> OmniClass23 -> native). Each rung names a TEXT shared parameter to read (type-first); point 'param' at any parameter to introduce a classification the code has never seen. An explicit 'order' takes precedence over the four-way Classification Standard picker (_BIM_COORD/sting_classification.json), which stays in charge for projects that do not define one.",
+  "_omniClassTable_comment": "Phase 199 — which OmniClass TABLE OmniClass_Assign classifies by + the table the BOQ OmniClass column names. Any real OmniClass table works (11/12/13/14/21/22/23/31/32/33/34/35/36/41/49 — note OmniClass has NO table 24-28; the CSI MasterFormat *divisions* 21-28 are the MasterFormat column, written by CSI_Assign). BOQ-relevant: '21' = Elements (UniFormat-style elemental breakdown, default), '23' = Products, '41' = Materials (element axes); '13'/'14' = Spaces (each element inherits its host room's code → cost-by-space cut). Switching is this one line; the assigner loads STING_OMNICLASS_<table>_MAP.csv. Tables 21 (Elements), 23 (Products, from Autodesk Classification Manager), 41 (Materials, from NBIMS-US OmniClass Table 41) + 13 (Spaces) ship corporate maps; any other table needs its map shipped or supplied via _BIM_COORD/omniclass_map.csv.",
+  "omniClassTable": "21",
+  "_tagClassifications_comment": "Phase 199f — classification code(s) stamped into each element's TAG7 rich narrative so they show on drawings. KUT annotates by MasterFormat. List any classification text parameter(s); [] = none. Set via the 'Classification on Tags…' command. Run CSI_Assign (or OmniClass_Assign) so the values exist, then Auto Tag / Build Tags to refresh.",
+  "tagClassifications": [ "CSI_SECTION_TXT" ],
+  "order": [
+    { "id": "csi",         "param": "CSI_SECTION_TXT",    "prefix": "CSI",  "label": "CSI.MasterFormat" },
+    { "id": "omniclass23", "param": "STING_OMNICLASS_23", "prefix": "OMNI", "label": "OmniClass23" },
+    { "id": "uniclass.pr", "param": "UNICLASS_PR_TXT",    "prefix": "PR",   "label": "Uniclass.Pr" },
+    { "id": "uniclass.ss", "param": "UNICLASS_SS_TXT",    "prefix": "SS",   "label": "Uniclass.Ss" },
+    { "id": "uniclass.ef", "param": "UNICLASS_EF_TXT",    "prefix": "EF",   "label": "Uniclass.Ef" },
+    { "id": "native" }
+  ]
+}


### PR DESCRIPTION
## What this adds

A second classification axis alongside CSI MasterFormat, and the switch that decides which one a project annotates its drawings with.

MasterFormat answers *what work result is this billed under*. OmniClass answers a different question — what **element**, **product**, **material** or **space** this is. A BOQ that can only cut one way cannot show cost by elemental breakdown, or by space function, and that is exactly the cut an owner asks for at the point they want to compare a scheme against a benchmark.

| Command | Tag | Mode |
|---|---|---|
| OmniClass Assign | `OmniClass_Assign` | Manual — writes `ASS_OMNICLASS_TXT` (+ `CLS_OMNICLASS_TITLE_TXT`) |
| OmniClass Audit | `OmniClass_Audit` | ReadOnly — % classified, unmapped keys, ambiguous ties, CSV |
| OmniClass Table… | `OmniClass_SetTable` | ReadOnly — picks the active table |
| Classification on Tags… | `ClassificationTags_Set` | ReadOnly — picks what gets stamped on tags |

Resolution is three-tier and says so: a **native OmniClass Number authored on the type** wins (Revit's own Table-23 parameter), then the map heuristic, and the audit reports the residual so a project closes the gap deliberately instead of trusting a headline percentage. Each table declares what it matches on — the element itself (21 Elements / 23 Products), its **host room** (13/14 Spaces), or its **material** (41) — and a project map can override that with a `# matchOn:` directive.

Four corporate maps ship (21, 23, 41, 13). The other eleven OmniClass tables still resolve; they need a map supplied at `_BIM_COORD/omniclass_map.csv`.

`ClassificationTags_Set` is not a setting that does nothing: the TAG7 narrative builder reads `tagClassifications` and appends "classified as MasterFormat 22 13 16", so the code reaches the drawing. Empty by default, so no existing project's narrative changes.

## Why it was worth recovering

This is the piece that makes the BOQ answer more than one question, and it is ~1,000 lines of resolver, map data and audit that nothing on `main` replaces. The four shipped maps are the expensive part — Table 23 is derived from Autodesk's Classification Manager and Table 41 from NBIMS-US, and they are the difference between "OmniClass is supported" and "OmniClass works out of the box".

## Provenance

Ported from `claude/kut-lifecycle-integration` (cut 2026-06-21, 46 commits, never merged, 76 days behind). The branch is **not** merged — it would revert current behaviour. Files were taken individually onto today's `main` and repaired.

`KutKpiDashboardCommand.cs` from the same branch is **deliberately excluded**: it is superseded by `OwnerKpiDashboardCommand` on `main`, which does the same job but derives the project code from `PRJ_ORG_PROJECT_CODE_TXT` instead of hard-coding KUT. Porting it would reintroduce a second dashboard.

## Drift repaired, and the judgement calls

**1. `main` independently solved the same problem, differently.** The branch replaced `ResolveFallback`'s hard-coded ladder with a data-driven `order`. Meanwhile `main` grew `ClassificationStandard` — a four-way Uniclass / CSI / OmniClass / Native picker with its own command and config file — and wired *that* into `ResolveFallback`.

They are not equivalent: `order` can express a ladder over **any** text parameter (a bespoke owner classification table), which the four-way enum cannot. So rather than one replacing the other, they are layered:

- a project that authored a **non-empty `order`** gets the ladder;
- everything else — no policy file, or a policy that only sets `omniClassTable` / `tagClassifications` — keeps `ClassificationStandard` exactly as it behaves today.

That distinction is carried by a new `HasExplicitOrder` flag, and it matters: without it, opting into an OmniClass table would silently re-order a project's whole BOQ grouping. Two tests pin it.

The remaining seam is that a project *with* an explicit order sees the standard picker do nothing. Rather than leave that silent, `Classification_SetStandard` now warns in the dialog that the policy takes precedence.

**2. Path discipline.** `ClassificationPolicy.Load(projectDir)` built `<dir>/_BIM_COORD/...` by hand, as did the overlay map load and both policy writers — four sites that would have failed the zero-tolerance gate and, worse, written to the pre-consolidation sibling folder. Loading moved to `ClassificationReader`, which holds the `Document` and resolves through `StingPaths.MetaFile`; the POCO stays host-free and therefore unit-testable. The two writers share a new `PolicyFile` helper that **merges** into the existing JSON, so setting `omniClassTable` never drops `tagClassifications`.

**3. A performance trap I introduced and then removed.** The first version keyed the policy cache on the *resolved* policy path. `ResolveFallback` runs per element across a whole-project take-off, and `StingPaths.MetaFile` probes the disk on every call — that is thousands of `File.Exists` calls inside the BOQ loop. It now keys on the model path, which is free.

**4. `CsiMasterFormat` grammar.** `CsiRule` gains optional 7th/8th columns (`Nrm2`, `Unit`) and the split widens from 6 to 8; six-column legacy rows are unaffected. Regexes are now compiled `IgnoreCase` — every shipped row already carries `(?i)`, so this only rescues hand-authored overlay rows that would otherwise have matched nothing **silently**. `Resolve` gains an overload reporting the winning score and how many rules tied on **distinct** sections; that tie count is what the audit reports as ambiguity (two rules that tie but agree on the code are correctly not flagged). The NRM2 bridge that *consumes* the `Nrm2` column lands with the BOQ work, not here.

## Verified

- `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings**
- `dotnet test StingTools.Boq.Tests` → **845 passed, 0 failed** (26 of them new)
- `tools/check_path_discipline.ps1` → Tier 1 = 0, Tier 2 = 0, 16 sites resolving correctly
- `tools/check_workflow_wiring.ps1` → **Tier 4 = 0**; all four new buttons dispatch
- `tools/check_kut_documents.py` → 80 assertions, green

Tests read the **shipped** map CSVs and the **shipped** KUT overlay, not fixtures restating them. Data-file JSON is not compile-checked — Newtonsoft leaves a mistyped field at its default and it goes runtime-dead — so the overlay is parsed by the real parser and its values asserted. I confirmed that gate bites by flipping `tagClassifications` from an array to a string: the test fails.

## Not verified

**Nothing here was exercised inside Revit.** That cannot be done from a terminal session. Untested at runtime: the element/room/material walks, the native-`OMNICLASS_CODE` read, worksharing editability, the TAG7 stamp appearing on an actual tag, and both `TaskDialog` writers. The pure resolver, table registry, policy parsing and shipped map contents are covered by the 26 tests; the Revit-bound half is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1S3eCuoayfcdhoiXLsoc
