### PR TITLE
feat(boq): let the issued specification write the bill, and make the rate chain a project setting

### DIFF
--- a/StingTools.Boq.Tests/CsiNrm2BridgeTests.cs
+++ b/StingTools.Boq.Tests/CsiNrm2BridgeTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Classification;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase A (KUT lifecycle) — CSI MasterFormat Nrm2 column + CSI↔NRM2 bridge.
+    // Pure logic; no Revit. Validates that one CSI rule resolves both the CSI
+    // section and the NRM2 work-section, and that SYS-specific rows bill
+    // consistently (Pipes+SAN under plumbing, Pipes+CHW under HVAC).
+    public class CsiNrm2BridgeTests
+    {
+        [Fact]
+        public void ParseCsvLines_ReadsOptionalNrm2Column()
+        {
+            var lines = new[]
+            {
+                "Category,FamilyRegex,TypeRegex,Sys,Section,Title,Nrm2",
+                "Pipes,,,SAN,22 13 16,Sanitary Waste and Vent Piping,32",
+                "Pipes,,,CHW,23 21 13,Hydronic Piping,33",
+            };
+            var rules = CsiMasterFormat.ParseCsvLines(lines);
+
+            Assert.Equal(2, rules.Count);
+            Assert.Equal("32", rules[0].Nrm2);
+            Assert.Equal("SAN", rules[0].Sys);
+            Assert.Equal("33", rules[1].Nrm2);
+        }
+
+        [Fact]
+        public void ParseCsvLines_LegacySixColumnRow_HasEmptyNrm2()
+        {
+            var lines = new[]
+            {
+                "Category,FamilyRegex,TypeRegex,Sys,Section,Title",
+                "Floors,,,,09 60 00,Flooring",
+            };
+            var rules = CsiMasterFormat.ParseCsvLines(lines);
+
+            Assert.Single(rules);
+            Assert.Equal("Flooring", rules[0].Title);
+            Assert.Equal("", rules[0].Nrm2);   // blank ⇒ BOQ falls back to DeriveNrm2Section
+        }
+
+        [Fact]
+        public void BuildSectionToNrm2_MapsNormalisedSectionToCode_SkipsBlankNrm2()
+        {
+            var rules = new List<CsiRule>
+            {
+                new CsiRule { Section = "22 13 16", Nrm2 = "32" },
+                new CsiRule { Section = "23 21 13", Nrm2 = "33" },
+                new CsiRule { Section = "09 60 00", Nrm2 = "" },   // no bridge — skipped
+            };
+            var map = CsiMasterFormat.BuildSectionToNrm2(rules);
+
+            // Keys are whitespace-normalised, so spaced + unspaced reconcile.
+            Assert.Equal("32", map[CsiMasterFormat.NormalizeSection("22 13 16")]);
+            Assert.Equal("33", map[CsiMasterFormat.NormalizeSection("23 21 13")]);
+            Assert.False(map.ContainsKey(CsiMasterFormat.NormalizeSection("09 60 00")));
+        }
+
+        [Fact]
+        public void BuildSectionToNrm2_FirstRuleWinsOnSectionCollision()
+        {
+            // Project-overlay rows are loaded first, so the first Nrm2 wins.
+            var rules = new List<CsiRule>
+            {
+                new CsiRule { Section = "22 13 16", Nrm2 = "99" }, // overlay
+                new CsiRule { Section = "22 13 16", Nrm2 = "32" }, // corporate
+            };
+            var map = CsiMasterFormat.BuildSectionToNrm2(rules);
+            Assert.Equal("99", map[CsiMasterFormat.NormalizeSection("22 13 16")]);
+        }
+
+        // ---- rule-first resolution -------------------------------------------
+        // BuildSectionToNrm2 can only hold ONE answer per section, and that is not
+        // enough: 03 30 00 Cast-in-Place Concrete is NRM2 5 for a slab and 14 for a
+        // wall. Reading the section map alone bills every concrete slab, column,
+        // foundation, stair and ramp under masonry, purely because the wall row is
+        // listed first. Nrm2For reads the matched RULE first, which is why.
+        [Fact]
+        public void Nrm2For_PrefersTheMatchedRule_OverTheSectionMap()
+        {
+            var rules = new List<CsiRule>
+            {
+                new CsiRule { Category = "Walls",  TypeRegex = "(?i)concrete", Section = "03 30 00", Title = "Cast-in-Place Concrete", Nrm2 = "14" },
+                new CsiRule { Category = "Floors", Section = "03 30 00", Title = "Cast-in-Place Concrete", Nrm2 = "5" },
+            };
+            var map = CsiMasterFormat.BuildSectionToNrm2(rules);
+            Assert.Equal("14", map[CsiMasterFormat.NormalizeSection("03 30 00")]);   // first wins, as designed
+
+            var floorRule = CsiMasterFormat.Resolve(rules, "Floors", "Floor", "Slab 200mm", "");
+            Assert.Equal("5", CsiMasterFormat.Nrm2For(floorRule, map, "03 30 00"));  // NOT 14
+
+            var wallRule = CsiMasterFormat.Resolve(rules, "Walls", "Basic Wall", "Concrete 200", "");
+            Assert.Equal("14", CsiMasterFormat.Nrm2For(wallRule, map, "03 30 00"));
+        }
+
+        [Fact]
+        public void Nrm2For_FallsBackToTheSectionMap_ThenToNoOpinion()
+        {
+            var map = new Dictionary<string, string> { [CsiMasterFormat.NormalizeSection("22 13 16")] = "32" };
+            // No matched rule (an element carrying a stamped section the map never matched)
+            // -> the section map is the fallback.
+            Assert.Equal("32", CsiMasterFormat.Nrm2For(null, map, "221316"));
+            // A rule with a blank Nrm2 must not out-vote the section map.
+            Assert.Equal("32", CsiMasterFormat.Nrm2For(new CsiRule { Section = "22 13 16" }, map, "22 13 16"));
+            // Nothing known -> null, meaning "let DeriveNrm2Section decide", NOT a guess.
+            Assert.Null(CsiMasterFormat.Nrm2For(null, map, "99 99 99"));
+            Assert.Null(CsiMasterFormat.Nrm2For(null, null, "22 13 16"));
+            Assert.Null(CsiMasterFormat.Nrm2For(null, map, ""));
+        }
+
+        [Fact]
+        public void ShippedMap_ConcreteRowsBillUnderTheirOwnSection_NotTheFirstOne()
+        {
+            var rules = LoadShippedCsiMap();
+            var map = CsiMasterFormat.BuildSectionToNrm2(rules);
+
+            // Every one of these resolves to CSI 03 30 00, and every one must keep its
+            // own NRM2 answer rather than inheriting the concrete-wall row's.
+            foreach (var cat in new[] { "Floors", "Structural Columns", "Structural Foundations", "Stairs", "Ramps" })
+            {
+                var rule = CsiMasterFormat.Resolve(rules, cat, "", "", "");
+                Assert.NotNull(rule);
+                Assert.Equal("5", CsiMasterFormat.Nrm2For(rule, map, rule.Section));
+            }
+            var wall = CsiMasterFormat.Resolve(rules, "Walls", "Basic Wall", "Concrete 200mm", "");
+            Assert.Equal("14", CsiMasterFormat.Nrm2For(wall, map, wall.Section));
+        }
+
+        private static List<CsiRule> LoadShippedCsiMap()
+        {
+            string path = Path.Combine(System.AppContext.BaseDirectory, "Data", "STING_CSI_MASTERFORMAT_MAP.csv");
+            Assert.True(File.Exists(path), $"Shipped CSI map not found at {path}");
+            return CsiMasterFormat.ParseCsvLines(File.ReadAllLines(path));
+        }
+
+        [Fact]
+        public void ShippedMap_BridgesSysSpecificPipeRows()
+        {
+            string path = Path.Combine(System.AppContext.BaseDirectory, "Data", "STING_CSI_MASTERFORMAT_MAP.csv");
+            Assert.True(File.Exists(path), $"Shipped CSI map not found at {path}");
+
+            var rules = CsiMasterFormat.ParseCsvLines(File.ReadAllLines(path));
+            Assert.NotEmpty(rules);
+
+            // Sanity: SAN pipes resolve to plumbing (32), CHW pipes to HVAC (33).
+            var san = CsiMasterFormat.Resolve(rules, "Pipes", "", "", "SAN");
+            var chw = CsiMasterFormat.Resolve(rules, "Pipes", "", "", "CHW");
+            Assert.NotNull(san);
+            Assert.NotNull(chw);
+            Assert.Equal("32", san.Nrm2);
+            Assert.Equal("33", chw.Nrm2);
+
+            // Every shipped row carries an Nrm2 value (the KUT category set is fully bridged).
+            Assert.All(rules, r => Assert.False(string.IsNullOrWhiteSpace(r.Nrm2), $"row {r.Category}/{r.Section} missing Nrm2"));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/FfeTreatmentTests.cs
+++ b/StingTools.Boq.Tests/FfeTreatmentTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using StingTools.BOQ;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase C.2 (KUT lifecycle) — FF&E BOQ-treatment resolution. KUT default is the
+    // transparent Owner-procured FF&E category ("ffe"); categories may be flipped to
+    // measured, excluded, or the explicit contractual pcSum.
+    public class FfeTreatmentTests
+    {
+        [Theory]
+        [InlineData("ffe", "ffe")]
+        [InlineData("owner-procured", "ffe")]
+        [InlineData("", "ffe")]
+        [InlineData(null, "ffe")]
+        [InlineData("nonsense", "ffe")]
+        [InlineData("pcSum", "pcSum")]
+        [InlineData("PC", "pcSum")]
+        [InlineData("provisional", "pcSum")]
+        [InlineData("measured", "measured")]
+        [InlineData("Measure", "measured")]
+        [InlineData("ownerSupplied-excluded", "ownerSupplied-excluded")]
+        [InlineData("excluded", "ownerSupplied-excluded")]
+        public void Normalize_TolerantOfAliases(string raw, string expected)
+            => Assert.Equal(expected, FfeTreatment.Normalize(raw));
+
+        [Fact]
+        public void Resolve_DefaultsToFfe_WhenNoOverride()
+        {
+            Assert.Equal(FfeTreatment.Ffe, FfeTreatment.Resolve("Furniture", "ffe", null));
+            Assert.Equal(FfeTreatment.Ffe, FfeTreatment.Resolve("Furniture", null, new Dictionary<string, string>()));
+        }
+
+        [Fact]
+        public void Resolve_PerCategoryOverrideWins_CaseInsensitive()
+        {
+            var overrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Casework"] = "measured",
+                ["Specialty Equipment"] = "ownerSupplied-excluded",
+                ["Lighting Fixtures"] = "pcSum",
+            };
+            Assert.Equal(FfeTreatment.Measured, FfeTreatment.Resolve("casework", "ffe", overrides));
+            Assert.Equal(FfeTreatment.Excluded, FfeTreatment.Resolve("Specialty Equipment", "ffe", overrides));
+            Assert.Equal(FfeTreatment.PcSum, FfeTreatment.Resolve("lighting fixtures", "ffe", overrides));
+            // Unlisted category falls back to the map default.
+            Assert.Equal(FfeTreatment.Ffe, FfeTreatment.Resolve("Furniture", "ffe", overrides));
+        }
+
+        [Fact]
+        public void Resolve_ExactlyOneTreatment_NeverBlank()
+        {
+            foreach (var cat in new[] { "Furniture", "Casework", "Lighting Fixtures", "Unknown" })
+            {
+                string t = FfeTreatment.Resolve(cat, "ffe", null);
+                Assert.Contains(t, new[] { FfeTreatment.Ffe, FfeTreatment.PcSum, FfeTreatment.Measured, FfeTreatment.Excluded });
+            }
+        }
+    }
+}

