### PR TITLE
fix(matsched): the unpriced message names the action, not a path that misleads

### DIFF
--- a/StingTools.Boq.Tests/MaterialScheduleReconcilerTests.cs
+++ b/StingTools.Boq.Tests/MaterialScheduleReconcilerTests.cs
@@ -90,6 +90,41 @@ namespace StingTools.Boq.Tests
         }
 
         [Fact]
+        public void The_Unpriced_Message_Never_Names_The_BIM_COORD_ALIAS()
+        {
+            // It used to say "add a row keyed 'X' to _BIM_COORD/commodity_rates.csv".
+            // _BIM_COORD is the ALIAS; the live folder is _data/coord. A reader
+            // following that literally opened a stale legacy folder, found
+            // nothing, and concluded the file was missing — which it was, because
+            // until the rate editor nothing in the codebase ever wrote it.
+            var doc = TwoStages(1_400_000, 1_400_000);
+            doc.Stages[0].Commodities[0].RateUGX = 0;
+            doc.Options.ShowPrices = true;
+
+            var r3 = Reconciler.Check(doc).Issues.Single(i => i.Code == "R3");
+
+            Assert.DoesNotContain("_BIM_COORD", r3.Message);
+            Assert.DoesNotContain("commodity_rates.csv", r3.Message);
+        }
+
+        [Fact]
+        public void The_Unpriced_Message_Names_The_Action_And_Says_The_Total_Is_Short()
+        {
+            // The key is the row's display name, so most of them carry a
+            // non-ASCII em dash an exact lookup will miss if it is retyped.
+            // Price Commodities seeds it, so nothing has to be typed.
+            var doc = TwoStages(1_400_000, 1_400_000);
+            doc.Stages[0].Commodities[0].RateUGX = 0;
+            doc.Options.ShowPrices = true;
+
+            var r3 = Reconciler.Check(doc).Issues.Single(i => i.Code == "R3");
+
+            Assert.Contains("Price Commodities", r3.Message);
+            Assert.Contains("nothing has to be retyped", r3.Message);
+            Assert.Contains("under-statement", r3.Message);
+        }
+
+        [Fact]
         public void An_Unpriced_Commodity_Is_Not_Flagged_When_Prices_Are_Hidden()
         {
             var doc = TwoStages(1_400_000, 1_400_000);

--- a/StingTools.Boq.Tests/RateProvenanceLabelTests.cs
+++ b/StingTools.Boq.Tests/RateProvenanceLabelTests.cs
@@ -143,5 +143,43 @@ namespace StingTools.Boq.Tests
 
             Assert.Contains("should not", s);
         }
-    }
+    
+        // ── where the rates file is ─────────────────────────────────────────
+
+        [Fact]
+        public void A_Clean_Export_Gets_No_Path_Note()
+        {
+            // A path nobody needs is noise.
+            Assert.Null(RateProvenanceLabel.RatesFileNote(@"C:\p\_data\coord\commodity_rates.csv", 0));
+        }
+
+        [Fact]
+        public void The_Note_Names_The_RESOLVED_Path_Not_The_Alias()
+        {
+            // _BIM_COORD is the alias; the live folder is _data/coord. Naming
+            // the alias sent a reader into a stale legacy folder to conclude
+            // the file was missing.
+            string s = RateProvenanceLabel.RatesFileNote(@"D:\job\_data\coord\commodity_rates.csv", 25);
+
+            Assert.Contains(@"D:\job\_data\coord\commodity_rates.csv", s);
+            Assert.DoesNotContain("_BIM_COORD", s);
+        }
+
+        [Fact]
+        public void The_Note_Leads_With_The_Action_Not_The_File()
+        {
+            string s = RateProvenanceLabel.RatesFileNote(@"C:\p\c.csv", 3);
+
+            Assert.StartsWith("Rates for the unpriced rows: use BOQ tab -> Price Commodities", s);
+        }
+
+        [Fact]
+        public void An_Unresolvable_Path_Says_Why_Rather_Than_Naming_A_Guess()
+        {
+            string s = RateProvenanceLabel.RatesFileNote("", 3);
+
+            Assert.Contains("has not been saved", s);
+            Assert.DoesNotContain("It writes commodity_rates.csv,", s);
+        }
+}
 }

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -127,6 +127,8 @@ namespace StingTools.BOQ.MaterialSchedule
             var msDoc = CommodityAggregator.Build(inputs);
             msDoc.ProjectName = doc.ProjectInformation?.Name ?? "";
             msDoc.ProjectCode = doc.ProjectInformation?.Number ?? "";