--- a/StingTools.Boq.Tests/RatePolicyTests.cs
+++ b/StingTools.Boq.Tests/RatePolicyTests.cs
@@ -1,0 +1,103 @@
+using StingTools.BOQ.Rates;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase 195 — host-free rate-provider policy overlay (boq_rate_policy.json).
+    public class RatePolicyTests
+    {
+        [Fact]
+        public void Parse_Null_Or_Blank_Yields_NoOp_Policy()
+        {
+            foreach (var raw in new[] { null, "", "   " })
+            {
+                var p = RatePolicy.Parse(raw);
+                Assert.True(p.IsEnabled("es-override"));
+                // Unset provider keeps its baseline priority.
+                Assert.Equal(95, p.EffectivePriority("es-override", 95));
+            }
+        }
+
+        [Fact]
+        public void Parse_Malformed_Json_Falls_Back_To_NoOp()
+        {
+            var p = RatePolicy.Parse("{ this is not json ");
+            Assert.True(p.IsEnabled("bcis-http"));
+            Assert.Equal(50, p.EffectivePriority("bcis-http", 50));
+        }
+
+        [Fact]
+        public void Priority_Override_Is_Applied_Baseline_Otherwise()
+        {
+            string json = @"{
+              ""providers"": {
+                ""es-override"":       { ""priority"": 98 },
+                ""project-rate-card"": { ""priority"": 93 },
+                ""material-library"":  { ""priority"": 85 }
+              }
+            }";
+            var p = RatePolicy.Parse(json);
+
+            Assert.Equal(98, p.EffectivePriority("es-override", 95));        // overridden
+            Assert.Equal(93, p.EffectivePriority("project-rate-card", 87));  // overridden
+            Assert.Equal(85, p.EffectivePriority("material-library", 95));   // overridden
+            Assert.Equal(96, p.EffectivePriority("fohlio", 96));             // untouched → baseline
+            Assert.Equal(100, p.EffectivePriority("param-override", 100));   // untouched → baseline
+        }
+
+        [Fact]
+        public void Enabled_False_Disables_Only_The_Named_Provider()
+        {
+            string json = @"{ ""providers"": { ""bcis-http"": { ""enabled"": false } } }";
+            var p = RatePolicy.Parse(json);
+
+            Assert.False(p.IsEnabled("bcis-http"));
+            Assert.True(p.IsEnabled("csv-default"));   // unnamed → enabled
+            Assert.True(p.IsEnabled("es-override"));    // unnamed → enabled
+        }
+
+        [Fact]
+        public void Provider_Ids_Match_Case_Insensitively()
+        {
+            string json = @"{ ""providers"": { ""ES-Override"": { ""priority"": 98, ""enabled"": false } } }";
+            var p = RatePolicy.Parse(json);
+
+            Assert.Equal(98, p.EffectivePriority("es-override", 95));
+            Assert.False(p.IsEnabled("es-override"));
+        }
+
+        [Fact]
+        public void Entry_With_Only_Enabled_Leaves_Priority_At_Baseline()
+        {
+            string json = @"{ ""providers"": { ""fohlio"": { ""enabled"": true } } }";
+            var p = RatePolicy.Parse(json);
+
+            Assert.True(p.IsEnabled("fohlio"));
+            Assert.Equal(96, p.EffectivePriority("fohlio", 96)); // priority unset → baseline
+        }
+    
+        // The SHIPPED KUT overlay, parsed by the real parser. Newtonsoft leaves an
+        // unrecognised or wrongly-typed field at its default, so a typo here is a silent
+        // no-op in Revit - the file has to be read, not merely be valid JSON.
+        [Fact]
+        public void ShippedKutOverlay_DisablesTheLiveFeed_AndReRanksTheChain()
+        {
+            string path = System.IO.Path.Combine(System.AppContext.BaseDirectory, "Data", "kut_boq_rate_policy.json");
+            Assert.True(System.IO.File.Exists(path), $"Shipped KUT rate policy not found at {path}");
+
+            var p = RatePolicy.Parse(System.IO.File.ReadAllText(path));
+
+            // "enabled": false has to survive as a bool, not land as null.
+            Assert.False(p.IsEnabled("bcis-http"));
+            // Provider ids are matched case-insensitively.
+            Assert.False(p.IsEnabled("BCIS-HTTP"));
+            // "priority" has to survive as an int and beat the baseline argument.
+            Assert.Equal(98, p.EffectivePriority("es-override", 1));
+            Assert.Equal(93, p.EffectivePriority("project-rate-card", 1));
+            Assert.Equal(85, p.EffectivePriority("material-library", 1));
+            // A provider the overlay never names keeps its compiled-in baseline and stays on.
+            Assert.True(p.IsEnabled("csv-default"));
+            Assert.Equal(90, p.EffectivePriority("csv-default", 90));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/SpecStoreTests.cs
+++ b/StingTools.Boq.Tests/SpecStoreTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using StingTools.BOQ;
+using StingTools.Core.Classification;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase H1 (KUT lifecycle) — SpecLink section store + CSI→unit bridge.
+    public class SpecStoreTests
+    {
+        [Fact]
+        public void Parse_ArrayShape_NormalisesSectionAndReadsFields()
+        {
+            string json = @"[
+              { ""section"": ""08 11 00"", ""title"": ""Metal Doors"", ""description"": ""Supply and install hollow metal doors per Part 2."", ""unit"": ""each"" }
+            ]";
+            var store = SpecStore.Parse(json);
+            Assert.Single(store);
+            var s = SpecStore.Get(store, "081100"); // unspaced lookup must hit the spaced key
+            Assert.NotNull(s);
+            Assert.Equal("Metal Doors", s.Title);
+            Assert.StartsWith("Supply and install", s.Description);
+            Assert.Equal("each", s.Unit);
+        }
+
+        [Fact]
+        public void Parse_ObjectShape_AndTextAlias()
+        {
+            string json = @"{ ""sections"": [ { ""section"": ""23 05 00"", ""text"": ""HVAC common work results."" } ] }";
+            var store = SpecStore.Parse(json);
+            var s = SpecStore.Get(store, "23 05 00");
+            Assert.NotNull(s);
+            Assert.Equal("HVAC common work results.", s.Description); // 'text' aliases 'description'
+        }
+
+        [Fact]
+        public void Parse_BadJson_ReturnsEmpty_NotThrow()
+        {
+            Assert.Empty(SpecStore.Parse("{not valid"));
+            Assert.Empty(SpecStore.Parse(""));
+            Assert.Empty(SpecStore.Parse(null));
+        }
+
+        [Fact]
+        public void Get_UnknownSection_ReturnsNull()
+        {
+            var store = SpecStore.Parse(@"[{ ""section"": ""08 11 00"", ""description"": ""x"" }]");
+            Assert.Null(SpecStore.Get(store, "99 99 99"));
+            Assert.Null(SpecStore.Get(store, ""));
+        }
+
+        [Fact]
+        public void BuildSectionToUnit_ReadsUnitColumn_EarliestWinsOnTie()
+        {
+            var rules = new List<CsiRule>
+            {
+                new CsiRule { Section = "08 11 00", Unit = "each" },   // earliest
+                new CsiRule { Section = "08 11 00", Unit = "m2" },     // tie — must NOT override
+                new CsiRule { Section = "03 30 00", Unit = "m3" },
+                new CsiRule { Section = "09 99 99", Unit = "" },       // blank skipped
+            };
+            var map = CsiMasterFormat.BuildSectionToUnit(rules);
+            Assert.Equal("each", map["081100"]);
+            Assert.Equal("m3", map["033000"]);
+            Assert.False(map.ContainsKey("099999"));
+        }
+
+        [Fact]
+        public void ParseManualCsv_HeaderAware_MapsColumnsByName()
+        {
+            var lines = new[]
+            {
+                "Section,Title,Description,Unit",
+                "08 11 00,Metal Doors,\"Supply, fit and finish hollow metal doors.\",each",
+                "03 30 00,Concrete,Cast-in-situ structural concrete.,m3",
+            };
+            var store = SpecStore.ParseManualCsv(lines);
+            Assert.Equal(2, store.Count);
+            Assert.Equal("Metal Doors", store["081100"].Title);
+            Assert.Contains("hollow metal", store["081100"].Description); // quoted comma preserved
+            Assert.Equal("each", store["081100"].Unit);
+            Assert.Equal("m3", store["033000"].Unit);
+        }
+
+        [Fact]
+        public void ParseManualCsv_NoHeader_PositionalSectionThenTitle()
+        {
+            var lines = new[] { "08 11 00,Metal Doors", "08 50 00,Windows" };
+            var store = SpecStore.ParseManualCsv(lines);
+            Assert.Equal(2, store.Count);
+            Assert.Equal("Windows", store["085000"].Title);
+        }
+
+        [Fact]
+        public void ManualCsv_RoundTrips_ThroughSerializeAndParse()
+        {
+            var lines = new[]
+            {
+                "Section,Title,Description,Unit",
+                "23 05 00,HVAC Common,Common work results for HVAC.,",
+            };
+            var store = SpecStore.ParseManualCsv(lines);
+            string json = SpecStore.Serialize(store);
+            var reparsed = SpecStore.Parse(json);          // Serialize → Parse must round-trip
+            var s = SpecStore.Get(reparsed, "230500");
+            Assert.NotNull(s);
+            Assert.Equal("HVAC Common", s.Title);
+            Assert.Equal("Common work results for HVAC.", s.Description);
+        }
+
+        [Fact]
+        public void ParseCsvLines_EighthUnitColumn_BackCompatWithSixColRows()
+        {
+            var lines = new[]
+            {
+                "Category,FamilyRegex,TypeRegex,Sys,Section,Title,Nrm2,Unit",
+                "Doors,,,,08 11 00,Metal Doors,20,each",   // 8-col
+                "Windows,,,,08 50 00,Windows,20",          // 7-col (no Unit)
+                "Walls,,,,03 30 00,Concrete",              // 6-col (no Nrm2/Unit)
+            };
+            var rules = CsiMasterFormat.ParseCsvLines(lines);
+            Assert.Equal(3, rules.Count);
+            Assert.Equal("each", rules[0].Unit);
+            Assert.Equal("20", rules[0].Nrm2);
+            Assert.Equal("", rules[1].Unit);   // 7-col row → empty unit, no crash
+            Assert.Equal("", rules[2].Nrm2);   // 6-col row → empty nrm2 + unit
+            Assert.Equal("", rules[2].Unit);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -76,6 +76,12 @@
     <Compile Include="..\StingTools\Core\Classification\CsiMasterFormat.cs" Link="Classification\CsiMasterFormat.cs" />
     <Compile Include="..\StingTools\Core\Classification\OmniClassTables.cs" Link="Classification\OmniClassTables.cs" />
     <Compile Include="..\StingTools\Core\Classification\ClassificationPolicy.cs" Link="Classification\ClassificationPolicy.cs" />
+    <!-- Spec store + tender gate + rate policy + FF&amp;E vocabulary - the Revit-free
+         halves of the KUT lifecycle BOQ work. SpecCompletenessGate needs the BOQ model
+         (BOQLineItem / BOQDocument), which is itself Document-free. -->
+    <Compile Include="..\StingTools\BOQ\SpecStore.cs" Link="SpecStore.cs" />
+    <Compile Include="..\StingTools\BOQ\FfeTreatment.cs" Link="FfeTreatment.cs" />
+    <Compile Include="..\StingTools\BOQ\Rates\RatePolicy.cs" Link="Rates\RatePolicy.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -129,6 +135,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="..\StingTools\Data\STING_OMNICLASS_41_MAP.csv" Link="Data\STING_OMNICLASS_41_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- The SHIPPED CSI MasterFormat map, so the CSI-&gt;NRM2 bridge test asserts the
+         codes that actually reach a bill rather than a fixture restating them. -->
+    <None Include="..\StingTools\Data\STING_CSI_MASTERFORMAT_MAP.csv" Link="Data\STING_CSI_MASTERFORMAT_MAP.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- The SHIPPED KUT rate-policy overlay - JSON field types are not compile-checked. -->
+    <None Include="..\project-templates\KUT\_BIM_COORD\boq_rate_policy.json" Link="Data\kut_boq_rate_policy.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <!-- The SHIPPED KUT classification overlay. Data-file JSON is not compile-checked:

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -22,6 +22,7 @@ using StingTools.BOQ.Rates;
 using StingTools.BOQ.Sync;
 using StingTools.BOQ.Takeoff;
 using StingTools.Core;
+using StingTools.Core.Classification;
 using StingTools.Core.Storage;
 using StingTools.Temp;
 
@@ -749,6 +750,45 @@ namespace StingTools.BOQ
 
             string disc = ResolveDiscipline(el, catName);
             string nrm2Section = DeriveNrm2Section(doc, el, catName, disc);
+
+            // (f) Spec reference + CSI -> NRM2 bridge.
+            //
+            // The element carries CSI_SECTION_TXT once CSI_Assign has run. When it has
+            // not, resolve the section straight from the shipped map so the bill's
+            // MasterFormat column is populated for the WHOLE model rather than only for
+            // elements that happened to be pre-stamped - the stamp still wins when
+            // present, so an assign pass is an override, not a prerequisite.
+            string csiSection = ParameterHelpers.GetString(el, ParamRegistry.CSI_SECTION) ?? "";
+            string csiTitle = ParameterHelpers.GetString(el, ParamRegistry.CSI_TITLE) ?? "";
+            CsiRule csiRule = null;
+            try
+            {
+                var rules = StingTools.Commands.Classification.CsiMap.Rules(doc);
+                if (rules != null && rules.Count > 0)
+                    csiRule = CsiMasterFormat.Resolve(rules, catName, GetFamilyName(el), el.Name ?? "",
+                        ParameterHelpers.GetString(el, ParamRegistry.SYS) ?? "");
+                if (csiRule != null)
+                {
+                    if (string.IsNullOrEmpty(csiSection)) csiSection = csiRule.Section ?? "";
+                    if (string.IsNullOrEmpty(csiTitle)) csiTitle = csiRule.Title ?? "";
+                }
+            }
+            catch (Exception ex) { StingLog.WarnRateLimited("CsiResolve", $"CSI map resolve: {ex.Message}"); }
+
+            // A rule that names its NRM2 work section overrides the category derivation,
+            // so a SYS-specific row (Pipes+SAN -> 32, Pipes+CHW -> 33) bills under the
+            // section its specification sits in instead of one bucket for every pipe.
+            // Nrm2For reads the MATCHED RULE first - six shipped rows share section
+            // 03 30 00 with two different answers, and a section-keyed lookup alone would
+            // bill every concrete slab and foundation under masonry.
+            try
+            {
+                string bridged = CsiMasterFormat.Nrm2For(csiRule,
+                    StingTools.Commands.Classification.CsiMap.SectionToNrm2(doc), csiSection);
+                if (!string.IsNullOrEmpty(bridged)) nrm2Section = bridged;
+            }
+            catch (Exception ex) { StingLog.WarnRateLimited("CsiNrm2", $"CSI-NRM2 bridge: {ex.Message}"); }
+
             string sectionName = picked.description;
             if (string.IsNullOrEmpty(sectionName)) sectionName = catName;
 
@@ -791,6 +831,8 @@ namespace StingTools.BOQ
                 LastCosted = DateTime.UtcNow,
                 RateSource = rateSource,
                 RateConfidence = rateConfidence,
+                CsiSection = csiSection,
+                CsiTitle = csiTitle,
                 LabourUGX = splitLabour,     // G4 — L/P/M split (null when source gives none)
                 PlantUGX = splitPlant,
                 MaterialUGX = splitMaterial,
@@ -798,6 +840,53 @@ namespace StingTools.BOQ
                 CarbonQuality = carbonQuality,
                 CarbonMaterial = carbonMaterial
             };
+
+            // The SPEC writes the bill. When the element's CSI section is described by an
+            // issued SpecLink store, that text becomes the line description - one source
+            // of truth instead of a generated NRM2 template that drifts from what was
+            // actually specified. A no-op for every project that has not run
+            // SpecLink_ImportFolder, which is the dominant case.
+            //
+            // The Unit is deliberately NOT overridden. The rate's unit and the quantity's
+            // unit must agree, so a spec that measures a section differently from the way
+            // it is priced is surfaced as a QA note for the QS, never silently re-measured.
+            if (!string.IsNullOrEmpty(csiSection))
+            {
+                try
+                {
+                    var spec = SpecStore.Get(
+                        StingTools.Commands.Classification.CsiMap.SpecSections(doc), csiSection);
+                    if (spec != null)
+                    {
+                        if (!string.IsNullOrWhiteSpace(spec.Description))
+                        {
+                            line.ResolvedNRM2Paragraph = spec.Description;
+                            line.SpecSourced = true;
+                        }
+                        if (!string.IsNullOrWhiteSpace(spec.Unit)) line.CsiUnit = spec.Unit;
+                    }
+                    // No spec opinion? the map's own Unit column is the advisory fallback.
+                    if (string.IsNullOrWhiteSpace(line.CsiUnit))
+                    {
+                        if (csiRule != null && !string.IsNullOrWhiteSpace(csiRule.Unit)) line.CsiUnit = csiRule.Unit;
+                        else
+                        {
+                            var unitMap = StingTools.Commands.Classification.CsiMap.SectionToUnit(doc);
+                            if (unitMap != null && unitMap.TryGetValue(
+                                    CsiMasterFormat.NormalizeSection(csiSection), out string cu) &&
+                                !string.IsNullOrWhiteSpace(cu))
+                                line.CsiUnit = cu;
+                        }
+                    }
+                    if (!string.IsNullOrWhiteSpace(line.CsiUnit) && !string.IsNullOrWhiteSpace(line.Unit) &&
+                        !BoqUnits.Align(line.CsiUnit, line.Unit))
+                    {
+                        string m = $"Measurement-vs-spec: priced per {line.Unit}, specified per {line.CsiUnit}";
+                        line.Note = string.IsNullOrEmpty(line.Note) ? m : line.Note + "; " + m;
+                    }
+                }
+                catch (Exception ex) { StingLog.WarnRateLimited("SpecText", $"Spec-text bridge: {ex.Message}"); }
+            }
 
             // Mark provisional sums on the element if configured via existing parameter.
             bool isPS = ParameterHelpers.GetInt(el, "CST_PROVISIONAL_SUM", 0) == 1;

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -274,6 +274,34 @@ namespace StingTools.BOQ
         public List<long> ConstituentElementIds = new List<long>();
         public string AggregationKey;       // grouping key used to collapse the row (debug/export)
 
+        // -- spec reference (KUT lifecycle Phase A / H1) -----------------------
+        /// <summary>The element's CSI MasterFormat section (CSI_SECTION_TXT, or resolved
+        /// from the shipped map when the element was never CSI_Assign-stamped) and its
+        /// title. Carried on the line so the bill shows a spec reference per row, the
+        /// CSI-&gt;NRM2 bridge can bill it under its specification's work section, and the
+        /// spec-completeness gate can tell a priced line from an unspecified one.</summary>
+        public string CsiSection;
+        public string CsiTitle;
+
+        /// <summary>True when <see cref="ResolvedNRM2Paragraph"/> was taken VERBATIM from
+        /// the issued SpecLink section text rather than generated from an NRM2 template.
+        /// The paragraph enhancer must leave such a line alone - its appenders would
+        /// otherwise mutate contractual spec wording in a tender bill.</summary>
+        public bool SpecSourced;
+
+        /// <summary>The spec's preferred measurement basis for this line's CSI section.
+        /// ADVISORY: when it disagrees with <see cref="Unit"/> the line carries a
+        /// measurement-vs-spec note. It never re-measures the quantity - the rate's unit
+        /// and the quantity's unit have to stay the same dimension.</summary>
+        public string CsiUnit;
+
+        /// <summary>True when this line is Owner-procured FF&amp;E carried as a transparent
+        /// at-cost category rather than contractor-supplied work. Reserved by the spec
+        /// gate, which does not chase a spec for something the contractor never prices.
+        /// Nothing sets it yet - the Fohlio FF&amp;E treatment that does lands with the
+        /// Fohlio v2 work.</summary>
+        public bool FfeOwnerProcured;
+
         public double TotalUGX => Math.Round(Quantity * RateUGX, 0);
         public double TotalUSD => Math.Round(Quantity * RateUSD, 2);
 
@@ -299,6 +327,11 @@ namespace StingTools.BOQ
                 WastageQuantity = this.WastageQuantity,
                 MeasurementNote = this.MeasurementNote,
                 QuantityResolved = this.QuantityResolved,   // A-1 — must survive the clone
+                CsiSection = this.CsiSection,
+                CsiTitle = this.CsiTitle,
+                CsiUnit = this.CsiUnit,
+                SpecSourced = this.SpecSourced,             // a clone must not become re-enhanceable
+                FfeOwnerProcured = this.FfeOwnerProcured,
                 RateUGX = this.RateUGX,
                 RateUSD = this.RateUSD,
                 EmbodiedCarbonKg = this.EmbodiedCarbonKg,

--- a/StingTools/BOQ/BOQParagraphEnhancer.cs
+++ b/StingTools/BOQ/BOQParagraphEnhancer.cs
@@ -88,6 +88,13 @@ namespace StingTools.BOQ
                 {
                     if (item == null) continue;
 
+                    // When a line's description IS the issued SpecLink clause, leave it
+                    // exactly as the specification wrote it. Every appender below -
+                    // performance, compliance, "or approved equivalent", client-vocabulary
+                    // substitution - would otherwise edit contractual spec text inside a
+                    // tender bill. The spec is the authority; this generator is not.
+                    if (item.SpecSourced) { report.SpecPreservedCount++; continue; }
+
                     Element el = null;
                     if (item.RevitElementId > 0 && doc != null)
                     {
@@ -111,12 +118,15 @@ namespace StingTools.BOQ
             StingLog.Info($"BOQ paragraph enhancer: performance={report.PerformanceCount} compliance={report.ComplianceCount} "
                 + $"groups={report.GroupedCount} inclusion={report.InclusionCount} equivalent={report.OrEquivalentCount} "
                 + $"conditional={report.ConditionalCount} vocab={report.VocabCount} smartName={report.SmartNameCount} "
-                + $"specRef={report.SpecRefCount}");
+                + $"specRef={report.SpecRefCount} specPreserved={report.SpecPreservedCount}");
             return report;
         }
 
         public class EnhancementReport
         {
+            /// <summary>Lines left verbatim because their description came from the
+            /// issued specification rather than from an NRM2 template.</summary>
+            public int SpecPreservedCount;
             public int PerformanceCount;
             public int ComplianceCount;
             public int GroupedCount;

--- a/StingTools/BOQ/BOQProfessionalExportCommand.cs
+++ b/StingTools/BOQ/BOQProfessionalExportCommand.cs
@@ -34,6 +34,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
@@ -97,6 +98,52 @@ namespace StingTools.BOQ
                     };
                     if (gate.Show() != TaskDialogResult.Yes)
                         return Result.Cancelled;
+                }
+
+                // Spec-completeness gate. Money in a tender bill for something the
+                // specification does not describe is what a scope dispute is made of, so
+                // count it before the file is written rather than after it is issued.
+                //
+                // OFF by default (COST_REQUIRE_SPEC_FOR_TENDER = 0): a project that has
+                // not adopted SpecLink sees no change. 1 = warn and let the QS proceed
+                // knowingly; 2 = block. The definition of "priced but unspecified" is
+                // shared with SpecLink_Reconcile so the gate and the report agree.
+                int specMode = (int)TagConfig.GetConfigDouble("COST_REQUIRE_SPEC_FOR_TENDER", 0.0);
+                if (specMode > 0)
+                {
+                    var specGate = SpecCompletenessGate.Evaluate(boq);
+                    if (!specGate.Passes)
+                    {
+                        var top = SpecCompletenessGate.TopUnspecified(boq, 8);
+                        var lines = new StringBuilder();
+                        lines.AppendLine(
+                            $"• {specGate.PricedUnspecifiedCount} priced row(s) carry no CSI/spec reference — " +
+                            $"UGX {specGate.PricedUnspecifiedValueUGX:N0} " +
+                            $"({specGate.UnspecifiedValueFraction * 100:F1}% of priced value).");
+                        lines.AppendLine();
+                        lines.AppendLine("Largest unspecified:");
+                        foreach (var li in top)
+                            lines.AppendLine($"   {li.Category,-22} {li.ItemName,-28} UGX {li.TotalUGX:N0}");
+                        lines.AppendLine();
+                        lines.Append(specMode >= 2
+                            ? "COST_REQUIRE_SPEC_FOR_TENDER is set to block. Run CSI Assign / SpecLink Import, then re-export."
+                            : "Run CSI Assign (and SpecLink Import for the clause text), or proceed knowingly.");
+
+                        var sg = new TaskDialog("Professional BOQ — spec gate")
+                        {
+                            MainInstruction = "This bill prices work the specification does not describe.",
+                            MainContent = lines.ToString(),
+                            CommonButtons = specMode >= 2
+                                ? TaskDialogCommonButtons.Close
+                                : TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                            DefaultButton = specMode >= 2 ? TaskDialogResult.Close : TaskDialogResult.No,
+                            AllowCancellation = true
+                        };
+                        var sgRes = sg.Show();
+                        StingLog.Info($"BOQ spec gate (mode {specMode}): {specGate.PricedUnspecifiedCount} unspecified " +
+                                      $"of {specGate.PricedTotalCount} priced, UGX {specGate.PricedUnspecifiedValueUGX:N0} at risk.");
+                        if (specMode >= 2 || sgRes != TaskDialogResult.Yes) return Result.Cancelled;
+                    }
                 }
 
                 // Phase 108h / 108j — tender config acquisition.

--- a/StingTools/BOQ/FfeTreatment.cs
+++ b/StingTools/BOQ/FfeTreatment.cs
@@ -1,0 +1,54 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  FfeTreatment.cs — Phase C (KUT lifecycle). Pure, host-free resolution of how
+//  an FF&E (Fohlio-mapped) category is carried in the bill. No Autodesk.Revit.*
+//  so it can be unit-tested in StingTools.Boq.Tests.
+//
+//  KUT default (Phase C.2): FF&E is carried as a TRANSPARENT, separately-totalled
+//  Owner-procured category — priced at cost from the Fohlio register, shown as its
+//  own subtotal, and EXCLUDED from the construction contractor's prelims / OH&P /
+//  contingency (those are not earned on Owner-direct FF&E). This follows NRM1
+//  Group 8 (Furniture, Fittings & Equipment) / ICMS FF&E classification — not a
+//  "provisional sum" (FF&E here is defined and priced, not deferred).
+//  Per-category overrides: "measured" (contractor-supplied, full markups),
+//  "ownerSupplied-excluded" (out of this bill), or "pcSum" (the explicit
+//  contractual Provisional / Prime-Cost mechanism for those who want it). An item
+//  is exactly one of the four — never double-counted.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.BOQ
+{
+    public static class FfeTreatment
+    {
+        public const string Ffe      = "ffe";                    // default — transparent Owner-procured FF&E category
+        public const string PcSum    = "pcSum";                  // explicit opt-in — contractual provisional / prime-cost sum
+        public const string Measured = "measured";
+        public const string Excluded = "ownerSupplied-excluded";
+
+        /// <summary>Canonicalise a raw treatment string. Aliases tolerated:
+        /// exclud*/ownerSupplied* → excluded; measur* → measured; pc*/provision* →
+        /// pcSum. Anything else (incl. empty, "ffe", "owner-procured") → the safe
+        /// default, the transparent FF&amp;E category.</summary>
+        public static string Normalize(string raw)
+        {
+            string s = (raw ?? "").Trim().ToLowerInvariant();
+            if (s.Contains("exclud") || s.StartsWith("ownersupplied")) return Excluded;
+            if (s.StartsWith("measur")) return Measured;
+            if (s.StartsWith("pc") || s.Contains("provision")) return PcSum;
+            return Ffe;
+        }
+
+        /// <summary>Resolve the treatment for a category: per-category override →
+        /// map default → the transparent FF&amp;E category. Case-insensitive match.</summary>
+        public static string Resolve(string category, string mapDefault, IDictionary<string, string> byCategory)
+        {
+            string raw = null;
+            if (!string.IsNullOrEmpty(category) && byCategory != null)
+                foreach (var kv in byCategory)
+                    if (string.Equals(kv.Key, category, StringComparison.OrdinalIgnoreCase)) { raw = kv.Value; break; }
+            if (string.IsNullOrWhiteSpace(raw)) raw = mapDefault;
+            return Normalize(raw);
+        }
+    }
+}

--- a/StingTools/BOQ/Rates/RatePolicy.cs
+++ b/StingTools/BOQ/Rates/RatePolicy.cs
@@ -1,0 +1,115 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RatePolicy.cs — Project-scoped overlay for the rate-provider waterfall.
+//
+//  Phase 195. The rate-provider priorities baked into each IRateProvider are
+//  the corporate baseline. A project that wants a different commercial
+//  ordering (or wants to disable a provider entirely — e.g. switch off the
+//  live BCIS HTTP feed so a tender runs deterministically offline) drops a
+//  `<project>/_BIM_COORD/boq_rate_policy.json` file:
+//
+//    {
+//      "providers": {
+//        "bcis-http":         { "enabled": false },
+//        "es-override":       { "priority": 98 },
+//        "project-rate-card": { "priority": 93 },
+//        "material-library":  { "priority": 85 }
+//      }
+//    }
+//
+//  Every field is optional. Omitting a provider id leaves its baseline
+//  priority + enabled state untouched. `enabled` defaults to true; `priority`
+//  defaults to the provider's compiled-in baseline.
+//
+//  HOST-FREE — no Autodesk.Revit references, and it does not build the path
+//  either: RateProviderRegistry holds the Document and resolves the file
+//  through StingPaths. That keeps this class linkable into
+//  StingTools.Boq.Tests and unit-verified independently of Revit.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace StingTools.BOQ.Rates
+{
+    /// <summary>
+    /// Per-provider overlay entry. Both fields nullable so "unset" is
+    /// distinguishable from "explicitly set to the default value".
+    /// </summary>
+    public sealed class RatePolicyEntry
+    {
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        [JsonProperty("priority")]
+        public int? Priority { get; set; }
+    }
+
+    /// <summary>
+    /// The deserialised <c>boq_rate_policy.json</c>. An empty policy (no file,
+    /// or an empty <c>providers</c> map) is a no-op overlay — every provider
+    /// keeps its baseline priority and stays enabled.
+    /// </summary>
+    public sealed class RatePolicy
+    {
+        [JsonProperty("providers")]
+        public Dictionary<string, RatePolicyEntry> Providers { get; set; }
+            = new Dictionary<string, RatePolicyEntry>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>An overlay that changes nothing — used when no file exists.</summary>
+        public static RatePolicy Empty => new RatePolicy();
+
+        /// <summary>
+        /// Parse a policy from raw JSON. Returns an empty (no-op) policy on
+        /// null/blank input or malformed JSON — a broken policy file must
+        /// never break costing, it just falls back to the baseline order.
+        /// </summary>
+        public static RatePolicy Parse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return Empty;
+            try
+            {
+                var p = JsonConvert.DeserializeObject<RatePolicy>(json);
+                if (p == null) return Empty;
+                if (p.Providers == null)
+                    p.Providers = new Dictionary<string, RatePolicyEntry>(StringComparer.OrdinalIgnoreCase);
+                else if (!(p.Providers.Comparer is StringComparer sc) || sc != StringComparer.OrdinalIgnoreCase)
+                {
+                    // Newtonsoft builds a case-sensitive dictionary by default;
+                    // re-key case-insensitively so "ES-Override" matches "es-override".
+                    var ci = new Dictionary<string, RatePolicyEntry>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var kv in p.Providers) ci[kv.Key] = kv.Value;
+                    p.Providers = ci;
+                }
+                return p;
+            }
+            catch
+            {
+                return Empty;
+            }
+        }
+
+        /// <summary>
+        /// True unless the provider is explicitly disabled in the policy.
+        /// Unknown ids are enabled (the policy only ever subtracts what it names).
+        /// </summary>
+        public bool IsEnabled(string providerId)
+        {
+            if (string.IsNullOrEmpty(providerId)) return true;
+            if (Providers != null && Providers.TryGetValue(providerId, out var e) && e?.Enabled == false)
+                return false;
+            return true;
+        }
+
+        /// <summary>
+        /// The effective priority for a provider: the policy override when set,
+        /// otherwise the compiled-in baseline.
+        /// </summary>
+        public int EffectivePriority(string providerId, int baseline)
+        {
+            if (!string.IsNullOrEmpty(providerId) && Providers != null &&
+                Providers.TryGetValue(providerId, out var e) && e?.Priority != null)
+                return e.Priority.Value;
+            return baseline;
+        }
+    }
+}