+            // Resolved, not the alias — see MaterialScheduleDocument.ProjectRatesPath.
+            msDoc.ProjectRatesPath = StingPaths.MetaFile(doc, "_BIM_COORD", "commodity_rates.csv") ?? "";
 
             AppendManualRows(doc, msDoc, boq, lib.Stages, result);
             AppendSiteTools(doc, msDoc, lib, inputs.Rates, result);
@@ -140,6 +142,12 @@ namespace StingTools.BOQ.MaterialSchedule
                 string provenance = RateProvenanceLabel.Summary(
                     msDoc.Stages.SelectMany(st => st.Commodities));
                 if (!string.IsNullOrEmpty(provenance)) msDoc.Warnings.Add(provenance);
+
+                string rates = RateProvenanceLabel.RatesFileNote(
+                    msDoc.ProjectRatesPath,
+                    msDoc.Stages.SelectMany(st => st.Commodities)
+                         .Count(c => c != null && c.IsUnpriced && !c.IsMemorandum));
+                if (!string.IsNullOrEmpty(rates)) msDoc.Warnings.Add(rates);
             }
 
             result.Document = msDoc;

--- a/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
+++ b/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
@@ -148,6 +148,17 @@ namespace StingTools.Core.MaterialSchedule
         /// closed, so a workbook reviewed later could not say why it looked the
         /// way it did. A deliverable has to carry its own explanation.
         /// </summary>
+        /// <summary>
+        /// The project rate file this run resolved, absolute.
+        ///
+        /// Carried on the document because the reconciler is Revit-free and
+        /// cannot ask StingPaths. It matters: every message used to name
+        /// "_BIM_COORD/commodity_rates.csv", which is the ALIAS. The live
+        /// folder is _data/coord, and a user following the text literally
+        /// landed in a stale legacy folder and concluded the file was missing.
+        /// </summary>
+        public string ProjectRatesPath = "";
+
         public List<string> Warnings = new List<string>();
 
         /// <summary>MAT-SCHED-8 — model rows dropped as not-a-material, by category.

--- a/StingTools/Core/MaterialSchedule/RateProvenanceLabel.cs
+++ b/StingTools/Core/MaterialSchedule/RateProvenanceLabel.cs
@@ -87,5 +87,40 @@ namespace StingTools.Core.MaterialSchedule
                    + "happen — report it rather than trusting the number.";
             return s;
         }
+
+        /// <summary>
+        /// Where this run's project rates live, stated ONCE.
+        ///
+        /// The per-row R3 messages used to repeat "_BIM_COORD/commodity_rates.csv"
+        /// on every unpriced row — 25 times in one export, and wrong: _BIM_COORD
+        /// is the alias, the live folder is _data/coord, and a reader following
+        /// it literally opened a stale legacy folder and concluded the file did
+        /// not exist. It genuinely did not, because until the rate editor
+        /// NOTHING in the codebase ever wrote it.
+        ///
+        /// So: the rows name the action, this names the file, and the path is
+        /// the RESOLVED absolute one rather than a relative guess.
+        ///
+        /// Returns NULL when nothing is unpriced — a path nobody needs is noise
+        /// on a clean export.
+        /// </summary>
+        public static string RatesFileNote(string resolvedPath, int unpricedCount)
+        {
+            if (unpricedCount <= 0) return null;
+
+            string s = "Rates for the unpriced rows: use BOQ tab -> Price Commodities, which lists "
+                     + "every commodity with the unpriced ones first and needs only a number typed "
+                     + "— the keys come from the schedule, and most of them contain characters that "
+                     + "cannot be retyped reliably.";
+
+            if (!string.IsNullOrWhiteSpace(resolvedPath))
+                s += " It writes " + resolvedPath.Trim()
+                   + ", which is a plain CSV: hand-editable, and copyable to the next project.";
+            else
+                s += " It writes commodity_rates.csv in the project's coordination folder — but this "
+                   + "run could not resolve that path, which usually means the project has not been "
+                   + "saved.";
+            return s;
+        }
     }
 }