--- a/StingTools/BOQ/Rates/RateProviderRegistry.cs
+++ b/StingTools/BOQ/Rates/RateProviderRegistry.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Autodesk.Revit.DB;
 using StingTools.Core;
@@ -31,18 +32,50 @@ namespace StingTools.BOQ.Rates
             = new ConcurrentDictionary<string, RateProviderRegistry>(StringComparer.OrdinalIgnoreCase);
 
         private readonly List<IRateProvider> _providers;
+        private readonly RatePolicy _policy;
         private readonly double _ugxPerUsd;
         private readonly double _ugxPerGbp;
 
         private RateProviderRegistry(IEnumerable<IRateProvider> providers,
+                                     RatePolicy policy,
                                      double ugxPerUsd, double ugxPerGbp)
         {
+            _policy = policy ?? RatePolicy.Empty;
             _providers = providers
                 .Where(p => p != null)
-                .OrderByDescending(p => p.Priority)
+                // Order by the POLICY-effective priority so a project-scoped
+                // boq_rate_policy.json can re-rank the chain without a recompile.
+                // Disabled providers stay in the list and are skipped at Resolve time,
+                // which keeps the ResolveAll diagnostics honest about what exists.
+                .OrderByDescending(EffPriority)
                 .ToList();
             _ugxPerUsd = ugxPerUsd > 0 ? ugxPerUsd : 3700.0;
             _ugxPerGbp = ugxPerGbp > 0 ? ugxPerGbp : 4700.0;
+        }
+
+        /// <summary>Policy-effective priority for a provider (project override, else the
+        /// provider's compiled-in baseline).</summary>
+        private int EffPriority(IRateProvider p) => _policy.EffectivePriority(p.Id, p.Priority);
+
+        /// <summary>Read &lt;project&gt;/_BIM_COORD/boq_rate_policy.json. Never throws - a
+        /// missing or malformed file yields an empty (no-op) policy, because a broken
+        /// overlay must not be able to stop a project costing.</summary>
+        private static RatePolicy LoadPolicy(Document doc)
+        {
+            try
+            {
+                string path = StingPaths.MetaFile(doc, "_BIM_COORD", "boq_rate_policy.json");
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return RatePolicy.Empty;
+                var policy = RatePolicy.Parse(File.ReadAllText(path));
+                if (policy?.Providers != null && policy.Providers.Count > 0)
+                    StingLog.Info($"RateProviderRegistry: applied boq_rate_policy.json ({policy.Providers.Count} provider override(s)).");
+                return policy ?? RatePolicy.Empty;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"RateProviderRegistry.LoadPolicy: {ex.Message}");
+                return RatePolicy.Empty;
+            }
         }
 
         /// <summary>
@@ -58,7 +91,7 @@ namespace StingTools.BOQ.Rates
             double ugxPerGbp = 0)
         {
             string key = doc?.PathName ?? "default";
-            return _cache.GetOrAdd(key, _ => Build(doc, csvRates, cobieCostCodes, ugxPerUsd, ugxPerGbp));
+            return _cache.GetOrAdd(key, _ => Build(doc, csvRates, cobieCostCodes, LoadPolicy(doc), ugxPerUsd, ugxPerGbp));
         }
 
         /// <summary>
@@ -71,6 +104,7 @@ namespace StingTools.BOQ.Rates
             Document doc,
             Dictionary<string, (double rate, string unit)> csvRates,
             Dictionary<string, string> cobieCostCodes,
+            RatePolicy policy,
             double ugxPerUsd, double ugxPerGbp)
         {
             var providers = new List<IRateProvider>
@@ -110,7 +144,7 @@ namespace StingTools.BOQ.Rates
             }
             catch (Exception ex) { StingLog.Warn($"RateProviderRegistry feeds: {ex.Message}"); }
 
-            return new RateProviderRegistry(providers, ugxPerUsd, ugxPerGbp);
+            return new RateProviderRegistry(providers, policy, ugxPerUsd, ugxPerGbp);
         }
 
         /// <summary>
@@ -172,7 +206,9 @@ namespace StingTools.BOQ.Rates
         {
             if (provider == null) return;
             _providers.Add(provider);
-            _providers.Sort((a, b) => b.Priority.CompareTo(a.Priority));
+            // Re-sort by POLICY-effective priority so an externally-registered provider
+            // lands at its overlaid rank, or at its baseline when the policy is silent.
+            _providers.Sort((a, b) => EffPriority(b).CompareTo(EffPriority(a)));
             StingLog.Info($"RateProviderRegistry: registered {provider.Id} (priority {provider.Priority}).");
         }
 
@@ -193,6 +229,9 @@ namespace StingTools.BOQ.Rates
                 // Fetch-live-rates action (results land as model overrides) and
                 // remain visible in the ResolveAll diagnostic. Skip them here.
                 if (provider.RequiresNetwork) continue;
+                // A project policy may switch a provider off outright - e.g. disable a
+                // live HTTP feed so a tender prices deterministically and reproducibly.
+                if (!_policy.IsEnabled(provider.Id)) continue;
                 try
                 {
                     var lookup = provider.Resolve(req);
@@ -217,6 +256,9 @@ namespace StingTools.BOQ.Rates
             var results = new List<(IRateProvider, RateLookup)>(_providers.Count);
             foreach (var provider in _providers)
             {
+                // Report a policy-disabled provider as present-but-silent rather than
+                // hiding it: the heat-map should show WHY nothing came from it.
+                if (!_policy.IsEnabled(provider.Id)) { results.Add((provider, null)); continue; }
                 try { results.Add((provider, provider.Resolve(req))); }
                 catch (Exception ex)
                 {

--- a/StingTools/BOQ/SpecCompletenessGate.cs
+++ b/StingTools/BOQ/SpecCompletenessGate.cs
@@ -1,0 +1,75 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SpecCompletenessGate.cs — Phase H2 (KUT lifecycle, max automation).
+//
+//  Pure, host-free tender gate: counts priced BOQ lines that carry no CSI/spec
+//  reference (PRICED_UNSPECIFIED — money is in the bill for something the spec
+//  doesn't describe). A tender that goes out with PRICED_UNSPECIFIED > 0 invites
+//  scope disputes; the professional (tender) export consults this before writing
+//  and warns / blocks per the COST_REQUIRE_SPEC_FOR_TENDER config.
+//
+//  Mirrors the SpecLink_Reconcile Phase-B PRICED_UNSPECIFIED definition so the
+//  gate and the reconciliation report agree. Operates on the pure BOQDocument
+//  (no Autodesk.Revit.*), so it is unit-tested in StingTools.Boq.Tests.
+// ══════════════════════════════════════════════════════════════════════════
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.BOQ
+{
+    public sealed class SpecGateResult
+    {
+        public int PricedUnspecifiedCount;
+        public double PricedUnspecifiedValueUGX;
+        public int PricedTotalCount;
+        public double PricedTotalValueUGX;
+
+        /// <summary>Share of priced value with no spec reference (0..1).</summary>
+        public double UnspecifiedValueFraction =>
+            PricedTotalValueUGX > 0 ? PricedUnspecifiedValueUGX / PricedTotalValueUGX : 0.0;
+
+        public bool Passes => PricedUnspecifiedCount == 0;
+    }
+
+    public static class SpecCompletenessGate
+    {
+        /// <summary>A line is "priced" when it is a modelled measured/priced row with a
+        /// positive value. Provisional sums + owner-procured FF&amp;E are intentionally
+        /// excluded — a PC sum is unspecified BY DESIGN, not a gap to chase.</summary>
+        private static bool IsPriced(BOQLineItem li) =>
+            li != null
+            && li.Source == BOQRowSource.Model
+            && !li.FfeOwnerProcured
+            && li.TotalUGX > 0;
+
+        private static bool IsSpecified(BOQLineItem li) =>
+            !string.IsNullOrWhiteSpace(li?.CsiSection);
+
+        public static SpecGateResult Evaluate(IEnumerable<BOQLineItem> lines)
+        {
+            var r = new SpecGateResult();
+            foreach (var li in (lines ?? Enumerable.Empty<BOQLineItem>()).Where(IsPriced))
+            {
+                r.PricedTotalCount++;
+                r.PricedTotalValueUGX += li.TotalUGX;
+                if (!IsSpecified(li))
+                {
+                    r.PricedUnspecifiedCount++;
+                    r.PricedUnspecifiedValueUGX += li.TotalUGX;
+                }
+            }
+            return r;
+        }
+
+        public static SpecGateResult Evaluate(BOQDocument doc) =>
+            Evaluate(doc?.AllItems);
+
+        /// <summary>The first N priced-unspecified lines (highest value first) for the
+        /// gate dialog — enough to point the QS at what to spec.</summary>
+        public static List<BOQLineItem> TopUnspecified(BOQDocument doc, int n = 10) =>
+            (doc?.AllItems ?? new List<BOQLineItem>())
+            .Where(li => IsPriced(li) && !IsSpecified(li))
+            .OrderByDescending(li => li.TotalUGX)
+            .Take(n)
+            .ToList();
+    }
+}

--- a/StingTools/BOQ/SpecStore.cs
+++ b/StingTools/BOQ/SpecStore.cs
@@ -1,0 +1,186 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SpecStore.cs — Phase H1 (KUT lifecycle, max automation).
+//
+//  Pure, host-free reader for the SpecLink section store at
+//  <project>/_BIM_COORD/speclink/sections.json — a normalised CSI section →
+//  { title, description, unit } map produced by SpecLink_ImportFolder (Phase H4)
+//  from an exported RIB/Deltek SpecLink project manual.
+//
+//  The BOQ engine consumes it so the SPEC writes the bill: when a priced element
+//  carries a CSI section that the store describes, the line description becomes the
+//  issued spec text (single source of truth) instead of a generated NRM2 template,
+//  and the spec's preferred unit is carried as a measurement-basis advisory.
+//
+//  Zero Autodesk.Revit.* dependencies on purpose (unit-tested in StingTools.Boq.Tests).
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StingTools.Core.Classification;
+
+namespace StingTools.BOQ
+{
+    public sealed class SpecSection
+    {
+        public string Section = "";       // normalised CSI section
+        public string Title = "";
+        public string Description = "";    // Part 2/3 narrative — drives the BOQ line text
+        public string Unit = "";           // spec measurement basis (m2/m3/m/kg/each)
+    }
+
+    public static class SpecStore
+    {
+        /// <summary>Parse the sections.json content into a normalised-section → SpecSection
+        /// map. Accepts either a JSON object keyed by section, or an array of
+        /// { section, title, description, unit } rows. Tolerant of missing fields and
+        /// bad JSON (returns whatever parsed; empty on total failure).</summary>
+        public static Dictionary<string, SpecSection> Parse(string json)
+        {
+            var d = new Dictionary<string, SpecSection>(StringComparer.Ordinal);
+            if (string.IsNullOrWhiteSpace(json)) return d;
+            try
+            {
+                var tok = JToken.Parse(json);
+                if (tok is JObject obj)
+                {
+                    // { "sections": [...] } or a bare section-keyed object.
+                    if (obj["sections"] is JArray arr) AddArray(d, arr);
+                    else foreach (var p in obj.Properties()) AddRow(d, p.Name, p.Value as JObject);
+                }
+                else if (tok is JArray topArr) AddArray(d, topArr);
+            }
+            catch { /* tolerant — partial/empty store is fine */ }
+            return d;
+        }
+
+        private static void AddArray(Dictionary<string, SpecSection> d, JArray arr)
+        {
+            foreach (var t in arr)
+                if (t is JObject o) AddRow(d, (string)o["section"], o);
+        }
+
+        private static void AddRow(Dictionary<string, SpecSection> d, string section, JObject o)
+        {
+            if (o == null) return;
+            string sec = CsiMasterFormat.NormalizeSection(section ?? (string)o["section"]);
+            if (sec.Length == 0 || d.ContainsKey(sec)) return;
+            d[sec] = new SpecSection
+            {
+                Section = sec,
+                Title = ((string)o["title"] ?? "").Trim(),
+                Description = ((string)o["description"] ?? (string)o["text"] ?? "").Trim(),
+                Unit = ((string)o["unit"] ?? "").Trim(),
+            };
+        }
+
+        /// <summary>Look up the spec section for a (possibly un-normalised) CSI section.</summary>
+        public static SpecSection Get(Dictionary<string, SpecSection> store, string csiSection)
+        {
+            if (store == null || string.IsNullOrWhiteSpace(csiSection)) return null;
+            return store.TryGetValue(CsiMasterFormat.NormalizeSection(csiSection), out var s) ? s : null;
+        }
+
+        // ──────────────────────────────────────────────────────────────────────
+        //  Phase H4 — manual-CSV import. SpecLink_ImportFolder feeds an exported
+        //  project-manual CSV (the table of contents, optionally with a description
+        //  / unit column) through ParseManualCsv → Serialize → sections.json, which
+        //  is then what Parse() reads at BOQ-build time. Header-aware (maps Section /
+        //  Title / Description|Text / Unit by name, case-insensitive); falls back to
+        //  positional (col0=section, col1=title) when the header is absent.
+        // ──────────────────────────────────────────────────────────────────────
+        public static Dictionary<string, SpecSection> ParseManualCsv(IEnumerable<string> lines)
+        {
+            var d = new Dictionary<string, SpecSection>(StringComparer.Ordinal);
+            int iSec = 0, iTitle = 1, iDesc = -1, iUnit = -1;
+            bool headerSeen = false;
+            foreach (var raw in lines ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(raw)) continue;
+                string line = raw.TrimEnd('\r');
+                if (line.TrimStart().StartsWith("#")) continue;
+                var f = SplitCsv(line);
+                if (f.Count == 0) continue;
+
+                if (!headerSeen)
+                {
+                    // Treat the first non-comment row as a header iff it names a section column.
+                    var lower = f.Select(x => x.Trim().ToLowerInvariant()).ToList();
+                    int hs = lower.FindIndex(x => x == "section" || x == "csi" || x == "csisection");
+                    if (hs >= 0)
+                    {
+                        iSec = hs;
+                        iTitle = lower.FindIndex(x => x == "title" || x == "name");
+                        iDesc = lower.FindIndex(x => x == "description" || x == "text" || x == "spec" || x == "body");
+                        iUnit = lower.FindIndex(x => x == "unit" || x == "uom");
+                        if (iTitle < 0) iTitle = 1;
+                        headerSeen = true;
+                        continue;   // consume the header row
+                    }
+                    headerSeen = true;  // no header → positional, and this row IS data
+                }
+
+                string sec = CsiMasterFormat.NormalizeSection(Field(f, iSec));
+                if (sec.Length == 0 || d.ContainsKey(sec)) continue;
+                d[sec] = new SpecSection
+                {
+                    Section = sec,
+                    Title = Field(f, iTitle),
+                    Description = Field(f, iDesc),
+                    Unit = Field(f, iUnit),
+                };
+            }
+            return d;
+        }
+
+        /// <summary>Serialize a store to the array-shaped sections.json that Parse reads.</summary>
+        public static string Serialize(Dictionary<string, SpecSection> store)
+        {
+            var arr = new JArray();
+            foreach (var s in (store ?? new Dictionary<string, SpecSection>()).Values
+                         .OrderBy(v => v.Section, StringComparer.Ordinal))
+            {
+                arr.Add(new JObject
+                {
+                    ["section"] = s.Section,
+                    ["title"] = s.Title ?? "",
+                    ["description"] = s.Description ?? "",
+                    ["unit"] = s.Unit ?? "",
+                });
+            }
+            return new JObject { ["sections"] = arr }.ToString(Formatting.Indented);
+        }
+
+        private static string Field(IReadOnlyList<string> f, int i) =>
+            i >= 0 && i < f.Count ? (f[i] ?? "").Trim() : "";
+
+        /// <summary>Minimal RFC-4180-ish splitter (quoted fields, doubled quotes).</summary>
+        private static List<string> SplitCsv(string line)
+        {
+            var outp = new List<string>();
+            if (line == null) return outp;
+            var sb = new StringBuilder();
+            bool q = false;
+            for (int i = 0; i < line.Length; i++)
+            {
+                char c = line[i];
+                if (q)
+                {
+                    if (c == '"')
+                    {
+                        if (i + 1 < line.Length && line[i + 1] == '"') { sb.Append('"'); i++; }
+                        else q = false;
+                    }
+                    else sb.Append(c);
+                }
+                else if (c == '"') q = true;
+                else if (c == ',') { outp.Add(sb.ToString()); sb.Clear(); }
+                else sb.Append(c);
+            }
+            outp.Add(sb.ToString());
+            return outp;
+        }
+    }
+}

--- a/StingTools/Commands/Classification/CsiCommands.cs
+++ b/StingTools/Commands/Classification/CsiCommands.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,6 +8,7 @@ using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using ClosedXML.Excel;
+using StingTools.BOQ;
 using StingTools.Core;
 using StingTools.Core.Classification;
 
@@ -59,6 +61,62 @@ namespace StingTools.Commands.Classification
 
         public static List<Element> Scope(UIDocument uidoc, Document doc, out string label)
             => StingTools.Tags.TagSchemeCommandHelper.CollectScope(uidoc, doc, out label);
+
+        // ---- per-document caches -------------------------------------------------
+        // BuildLineItemFromElement asks for these once per element, so the CSV/JSON
+        // load must happen once per BuildBOQDocument run, not once per element.
+        // Mirrors RateProviderRegistry's per-PathName caching; Invalidate() is wired
+        // alongside it on Cost_ReloadRules and after SpecLink_ImportFolder writes.
+        private static readonly ConcurrentDictionary<string, List<CsiRule>> _rulesCache
+            = new ConcurrentDictionary<string, List<CsiRule>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, Dictionary<string, string>> _nrm2Cache
+            = new ConcurrentDictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, Dictionary<string, string>> _unitCache
+            = new ConcurrentDictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, Dictionary<string, SpecSection>> _specCache
+            = new ConcurrentDictionary<string, Dictionary<string, SpecSection>>(StringComparer.OrdinalIgnoreCase);
+
+        private static string CacheKey(Document doc) => doc?.PathName ?? "default";
+
+        /// <summary>Parsed corporate + project-overlay CSI rules, cached per document.</summary>
+        public static List<CsiRule> Rules(Document doc)
+            => _rulesCache.GetOrAdd(CacheKey(doc), _ => Load(doc, out int _, out int _));
+
+        /// <summary>Normalised CSI section -&gt; NRM2 work-section code. The fallback for an
+        /// element carrying a stamped section no rule matched - prefer
+        /// <see cref="CsiMasterFormat.Nrm2For"/>, which reads the matched rule first.</summary>
+        public static Dictionary<string, string> SectionToNrm2(Document doc)
+            => _nrm2Cache.GetOrAdd(CacheKey(doc), _ => CsiMasterFormat.BuildSectionToNrm2(Rules(doc)));
+
+        /// <summary>Normalised CSI section -&gt; preferred measurement unit (advisory).</summary>
+        public static Dictionary<string, string> SectionToUnit(Document doc)
+            => _unitCache.GetOrAdd(CacheKey(doc), _ => CsiMasterFormat.BuildSectionToUnit(Rules(doc)));
+
+        /// <summary>Normalised CSI section -&gt; issued SpecLink section text, from
+        /// &lt;project&gt;/_BIM_COORD/speclink/sections.json. EMPTY when the store is absent,
+        /// which is the dominant case - a project that has never run SpecLink_ImportFolder
+        /// sees no change to its bill.</summary>
+        public static Dictionary<string, SpecSection> SpecSections(Document doc)
+            => _specCache.GetOrAdd(CacheKey(doc), _ =>
+            {
+                var empty = new Dictionary<string, SpecSection>(StringComparer.Ordinal);
+                try
+                {
+                    string p = StingPaths.MetaFile(doc, "_BIM_COORD", "speclink", "sections.json");
+                    if (string.IsNullOrEmpty(p) || !File.Exists(p)) return empty;
+                    var store = SpecStore.Parse(File.ReadAllText(p));
+                    StingLog.Info($"CsiMap: loaded SpecLink store ({store.Count} section(s)) from {p}");
+                    return store;
+                }
+                catch (Exception ex) { StingLog.Warn($"Spec store load: {ex.Message}"); return empty; }
+            });
+
+        /// <summary>Drop every per-document cache so an edited map / re-imported spec is
+        /// picked up without restarting Revit.</summary>
+        public static void Invalidate()
+        {
+            _rulesCache.Clear(); _nrm2Cache.Clear(); _unitCache.Clear(); _specCache.Clear();
+        }
 
         /// <summary>
         /// The type name to match TypeRegex against.

--- a/StingTools/Commands/Classification/SpecLinkImportCommand.cs
+++ b/StingTools/Commands/Classification/SpecLinkImportCommand.cs
@@ -1,0 +1,106 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SpecLinkImportCommand.cs — Phase H4 (KUT lifecycle, max automation).
+//
+//  SpecLink_ImportFolder (read-only). Watch-folder front for the spec→bill loop:
+//  scans <project>/_BIM_COORD/speclink/ for exported SpecLink project-manual CSVs
+//  (RIB/Deltek SpecLink has no public API — Word/PDF/CSV export is the integration
+//  surface) and builds sections.json — the store SpecStore reads at BOQ-build time
+//  so the issued specification writes the line descriptions (Phase H1).
+//
+//  Mirrors the StingBridge watch-IFC drop-folder pattern: drop the export in,
+//  run the command (or chain it as step 0 of WORKFLOW_KUT_LifecycleReconcile so
+//  the lifecycle coordinator refreshes the spec store unattended).
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.BOQ;
+using StingTools.Core;
+
+namespace StingTools.Commands.Classification
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    public class SpecLinkImportCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx?.Doc == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            string specDir = StingPaths.Meta(doc, "_BIM_COORD", "speclink");
+            if (string.IsNullOrEmpty(specDir))
+            {
+                TaskDialog.Show("SpecLink import", "Save the project first so STING can find its _BIM_COORD folder.");
+                return Result.Cancelled;
+            }
+            Directory.CreateDirectory(specDir);
+            // Newest export wins. A re-issued SpecLink manual is dropped beside
+            // the previous one; ordering by last-write-time DESCENDING + the
+            // first-seen-wins merge below means the most recent file's section
+            // text supersedes an older file's on a collision, without the user
+            // having to delete the superseded export.
+            var csvs = Directory.EnumerateFiles(specDir, "*.csv", SearchOption.TopDirectoryOnly)
+                .Where(p => !Path.GetFileName(p).Equals("sections.json", StringComparison.OrdinalIgnoreCase))
+                .Select(p => new FileInfo(p))
+                .OrderByDescending(fi => fi.LastWriteTimeUtc)
+                .ThenBy(fi => fi.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(fi => fi.FullName)
+                .ToList();
+
+            if (csvs.Count == 0)
+            {
+                TaskDialog.Show("SpecLink import",
+                    "No CSV found in:\n" + specDir + "\n\nExport the SpecLink project manual " +
+                    "(table of contents, optionally with description + unit columns) as CSV and drop it here, " +
+                    "then re-run. Columns: Section, Title[, Description][, Unit].");
+                return Result.Cancelled;
+            }
+
+            // Merge — newest file (first in the time-ordered list) + earliest
+            // row within a file wins on a section collision.
+            var merged = new Dictionary<string, SpecSection>(StringComparer.Ordinal);
+            int rows = 0, files = 0;
+            foreach (var p in csvs)
+            {
+                try
+                {
+                    var part = SpecStore.ParseManualCsv(File.ReadAllLines(p));
+                    files++;
+                    int added = 0;
+                    foreach (var kv in part)
+                    {
+                        rows++;
+                        if (!merged.ContainsKey(kv.Key)) { merged[kv.Key] = kv.Value; added++; }
+                    }
+                    StingLog.Info($"SpecLink import {Path.GetFileName(p)}: {added} new section(s) of {part.Count} (newer files take precedence).");
+                }
+                catch (Exception ex) { StingLog.Warn($"SpecLink import {Path.GetFileName(p)}: {ex.Message}"); }
+            }
+
+            int withDesc = merged.Values.Count(s => !string.IsNullOrWhiteSpace(s.Description));
+            string outPath = Path.Combine(specDir, "sections.json");
+            try { File.WriteAllText(outPath, SpecStore.Serialize(merged)); }
+            catch (Exception ex)
+            {
+                StingLog.Error("SpecLink import write", ex);
+                TaskDialog.Show("SpecLink import", "Could not write sections.json:\n" + ex.Message);
+                return Result.Failed;
+            }
+
+            // Drop the per-document spec cache so the next BOQ build reads the fresh store.
+            CsiMap.Invalidate();
+
+            TaskDialog.Show("SpecLink import",
+                $"Imported {merged.Count} spec section(s) from {files} CSV file(s) ({rows} rows read).\n" +
+                $"{withDesc} carry description text (these drive BOQ line descriptions).\n\n" +
+                "Newest export wins on a section collision — re-issued manuals supersede older drops automatically.\n\n" +
+                "Written:\n" + outPath + "\n\nRe-run a BOQ export — spec'd items now bill from the specification.");
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/Commands/Cost/CostCommands.cs
+++ b/StingTools/Commands/Cost/CostCommands.cs
@@ -353,6 +353,10 @@ namespace StingTools.Commands.Cost
             BOQCostManager.InvalidateRateTables();
             StingTools.Temp.BOQTemplateLibrary.Invalidate();
             StingTools.Core.Materials.SlabSystemLoader.Invalidate();
+            // The CSI rule list, the CSI->NRM2 / unit bridges and the SpecLink section
+            // store are cached per document too; an edited csi_map.csv or a re-imported
+            // spec is invisible to the next build without this.
+            StingTools.Commands.Classification.CsiMap.Invalidate();
 
             // Phase 2B — external live-rate feeds (BCIS / Planscape) are now part
             // of the default build chain (RateProviderRegistry.Build →

--- a/StingTools/Core/Classification/CsiMasterFormat.cs
+++ b/StingTools/Core/Classification/CsiMasterFormat.cs
@@ -142,6 +142,63 @@ namespace StingTools.Core.Classification
             return best;
         }
 
+        /// <summary>CSI section -&gt; NRM2 work-section bridge. Builds a normalised-section
+        /// -&gt; NRM2-code lookup from every rule that carries an Nrm2. Pure (host-free).
+        /// The EARLIEST rule wins on a section collision, because project-overlay rows are
+        /// loaded before corporate ones and are meant to override them.
+        ///
+        /// <para>Prefer <see cref="Nrm2For"/> over indexing this directly. One CSI section
+        /// can legitimately bill under two NRM2 sections depending on what the element is -
+        /// 03 30 00 Cast-in-Place Concrete is NRM2 5 for a slab and 14 for a wall - and a
+        /// section-keyed lookup has to pick one. This map is the fallback for an element
+        /// that carries a stamped CSI section no rule matched; the matched rule's own Nrm2
+        /// is the answer whenever there is one.</para></summary>
+        public static Dictionary<string, string> BuildSectionToNrm2(IEnumerable<CsiRule> rules)
+        {
+            var d = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var r in rules ?? Enumerable.Empty<CsiRule>())
+            {
+                if (r == null || string.IsNullOrWhiteSpace(r.Nrm2) || string.IsNullOrWhiteSpace(r.Section)) continue;
+                string key = NormalizeSection(r.Section);
+                if (key.Length == 0 || d.ContainsKey(key)) continue;
+                d[key] = r.Nrm2.Trim();
+            }
+            return d;
+        }
+
+        /// <summary>CSI section -&gt; preferred measurement unit. Same shape and same
+        /// first-wins rule as <see cref="BuildSectionToNrm2"/>; lets a spec drive the BOQ
+        /// measurement-basis advisory.</summary>
+        public static Dictionary<string, string> BuildSectionToUnit(IEnumerable<CsiRule> rules)
+        {
+            var d = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var r in rules ?? Enumerable.Empty<CsiRule>())
+            {
+                if (r == null || string.IsNullOrWhiteSpace(r.Unit) || string.IsNullOrWhiteSpace(r.Section)) continue;
+                string key = NormalizeSection(r.Section);
+                if (key.Length == 0 || d.ContainsKey(key)) continue;
+                d[key] = r.Unit.Trim();
+            }
+            return d;
+        }
+
+        /// <summary>The NRM2 work section for a priced line: the MATCHED rule's own Nrm2
+        /// first, then the section-keyed bridge, then null meaning "no opinion - let the
+        /// category derivation decide".
+        ///
+        /// <para>Rule-first is the whole point. Six of the shipped rows share section
+        /// 03 30 00 with two different NRM2 answers, so reading the section map alone would
+        /// bill every concrete slab, column, foundation, stair and ramp under NRM2 14
+        /// (masonry) purely because the concrete-wall row is listed first.</para></summary>
+        public static string Nrm2For(CsiRule matched, IReadOnlyDictionary<string, string> sectionToNrm2, string csiSection)
+        {
+            if (matched != null && !string.IsNullOrWhiteSpace(matched.Nrm2)) return matched.Nrm2.Trim();
+            if (sectionToNrm2 != null && !string.IsNullOrWhiteSpace(csiSection) &&
+                sectionToNrm2.TryGetValue(NormalizeSection(csiSection), out string n) && !string.IsNullOrWhiteSpace(n))
+                return n;
+            return null;
+        }
+
         /// <summary>Canonical key for a CSI section number. Removes ALL whitespace (and
         /// upper-cases) so spaced "23 05 00" and unspaced "230500" reconcile to the same
         /// key — SpecLink exports spaced, models often store unspaced. Dots are preserved,

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -343,7 +343,7 @@ namespace StingTools.Core
             "CombineParams", "BuildTags", "ValidateTags", "PreTagAudit", "TokenConfidenceAudit",
             "TagScheme_Render", "TagScheme_Inspect", "TagScheme_Audit",
             "LOD_Verify", "LOD_Stamp", "Program_Audit", "OwnerStandards_Audit",