--- a/StingTools/Core/MaterialSchedule/Reconciler.cs
+++ b/StingTools/Core/MaterialSchedule/Reconciler.cs
@@ -105,15 +105,27 @@ namespace StingTools.Core.MaterialSchedule
                         Code = "R3",
                         StageId = stage.StageId,
                         CommodityKey = c.CommodityKey,
-                        // Name the key and the file. 47 door and window rows came
-                        // back unpriced in one export; "has no rate" alone leaves
-                        // the reader to work out WHERE a rate goes, and the key is
-                        // a 70-character Revit type name nobody will retype from
-                        // memory.
+                        // Name the ACTION, not the file.
+                        //
+                        // This used to say "add a row keyed 'X' to
+                        // _BIM_COORD/commodity_rates.csv", which was wrong twice
+                        // over. _BIM_COORD is the ALIAS - the live folder is
+                        // _data/coord - so a reader following it literally landed
+                        // in a stale legacy folder and concluded the file was
+                        // missing. And the key is the row's DISPLAY NAME, so most
+                        // of them carry a non-ASCII em dash that an exact
+                        // OrdinalIgnoreCase lookup will miss in silence if it is
+                        // retyped as a hyphen.
+                        //
+                        // Price Commodities seeds the key from the schedule, so
+                        // it never has to be typed. The resolved path is stated
+                        // ONCE, in the export notes, for anyone preparing rates
+                        // outside Revit - repeating it on 25 rows was noise.
                         Message = $"'{c.Description}' ({c.OrderQuantity:N0} {c.SupplierUnit}) in "
-                                + $"{stage.Title} has no rate. It will total zero in a priced schedule. "
-                                + $"Add a row keyed '{c.CommodityKey}' to "
-                                + "_BIM_COORD/commodity_rates.csv to price it."
+                                + $"{stage.Title} has no rate, so it totals zero here and the grand "
+                                + "total is that much of an under-statement. Price it with "
+                                + "BOQ tab -> Price Commodities: this row is already listed there, "
+                                + "so nothing has to be retyped."
                     });
         }
 


### PR DESCRIPTION
## The message was wrong in three ways, and printed 25 times

> Add a row keyed `'X'` to `_BIM_COORD/commodity_rates.csv` to price it.

1. **`_BIM_COORD` is the alias.** The live folder is `_data/coord`. Following the text literally opens a stale legacy folder — in the test project, one JSON file from 7 August — and the reader concludes the file is missing. It was, because **until the rate editor nothing in the codebase ever wrote it**.
2. **The key is the row's display name.** 21 of the 25 keys that export asked for carry a non-ASCII em dash, and `Resolve` is an exact `OrdinalIgnoreCase` hit — retype one as a hyphen and the row stays unpriced with no error.
3. **It named a file, not a thing to do**, when Price Commodities now seeds every one of those keys from the schedule.

## What it says now

Per row, the action:

> `'Generic - 225mm'` (611 m2) in ELEMENT 03: ROOF has no rate, so it totals zero here and the grand total is that much of an under-statement. Price it with **BOQ tab -> Price Commodities**: this row is already listed there, so nothing has to be retyped.

Once, in the export notes, the file — **resolved and absolute**, not a relative guess:

> Rates for the unpriced rows: use BOQ tab -> Price Commodities... It writes `D:\...\_data\coord\commodity_rates.csv`, which is a plain CSV: hand-editable, and copyable to the next project.

`MaterialScheduleDocument` gained `ProjectRatesPath` to carry it, because the reconciler is Revit-free and cannot ask `StingPaths` itself.

The R3 text also now says what an unpriced row does to the bottom line — the schedule is **short**, not cheap — rather than leaving the reader to work that out.

## Verified

- Boq tests **832 -> 838**
- `dotnet build -c Release` **0 errors / 0 warnings**, gates pass
- **Three mutations, each failing:** emitting the path note on a clean export (1), falling back to naming the alias when the path will not resolve (1), restoring the old R3 message (**2** — the regression tests assert the message names neither `_BIM_COORD` nor the file, so the alias cannot come back)

## Not verified

No export has been produced with the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