-            "CSI_Assign", "SpecLink_Reconcile",
+            "CSI_Assign", "SpecLink_Reconcile", "SpecLink_ImportFolder",
             "Fohlio_Export", "Fohlio_Import", "Fohlio_Audit",
             "Fohlio_ExportFinishes", "Fohlio_ImportFinishes", "DeviceCoord_Audit", "ComCheck_Export",
             "Hvac_LifeCycleCompare", "PrototypeDrift_Report",
@@ -1592,6 +1592,7 @@ namespace StingTools.Core
                 case "OwnerStandards_Audit": return new Commands.Validation.OwnerStandardsAuditCommand();
                 case "CSI_Assign": return new Commands.Classification.CsiAssignCommand();
                 case "SpecLink_Reconcile": return new Commands.Classification.SpecLinkReconcileCommand();
+                case "SpecLink_ImportFolder": return new Commands.Classification.SpecLinkImportCommand();
                 case "Classification_SetStandard": return new Commands.Classification.ClassificationSetStandardCommand();
                 case "Keynote_Assign": return new Commands.Classification.KeynoteAssignCommand();
                 case "Fohlio_Export": return new ExLink.FohlioExportCommand();

--- a/StingTools/Data/STING_CSI_MASTERFORMAT_MAP.csv
+++ b/StingTools/Data/STING_CSI_MASTERFORMAT_MAP.csv
@@ -17,97 +17,118 @@
 # Most-specific row wins (more matched qualifiers = higher score; ties: first).
 # Starter baseline — codes are common approximations to be confirmed against the
 # project's RIB SpecLink spec. Projects extend/override via _BIM_COORD/csi_map.csv.
-Category,FamilyRegex,TypeRegex,Sys,Section,Title
-Doors,,,,08 11 00,Metal Doors and Frames
-Doors,(?i)wood,,,08 14 00,Wood Doors and Frames
-Doors,(?i)glass|alum|storefront,,,08 41 00,Entrances and Storefronts
-Doors,(?i)overhead|coiling|roller,,,08 33 00,Coiling Doors and Grilles
-Windows,,,,08 50 00,Windows
-Curtain Panels,,,,08 44 00,Curtain Wall and Glazed Assemblies
-Curtain Wall Mullions,,,,08 44 00,Curtain Wall and Glazed Assemblies
-Walls,,,,09 29 00,Gypsum Board
+# ---------------------------------------------------------------------------
+# Nrm2 / Unit (optional 7th + 8th columns)
+#
+#   Nrm2  the NRM2 work section this row's elements are BILLED under. When set it
+#         overrides BOQCostManager.DeriveNrm2Section, which can only key off the
+#         Revit CATEGORY - so a SYS-specific row (Pipes+SAN vs Pipes+CHW) bills
+#         under the section its specification sits in rather than one bucket for
+#         every pipe. Blank = let the category derivation decide.
+#   Unit  the section's preferred measurement basis. ADVISORY only: it never
+#         re-measures a quantity, it flags a line whose rate is priced per a
+#         different basis than the spec measures.
+#
+# The bridge resolves from the MATCHED RULE first. Section 03 30 00 is NRM2 5 for
+# a concrete floor and 14 for a concrete wall; a section-keyed lookup has to pick
+# one and would bill every slab, column and foundation under masonry.
+#
+# The division 31/32/33 site, civil and external-utility rows carry the mapping
+# implied by their division and this file's existing convention. They are worth a
+# QS's eye before a site-works tender - they are data, and changing one is a
+# one-line edit here.
+# ---------------------------------------------------------------------------
+Category,FamilyRegex,TypeRegex,Sys,Section,Title,Nrm2,Unit
+Doors,,,,08 11 00,Metal Doors and Frames,20,each
+Doors,(?i)wood,,,08 14 00,Wood Doors and Frames,20,
+Doors,(?i)glass|alum|storefront,,,08 41 00,Entrances and Storefronts,20,
+Doors,(?i)overhead|coiling|roller,,,08 33 00,Coiling Doors and Grilles,20,
+Windows,,,,08 50 00,Windows,20,
+Curtain Panels,,,,08 44 00,Curtain Wall and Glazed Assemblies,17,
+Curtain Wall Mullions,,,,08 44 00,Curtain Wall and Glazed Assemblies,17,
+Walls,,,,09 29 00,Gypsum Board,14,
 # Walls/Floors/Roofs/Ceilings/Pipes/Ducts/Conduits/Stairs/Railings/Toposolids are
 # SYSTEM elements: they have no family, so their discriminators must sit in the
 # TypeRegex column (3rd), not FamilyRegex (2nd). These two rows were on
 # FamilyRegex and had never fired — see CsiMap.TypeName in CsiCommands.cs.
-Walls,,(?i)masonry|block|brick,,04 20 00,Unit Masonry
-Walls,,(?i)concrete,,03 30 00,Cast-in-Place Concrete
-Floors,,,,09 60 00,Flooring
-Ceilings,,,,09 51 00,Acoustical Ceilings
-Roofs,,,,07 50 00,Membrane Roofing
-Specialty Equipment,,,,10 00 00,Specialties
-Specialty Equipment,(?i)sign,,,10 14 00,Signage
-Specialty Equipment,(?i)toilet|cubicle|partition,,,10 21 13,Toilet Compartments
-Specialty Equipment,(?i)locker,,,10 51 00,Lockers
-Specialty Equipment,(?i)extinguisher,,,10 44 00,Fire Protection Specialties
-Specialty Equipment,(?i)bench|pew|seating,,,12 60 00,Multiple Seating
-Furniture,,,,12 50 00,Furniture
-Furniture Systems,,,,12 50 00,Furniture
-Casework,,,,12 32 00,Manufactured Wood Casework
-Casework,(?i)custom|millwork|joinery,,,06 40 00,Architectural Woodwork
-Sprinklers,,,,21 13 00,Fire-Suppression Sprinkler Systems
-Pipes,,,FP,21 11 00,Facility Fire-Suppression Water-Service Piping
-Mechanical Equipment,(?i)fire pump,,,21 30 00,Fire Pumps
-Plumbing Fixtures,,,,22 40 00,Plumbing Fixtures
-Plumbing Fixtures,(?i)water closet|wc|urinal,,,22 42 13,Commercial Water Closets and Urinals
-Plumbing Fixtures,(?i)lavatory|basin|sink,,,22 42 16,Commercial Lavatories and Sinks
-Pipes,,,DCW,22 11 16,Domestic Water Piping
-Pipes,,,DHW,22 11 16,Domestic Water Piping
-Pipes,,,HWS,22 11 16,Domestic Water Piping
-Pipes,,,SAN,22 13 16,Sanitary Waste and Vent Piping
-Pipes,,,RWD,22 14 13,Facility Storm Drainage Piping
-Pipes,,,GAS,23 11 23,Facility Natural-Gas Piping
-Mechanical Equipment,(?i)water heater|calorifier|cylinder|dhw,,,22 33 00,Electric Domestic Water Heaters
-Mechanical Equipment,(?i)booster|pump set,,,22 11 23,Domestic Water Pumps
-Ducts,,,,23 31 00,HVAC Ducts and Casings
-Duct Fittings,,,,23 31 00,HVAC Ducts and Casings
-Flex Ducts,,,,23 31 00,HVAC Ducts and Casings
-Duct Accessory,,,,23 33 00,Air Duct Accessories
-Air Terminals,,,,23 37 13,Diffusers Registers and Grilles
-Pipes,,,CHW,23 21 13,Hydronic Piping
-Pipes,,,HHW,23 21 13,Hydronic Piping
-Pipes,,,LHW,23 21 13,Hydronic Piping
-Pipes,,,CWS,23 21 13,Hydronic Piping
-Pipes,,,REFRIG,23 23 00,Refrigerant Piping
-Pipe Fittings,,,,23 21 13,Hydronic Piping
-Mechanical Equipment,(?i)ahu|air handling,,,23 73 00,Indoor Central-Station Air-Handling Units
-Mechanical Equipment,(?i)fcu|fan coil,,,23 82 19,Fan Coil Units
-Mechanical Equipment,(?i)vav,,,23 36 00,Air Terminal Units
-Mechanical Equipment,(?i)chiller,,,23 64 00,Packaged Water Chillers
-Mechanical Equipment,(?i)boiler,,,23 52 00,Heating Boilers
-Mechanical Equipment,(?i)cooling tower,,,23 65 00,Cooling Towers
-Mechanical Equipment,(?i)pump,,,23 21 23,Hydronic Pumps
-Mechanical Equipment,(?i)\bfan\b|exhaust,,,23 34 00,HVAC Fans
-Mechanical Equipment,(?i)vrf|vrv|heat pump,,,23 81 26,Split-System Air-Conditioners
-Mechanical Equipment,(?i)doas|energy recovery|erv|hrv,,,23 72 00,Air-to-Air Energy Recovery Equipment
-Mechanical Equipment,,,,23 00 00,Heating Ventilating and Air Conditioning (HVAC)
-Electrical Equipment,(?i)panel|mdb|distribution board|\bdb\b,,,26 24 16,Panelboards
-Electrical Equipment,(?i)switchboard|switchgear,,,26 24 13,Switchboards
-Electrical Equipment,(?i)transformer,,,26 22 00,Low-Voltage Transformers
-Electrical Equipment,(?i)ats|transfer switch,,,26 36 00,Transfer Switches
-Electrical Equipment,(?i)generator|genset,,,26 32 13,Engine Generators
-Electrical Equipment,(?i)\bups\b,,,26 33 53,Static Uninterruptible Power Supply
-Electrical Equipment,(?i)busbar|busway,,,26 25 00,Enclosed Bus Assemblies
-Electrical Equipment,,,,26 00 00,Electrical
-Electrical Fixtures,,,,26 27 26,Wiring Devices
-Lighting Fixtures,,,,26 51 00,Interior Lighting
-Lighting Fixtures,(?i)exterior|flood|pole|bollard|external,,,26 56 00,Exterior Lighting
-Lighting Fixtures,(?i)emergency|exit,,,26 52 00,Emergency Lighting
-Lighting Devices,,,,26 09 23,Lighting Control Devices
-Conduits,,,,26 05 33,Raceways and Boxes for Electrical Systems
-Conduit Fittings,,,,26 05 33,Raceways and Boxes for Electrical Systems
-Cable Trays,,,,26 05 36,Cable Trays for Electrical Systems
-Cable Tray Fittings,,,,26 05 36,Cable Trays for Electrical Systems
-Communication Devices,,,,27 10 00,Structured Cabling
-Data Devices,,,,27 10 00,Structured Cabling
-Communication Devices,(?i)nurse call,,,27 52 23,Nurse Call and Code Blue Systems
-Communication Devices,(?i)pa\b|public address|speaker|tannoy,,,27 51 16,Public Address and Mass Notification Systems
-Telephone Devices,,,,27 10 00,Structured Cabling
-Fire Alarm Devices,,,,28 31 00,Fire Detection and Alarm
-Security Devices,,,,28 20 00,Electronic Surveillance
-Security Devices,(?i)cctv|camera,,,28 23 00,Video Surveillance
-Security Devices,(?i)access control|card reader,,,28 13 00,Access Control and Intrusion Detection
-Nurse Call Devices,,,,28 17 00,Nurse Call Systems
+Walls,,(?i)masonry|block|brick,,04 20 00,Unit Masonry,14,
+Walls,,(?i)concrete,,03 30 00,Cast-in-Place Concrete,14,
+Floors,,,,09 60 00,Flooring,5,
+Ceilings,,,,09 51 00,Acoustical Ceilings,19,
+Roofs,,,,07 50 00,Membrane Roofing,17,
+Specialty Equipment,,,,10 00 00,Specialties,22,
+Specialty Equipment,(?i)sign,,,10 14 00,Signage,22,
+Specialty Equipment,(?i)toilet|cubicle|partition,,,10 21 13,Toilet Compartments,22,
+Specialty Equipment,(?i)locker,,,10 51 00,Lockers,22,
+Specialty Equipment,(?i)extinguisher,,,10 44 00,Fire Protection Specialties,22,
+Specialty Equipment,(?i)bench|pew|seating,,,12 60 00,Multiple Seating,22,
+Furniture,,,,12 50 00,Furniture,22,
+Furniture Systems,,,,12 50 00,Furniture,22,
+Casework,,,,12 32 00,Manufactured Wood Casework,22,
+Casework,(?i)custom|millwork|joinery,,,06 40 00,Architectural Woodwork,22,
+Sprinklers,,,,21 13 00,Fire-Suppression Sprinkler Systems,36,
+Pipes,,,FP,21 11 00,Facility Fire-Suppression Water-Service Piping,36,
+Mechanical Equipment,(?i)fire pump,,,21 30 00,Fire Pumps,36,
+Plumbing Fixtures,,,,22 40 00,Plumbing Fixtures,32,
+Plumbing Fixtures,(?i)water closet|wc|urinal,,,22 42 13,Commercial Water Closets and Urinals,32,
+Plumbing Fixtures,(?i)lavatory|basin|sink,,,22 42 16,Commercial Lavatories and Sinks,32,
+Pipes,,,DCW,22 11 16,Domestic Water Piping,32,
+Pipes,,,DHW,22 11 16,Domestic Water Piping,32,
+Pipes,,,HWS,22 11 16,Domestic Water Piping,32,
+Pipes,,,SAN,22 13 16,Sanitary Waste and Vent Piping,32,
+Pipes,,,RWD,22 14 13,Facility Storm Drainage Piping,32,
+Pipes,,,GAS,23 11 23,Facility Natural-Gas Piping,33,
+Mechanical Equipment,(?i)water heater|calorifier|cylinder|dhw,,,22 33 00,Electric Domestic Water Heaters,32,
+Mechanical Equipment,(?i)booster|pump set,,,22 11 23,Domestic Water Pumps,32,
+Ducts,,,,23 31 00,HVAC Ducts and Casings,33,
+Duct Fittings,,,,23 31 00,HVAC Ducts and Casings,33,
+Flex Ducts,,,,23 31 00,HVAC Ducts and Casings,33,
+Duct Accessory,,,,23 33 00,Air Duct Accessories,33,
+Air Terminals,,,,23 37 13,Diffusers Registers and Grilles,33,
+Pipes,,,CHW,23 21 13,Hydronic Piping,33,
+Pipes,,,HHW,23 21 13,Hydronic Piping,33,
+Pipes,,,LHW,23 21 13,Hydronic Piping,33,
+Pipes,,,CWS,23 21 13,Hydronic Piping,33,
+Pipes,,,REFRIG,23 23 00,Refrigerant Piping,33,
+Pipe Fittings,,,,23 21 13,Hydronic Piping,33,
+Mechanical Equipment,(?i)ahu|air handling,,,23 73 00,Indoor Central-Station Air-Handling Units,33,
+Mechanical Equipment,(?i)fcu|fan coil,,,23 82 19,Fan Coil Units,33,
+Mechanical Equipment,(?i)vav,,,23 36 00,Air Terminal Units,33,
+Mechanical Equipment,(?i)chiller,,,23 64 00,Packaged Water Chillers,33,
+Mechanical Equipment,(?i)boiler,,,23 52 00,Heating Boilers,33,
+Mechanical Equipment,(?i)cooling tower,,,23 65 00,Cooling Towers,33,
+Mechanical Equipment,(?i)pump,,,23 21 23,Hydronic Pumps,33,
+Mechanical Equipment,(?i)\bfan\b|exhaust,,,23 34 00,HVAC Fans,33,
+Mechanical Equipment,(?i)vrf|vrv|heat pump,,,23 81 26,Split-System Air-Conditioners,33,
+Mechanical Equipment,(?i)doas|energy recovery|erv|hrv,,,23 72 00,Air-to-Air Energy Recovery Equipment,33,
+Mechanical Equipment,,,,23 00 00,Heating Ventilating and Air Conditioning (HVAC),33,
+Electrical Equipment,(?i)panel|mdb|distribution board|\bdb\b,,,26 24 16,Panelboards,34,
+Electrical Equipment,(?i)switchboard|switchgear,,,26 24 13,Switchboards,34,
+Electrical Equipment,(?i)transformer,,,26 22 00,Low-Voltage Transformers,34,
+Electrical Equipment,(?i)ats|transfer switch,,,26 36 00,Transfer Switches,34,
+Electrical Equipment,(?i)generator|genset,,,26 32 13,Engine Generators,34,
+Electrical Equipment,(?i)\bups\b,,,26 33 53,Static Uninterruptible Power Supply,34,
+Electrical Equipment,(?i)busbar|busway,,,26 25 00,Enclosed Bus Assemblies,34,
+Electrical Equipment,,,,26 00 00,Electrical,34,
+Electrical Fixtures,,,,26 27 26,Wiring Devices,34,
+Lighting Fixtures,,,,26 51 00,Interior Lighting,35,
+Lighting Fixtures,(?i)exterior|flood|pole|bollard|external,,,26 56 00,Exterior Lighting,35,
+Lighting Fixtures,(?i)emergency|exit,,,26 52 00,Emergency Lighting,35,
+Lighting Devices,,,,26 09 23,Lighting Control Devices,35,
+Conduits,,,,26 05 33,Raceways and Boxes for Electrical Systems,34,
+Conduit Fittings,,,,26 05 33,Raceways and Boxes for Electrical Systems,34,
+Cable Trays,,,,26 05 36,Cable Trays for Electrical Systems,34,
+Cable Tray Fittings,,,,26 05 36,Cable Trays for Electrical Systems,34,
+Communication Devices,,,,27 10 00,Structured Cabling,34,
+Data Devices,,,,27 10 00,Structured Cabling,34,
+Communication Devices,(?i)nurse call,,,27 52 23,Nurse Call and Code Blue Systems,36,
+Communication Devices,(?i)pa\b|public address|speaker|tannoy,,,27 51 16,Public Address and Mass Notification Systems,34,
+Telephone Devices,,,,27 10 00,Structured Cabling,34,
+Fire Alarm Devices,,,,28 31 00,Fire Detection and Alarm,36,
+Security Devices,,,,28 20 00,Electronic Surveillance,36,
+Security Devices,(?i)cctv|camera,,,28 23 00,Video Surveillance,36,
+Security Devices,(?i)access control|card reader,,,28 13 00,Access Control and Intrusion Detection,36,
+Nurse Call Devices,,,,28 17 00,Nurse Call Systems,36,
 #
 # ── Division 02 — Existing Conditions — DELIBERATELY ABSENT ──────────────────
 # Naming-based Division 02 rows were drafted and then WITHDRAWN. Revit expresses
@@ -133,75 +154,75 @@ Nurse Call Devices,,,,28 17 00,Nurse Call Systems
 # precast / steel discriminators above each default override it when the family
 # name says otherwise. Confirm against the SpecLink books and override in
 # _BIM_COORD/csi_map.csv.
-Structural Framing,(?i)precast,,,03 41 00,Precast Structural Concrete
-Structural Framing,(?i)concrete|\bRC\b,,,03 30 00,Cast-in-Place Concrete
-Structural Framing,(?i)joist|purlin,,,05 21 00,Steel Joist Framing
-Structural Framing,,,,05 12 00,Structural Steel Framing
-Structural Columns,(?i)precast,,,03 41 00,Precast Structural Concrete
-Structural Columns,(?i)steel|\bUC\b|\bW\d|HSS|CHS|SHS|RHS,,,05 12 00,Structural Steel Framing
-Structural Columns,,,,03 30 00,Cast-in-Place Concrete
-Structural Foundations,(?i)bored pile|\bCFA\b,,,31 63 00,Bored Piles
-Structural Foundations,(?i)pile,,,31 62 00,Driven Piles
-Structural Foundations,(?i)shoring|underpin|sheet pile,,,31 40 00,Shoring and Underpinning
-Structural Foundations,,,,03 30 00,Cast-in-Place Concrete
-Floors,,(?i)metal deck|steel deck|profiled deck,,05 31 00,Steel Decking
-Walls,,(?i)cold.?formed|\bSFS\b|stone skin|rainscreen,,05 40 00,Cold-Formed Metal Framing
-Stairs,,(?i)metal|steel,,05 51 00,Metal Stairs
-Stairs,,(?i)wood|timber,,06 43 00,Wood Stairs and Railings
-Stairs,,,,03 30 00,Cast-in-Place Concrete
-Railings,,(?i)wood|timber,,06 43 00,Wood Stairs and Railings
-Railings,,(?i)decorative|ornamental|bronze|brass,,05 73 00,Decorative Metal Railings
-Railings,,(?i)fence|gate,,32 31 00,Fences and Gates
-Railings,,,,05 52 00,Metal Railings
-Ramps,,,,03 30 00,Cast-in-Place Concrete
+Structural Framing,(?i)precast,,,03 41 00,Precast Structural Concrete,5,
+Structural Framing,(?i)concrete|\bRC\b,,,03 30 00,Cast-in-Place Concrete,5,
+Structural Framing,(?i)joist|purlin,,,05 21 00,Steel Joist Framing,15,
+Structural Framing,,,,05 12 00,Structural Steel Framing,15,
+Structural Columns,(?i)precast,,,03 41 00,Precast Structural Concrete,5,
+Structural Columns,(?i)steel|\bUC\b|\bW\d|HSS|CHS|SHS|RHS,,,05 12 00,Structural Steel Framing,15,
+Structural Columns,,,,03 30 00,Cast-in-Place Concrete,5,
+Structural Foundations,(?i)bored pile|\bCFA\b,,,31 63 00,Bored Piles,5,m
+Structural Foundations,(?i)pile,,,31 62 00,Driven Piles,5,
+Structural Foundations,(?i)shoring|underpin|sheet pile,,,31 40 00,Shoring and Underpinning,4,
+Structural Foundations,,,,03 30 00,Cast-in-Place Concrete,5,
+Floors,,(?i)metal deck|steel deck|profiled deck,,05 31 00,Steel Decking,15,
+Walls,,(?i)cold.?formed|\bSFS\b|stone skin|rainscreen,,05 40 00,Cold-Formed Metal Framing,15,
+Stairs,,(?i)metal|steel,,05 51 00,Metal Stairs,20,
+Stairs,,(?i)wood|timber,,06 43 00,Wood Stairs and Railings,16,
+Stairs,,,,03 30 00,Cast-in-Place Concrete,5,
+Railings,,(?i)wood|timber,,06 43 00,Wood Stairs and Railings,16,
+Railings,,(?i)decorative|ornamental|bronze|brass,,05 73 00,Decorative Metal Railings,20,
+Railings,,(?i)fence|gate,,32 31 00,Fences and Gates,4,m
+Railings,,,,05 52 00,Metal Railings,20,
+Ramps,,,,03 30 00,Cast-in-Place Concrete,5,
 #
 # ── Division 14 — Conveying Equipment ────────────────────────────────────────
 # A1 Deliverable C: "CIRCULATION: vertical circulation stairs and elevators".
 # Revit has no Elevators category — lifts are modelled as Specialty Equipment
 # or Generic Models, so both are matched by name.
-Specialty Equipment,(?i)elevator|\blift\b,,,14 20 00,Elevators
-Specialty Equipment,(?i)escalator|moving walk,,,14 31 00,Escalators
-Specialty Equipment,(?i)wheelchair lift|platform lift,,,14 42 00,Wheelchair Lifts
-Generic Models,(?i)elevator|\blift\b,,,14 20 00,Elevators
-Mechanical Equipment,(?i)elevator|\blift\b,,,14 20 00,Elevators
+Specialty Equipment,(?i)elevator|\blift\b,,,14 20 00,Elevators,33,
+Specialty Equipment,(?i)escalator|moving walk,,,14 31 00,Escalators,33,
+Specialty Equipment,(?i)wheelchair lift|platform lift,,,14 42 00,Wheelchair Lifts,33,
+Generic Models,(?i)elevator|\blift\b,,,14 20 00,Elevators,33,
+Mechanical Equipment,(?i)elevator|\blift\b,,,14 20 00,Elevators,33,
 #
 # ── Division 31 — Earthwork (A2 Civil) ───────────────────────────────────────
-Topography,,,,31 20 00,Earth Moving
-Toposolid,,,,31 20 00,Earth Moving
-Toposolid,,(?i)grading|regrade|formation,,31 22 00,Grading
-Pads,,,,31 23 00,Excavation and Fill
-Generic Models,(?i)erosion|silt fence|sediment|swale,,,31 25 00,Erosion and Sedimentation Controls
+Topography,,,,31 20 00,Earth Moving,4,m3
+Toposolid,,,,31 20 00,Earth Moving,4,m3
+Toposolid,,(?i)grading|regrade|formation,,31 22 00,Grading,4,
+Pads,,,,31 23 00,Excavation and Fill,4,m3
+Generic Models,(?i)erosion|silt fence|sediment|swale,,,31 25 00,Erosion and Sedimentation Controls,4,
 #
 # ── Division 32 — Exterior Improvements (A2 Civil + A1 Site/Landscape) ───────
-Roads,,(?i)concrete,,32 13 13,Concrete Paving
-Roads,,,,32 12 16,Asphalt Paving
-Parking,(?i)stripe|marking|bay line,,,32 17 23,Pavement Markings
-Parking,,,,32 12 16,Asphalt Paving
-Floors,,(?i)paving|pavement|sidewalk|walkway|hardstand|plaza,,32 14 00,Unit Paving
-Generic Models,(?i)\bkerb\b|\bcurb\b|gutter,,,32 16 13,Concrete Curbs and Gutters
-Walls,,(?i)retaining,,32 32 00,Retaining Walls
-Generic Models,(?i)fence|gate|balustrade,,,32 31 00,Fences and Gates
-Site,(?i)bench|bollard|litter|planter|seat|shelter,,,32 33 00,Site Furnishings
-Site,,,,32 30 00,Site Improvements
-Entourage,,,,32 30 00,Site Improvements
-Planting,(?i)tree,,,32 93 43,Trees
-Planting,(?i)turf|grass|lawn|sod,,,32 92 00,Turf and Grasses
-Planting,,,,32 93 00,Plants
-Pipes,,,IRR,32 84 00,Planting Irrigation
-Sprinklers,(?i)irrigation|lawn|landscape,,,32 84 00,Planting Irrigation
+Roads,,(?i)concrete,,32 13 13,Concrete Paving,4,m2
+Roads,,,,32 12 16,Asphalt Paving,4,
+Parking,(?i)stripe|marking|bay line,,,32 17 23,Pavement Markings,4,
+Parking,,,,32 12 16,Asphalt Paving,4,
+Floors,,(?i)paving|pavement|sidewalk|walkway|hardstand|plaza,,32 14 00,Unit Paving,4,m2
+Generic Models,(?i)\bkerb\b|\bcurb\b|gutter,,,32 16 13,Concrete Curbs and Gutters,4,m
+Walls,,(?i)retaining,,32 32 00,Retaining Walls,4,m2
+Generic Models,(?i)fence|gate|balustrade,,,32 31 00,Fences and Gates,4,m
+Site,(?i)bench|bollard|litter|planter|seat|shelter,,,32 33 00,Site Furnishings,4,
+Site,,,,32 30 00,Site Improvements,4,
+Entourage,,,,32 30 00,Site Improvements,4,
+Planting,(?i)tree,,,32 93 43,Trees,4,
+Planting,(?i)turf|grass|lawn|sod,,,32 92 00,Turf and Grasses,4,m2
+Planting,,,,32 93 00,Plants,4,
+Pipes,,,IRR,32 84 00,Planting Irrigation,4,m
+Sprinklers,(?i)irrigation|lawn|landscape,,,32 84 00,Planting Irrigation,4,m
 #
 # ── Division 33 — Utilities (A2 Civil) ───────────────────────────────────────
 # Site runs are separated from in-building services by a TypeRegex on the pipe /
 # conduit TYPE name (site pipe types are named "Site …", "Buried …" etc.), which
 # scores above the plain SYS rows in Divisions 22/23/26 so the site utility wins.
-Pipes,,(?i)site|external|buried|underground,DCW,33 11 00,Water Utility Distribution Piping
-Pipes,,(?i)site|external|buried|underground,GAS,33 51 00,Natural-Gas Distribution
-Pipes,,,BGD,33 31 00,Sanitary Utility Sewerage Piping
-Pipes,,,SWD,33 41 00,Storm Utility Drainage Piping
-Pipes,,,SDS,33 46 00,Subdrainage
-Conduits,,(?i)site|external|buried|underground,,33 71 00,Electrical Utility Transmission and Distribution
-Generic Models,(?i)manhole|inspection chamber,,,33 39 00,Sanitary Utility Sewerage Structures
-Generic Models,(?i)soakaway|catch.?basin|gully|storm,,,33 44 00,Storm Utility Water Drains
-Generic Models,(?i)septic,,,33 36 00,Utility Septic Tanks
-Generic Models,(?i)water tank|reservoir|storage tank,,,33 16 00,Water Utility Storage Tanks
-Mechanical Equipment,(?i)sewage treatment|package plant|\bSTW\b,,,33 30 00,Sanitary Sewerage Utilities
+Pipes,,(?i)site|external|buried|underground,DCW,33 11 00,Water Utility Distribution Piping,32,m
+Pipes,,(?i)site|external|buried|underground,GAS,33 51 00,Natural-Gas Distribution,33,m
+Pipes,,,BGD,33 31 00,Sanitary Utility Sewerage Piping,32,m
+Pipes,,,SWD,33 41 00,Storm Utility Drainage Piping,32,m
+Pipes,,,SDS,33 46 00,Subdrainage,32,m
+Conduits,,(?i)site|external|buried|underground,,33 71 00,Electrical Utility Transmission and Distribution,34,m
+Generic Models,(?i)manhole|inspection chamber,,,33 39 00,Sanitary Utility Sewerage Structures,32,
+Generic Models,(?i)soakaway|catch.?basin|gully|storm,,,33 44 00,Storm Utility Water Drains,32,
+Generic Models,(?i)septic,,,33 36 00,Utility Septic Tanks,32,
+Generic Models,(?i)water tank|reservoir|storage tank,,,33 16 00,Water Utility Storage Tanks,32,
+Mechanical Equipment,(?i)sewage treatment|package plant|\bSTW\b,,,33 30 00,Sanitary Sewerage Utilities,32,

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -258,6 +258,7 @@ namespace StingTools.UI
                     case "OmniClass_SetTable":       RunCommand<Commands.Classification.OmniClassSetTableCommand>(app); break;
                     case "ClassificationTags_Set":   RunCommand<Commands.Classification.ClassificationTagsSetCommand>(app); break;
                     case "SpecLink_Reconcile":       RunCommand<Commands.Classification.SpecLinkReconcileCommand>(app); break;
+                    case "SpecLink_ImportFolder":    RunCommand<Commands.Classification.SpecLinkImportCommand>(app); break;
                     case "Prod_GenerateRules":       RunCommand<Commands.Classification.GenerateProdCodeRulesCommand>(app); break;
                     case "Prod_CoverageAudit":       RunCommand<Commands.Classification.ProdCoverageAuditCommand>(app); break;
 

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -3757,6 +3757,8 @@
                                             ToolTip="Read-only dry-run: % classified, unmapped keys, and ambiguous (tied-rule) elements for the active OmniClass table — CSV + summary. Run before Assign to see the holes"/>
                                     <Button Style="{StaticResource ActionBtn}" Content="Classification on Tags…" Tag="ClassificationTags_Set" Click="Cmd_Click"
                                             ToolTip="Optionally stamp a classification code (MasterFormat / OmniClass / both / none) into each element's rich TAG7 narrative so it shows on drawings. Per-project, data-driven (classification_policy.json), off by default. Re-run Auto Tag / Build Tags to refresh"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="SpecLink Import" Tag="SpecLink_ImportFolder" Click="Cmd_Click"
+                                            ToolTip="Read the SpecLink project-manual CSV(s) dropped in _BIM_COORD/speclink/ into sections.json. The issued clause text then writes the BOQ line descriptions instead of a generated NRM2 template. Newest export wins on a section collision"/>
                                     <Button Style="{StaticResource BlueBtn}" Content="SpecLink Reconcile" Tag="SpecLink_Reconcile" Click="Cmd_Click"
                                             ToolTip="Compare model CSI sections against the SpecLink spec TOC — spec gaps / over-spec / title mismatches; XLSX report"/>
                                 </WrapPanel>

--- a/project-templates/KUT/_BIM_COORD/boq_rate_policy.json
+++ b/project-templates/KUT/_BIM_COORD/boq_rate_policy.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "KUT (Kampala Uganda Temple) BOQ rate-provider policy overlay. Phase 195. This file re-ranks and gates the corporate rate-provider waterfall for THIS project only. Leave a provider out to keep its compiled-in baseline. 'enabled:false' switches a provider off so a tender runs deterministically; 'priority' (higher wins) re-ranks the chain. The full resolved chain for KUT is documented below.",
+  "_chain_high_to_low": [
+    "param-override (100)  inline CST_UNIT_RATE_UGX edit  ALWAYS WINS",
+    "es-override (98)      sticky per-element manual correction (Extensible Storage)",
+    "fohlio (96)           Owner FF&E procurement PO price (links Fohlio, never duplicates) - the provider arrives with the Fohlio FF&E work; until then this entry names an id nothing registers and is simply inert",
+    "project-rate-card (93) negotiated sub-contractor rate card (_BIM_COORD/rate_card.json)",
+    "csv-default (90)      cost_rates_5d.csv category rate",
+    "material-library (85) MAT panel ALL_MODEL_COST / MATERIAL_LOOKUP.csv",
+    "cobie-typemap (75)    COBIE_TYPE_MAP.csv -> rate code",
+    "default-baseline (60) Scheduling4DEngine fallback",
+    "bcis-http (DISABLED)  live BCIS HTTP feed - off for deterministic KUT tenders"
+  ],
+  "providers": {
+    "bcis-http": { "enabled": false },
+    "es-override": { "priority": 98 },
+    "fohlio": { "priority": 96 },
+    "project-rate-card": { "priority": 93 },
+    "material-library": { "priority": 85 }
+  }
+}


### PR DESCRIPTION
## What this adds

**The issued specification writes the bill.**

A BOQ line's description has, until now, been generated from an NRM2 template. If the project also has an issued specification, that is two descriptions of the same work — and they drift. Worse, the paragraph enhancer then edits its own description further (performance clauses, compliance clauses, "or approved equivalent", client-vocabulary substitution). Applied to text that came from a contract document, that is editing a contractual clause inside a tender bill.

| Piece | What it does |
|---|---|
| `SpecLink_ImportFolder` | Reads exported SpecLink project-manual CSV(s) dropped in `_BIM_COORD/speclink/` into `sections.json`. Newest export wins on a section collision, so a re-issued manual supersedes an older drop without anyone deleting files. |
| `SpecStore` | Parses the store (object or array shape, `text` aliases `description`). The BOQ build looks up each line's CSI section; when the spec describes it, the clause text becomes the line description **verbatim** and `SpecSourced` is set. |
| `BOQParagraphEnhancer` | Early-continues on `SpecSourced` and counts it. The spec is the authority; this generator is not. |
| `SpecCompletenessGate` | Counts priced lines carrying no spec reference *before* the professional export writes the file, with the value at risk and the largest offenders. **Off by default** (`COST_REQUIRE_SPEC_FOR_TENDER = 0`); `1` warns, `2` blocks. |

RIB/Deltek SpecLink has no public API, so a Word/PDF/CSV export is the integration surface — hence a watch-folder, mirroring the StingBridge IFC drop-folder pattern. The command is workflow-resolvable, so it can be step 0 of a lifecycle chain rather than a manual pre-step.

**The CSI map gains an NRM2 column.** `DeriveNrm2Section` can only key off the Revit category, so every pipe billed identically whether it carried sanitary waste or chilled water. A rule that names its NRM2 work section now overrides that, and all 144 shipped rows carry a code.

**The rate chain becomes a project setting.** `_BIM_COORD/boq_rate_policy.json` re-ranks and gates the rate-provider waterfall — a tender can switch the live BCIS feed off and price deterministically. Disabled providers stay in the chain and are skipped at resolve time, so the rate-source heat-map shows them as present-but-silent rather than hiding *why* nothing came from them.

## A defect found while porting

The branch resolved the CSI→NRM2 bridge through a **section-keyed dictionary**. Six shipped rows share CSI section `03 30 00` (Cast-in-Place Concrete) with two different NRM2 answers — **14** for a concrete wall, **5** for a slab, column, foundation, stair or ramp. First-wins therefore billed every concrete slab and foundation in the model under **masonry**, purely because the wall row is listed first.

`CsiMasterFormat.Nrm2For` now reads the **matched rule** first and falls back to the section map only for an element carrying a stamped section that no rule matched. The section map keeps first-wins, which is correct *there*: project-overlay rows load before corporate ones and are meant to override them. Three tests pin this, one of them against the shipped map; reverting to section-first fails two of them, which I confirmed.

## Why it was worth recovering

The spec-to-bill loop is the piece that stops a tender bill and a project manual describing the same work two different ways, and the gate is what catches money in a bill for work nobody specified — before it is issued rather than during the dispute. Neither exists on `main` in any form.

## Provenance

Ported from `claude/kut-lifecycle-integration` (cut 2026-06-21, never merged, 76 days behind). The branch is **not** merged — it would revert current behaviour. `KutKpiDashboardCommand` from the same branch remains **deliberately excluded**, superseded by `OwnerKpiDashboardCommand` on `main`, which does the same job without hard-coding the project.

## Drift repaired, and the judgement calls

**1. Path discipline.** `RatePolicy.Load(projectDir)` and the spec/overlay folder lookups built `<dir>/_BIM_COORD/...` by hand — writing to the pre-consolidation sibling folder and failing the zero-tolerance gate. Path building moved to the callers that hold a `Document` (`RateProviderRegistry`, `CsiMap`, `SpecLinkImportCommand`) and resolves through `StingPaths`; the POCOs stay host-free and unit-testable.

**2. The shipped CSI map moved under the branch.** `main`'s version has grown to 144 rows against the branch's 115, and fixed rows that had never fired. I kept `main`'s file and added the `Nrm2` / `Unit` columns to it rather than taking the branch's.

34 site / civil / external-utility sections `main` added had no branch mapping. They carry the code implied by their CSI division and this file's existing convention (31/32 → 4 site works; 33 water/sanitary/storm → 32; 33 51 00 gas → 33; 33 71 00 → 34), and the file header calls them out as **worth a QS's eye before a site-works tender**. This is not a downgrade: previously those rows fell through to the category-keyword fallback, which for "Generic Models", "Topography" and "Pads" lands in a bucket. They are data — changing one is a one-line edit.

**3. Two branch test files are NOT recovered.** `BoqTotalsTests` and `BoqUnitsTests` are written against a `BoqTotals` / `BoqUnits` API that `main` deliberately replaced: the WP1 consolidation already implements the canonical cascade + VAT waterfall, `BoqUnits` already keeps tonne and kg distinct, and `Rc2AlignmentTests` already covers both. Porting them would mean reverting `main`'s newer API — the regression this whole exercise exists to avoid.

**4. `FfeTreatment` lands ahead of its consumer, on purpose.** It is the pure vocabulary (four treatments + alias normalisation) with its tests. Nothing resolves an FF&E treatment yet — `FohlioMap.TreatmentFor` does, and arrives with the Fohlio v2 work. `BOQLineItem.FfeOwnerProcured` is live now because the spec gate already reasons about it: a contractor never prices Owner-direct FF&E, so it is not a spec gap to chase.

**5. `SpecCompletenessGate` is not in the test project.** It depends on `BOQModels`, which imports `Autodesk.Revit.DB`. Adding Revit stubs to reach it would test the stubs. Left out rather than faked; it is exercised only through the export command.

**6. Cache invalidation.** The CSI rule list, both bridges and the spec store are cached per document (the BOQ build asks per element). `Cost_ReloadRules` now clears them, and `SpecLink_ImportFolder` clears them after writing — otherwise a freshly imported spec would be invisible until Revit restarted.

## Verified

- `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings**
- `dotnet test StingTools.Boq.Tests` → **899 passed, 0 failed** (54 new)
- `tools/check_path_discipline.ps1` → Tier 1 = 0, Tier 2 = 0
- `tools/check_workflow_wiring.ps1` → **Tier 4 = 0**; `SpecLink_ImportFolder` dispatches from the button, the handler and `WorkflowEngine.ResolveCommand`
- `tools/check_kut_documents.py` → 80 assertions, green

The shipped CSI map and the shipped KUT rate-policy overlay are read by the **real** parsers in tests. Data-file JSON is not compile-checked — Newtonsoft leaves a mistyped field at its default and it goes runtime-dead — so the overlay's `enabled` bool and `priority` int are asserted, not just its parseability.

## Not verified

**Nothing here was exercised inside Revit.** That cannot be done from a terminal session. Untested at runtime: the CSV drop-folder scan and merge, spec text reaching a real BOQ line, the tender gate dialog in either mode, the policy-disabled provider skip, and the `Cost_ReloadRules` cache drop. The pure halves — store parsing, manual-CSV parsing, the bridge and its rule-first resolution, policy parsing, FF&E normalisation, and the shipped data files — are covered by the 54 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1S3eCuoayfcdhoiXLsoc
