### PR TITLE
feat(twin): join the four ledgers — spec, cost, procurement, commissioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,8 @@ marketing-site/tests/.bundle.test.mjs
 
 # Bonsai extension: core wheel is built at package time (see BUILD.md)
 stingtools-bonsai/wheels/*.whl
+
+# Niagara BMS station connection (base URL + API key or username/password) is
+# user-created at runtime under <project>/_BIM_COORD/ and must never be committed.
+niagara_connection.json
+**/niagara_connection.json

--- a/StingTools.Boq.Tests/BmsValuationTests.cs
+++ b/StingTools.Boq.Tests/BmsValuationTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using StingTools.Core.Twin;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // Phase H3 (KUT lifecycle) — BMS commissioning-valuation arithmetic.
+    public class BmsValuationTests
+    {
+        [Theory]
+        [InlineData("ok", true, true)]
+        [InlineData("", true, true)]        // Baja empty-status object = OK
+        [InlineData("{ok}", true, true)]    // decorated status
+        [InlineData("online", true, true)]
+        [InlineData("fault", true, false)]  // in-service status but faulted
+        [InlineData("down", true, false)]
+        [InlineData("stale", true, false)]
+        [InlineData("disabled", true, false)]
+        [InlineData("ok", false, false)]    // live status but no present value = dead point
+        [InlineData(null, true, true)]      // absent status coalesces to Baja empty-OK; hasValue gate still protects
+        [InlineData(null, false, false)]    // absent status + no value = not commissioned
+        public void IsCommissioned_StatusAndValue(string status, bool hasVal, bool expected)
+            => Assert.Equal(expected, BmsValuation.IsCommissioned(status, hasVal));
+
+        [Fact]
+        public void Compute_RollsUpValueAndCounts()
+        {
+            var assets = new List<BmsAsset>
+            {
+                new BmsAsset { DeviceId = "AHU-1", ValueUGX = 1_000_000, Commissioned = true },
+                new BmsAsset { DeviceId = "FCU-2", ValueUGX = 400_000,   Commissioned = false }, // configured, not live
+                new BmsAsset { DeviceId = "",      ValueUGX = 200_000,   Commissioned = false }, // no point yet
+            };
+            var r = BmsValuation.Compute(assets);
+            Assert.Equal(3, r.MonitorableCount);
+            Assert.Equal(1_600_000, r.MonitorableValueUGX);
+            Assert.Equal(1, r.CommissionedCount);
+            Assert.Equal(1_000_000, r.CommissionedValueUGX);
+            Assert.Equal(1, r.NoPointCount);
+            Assert.Equal(1_000_000.0 / 1_600_000.0, r.CommissionedValueFraction, 4);
+        }
+
+        [Fact]
+        public void Compute_EmptyScope_ZeroFractionNoDivByZero()
+        {
+            var r = BmsValuation.Compute(new List<BmsAsset>());
+            Assert.Equal(0, r.MonitorableCount);
+            Assert.Equal(0.0, r.CommissionedValueFraction);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/ShippedFohlioMapTests.cs
+++ b/StingTools.Boq.Tests/ShippedFohlioMapTests.cs
@@ -1,0 +1,99 @@
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using StingTools.BOQ;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    // The shipped KUT Fohlio overlay decides how FF&E is carried in a priced bill.
+    // It is a data file, so nothing about it is compile-checked: Newtonsoft leaves an
+    // unrecognised or wrongly-typed key at its default, and "ffe" silently becoming the
+    // fallback looks identical to "ffe" being read.
+    //
+    // What this DOES prove: the keys FohlioMap reads are present and spelled as it
+    // expects, they carry the right JSON types, the treatment value is one the code
+    // recognises rather than a typo that normalises to the default by accident, and the
+    // cost columns the BOQ rate provider depends on exist.
+    //
+    // What it does NOT prove: that FohlioMap's C# property names still match. FohlioMap
+    // imports Autodesk.Revit.DB, so it cannot be linked here; renaming a property without
+    // renaming the JSON would slip past. The names below are therefore written as the
+    // literal contract, not derived from the type.
+    public class ShippedFohlioMapTests
+    {
+        private static JObject Load()
+        {
+            string path = Path.Combine(System.AppContext.BaseDirectory, "Data", "kut_fohlio_map.json");
+            Assert.True(File.Exists(path), $"Shipped KUT Fohlio map not found at {path}");
+            return JObject.Parse(File.ReadAllText(path));
+        }
+
+        [Fact]
+        public void BoqTreatment_IsAStringTheCodeRecognises()
+        {
+            var o = Load();
+            var t = o["BoqTreatment"];
+            Assert.NotNull(t);
+            Assert.Equal(JTokenType.String, t.Type);
+
+            string raw = (string)t;
+            // Round-tripping through the real normaliser is the point: a typo like "FFE "
+            // or "ffee" would also come back as Ffe (it is the safe default), so assert
+            // the raw value is one of the four canonical tokens as well.
+            Assert.Equal(FfeTreatment.Ffe, FfeTreatment.Normalize(raw));
+            Assert.Contains(raw, new[] { FfeTreatment.Ffe, FfeTreatment.PcSum, FfeTreatment.Measured, FfeTreatment.Excluded });
+        }
+
+        [Fact]
+        public void BoqTreatmentByCategory_IsAnObject_NotAnArray()
+        {
+            var o = Load();
+            var byCat = o["BoqTreatmentByCategory"];
+            Assert.NotNull(byCat);
+            // An array here would deserialise to null and silently disable every
+            // per-category override.
+            Assert.Equal(JTokenType.Object, byCat.Type);
+            // Whatever overrides it carries must be values the code recognises.
+            foreach (var pr in ((JObject)byCat).Properties())
+            {
+                Assert.Equal(JTokenType.String, pr.Value.Type);
+                string v = (string)pr.Value;
+                Assert.Contains(FfeTreatment.Normalize(v),
+                    new[] { FfeTreatment.Ffe, FfeTreatment.PcSum, FfeTreatment.Measured, FfeTreatment.Excluded });
+            }
+        }
+
+        [Fact]
+        public void CostColumns_ArePresent_SoTheRateProviderHasSomethingToRead()
+        {
+            var o = Load();
+            var cols = o["Columns"] as JArray;
+            Assert.NotNull(cols);
+            var byParam = cols.OfType<JObject>().ToDictionary(c => (string)c["Param"], c => c);
+
+            // FohlioRateProvider reads these two off the element; Fohlio_Import writes
+            // them from these columns. Without them the provider can never fire.
+            Assert.True(byParam.ContainsKey("FOHLIO_UNIT_COST_NR"), "Unit-cost column missing");
+            Assert.True(byParam.ContainsKey("FOHLIO_CURRENCY_TXT"), "Currency column missing");
+            // The import writes the numeric cost via SetDouble, not the text-diff path,
+            // but the currency is a normal write-back field.
+            Assert.True((bool)byParam["FOHLIO_CURRENCY_TXT"]["WriteBack"]);
+
+            // The link key must stay a write-back field or nothing links back to Fohlio.
+            Assert.True(byParam.ContainsKey("FOHLIO_REF_TXT"));
+            Assert.True((bool)byParam["FOHLIO_REF_TXT"]["WriteBack"]);
+        }
+
+        [Fact]
+        public void FfeCategories_AreListed()
+        {
+            var cats = Load()["Categories"] as JArray;
+            Assert.NotNull(cats);
+            Assert.NotEmpty(cats);
+            // IsFfeCategory matches on these; an empty list would mean no element is ever
+            // treated as FF&E and the whole treatment becomes dead.
+            Assert.All(cats, c => Assert.False(string.IsNullOrWhiteSpace((string)c)));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -82,6 +82,10 @@
     <Compile Include="..\StingTools\BOQ\SpecStore.cs" Link="SpecStore.cs" />
     <Compile Include="..\StingTools\BOQ\FfeTreatment.cs" Link="FfeTreatment.cs" />
     <Compile Include="..\StingTools\BOQ\Rates\RatePolicy.cs" Link="Rates\RatePolicy.cs" />
+    <!-- BMS commissioning-valuation arithmetic + the point-status decision. Revit-free
+         and network-free on purpose: the command walks the model and queries the
+         station, this only does the maths. -->
+    <Compile Include="..\StingTools\Core\Twin\BmsValuation.cs" Link="Twin\BmsValuation.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -144,6 +148,11 @@
     </None>
     <!-- The SHIPPED KUT rate-policy overlay - JSON field types are not compile-checked. -->
     <None Include="..\project-templates\KUT\_BIM_COORD\boq_rate_policy.json" Link="Data\kut_boq_rate_policy.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- The SHIPPED KUT Fohlio overlay - it decides how FF&amp;E is carried in a
+         priced bill, and a mistyped key there is a silent default, not an error. -->
+    <None Include="..\project-templates\KUT\_BIM_COORD\fohlio_map.json" Link="Data\kut_fohlio_map.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <!-- The SHIPPED KUT classification overlay. Data-file JSON is not compile-checked:

--- a/StingTools.Cost.Tests/BoqTotalsFfeExemptionTests.cs
+++ b/StingTools.Cost.Tests/BoqTotalsFfeExemptionTests.cs
@@ -1,0 +1,81 @@
+using StingTools.BOQ;
+using Xunit;
+
+namespace StingTools.Cost.Tests
+{
+    // Owner-procured FF&E is bought direct from the supplier's register. It is real
+    // money in the bill, but a main contractor does not earn overhead, profit or
+    // contingency on goods it never bought — so it comes out of the markup BASE while
+    // staying in the works total. These tests pin that distinction and, just as
+    // importantly, pin that a project which never sets an FF&E treatment sees
+    // arithmetic identical to before.
+    public class BoqTotalsFfeExemptionTests
+    {
+        private const double Works = 100_000_000.0;
+        private const double PrelimPct = 12.0, OhpPct = 8.0, ContPct = 10.0, VatPct = 18.0;
+
+        private static BoqMarkupBreakdown Compute(double exempt) =>
+            BoqTotals.Compute(Works, Works * PrelimPct / 100.0, OhpPct, ContPct, VatPct, exempt);
+
+        [Fact]
+        public void ZeroExemption_Reproduces_The_Previous_Arithmetic_Exactly()
+        {
+            var oldWay = BoqTotals.Compute(Works, Works * PrelimPct / 100.0, OhpPct, ContPct, VatPct);
+            var withZero = Compute(0);
+
+            Assert.Equal(oldWay.Works, withZero.Works, 6);
+            Assert.Equal(oldWay.Prelims, withZero.Prelims, 6);
+            Assert.Equal(oldWay.Overhead, withZero.Overhead, 6);
+            Assert.Equal(oldWay.Contingency, withZero.Contingency, 6);
+            Assert.Equal(oldWay.NetExVat, withZero.NetExVat, 6);
+            Assert.Equal(oldWay.Vat, withZero.Vat, 6);
+            Assert.Equal(oldWay.GrandTotal, withZero.GrandTotal, 6);
+        }
+
+        [Fact]
+        public void ExemptWorks_Leave_The_Bill_But_Leave_The_Markup_Base()
+        {
+            const double exempt = 20_000_000.0;
+            var b = Compute(exempt);
+
+            // Prelims keep the FULL works base: site establishment, storage and handling
+            // are earned on Owner-supplied goods too.
+            Assert.Equal(Works * 0.12, b.Prelims, 6);
+
+            // OH&P and contingency are computed on (works + prelims - exempt).
+            double ohpBase = Works + b.Prelims - exempt;
+            Assert.Equal(ohpBase * 0.08, b.Overhead, 6);
+            Assert.Equal((ohpBase + b.Overhead) * 0.10, b.Contingency, 6);
+
+            // The exempt value is still IN the bill — it is money the Owner spends.
+            Assert.Equal(Works + b.Prelims + b.Overhead + b.Contingency, b.NetExVat, 6);
+            Assert.Equal(Works, b.Works, 6);
+        }
+
+        [Fact]
+        public void MoreExemption_Always_Lowers_The_Contract_Sum_Never_The_Works()
+        {
+            var none = Compute(0);
+            var some = Compute(20_000_000);
+            var most = Compute(80_000_000);
+
+            Assert.True(some.NetExVat < none.NetExVat);
+            Assert.True(most.NetExVat < some.NetExVat);
+            Assert.Equal(none.Works, most.Works, 6);   // the works subtotal never moves
+        }
+
+        [Theory]
+        [InlineData(-5_000_000.0)]                     // nonsense negative
+        [InlineData(500_000_000.0)]                    // larger than the works
+        public void OutOfRangeExemption_Is_Clamped_Not_Trusted(double exempt)
+        {
+            var b = Compute(exempt);
+            // Clamped into [0, works], so no markup can ever go negative and no
+            // exemption can invert the base into a bigger markup than none at all.
+            Assert.True(b.Overhead >= 0);
+            Assert.True(b.Contingency >= 0);
+            Assert.True(b.Overhead <= Compute(0).Overhead);
+            Assert.True(b.NetExVat >= b.Works);        // prelims are never exempted
+        }
+    }
+}

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -688,6 +688,24 @@ namespace StingTools.BOQ
             // Skip phase-demolished or temporary elements — they don't belong in the cost plan.
             if (IsPhaseDemolished(doc, el)) return null;
 
+            // FF&E treatment. Fohlio-mapped categories are Owner procurement, not
+            // contractor-supplied work, and how they appear in the bill is a project
+            // decision (_BIM_COORD/fohlio_map.json). Resolved ONCE, up front, so exactly
+            // one treatment applies per element and nothing is double-counted.
+            string ffeTreatment = null;   // null => not an FF&E (Fohlio-mapped) category
+            try
+            {
+                var fmap = StingTools.ExLink.FohlioMap.Cached(doc);
+                if (fmap != null && fmap.IsFfeCategory(catName))
+                {
+                    ffeTreatment = fmap.TreatmentFor(catName);
+                    // Owner-supplied and outside this bill: leave the row out entirely
+                    // rather than pricing it at zero, which would read as free work.
+                    if (ffeTreatment == StingTools.BOQ.FfeTreatment.Excluded) return null;
+                }
+            }
+            catch (Exception ex) { StingLog.WarnRateLimited("FfeTreatment", $"FF&E treatment: {ex.Message}"); }
+
             // (a) Rate lookup — CSV by category → CSV by PROD code → COBie type map → default
             string rateSource;
             int rateConfidence;
@@ -886,6 +904,23 @@ namespace StingTools.BOQ
                     }
                 }
                 catch (Exception ex) { StingLog.WarnRateLimited("SpecText", $"Spec-text bridge: {ex.Message}"); }
+            }
+
+            // Apply the FF&E treatment resolved above. "measured" needs nothing — it is
+            // a normal model line that happens to be priced from the Fohlio rate.
+            if (ffeTreatment == StingTools.BOQ.FfeTreatment.Ffe)
+            {
+                line.FfeOwnerProcured = true;
+                string note = "FF&E — Owner-procured via the Fohlio register (at cost; excl. OH&P + contingency)" +
+                    (string.IsNullOrEmpty(line.CsiSection) ? "" : $" (spec {line.CsiSection})");
+                line.Note = string.IsNullOrEmpty(line.Note) ? note : $"{line.Note}; {note}";
+            }
+            else if (ffeTreatment == StingTools.BOQ.FfeTreatment.PcSum)
+            {
+                line.Source = BOQRowSource.ProvisionalSum;
+                string pcNote = "PC sum — Fohlio FF&E register" +
+                    (string.IsNullOrEmpty(line.CsiSection) ? "" : $" (spec {line.CsiSection})");
+                line.Note = string.IsNullOrEmpty(line.Note) ? pcNote : $"{line.Note}; {pcNote}";
             }
 
             // Mark provisional sums on the element if configured via existing parameter.

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -452,13 +452,21 @@ namespace StingTools.BOQ
         public double PrelimContributionUGX =>
             PrelimsItemised ? PrelimsItemisedUGX : SubtotalUGX * PrelimPct / 100.0;
 
+        /// <summary>Σ of Owner-procured FF&amp;E line totals — a transparent at-cost
+        /// category bought direct from the Fohlio register, not contractor-supplied work.
+        /// Shown as its own subtotal and removed from the OH&amp;P + contingency base: a
+        /// main contractor does not earn profit on goods the Owner buys. Zero for every
+        /// project that has not set an FF&amp;E treatment, so the totals are unchanged.</summary>
+        public double FfeOwnerProcuredUGX => AllItems.Where(i => i.FfeOwnerProcured).Sum(i => i.TotalUGX);
+
         /// <summary>
         /// WP1 — the single canonical markup waterfall (see <see cref="BoqTotals"/>).
         /// Replaces the old parallel "% × subtotal for everything, no VAT" formula.
         /// All component properties below and every external surface read from this.
         /// </summary>
         public BoqMarkupBreakdown Markup =>
-            BoqTotals.Compute(SubtotalUGX, PrelimContributionUGX, OverheadPct, ContingencyPct, VatPct);
+            BoqTotals.Compute(SubtotalUGX, PrelimContributionUGX, OverheadPct, ContingencyPct, VatPct,
+                              FfeOwnerProcuredUGX);
 
         public double OverheadProfitUGX => Markup.Overhead;
         public double ContingencyUGX    => Markup.Contingency;

--- a/StingTools/BOQ/BoqTotals.cs
+++ b/StingTools/BOQ/BoqTotals.cs
@@ -47,19 +47,33 @@ namespace StingTools.BOQ
     /// </summary>
     public static class BoqTotals
     {
+        /// <param name="markupExemptWorks">
+        /// The portion of <paramref name="works"/> a main contractor does not earn
+        /// overhead, profit or contingency on — Owner-procured FF&amp;E bought direct
+        /// from the supplier's register. It stays in the bill at cost (it is real money
+        /// the Owner spends) but is removed from the OH&amp;P and contingency BASE, which
+        /// is the arithmetic that makes an at-cost FF&amp;E line different from a
+        /// contractor-supplied one. Preliminaries keep the full works base: site
+        /// establishment, storage and handling are earned on Owner-supplied goods too.
+        /// <para>DEFAULTS TO 0, which reproduces the previous arithmetic exactly.</para>
+        /// </param>
         public static BoqMarkupBreakdown Compute(double works, double prelimsAbsolute,
-            double overheadPct, double contingencyPct, double vatPct)
+            double overheadPct, double contingencyPct, double vatPct,
+            double markupExemptWorks = 0)
         {
             var b = new BoqMarkupBreakdown
             {
                 Works = works,
                 Prelims = prelimsAbsolute
             };
+            // Never let a bad exempt figure invert the base.
+            double exempt = Math.Max(0, Math.Min(markupExemptWorks, works));
             double sub1 = works + b.Prelims;
-            b.Overhead = sub1 * (overheadPct / 100.0);
-            double sub2 = sub1 + b.Overhead;
-            b.Contingency = sub2 * (contingencyPct / 100.0);
-            b.NetExVat = sub2 + b.Contingency;
+            double ohpBase = sub1 - exempt;
+            b.Overhead = ohpBase * (overheadPct / 100.0);
+            double contBase = ohpBase + b.Overhead;
+            b.Contingency = contBase * (contingencyPct / 100.0);
+            b.NetExVat = sub1 + b.Overhead + b.Contingency;
             b.Vat = b.NetExVat * (vatPct / 100.0);
             b.GrandTotal = Math.Round(b.NetExVat + b.Vat, 0);
             return b;

--- a/StingTools/BOQ/Rates/RateProviderRegistry.cs
+++ b/StingTools/BOQ/Rates/RateProviderRegistry.cs
@@ -110,6 +110,10 @@ namespace StingTools.BOQ.Rates
             var providers = new List<IRateProvider>
             {
                 new ParameterOverrideRateProvider(),
+                // Owner FF&E procurement price (96) — above the material library and the
+                // CSV category rate, below an explicit inline override. Returns null when
+                // the element carries no Fohlio cost, so non-FF&E models are unaffected.
+                new FohlioRateProvider(),
                 new ExtensibleStorageRateProvider(),
                 // P3.4 — project rate card (incl. QS-Bill-imported rates at
                 // <project>/_BIM_COORD/rate_card.json). Priority 87 sits above

--- a/StingTools/BOQ/Rates/RateProviders.cs
+++ b/StingTools/BOQ/Rates/RateProviders.cs
@@ -62,6 +62,63 @@ namespace StingTools.BOQ.Rates
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    //  1b. Fohlio FF&E procurement rate (priority 96)
+    //  Owner-procured FF&E carries the supplier's purchase-order price, and that
+    //  price is the truth - not a rate-book average. STING COEXISTS with Fohlio
+    //  (link, never duplicate): the rate is read from FOHLIO_UNIT_COST_NR, written
+    //  by the official Fohlio Revit add-in or by STING's Fohlio_Import, falling back
+    //  to the ES import snapshot. Sits above the material-library / CSV rates so the
+    //  Owner's PO price wins, and below an explicit inline override (100).
+    // ──────────────────────────────────────────────────────────────────────
+    internal sealed class FohlioRateProvider : IRateProvider
+    {
+        public string Id => "fohlio";
+        public int Priority => 96;
+        public bool RequiresNetwork => false;
+
+        public RateLookup Resolve(RateRequest req)
+        {
+            if (req?.Element == null) return null;
+            try
+            {
+                double cost = ParameterHelpers.GetDouble(req.Element, ParamRegistry.FOHLIO_UNIT_COST, 0);
+                string currency = ParameterHelpers.GetString(req.Element, ParamRegistry.FOHLIO_CURRENCY);
+
+                if (cost <= 0)
+                {
+                    // Fall back to the snapshot captured at the last Fohlio import, so a
+                    // model whose parameter was cleared still prices off the last known PO.
+                    var snap = StingFohlioSnapshotSchema.Read(req.Element);
+                    if (snap != null && snap.UnitCost > 0)
+                    {
+                        cost = snap.UnitCost;
+                        if (string.IsNullOrEmpty(currency)) currency = snap.Currency;
+                    }
+                }
+                if (cost <= 0) return null;
+
+                return new RateLookup
+                {
+                    UnitRate = cost,
+                    // Fohlio quotes USD unless the export says otherwise; the registry's
+                    // FX adapter converts to the document currency.
+                    CurrencyCode = string.IsNullOrEmpty(currency) ? "USD" : currency.Trim().ToUpperInvariant(),
+                    Unit = string.IsNullOrEmpty(req.Unit) ? "each" : req.Unit,
+                    SourceId = Id,
+                    Confidence = 95,
+                    Provenance = "Fohlio FF&E procurement",
+                    MatchedKey = ParameterHelpers.GetString(req.Element, ParamRegistry.FOHLIO_REF)
+                };
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"FohlioRateProvider: {ex.Message}");
+                return null;
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     //  2. Extensible Storage override (priority 95)
     //  Reads StingCostRateOverrideSchema. CA-1 — a stored override is in the
     //  project BASE currency (UGX) unless it carries an explicit ovr.Currency;

--- a/StingTools/BOQ/Rates/RateSourceLabels.cs
+++ b/StingTools/BOQ/Rates/RateSourceLabels.cs
@@ -18,6 +18,7 @@ namespace StingTools.BOQ.Rates
             {
                 case "param-override": return "Override";
                 case "es-override":    return "Override";
+                case "fohlio":         return "Fohlio";
                 case "csv-default":    return "CSV";
                 case "cobie-typemap":  return "COBie";
                 case "default-baseline": return "Default";

--- a/StingTools/Commands/Cost/CostCommands.cs
+++ b/StingTools/Commands/Cost/CostCommands.cs
@@ -357,6 +357,8 @@ namespace StingTools.Commands.Cost
             // store are cached per document too; an edited csi_map.csv or a re-imported
             // spec is invisible to the next build without this.
             StingTools.Commands.Classification.CsiMap.Invalidate();
+            // The Fohlio map decides FF&E treatment per category and is read per element.
+            StingTools.ExLink.FohlioMap.Invalidate();
 
             // Phase 2B — external live-rate feeds (BCIS / Planscape) are now part
             // of the default build chain (RateProviderRegistry.Build →

--- a/StingTools/Commands/Twin/KutLifecycleReconcileCommand.cs
+++ b/StingTools/Commands/Twin/KutLifecycleReconcileCommand.cs
@@ -1,0 +1,287 @@
+// KutLifecycleReconcileCommand.cs — Phase D (KUT lifecycle integration).
+//
+// Joins the four ledgers that already key off the same Revit element —
+// SpecLink/CSI (specified) · BOQ (measured/priced) · Fohlio (procured) ·
+// Niagara (commissioned) — into one asset register and surfaces the two
+// commissioning-side gaps the single-ledger reconciles cannot see:
+//
+//   PRICED_NO_BMS_POINT   a priced MEP/equipment line whose element has no
+//                         BMS device id / endpoint (a handover gap), scoped to
+//                         monitorable categories only.
+//   COMMISSIONED_UNPRICED a Niagara station point with no priced BOQ line
+//                         (an asset-register gap).
+//
+// Read-only: BuildBOQDocument is the same path the BOQ audits use; the BMS
+// device source is IoTDeviceRegistry. The station export is optional — without
+// it the register + PRICED_NO_BMS_POINT still produce; COMMISSIONED_UNPRICED
+// needs the station file.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using ClosedXML.Excel;
+using StingTools.BOQ;
+using StingTools.Core;
+using StingTools.Core.Twin;
+using StingTools.ExLink;
+
+namespace StingTools.Commands.Twin
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class KutLifecycleReconcileCommand : IExternalCommand
+    {
+        // Categories that typically carry a BMS / IoT point — the scope for the
+        // PRICED_NO_BMS_POINT handover gap.
+        private static readonly HashSet<string> Monitorable = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Mechanical Equipment", "Electrical Equipment", "Lighting Fixtures", "Lighting Devices",
+            "Air Terminals", "Duct Accessory", "Plumbing Fixtures", "Fire Alarm Devices",
+            "Security Devices", "Communication Devices", "Data Devices", "Nurse Call Devices", "Sprinklers"
+        };
+
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            BOQDocument boq;
+            try { boq = BOQCostManager.BuildBOQDocument(doc); }
+            catch (Exception ex) { StingLog.Error("KUT_LifecycleReconcile BOQ", ex); TaskDialog.Show("KUT Lifecycle", "Could not build the BOQ:\n" + ex.Message); return Result.Failed; }
+            if (boq == null) { TaskDialog.Show("KUT Lifecycle", "No BOQ document."); return Result.Succeeded; }
+
+            // BMS devices by element.
+            var devByElem = new Dictionary<long, IoTDeviceRef>();
+            try
+            {
+                foreach (var d in new IoTDeviceRegistry(doc).All())
+                    if (d?.BimElementId != null) devByElem[d.BimElementId.Value] = d;
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_LifecycleReconcile devices: " + ex.Message); }
+
+            // Optional Niagara station export (drives COMMISSIONED_UNPRICED).
+            HashSet<string> stationIds = null;
+            var dlg = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Optional: select the Niagara / BACnet station export (Cancel to skip the commissioned-unpriced check)",
+                Filter = "Station export (*.csv;*.xlsx)|*.csv;*.xlsx",
+                InitialDirectory = OutputLocationHelper.GetOutputDirectory(doc)
+            };
+            if (dlg.ShowDialog() == true)
+            {
+                try { stationIds = ReadIds(dlg.FileName); }
+                catch (Exception ex) { StingLog.Warn("KUT station read: " + ex.Message); }
+            }
+
+            var fmap = FohlioMap.Cached(doc);
+
+            // Build the unified register, one row per modelled BOQ asset.
+            var register = new List<AssetRow>();
+            var pricedDeviceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pricedNoBms = new List<AssetRow>();
+            double pricedNoBmsUgx = 0;
+
+            foreach (var it in boq.AllItems)
+            {
+                if (it == null || it.RevitElementId < 0) continue;   // manual/PS-only rows have no element
+                var el = doc.GetElement(new ElementId(it.RevitElementId));
+                string cat = it.Category ?? (el != null ? ParameterHelpers.GetCategoryName(el) : "");
+                bool priced = it.TotalUGX > 0;
+                bool ffe = fmap != null && fmap.IsFfeCategory(cat);
+                bool monitorable = Monitorable.Contains(cat ?? "");
+
+                devByElem.TryGetValue(it.RevitElementId, out var dev);
+                string devId = dev?.DeviceId ?? "";
+                string endpoint = dev?.EndpointAddress ?? "";
+                string fref = el != null ? ParameterHelpers.GetString(el, ParamRegistry.FOHLIO_REF) : "";
+
+                if (priced && !string.IsNullOrEmpty(devId)) pricedDeviceIds.Add(devId);
+
+                var row = new AssetRow
+                {
+                    ElementId = it.RevitElementId,
+                    Item = it.ItemName ?? "",
+                    Category = cat ?? "",
+                    CsiSection = it.CsiSection ?? "",
+                    Nrm2 = it.NRM2Section ?? "",
+                    AmountUgx = it.TotalUGX,
+                    FohlioRef = fref ?? "",
+                    BmsDevice = devId,
+                    BmsEndpoint = endpoint,
+                    Spec = string.IsNullOrEmpty(it.CsiSection) ? "✗" : "✓",
+                    Boq = priced ? "✓" : "✗",
+                    Fohlio = !ffe ? "—" : (string.IsNullOrEmpty(fref) ? "✗" : "✓"),
+                    Bms = !monitorable ? "—"
+                        : !string.IsNullOrEmpty(devId) && !string.IsNullOrEmpty(endpoint) ? "✓"
+                        : !string.IsNullOrEmpty(devId) ? "⚠" : "✗",
+                };
+                register.Add(row);
+
+                // PRICED_NO_BMS_POINT — priced, monitorable, missing device id or endpoint.
+                if (priced && monitorable && (string.IsNullOrEmpty(devId) || string.IsNullOrEmpty(endpoint)))
+                {
+                    pricedNoBms.Add(row);
+                    pricedNoBmsUgx += it.TotalUGX;
+                }
+            }
+
+            // COMMISSIONED_UNPRICED — station points with no priced BOQ line.
+            var commissionedUnpriced = stationIds == null
+                ? new List<string>()
+                : stationIds.Where(s => !pricedDeviceIds.Contains(s)).OrderBy(s => s).ToList();
+
+            string xlsx = WriteRegister(doc, register, pricedNoBms, commissionedUnpriced, stationIds != null);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Assets (modelled BOQ lines): {register.Count}");
+            sb.AppendLine($"   Spec ✓ {register.Count(r => r.Spec == "✓")} · BOQ ✓ {register.Count(r => r.Boq == "✓")} · " +
+                          $"Fohlio ✓ {register.Count(r => r.Fohlio == "✓")} · BMS ✓ {register.Count(r => r.Bms == "✓")}");
+            sb.AppendLine();
+            sb.AppendLine($"PRICED_NO_BMS_POINT:    {pricedNoBms.Count}  (UGX {pricedNoBmsUgx:N0} priced, no/incomplete BMS point)");
+            sb.AppendLine(stationIds == null
+                ? "COMMISSIONED_UNPRICED:  (skipped — no station export selected)"
+                : $"COMMISSIONED_UNPRICED:  {commissionedUnpriced.Count}  (station point, no priced BOQ line)");
+            if (pricedNoBms.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Top priced-no-BMS:");
+                foreach (var r in pricedNoBms.OrderByDescending(r => r.AmountUgx).Take(8))
+                    sb.AppendLine($"   {r.ElementId} {r.Category,-22} UGX {r.AmountUgx:N0}");
+            }
+            if (xlsx != null) { sb.AppendLine(); sb.AppendLine("Register: " + xlsx); }
+
+            new TaskDialog("KUT Lifecycle Reconcile")
+            {
+                MainInstruction = $"{register.Count} assets · {pricedNoBms.Count} priced-no-BMS · {commissionedUnpriced.Count} commissioned-unpriced",
+                MainContent = sb.ToString()
+            }.Show();
+            StingLog.Info($"KUT_LifecycleReconcile: assets={register.Count} pricedNoBms={pricedNoBms.Count}(UGX {pricedNoBmsUgx:N0}) " +
+                $"commissionedUnpriced={commissionedUnpriced.Count}");
+            return Result.Succeeded;
+        }
+
+        private sealed class AssetRow
+        {
+            public long ElementId;
+            public string Item, Category, CsiSection, Nrm2, FohlioRef, BmsDevice, BmsEndpoint;
+            public double AmountUgx;
+            public string Spec, Boq, Fohlio, Bms;
+        }
+
+        private static string WriteRegister(Document doc, List<AssetRow> register, List<AssetRow> pricedNoBms,
+            List<string> commissionedUnpriced, bool stationProvided)
+        {
+            try
+            {
+                using var wb = new XLWorkbook();
+
+                var ws = wb.AddWorksheet("Lifecycle Register");
+                string[] hdr = { "Element", "Category", "Item", "CSI section", "NRM2 §", "Amount UGX",
+                    "Fohlio ref", "BMS device", "BMS endpoint", "Spec", "BOQ", "Fohlio", "BMS" };
+                for (int c = 0; c < hdr.Length; c++) { ws.Cell(1, c + 1).Value = hdr[c]; ws.Cell(1, c + 1).Style.Font.Bold = true; }
+                int row = 2;
+                foreach (var r in register.OrderBy(r => r.Category).ThenByDescending(r => r.AmountUgx))
+                {
+                    ws.Cell(row, 1).Value = r.ElementId;
+                    ws.Cell(row, 2).Value = r.Category;
+                    ws.Cell(row, 3).Value = r.Item;
+                    ws.Cell(row, 4).Value = r.CsiSection;
+                    ws.Cell(row, 5).Value = r.Nrm2;
+                    ws.Cell(row, 6).Value = r.AmountUgx; ws.Cell(row, 6).Style.NumberFormat.Format = "#,##0";
+                    ws.Cell(row, 7).Value = r.FohlioRef;
+                    ws.Cell(row, 8).Value = r.BmsDevice;
+                    ws.Cell(row, 9).Value = r.BmsEndpoint;
+                    ws.Cell(row, 10).Value = r.Spec;
+                    ws.Cell(row, 11).Value = r.Boq;
+                    ws.Cell(row, 12).Value = r.Fohlio;
+                    ws.Cell(row, 13).Value = r.Bms;
+                    row++;
+                }
+                ws.SheetView.FreezeRows(1);
+                ws.Columns().AdjustToContents();
+
+                var gw = wb.AddWorksheet("Gaps");
+                string[] ghdr = { "Type", "Element / Point", "Category", "Amount UGX", "Note" };
+                for (int c = 0; c < ghdr.Length; c++) { gw.Cell(1, c + 1).Value = ghdr[c]; gw.Cell(1, c + 1).Style.Font.Bold = true; }
+                int gr = 2;
+                foreach (var r in pricedNoBms.OrderByDescending(r => r.AmountUgx))
+                {
+                    gw.Cell(gr, 1).Value = "PRICED_NO_BMS_POINT";
+                    gw.Cell(gr, 2).Value = r.ElementId;
+                    gw.Cell(gr, 3).Value = r.Category;
+                    gw.Cell(gr, 4).Value = r.AmountUgx; gw.Cell(gr, 4).Style.NumberFormat.Format = "#,##0";
+                    gw.Cell(gr, 5).Value = string.IsNullOrEmpty(r.BmsDevice) ? "No BMS device id" : "BMS device has no endpoint";
+                    gr++;
+                }
+                if (stationProvided)
+                    foreach (var s in commissionedUnpriced)
+                    {
+                        gw.Cell(gr, 1).Value = "COMMISSIONED_UNPRICED";
+                        gw.Cell(gr, 2).Value = s;
+                        gw.Cell(gr, 5).Value = "Station point with no priced BOQ line";
+                        gr++;
+                    }
+                gw.Columns().AdjustToContents();
+
+                string path = OutputLocationHelper.GetOutputPath(doc, $"STING_KUT_Lifecycle_Register_{DateTime.Now:yyyyMMdd}.xlsx");
+                wb.SaveAs(path);
+                return path;
+            }
+            catch (Exception ex) { StingLog.Warn("KUT lifecycle register: " + ex.Message); return null; }
+        }
+
+        private static HashSet<string> ReadIds(string path)
+        {
+            var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var idHeaders = new[] { "deviceid", "device", "point", "object", "name", "id" };
+
+            if (path.EndsWith(".xlsx", StringComparison.OrdinalIgnoreCase))
+            {
+                using var wb = new XLWorkbook(path);
+                var ws = wb.Worksheets.First();
+                var used = ws.RangeUsed();
+                if (used == null) return ids;
+                int fr = used.FirstRow().RowNumber(), lr = used.LastRow().RowNumber();
+                int fc = used.FirstColumn().ColumnNumber(), lc = used.LastColumn().ColumnNumber();
+                var hdr = new List<string>();
+                for (int c = fc; c <= lc; c++) hdr.Add(ws.Cell(fr, c).GetString().Trim().ToLowerInvariant());
+                int col = FindCol(hdr, idHeaders);
+                if (col < 0) return ids;
+                for (int r = fr + 1; r <= lr; r++)
+                {
+                    string v = ws.Cell(r, fc + col).GetString().Trim();
+                    if (v.Length > 0) ids.Add(v);
+                }
+            }
+            else
+            {
+                var lines = File.ReadAllLines(path);
+                if (lines.Length < 2) return ids;
+                var hdr = StingToolsApp.ParseCsvLine(lines[0]).Select(h => h.Trim().ToLowerInvariant()).ToList();
+                int col = FindCol(hdr, idHeaders);
+                if (col < 0) return ids;
+                for (int i = 1; i < lines.Length; i++)
+                {
+                    if (string.IsNullOrWhiteSpace(lines[i])) continue;
+                    var f = StingToolsApp.ParseCsvLine(lines[i]);
+                    if (col < f.Length && !string.IsNullOrWhiteSpace(f[col])) ids.Add(f[col].Trim());
+                }
+            }
+            return ids;
+        }
+
+        private static int FindCol(List<string> hdr, string[] cands)
+        {
+            foreach (var cand in cands)
+                for (int i = 0; i < hdr.Count; i++)
+                    if (!string.IsNullOrEmpty(hdr[i]) && hdr[i].Contains(cand)) return i;
+            return -1;
+        }
+    }
+}

--- a/StingTools/Commands/Twin/KutPushLifecycleGapsToAccCommand.cs
+++ b/StingTools/Commands/Twin/KutPushLifecycleGapsToAccCommand.cs
@@ -1,0 +1,220 @@
+// KutPushLifecycleGapsToAccCommand.cs — Phase G (KUT lifecycle integration).
+//
+// Pushes the model-derivable four-ledger gaps as ACC Issues so the coordination
+// team actions cost/spec/commissioning gaps in ACC alongside clash issues. Reuses
+// the LIVE ACC client (StingTools.V6.AccIssueSync) — same 3-legged OAuth, 429
+// back-off and credentials file as AccPullClashesCommand. Idempotent via a sidecar
+// keyed on a stable gap signature, mirroring pushed_clashes.json.
+//
+// Scope: the two gaps computable from the model alone —
+//   PRICED_UNSPECIFIED   a priced BOQ line with no CSI section (spec gap).
+//   PRICED_NO_BMS_POINT  a priced monitorable asset with no BMS device/endpoint.
+// The file-dependent gaps (SPECIFIED_UNPRICED needs the SpecLink ToC,
+// COMMISSIONED_UNPRICED needs the Niagara station export) stay with their
+// reconcile commands' XLSX outputs — a future enhancement can push those too.
+//
+// Read-only on the Revit side: the issue push is network, not a model transaction.
+// Network code — verify against a live ACC project before relying on it.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using StingTools.BOQ;
+using StingTools.Core;
+using StingTools.Core.Twin;
+using StingTools.V6;
+
+namespace StingTools.Commands.Twin
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class KutPushLifecycleGapsToAccCommand : IExternalCommand
+    {
+        // Categories that typically carry a BMS / IoT point — the scope for the
+        // PRICED_NO_BMS_POINT gap (mirrors KutLifecycleReconcileCommand.Monitorable).
+        private static readonly HashSet<string> Monitorable = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Mechanical Equipment", "Electrical Equipment", "Lighting Fixtures", "Lighting Devices",
+            "Air Terminals", "Duct Accessory", "Plumbing Fixtures", "Fire Alarm Devices",
+            "Security Devices", "Communication Devices", "Data Devices", "Nurse Call Devices", "Sprinklers"
+        };
+
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            // 1. Credentials (same gate as AccPullClashesCommand).
+            var creds = AccIssueSync.LoadCredentials();
+            if (string.IsNullOrEmpty(creds.ClientId) || string.IsNullOrEmpty(creds.RefreshToken) ||
+                string.IsNullOrEmpty(creds.ProjectId))
+            {
+                TaskDialog.Show("KUT — Push Lifecycle Gaps to ACC",
+                    "ACC credentials are not configured.\n\n" +
+                    "Create %APPDATA%\\Planscape\\acc_credentials.json with at least:\n" +
+                    "  ClientId, ClientSecret, RefreshToken, ProjectId\n" +
+                    "(set IssueTypeId so ACC accepts the issues).");
+                return Result.Cancelled;
+            }
+
+            // 2. Build the gap set from the model.
+            BOQDocument boq;
+            try { boq = BOQCostManager.BuildBOQDocument(doc); }
+            catch (Exception ex) { StingLog.Error("KUT_PushGapsToAcc BOQ", ex); TaskDialog.Show("KUT — Push Gaps", "Could not build the BOQ:\n" + ex.Message); return Result.Failed; }
+            if (boq == null) { TaskDialog.Show("KUT — Push Gaps", "No BOQ document."); return Result.Succeeded; }
+
+            var devByElem = new Dictionary<long, IoTDeviceRef>();
+            try
+            {
+                foreach (var d in new IoTDeviceRegistry(doc).All())
+                    if (d?.BimElementId != null) devByElem[d.BimElementId.Value] = d;
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_PushGapsToAcc devices: " + ex.Message); }
+
+            double valueFloor = TagConfig.GetConfigDouble("KUT_ACC_GAP_VALUE_FLOOR", 0.0);
+
+            var gaps = new List<GapIssue>();
+            foreach (var it in boq.AllItems)
+            {
+                if (it == null || it.RevitElementId < 0 || it.TotalUGX <= 0) continue; // priced model rows only
+                string cat = it.Category ?? "";
+                string room = LevelLoc(it);
+
+                // PRICED_UNSPECIFIED — priced, no CSI section.
+                if (string.IsNullOrEmpty(it.CsiSection))
+                    gaps.Add(new GapIssue
+                    {
+                        Type = "PRICED_UNSPECIFIED",
+                        ElementId = it.RevitElementId,
+                        Category = cat,
+                        AmountUgx = it.TotalUGX,
+                        Title = $"PRICED_UNSPECIFIED: {cat} (UGX {it.TotalUGX:N0}) has no specification",
+                        Body = $"Element {it.RevitElementId} '{it.ItemName}' ({cat}) is priced at UGX {it.TotalUGX:N0} " +
+                               $"(NRM2 §{it.NRM2Section}) but carries no CSI section. Assign a spec or confirm scope.{room}"
+                    });
+
+                // PRICED_NO_BMS_POINT — priced monitorable asset with no BMS endpoint.
+                if (Monitorable.Contains(cat) && it.TotalUGX >= valueFloor)
+                {
+                    devByElem.TryGetValue(it.RevitElementId, out var dev);
+                    bool noPoint = dev == null || string.IsNullOrEmpty(dev.DeviceId) || string.IsNullOrEmpty(dev.EndpointAddress);
+                    if (noPoint)
+                        gaps.Add(new GapIssue
+                        {
+                            Type = "PRICED_NO_BMS_POINT",
+                            ElementId = it.RevitElementId,
+                            Category = cat,
+                            AmountUgx = it.TotalUGX,
+                            Title = $"PRICED_NO_BMS_POINT: {cat} (UGX {it.TotalUGX:N0}) has no BMS point",
+                            Body = $"Element {it.RevitElementId} '{it.ItemName}' ({cat}, UGX {it.TotalUGX:N0}) is a priced " +
+                                   $"monitorable asset with no BMS device id / endpoint — a commissioning/handover gap. " +
+                                   $"Tag ICT_HEALTHIOT_DEVICE_ID_TXT + _ENDPOINT_TXT, then re-run.{room}"
+                        });
+                }
+            }
+
+            if (gaps.Count == 0)
+            {
+                TaskDialog.Show("KUT — Push Lifecycle Gaps to ACC",
+                    "No model-derivable lifecycle gaps found (every priced line has a CSI section, " +
+                    "and every priced monitorable asset has a BMS point). Nothing to push.");
+                return Result.Succeeded;
+            }
+
+            // 3. Idempotency — skip gaps already pushed.
+            string sidecar = SidecarPath(doc);
+            var pushed = LoadSidecar(sidecar);   // signature → issue id
+
+            int created = 0, skipped = 0, failed = 0;
+            foreach (var g in gaps)
+            {
+                string sig = $"{g.Type}:{g.ElementId}";
+                if (pushed.ContainsKey(sig)) { skipped++; continue; }
+
+                var issue = new AccIssue { Title = g.Title, Description = g.Body, Status = "open" };
+                string id;
+                try { id = AccIssueSync.PushIssueAsync(creds, issue).GetAwaiter().GetResult(); }
+                catch (Exception ex) { StingLog.Warn($"KUT_PushGapsToAcc push {sig}: {ex.Message}"); id = null; }
+
+                if (!string.IsNullOrEmpty(id)) { pushed[sig] = id; created++; }
+                else failed++;
+            }
+
+            SaveSidecar(sidecar, pushed);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Gaps found: {gaps.Count}  " +
+                          $"({gaps.Count(g => g.Type == "PRICED_UNSPECIFIED")} priced-unspecified, " +
+                          $"{gaps.Count(g => g.Type == "PRICED_NO_BMS_POINT")} priced-no-BMS)");
+            sb.AppendLine();
+            sb.AppendLine($"ACC issues created:  {created}");
+            sb.AppendLine($"Already pushed (skipped): {skipped}");
+            if (failed > 0) sb.AppendLine($"Failed (will retry next run): {failed}");
+            sb.AppendLine();
+            sb.AppendLine("Re-runs are idempotent (sidecar: _BIM_COORD/acc/pushed_lifecycle_gaps.json).");
+
+            new TaskDialog("KUT — Push Lifecycle Gaps to ACC")
+            {
+                MainInstruction = $"{created} issue(s) created · {skipped} skipped · {failed} failed",
+                MainContent = sb.ToString()
+            }.Show();
+            StingLog.Info($"KUT_PushLifecycleGapsToAcc: found={gaps.Count} created={created} skipped={skipped} failed={failed}");
+            return Result.Succeeded;
+        }
+
+        private static string LevelLoc(BOQLineItem it)
+        {
+            string s = string.Join(" · ", new[] { it.Level, it.Location }.Where(x => !string.IsNullOrEmpty(x)));
+            return string.IsNullOrEmpty(s) ? "" : $" [{s}]";
+        }
+
+        private sealed class GapIssue
+        {
+            public string Type, Category, Title, Body;
+            public long ElementId;
+            public double AmountUgx;
+        }
+
+        // ── Idempotency sidecar — <project>/_BIM_COORD/acc/pushed_lifecycle_gaps.json ──
+
+        private static string SidecarPath(Document doc)
+        {
+            string accDir = StingPaths.Meta(doc, "_BIM_COORD", "acc");
+            if (string.IsNullOrEmpty(accDir)) return null;   // unsaved project - no sidecar
+            try { Directory.CreateDirectory(accDir); } catch (Exception ex) { StingLog.Warn("KUT_PushGapsToAcc sidecar dir: " + ex.Message); }
+            return Path.Combine(accDir, "pushed_lifecycle_gaps.json");
+        }
+
+        private static Dictionary<string, string> LoadSidecar(string path)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            try
+            {
+                if (string.IsNullOrEmpty(path) || !File.Exists(path)) return map;
+                var jo = JObject.Parse(File.ReadAllText(path));
+                foreach (var p in jo.Properties()) map[p.Name] = (string)p.Value;
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_PushGapsToAcc sidecar load: " + ex.Message); }
+            return map;
+        }
+
+        private static void SaveSidecar(string path, Dictionary<string, string> map)
+        {
+            if (string.IsNullOrEmpty(path)) return;
+            try
+            {
+                var jo = new JObject();
+                foreach (var kv in map) jo[kv.Key] = kv.Value;
+                File.WriteAllText(path, jo.ToString(Newtonsoft.Json.Formatting.Indented));
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_PushGapsToAcc sidecar save: " + ex.Message); }
+        }
+    }
+}

--- a/StingTools/Commands/Twin/KutValuationFromBmsCommand.cs
+++ b/StingTools/Commands/Twin/KutValuationFromBmsCommand.cs
@@ -1,0 +1,136 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  KutValuationFromBmsCommand.cs — Phase H3 (KUT lifecycle, max automation).
+//
+//  KUT_ValuationFromBms (read-only). Joins the priced, monitorable BOQ scope to
+//  the live Niagara station: an asset whose BMS point is online + reporting a
+//  value is installed and communicating, hence certifiable as commissioned. The
+//  result is a commissioning-valuation % over the monitorable scope — the 5D
+//  signal that feeds the Phase 191 PaymentCert engine.
+//
+//  NETWORK CODE — needs a reachable Niagara station configured at
+//  <project>/_BIM_COORD/niagara_connection.json. Not exercised in the dev sandbox
+//  (no station); built clean against the documented APIs. Verify live before use.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.BOQ;
+using StingTools.Core;
+using StingTools.Core.Twin;
+
+namespace StingTools.Commands.Twin
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    public class KutValuationFromBmsCommand : IExternalCommand
+    {
+        // Same monitorable scope as the lifecycle reconcile (PRICED_NO_BMS_POINT).
+        private static readonly HashSet<string> Monitorable = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Mechanical Equipment", "Electrical Equipment", "Lighting Fixtures", "Lighting Devices",
+            "Air Terminals", "Duct Accessory", "Plumbing Fixtures", "Fire Alarm Devices",
+            "Security Devices", "Communication Devices", "Data Devices", "Nurse Call Devices", "Sprinklers"
+        };
+
+        public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
+        {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            if (ctx?.Doc == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+            Document doc = ctx.Doc;
+
+            var conn = NiagaraConnection.Load(
+                StingPaths.MetaFile(doc, "_BIM_COORD", "niagara_connection.json"));
+
+            // Unified source: live read when reachable (persists a snapshot),
+            // last good cached read when the station is down.
+            var snap = CommissioningSource.Resolve(
+                StingPaths.MetaFile(doc, "_BIM_COORD", "twin", "last_station_points.json"), conn);
+            if (snap.Source == CommissioningSourceKind.None || snap.Points.Count == 0)
+            {
+                if (conn == null || string.IsNullOrEmpty(conn.BaseUrl))
+                    TaskDialog.Show("BMS valuation",
+                        "No Niagara station configured and no cached snapshot.\n\nCreate " +
+                        "<project>/_BIM_COORD/niagara_connection.json with { \"baseUrl\": \"http://station:port\", " +
+                        "\"pointsPath\": \"/obix/...\" } (and apiKey or username/password). This file is gitignored — " +
+                        "never commit station credentials. Run once while the station is reachable to cache a snapshot.");
+                else
+                    TaskDialog.Show("BMS valuation",
+                        "Could not read live points from the Niagara station and no cached snapshot exists " +
+                        "(see StingTools.log). Check the URL / credentials / network and retry.");
+                return Result.Failed;
+            }
+            var points = snap.Points;
+
+            BOQDocument boq;
+            try { boq = BOQCostManager.BuildBOQDocument(doc); }
+            catch (Exception ex) { StingLog.Error("KUT_ValuationFromBms BOQ", ex); TaskDialog.Show("BMS valuation", "Could not build the BOQ:\n" + ex.Message); return Result.Failed; }
+            if (boq == null) { TaskDialog.Show("BMS valuation", "No BOQ document."); return Result.Succeeded; }
+
+            var devByElem = new Dictionary<long, IoTDeviceRef>();
+            try
+            {
+                foreach (var d in new IoTDeviceRegistry(doc).All())
+                    if (d?.BimElementId != null) devByElem[d.BimElementId.Value] = d;
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_ValuationFromBms devices: " + ex.Message); }
+
+            var assets = new List<BmsAsset>();
+            foreach (var it in boq.AllItems)
+            {
+                if (it == null || it.RevitElementId < 0 || it.TotalUGX <= 0) continue;
+                if (it.FfeOwnerProcured) continue;                         // owner-procured, not contractor commissioning
+                string cat = it.Category ?? "";
+                if (!Monitorable.Contains(cat)) continue;
+
+                devByElem.TryGetValue(it.RevitElementId, out var dev);
+                string devId = dev?.DeviceId ?? "";
+                bool commissioned = false;
+                string status = "";
+                if (!string.IsNullOrEmpty(devId) && points.TryGetValue(devId, out var pt))
+                {
+                    status = pt.Status;
+                    commissioned = BmsValuation.IsCommissioned(pt.Status, pt.HasValue);
+                }
+                assets.Add(new BmsAsset
+                {
+                    Tag = it.ItemName ?? "",
+                    DeviceId = devId,
+                    ValueUGX = it.TotalUGX,
+                    Commissioned = commissioned,
+                    Status = status
+                });
+            }
+
+            var r = BmsValuation.Compute(assets);
+
+            // CSV artefact.
+            string csvPath = "";
+            try
+            {
+                csvPath = OutputLocationHelper.GetOutputPath(doc, "STING_BMS_Valuation.csv");
+                var sb = new StringBuilder();
+                sb.AppendLine($"# BMS source: {snap.Detail}");
+                sb.AppendLine("Tag,DeviceId,AmountUGX,LiveStatus,Commissioned");
+                foreach (var a in assets.OrderByDescending(a => a.ValueUGX))
+                    sb.AppendLine($"\"{a.Tag.Replace("\"", "'")}\",{a.DeviceId},{a.ValueUGX:0},{a.Status},{(a.Commissioned ? "yes" : "no")}");
+                File.WriteAllText(csvPath, sb.ToString(), Encoding.UTF8);
+            }
+            catch (Exception ex) { StingLog.Warn("KUT_ValuationFromBms CSV: " + ex.Message); }
+
+            string body =
+                $"BMS source: {snap.Detail}\n\n" +
+                $"Monitorable priced scope: {r.MonitorableCount} assets, UGX {r.MonitorableValueUGX:N0}\n" +
+                $"Live on BMS (commissioned): {r.CommissionedCount} assets, UGX {r.CommissionedValueUGX:N0}\n" +
+                $"No BMS point yet: {r.NoPointCount} assets\n\n" +
+                $"Commissioning valuation: {r.CommissionedValueFraction:P1} of monitorable value.\n\n" +
+                "Feed this % to PayCert_Create for the monitorable scope. " +
+                (string.IsNullOrEmpty(csvPath) ? "" : "Per-asset CSV:\n" + csvPath);
+            TaskDialog.Show("BMS commissioning valuation", body);
+            return Result.Succeeded;
+        }
+    }
+}

--- a/StingTools/Core/ParamRegistry.cs
+++ b/StingTools/Core/ParamRegistry.cs
@@ -216,6 +216,13 @@ namespace StingTools.Core
         /// UUIDv5 in namespace a7c0b2e4-4d91-4a55-9c7e-7f6e5d4c3b2a.</summary>
         public const string FOHLIO_REF = "FOHLIO_REF_TXT";
         public const string FOHLIO_REF_GUID = "0ecf2056-1239-52bc-87f8-17c281e67209";
+        /// <summary>Fohlio procurement unit cost + quote currency, pulled into the BOQ
+        /// by FohlioRateProvider. UUIDv5 in namespace
+        /// a7c0b2e4-4d91-4a55-9c7e-7f6e5d4c3b2a.</summary>
+        public const string FOHLIO_UNIT_COST = "FOHLIO_UNIT_COST_NR";
+        public const string FOHLIO_UNIT_COST_GUID = "b6e507ab-bab5-5b7f-aecd-ca78bd14f4c5";
+        public const string FOHLIO_CURRENCY = "FOHLIO_CURRENCY_TXT";
+        public const string FOHLIO_CURRENCY_GUID = "f369abea-4433-541c-a409-128ec9c1675e";
         /// <summary>Phase 195 — EDGE/LEED Sustainability shared params (group 35
         /// SUS_SUSTAINABILITY). SUS_*_NR intensities are project-scoped; SUS_EDGE_LEVEL_TXT
         /// is project-scoped; SUS_EPD_REF_TXT binds to materials/types.</summary>

--- a/StingTools/Core/ParameterHelpers.cs
+++ b/StingTools/Core/ParameterHelpers.cs
@@ -541,6 +541,30 @@ namespace StingTools.Core
         /// Also writes the formatted string to the corresponding _TXT mirror param when bound.
         /// </summary>
         /// <param name="displayFormat">Format string for the _TXT mirror value. Defaults to "G".</param>
+        /// <summary>Read a numeric parameter as a double, with a fallback. Handles Double,
+        /// Integer and String storage; a String is parsed culture-invariantly, because a
+        /// value that round-tripped through a text mirror must not read differently on a
+        /// machine with a comma decimal separator.</summary>
+        public static double GetDouble(Element el, string paramName, double defaultValue = 0)
+        {
+            try
+            {
+                var p = el?.LookupParameter(paramName);
+                if (p == null || !p.HasValue) return defaultValue;
+                switch (p.StorageType)
+                {
+                    case StorageType.Double: return p.AsDouble();
+                    case StorageType.Integer: return p.AsInteger();
+                    case StorageType.String:
+                        string s = p.AsString();
+                        return double.TryParse(s, System.Globalization.NumberStyles.Any,
+                            System.Globalization.CultureInfo.InvariantCulture, out double v) ? v : defaultValue;
+                    default: return defaultValue;
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"GetDouble({paramName}): {ex.Message}"); return defaultValue; }
+        }
+
         public static bool SetDouble(Element el, string paramName, double value,
             bool overwrite = false, string displayFormat = null)
         {

--- a/StingTools/Core/Storage/StingFohlioSnapshotSchema.cs
+++ b/StingTools/Core/Storage/StingFohlioSnapshotSchema.cs
@@ -14,23 +14,35 @@ namespace StingTools.Core.Storage
 {
     public static class StingFohlioSnapshotSchema
     {
+        // v1 (Phase 192 C1) — FohlioRef + SnapshotJson + CapturedUtcTicks.
         public static readonly Guid SchemaGuid =
             new Guid("E1A7B2C4-1011-1245-8411-F6E5D4C3B2CD");
+        // v2 (Phase C — KUT lifecycle) — adds the procurement cost fields the
+        // FohlioRateProvider pulls into the BOQ. A new GUID is required because
+        // ExtensibleStorage schemas are immutable once registered in a document;
+        // Read falls back to v1 for elements snapshotted before this phase.
+        public static readonly Guid SchemaGuidV2 =
+            new Guid("E1A7B2C4-1011-1246-8411-F6E5D4C3B2CD");
 
         private const string SchemaName        = "StingFohlioSnapshotSchema";
+        private const string SchemaNameV2      = "StingFohlioSnapshotSchemaV2";
         private const string FieldFohlioRef    = "FohlioRef";
         private const string FieldSnapshotJson = "SnapshotJson";
         private const string FieldCapturedTicks= "CapturedUtcTicks";
+        private const string FieldUnitCost     = "UnitCost";
+        private const string FieldCurrency     = "Currency";
+        private const string FieldQtyFromFohlio= "QtyFromFohlio";
+        private const string FieldLeadTimeDays = "LeadTimeDays";
 
-        public static Schema GetOrCreate()
+        private static Schema GetOrCreateV2()
         {
             try
             {
-                var existing = Schema.Lookup(SchemaGuid);
+                var existing = Schema.Lookup(SchemaGuidV2);
                 if (existing != null) return existing;
 
-                var sb = new SchemaBuilder(SchemaGuid);
-                sb.SetSchemaName(SchemaName);
+                var sb = new SchemaBuilder(SchemaGuidV2);
+                sb.SetSchemaName(SchemaNameV2);
                 sb.SetVendorId(StingSchemaBuilder.VendorId);
                 sb.SetReadAccessLevel(AccessLevel.Public);
                 sb.SetWriteAccessLevel(AccessLevel.Vendor);
@@ -40,11 +52,19 @@ namespace StingTools.Core.Storage
                     .SetDocumentation("JSON of imported field→value pairs at the last Fohlio import");
                 sb.AddSimpleField(FieldCapturedTicks, typeof(long))
                     .SetDocumentation("DateTime.UtcNow.Ticks of the last Fohlio import. 0 = never");
+                sb.AddSimpleField(FieldUnitCost, typeof(double))
+                    .SetDocumentation("Fohlio procurement unit cost in the quote currency");
+                sb.AddSimpleField(FieldCurrency, typeof(string))
+                    .SetDocumentation("Fohlio quote currency (ISO 4217)");
+                sb.AddSimpleField(FieldQtyFromFohlio, typeof(double))
+                    .SetDocumentation("Quantity Fohlio holds for this item (for variance, not bill qty)");
+                sb.AddSimpleField(FieldLeadTimeDays, typeof(int))
+                    .SetDocumentation("Procurement lead time in days, from Fohlio");
                 return sb.Finish();
             }
             catch (Exception ex)
             {
-                StingLog.Warn($"StingFohlioSnapshotSchema.GetOrCreate: {ex.Message}");
+                StingLog.Warn($"StingFohlioSnapshotSchema.GetOrCreateV2: {ex.Message}");
                 return null;
             }
         }
@@ -54,6 +74,10 @@ namespace StingTools.Core.Storage
             public string FohlioRef = "";
             public string SnapshotJson = "";
             public long CapturedUtcTicks;
+            public double UnitCost;          // Phase C — 0 when never costed
+            public string Currency = "";
+            public double QtyFromFohlio;
+            public int LeadTimeDays;
 
             public DateTime? CapturedUtc =>
                 CapturedUtcTicks > 0 ? (DateTime?)new DateTime(CapturedUtcTicks, DateTimeKind.Utc) : null;
@@ -64,6 +88,24 @@ namespace StingTools.Core.Storage
             if (el == null) return null;
             try
             {
+                // Prefer the v2 (cost-bearing) entity, fall back to v1.
+                var schemaV2 = Schema.Lookup(SchemaGuidV2);
+                if (schemaV2 != null)
+                {
+                    var e2 = el.GetEntity(schemaV2);
+                    if (e2 != null && e2.IsValid())
+                        return new SnapshotData
+                        {
+                            FohlioRef = e2.Get<string>(FieldFohlioRef) ?? "",
+                            SnapshotJson = e2.Get<string>(FieldSnapshotJson) ?? "",
+                            CapturedUtcTicks = e2.Get<long>(FieldCapturedTicks),
+                            UnitCost = e2.Get<double>(FieldUnitCost),
+                            Currency = e2.Get<string>(FieldCurrency) ?? "",
+                            QtyFromFohlio = e2.Get<double>(FieldQtyFromFohlio),
+                            LeadTimeDays = e2.Get<int>(FieldLeadTimeDays),
+                        };
+                }
+
                 var schema = Schema.Lookup(SchemaGuid);
                 if (schema == null) return null;
                 var entity = el.GetEntity(schema);
@@ -82,17 +124,24 @@ namespace StingTools.Core.Storage
             }
         }
 
-        public static bool Write(Element el, string fohlioRef, string snapshotJson, DateTime capturedUtc)
+        /// <summary>Write the snapshot. The optional cost fields default to 0/empty,
+        /// so the existing Fohlio_Import callers stay source-compatible.</summary>
+        public static bool Write(Element el, string fohlioRef, string snapshotJson, DateTime capturedUtc,
+            double unitCost = 0, string currency = "", double qtyFromFohlio = 0, int leadTimeDays = 0)
         {
             if (el == null) return false;
             try
             {
-                var schema = GetOrCreate();
+                var schema = GetOrCreateV2();
                 if (schema == null) return false;
                 var entity = new Entity(schema);
                 entity.Set(FieldFohlioRef, fohlioRef ?? "");
                 entity.Set(FieldSnapshotJson, snapshotJson ?? "");
                 entity.Set(FieldCapturedTicks, capturedUtc.ToUniversalTime().Ticks);
+                entity.Set(FieldUnitCost, unitCost);
+                entity.Set(FieldCurrency, currency ?? "");
+                entity.Set(FieldQtyFromFohlio, qtyFromFohlio);
+                entity.Set(FieldLeadTimeDays, leadTimeDays);
                 el.SetEntity(entity);
                 return true;
             }

--- a/StingTools/Core/Twin/BmsValuation.cs
+++ b/StingTools/Core/Twin/BmsValuation.cs
@@ -1,0 +1,84 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  BmsValuation.cs — Phase H3 (KUT lifecycle, max automation).
+//
+//  Pure, host-free roll-up of "what fraction of the priced, monitorable BOQ is
+//  live on the BMS and therefore certifiable as commissioned" — the 5D valuation
+//  signal that feeds the Phase 191 PaymentCert engine. A monitorable asset whose
+//  Niagara point is online + reporting a present value is installed and
+//  communicating, i.e. it has earned its certificate.
+//
+//  Zero Autodesk.Revit.* / network dependencies on purpose (unit-tested in
+//  StingTools.Boq.Tests). The command (KutValuationFromBmsCommand) walks the model
+//  + queries the live station; this class only does the arithmetic + the
+//  point-status → commissioned decision.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Twin
+{
+    public sealed class BmsAsset
+    {
+        public string Tag = "";
+        public string DeviceId = "";
+        public double ValueUGX;
+        public bool Commissioned;   // resolved from the live point status
+        public string Status = "";  // raw Niagara status (ok / fault / down / stale / disabled / …)
+    }
+
+    public sealed class BmsValuationResult
+    {
+        public int MonitorableCount;
+        public double MonitorableValueUGX;
+        public int CommissionedCount;
+        public double CommissionedValueUGX;
+        public int NoPointCount;          // priced + monitorable but no BMS device id
+
+        /// <summary>Commissioned share of the monitorable priced value (0..1) — the
+        /// valuation percentage offered to the PaymentCert engine for the
+        /// monitorable scope.</summary>
+        public double CommissionedValueFraction =>
+            MonitorableValueUGX > 0 ? CommissionedValueUGX / MonitorableValueUGX : 0.0;
+    }
+
+    public static class BmsValuation
+    {
+        // Niagara / oBIX fault-status strings that mean "the point is in service":
+        // an empty status object {} is the Baja convention for OK.
+        private static readonly HashSet<string> LiveStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        { "ok", "", "{ok}", "normal", "online", "active", "inservice", "in service", "good" };
+
+        /// <summary>A point is commissioned when its status is in-service AND it is
+        /// reporting a present value (a configured-but-dead point reports a status but
+        /// no value). Conservative: anything fault/down/stale/disabled/null ⇒ false.</summary>
+        public static bool IsCommissioned(string status, bool hasPresentValue)
+        {
+            string s = (status ?? "").Trim();
+            // Strip Baja decoration like "{ok}" / "{fault}" → "ok"/"fault".
+            if (s.StartsWith("{") && s.EndsWith("}") && s.Length >= 2) s = s.Substring(1, s.Length - 2);
+            return hasPresentValue && LiveStatuses.Contains(s);
+        }
+
+        /// <summary>Roll up a set of priced-monitorable assets. <paramref name="assets"/>
+        /// is every priced monitorable BOQ line; assets with no DeviceId count toward
+        /// NoPoint (not commissioned).</summary>
+        public static BmsValuationResult Compute(IEnumerable<BmsAsset> assets)
+        {
+            var r = new BmsValuationResult();
+            foreach (var a in assets ?? Enumerable.Empty<BmsAsset>())
+            {
+                if (a == null) continue;
+                r.MonitorableCount++;
+                r.MonitorableValueUGX += a.ValueUGX;
+                if (string.IsNullOrWhiteSpace(a.DeviceId)) { r.NoPointCount++; continue; }
+                if (a.Commissioned)
+                {
+                    r.CommissionedCount++;
+                    r.CommissionedValueUGX += a.ValueUGX;
+                }
+            }
+            return r;
+        }
+    }
+}

--- a/StingTools/Core/Twin/CommissioningSource.cs
+++ b/StingTools/Core/Twin/CommissioningSource.cs
@@ -1,0 +1,141 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  CommissioningSource.cs — Phase 195 (KUT lifecycle, max automation).
+//
+//  Single source of truth for "what does the BMS say is live?". Every consumer
+//  of Niagara commissioning data (KUT_ValuationFromBms, the lifecycle reconcile,
+//  any future PayCert auto-feed) goes through Resolve() instead of calling
+//  NiagaraJsonClient.FetchPoints directly, so they all share one behaviour:
+//
+//    1. Station reachable  → fetch live points, PERSIST a snapshot to
+//       <project>/_BIM_COORD/twin/last_station_points.json (with capturedUtc),
+//       return Source=Live.
+//    2. Station down / no connection but a snapshot exists → return the CACHED
+//       points + their capturedUtc, Source=Cached. A valuation can still run
+//       off the last good read (with the staleness surfaced to the user).
+//    3. Neither → Source=None.
+//
+//  HOST-FREE — no Autodesk.Revit references, and it builds no project paths: the
+//  caller resolves the snapshot file through StingPaths and hands it in. That keeps
+//  the network/file behaviour decoupled from the command shell.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using StingTools.Core;
+
+namespace StingTools.Core.Twin
+{
+    public enum CommissioningSourceKind { None, Live, Cached }
+
+    /// <summary>The points the valuation should use, plus their provenance.</summary>
+    public sealed class CommissioningSnapshot
+    {
+        public Dictionary<string, NiagaraPoint> Points = new Dictionary<string, NiagaraPoint>(StringComparer.OrdinalIgnoreCase);
+        public CommissioningSourceKind Source = CommissioningSourceKind.None;
+        public DateTime AsOfUtc;
+
+        /// <summary>One-line provenance for the report + CSV header, e.g.
+        /// "live (captured 2026-06-21 14:33Z)" or "CACHED 2026-06-20 09:12Z (station unreachable)".</summary>
+        public string Detail
+        {
+            get
+            {
+                switch (Source)
+                {
+                    case CommissioningSourceKind.Live:
+                        return $"live (captured {AsOfUtc:yyyy-MM-dd HH:mm}Z)";
+                    case CommissioningSourceKind.Cached:
+                        return $"CACHED {AsOfUtc:yyyy-MM-dd HH:mm}Z (station unreachable — last good read)";
+                    default:
+                        return "no BMS data";
+                }
+            }
+        }
+    }
+
+    public static class CommissioningSource
+    {
+        /// <summary>
+        /// Resolve the commissioning points: live first, cached on live failure.
+        /// <paramref name="snapshotPath"/> is the ALREADY-RESOLVED cache file path (the
+        /// caller holds the Document and asks StingPaths); it may be null, in which case
+        /// nothing is persisted and only a live read can succeed.
+        /// <paramref name="conn"/> may be null, in which case only the cache is consulted.
+        /// </summary>
+        public static CommissioningSnapshot Resolve(string snapshotPath, NiagaraConnection conn)
+        {
+            // 1. Try live.
+            if (conn != null && !string.IsNullOrEmpty(conn.BaseUrl))
+            {
+                var live = NiagaraJsonClient.FetchPoints(conn);
+                if (live != null)
+                {
+                    var now = DateTime.UtcNow;
+                    Persist(snapshotPath, live, now);
+                    return new CommissioningSnapshot { Points = live, Source = CommissioningSourceKind.Live, AsOfUtc = now };
+                }
+                StingLog.Warn("CommissioningSource: live fetch failed — falling back to cached snapshot.");
+            }
+
+            // 2. Fall back to the persisted snapshot.
+            var cached = LoadCache(snapshotPath);
+            if (cached != null) return cached;
+
+            // 3. Nothing.
+            return new CommissioningSnapshot { Source = CommissioningSourceKind.None };
+        }
+
+        // ── snapshot persistence (host-free, never throws into the caller) ──
+
+        private sealed class Wire
+        {
+            [JsonProperty("capturedUtc")] public DateTime CapturedUtc { get; set; }
+            [JsonProperty("points")] public Dictionary<string, WirePoint> Points { get; set; }
+                = new Dictionary<string, WirePoint>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private sealed class WirePoint
+        {
+            [JsonProperty("status")] public string Status { get; set; } = "";
+            [JsonProperty("hasValue")] public bool HasValue { get; set; }
+        }
+
+        private static void Persist(string path, Dictionary<string, NiagaraPoint> pts, DateTime capturedUtc)
+        {
+            if (string.IsNullOrEmpty(path) || pts == null) return;
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                var wire = new Wire { CapturedUtc = capturedUtc };
+                foreach (var kv in pts)
+                    wire.Points[kv.Key] = new WirePoint { Status = kv.Value?.Status ?? "", HasValue = kv.Value?.HasValue ?? false };
+                File.WriteAllText(path, JsonConvert.SerializeObject(wire, Formatting.Indented));
+            }
+            catch (Exception ex) { StingLog.Warn($"CommissioningSource persist: {ex.Message}"); }
+        }
+
+        private static CommissioningSnapshot LoadCache(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+            try
+            {
+                if (!File.Exists(path)) return null;
+                var wire = JsonConvert.DeserializeObject<Wire>(File.ReadAllText(path));
+                if (wire?.Points == null || wire.Points.Count == 0) return null;
+
+                var pts = new Dictionary<string, NiagaraPoint>(StringComparer.OrdinalIgnoreCase);
+                foreach (var kv in wire.Points)
+                    pts[kv.Key] = new NiagaraPoint { Status = kv.Value?.Status ?? "", HasValue = kv.Value?.HasValue ?? false };
+
+                return new CommissioningSnapshot
+                {
+                    Points = pts,
+                    Source = CommissioningSourceKind.Cached,
+                    AsOfUtc = wire.CapturedUtc
+                };
+            }
+            catch (Exception ex) { StingLog.Warn($"CommissioningSource load cache: {ex.Message}"); return null; }
+        }
+    }
+}

--- a/StingTools/Core/Twin/NiagaraJsonClient.cs
+++ b/StingTools/Core/Twin/NiagaraJsonClient.cs
@@ -1,0 +1,133 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  NiagaraJsonClient.cs — Phase H3 (KUT lifecycle, max automation).
+//
+//  Minimal read-only HTTP client for a Tridium Niagara station's JSON Toolkit /
+//  oBIX export. GETs a points feed and returns deviceId → (status, hasValue) so
+//  KutValuationFromBmsCommand can decide which priced, monitorable assets are live
+//  on the BMS (= commissioned). Read-only — never writes to the station.
+//
+//  Connection config (gitignored, never committed), resolved by the CALLER through
+//  StingPaths so this class builds no project paths:
+//    <project>/_BIM_COORD/niagara_connection.json
+//    { "baseUrl": "http://station:8080", "pointsPath": "/obix/.../points",
+//      "apiKey": "…" | "username":"…","password":"…" }
+//
+//  NETWORK CODE — not exercised in the dev sandbox (no live station). Built clean
+//  against the documented HttpClient API; verify against a real Niagara station
+//  before production use.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+
+namespace StingTools.Core.Twin
+{
+    public sealed class NiagaraConnection
+    {
+        public string BaseUrl = "";
+        public string PointsPath = "/obix";   // station-specific points feed
+        public string ApiKey = "";
+        public string Username = "";
+        public string Password = "";
+
+        /// <summary>Read the station connection from an ALREADY-RESOLVED path. The caller
+        /// holds the Document and resolves through StingPaths; this class stays host-free
+        /// and builds no project paths of its own.</summary>
+        public static NiagaraConnection Load(string configPath)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(configPath) || !File.Exists(configPath)) return null;
+                var o = JObject.Parse(File.ReadAllText(configPath));
+                return new NiagaraConnection
+                {
+                    BaseUrl = ((string)o["baseUrl"] ?? "").TrimEnd('/'),
+                    PointsPath = (string)o["pointsPath"] ?? "/obix",
+                    ApiKey = (string)o["apiKey"] ?? "",
+                    Username = (string)o["username"] ?? "",
+                    Password = (string)o["password"] ?? "",
+                };
+            }
+            catch (Exception ex) { StingLog.Warn($"Niagara connection load: {ex.Message}"); return null; }
+        }
+    }
+
+    public sealed class NiagaraPoint { public string Status = ""; public bool HasValue; }
+
+    public static class NiagaraJsonClient
+    {
+        private static readonly HttpClient Http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+
+        /// <summary>Pure parse of a Niagara/oBIX points-feed JSON into deviceId →
+        /// point. Tolerant of the common shapes: a bare array, { points:[…] }, or a
+        /// dict keyed by id. Each point carries id/name/deviceId + status +
+        /// present_value/out/value. Host-free so it is unit-testable.</summary>
+        public static Dictionary<string, NiagaraPoint> ParsePoints(string json)
+        {
+            var d = new Dictionary<string, NiagaraPoint>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(json)) return d;
+            try
+            {
+                var tok = JToken.Parse(json);
+                JArray arr = tok as JArray ?? (tok as JObject)?["points"] as JArray;
+                if (arr != null) { foreach (var t in arr) AddPoint(d, t as JObject); }
+                else if (tok is JObject obj)
+                    foreach (var pr in obj.Properties()) AddPoint(d, pr.Value as JObject, pr.Name);
+            }
+            catch (Exception ex) { StingLog.Warn($"Niagara parse: {ex.Message}"); }
+            return d;
+        }
+
+        private static void AddPoint(Dictionary<string, NiagaraPoint> d, JObject o, string keyFallback = null)
+        {
+            if (o == null) return;
+            string id = ((string)o["deviceId"] ?? (string)o["id"] ?? (string)o["name"] ?? keyFallback ?? "").Trim();
+            if (id.Length == 0) return;
+            var val = o["present_value"] ?? o["presentValue"] ?? o["out"] ?? o["value"] ?? o["val"];
+            // Type-safe presence test — never (string)-cast a JArray (throws). oBIX
+            // <real val="…"/> arrives as an object with a "val" child; primitives arrive
+            // as JValue; an absent/null value means a configured-but-dead point.
+            bool hasVal;
+            if (val == null || val.Type == JTokenType.Null) hasVal = false;
+            else if (val.Type == JTokenType.Object) { var inner = val["val"]; hasVal = inner != null && inner.Type != JTokenType.Null && !string.IsNullOrWhiteSpace(inner.ToString()); }
+            else hasVal = !string.IsNullOrWhiteSpace(val.ToString());
+            d[id] = new NiagaraPoint { Status = (string)o["status"] ?? "", HasValue = hasVal };
+        }
+
+        /// <summary>GET the station points feed (read-only). Returns null on any
+        /// transport failure (logged) so the caller falls back to "no live data".</summary>
+        public static Dictionary<string, NiagaraPoint> FetchPoints(NiagaraConnection c)
+        {
+            if (c == null || string.IsNullOrEmpty(c.BaseUrl)) return null;
+            try
+            {
+                string url = c.BaseUrl + (c.PointsPath.StartsWith("/") ? c.PointsPath : "/" + c.PointsPath);
+                using (var req = new HttpRequestMessage(HttpMethod.Get, url))
+                {
+                    req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    if (!string.IsNullOrEmpty(c.ApiKey))
+                        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", c.ApiKey);
+                    else if (!string.IsNullOrEmpty(c.Username))
+                    {
+                        string basic = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{c.Username}:{c.Password}"));
+                        req.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
+                    }
+                    var resp = Http.SendAsync(req).GetAwaiter().GetResult();
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        StingLog.Warn($"Niagara fetch HTTP {(int)resp.StatusCode}");
+                        return null;
+                    }
+                    string body = resp.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    return ParsePoints(body);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"Niagara fetch: {ex.Message}"); return null; }
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -348,6 +348,7 @@ namespace StingTools.Core
             "Fohlio_ExportFinishes", "Fohlio_ImportFinishes", "DeviceCoord_Audit", "ComCheck_Export",
             "Hvac_LifeCycleCompare", "PrototypeDrift_Report",
             "Niagara_ExportPoints", "Niagara_Reconcile", "Owner_KpiDashboard", "KUT_KpiDashboard",
+            "KUT_ValuationFromBms", "KUT_LifecycleReconcile", "KUT_PushLifecycleGapsToAcc",
             "ACC_PullClashes", "ACC_SyncIssueStatus", "AccPullClashes", "AccSyncIssueStatus",
             "Lite_ComCheck",
             "ReviewComments_Import", "ReviewComments_Dashboard", "ReviewComments_Export", "ValidateTemplate",
@@ -1602,6 +1603,9 @@ namespace StingTools.Core
                 case "Fohlio_ImportFinishes": return new ExLink.FohlioImportFinishesCommand();
                 case "Niagara_ExportPoints": return new Commands.Twin.NiagaraPointListExportCommand();
                 case "Niagara_Reconcile":    return new Commands.Twin.NiagaraReconcileCommand();
+                case "KUT_ValuationFromBms":       return new Commands.Twin.KutValuationFromBmsCommand();
+                case "KUT_LifecycleReconcile":     return new Commands.Twin.KutLifecycleReconcileCommand();
+                case "KUT_PushLifecycleGapsToAcc": return new Commands.Twin.KutPushLifecycleGapsToAccCommand();
                 case "DeviceCoord_Audit": return new Commands.Validation.DeviceCoordinationCommand();
                 // "Lite_ComCheck" is the Electrical panel's button tag for this same
                 // command. A user writing a project-local preset reasonably copies the

--- a/StingTools/Data/WORKFLOW_KUT_LifecycleReconcile.json
+++ b/StingTools/Data/WORKFLOW_KUT_LifecycleReconcile.json
@@ -1,0 +1,19 @@
+{
+  "name": "KUT Lifecycle Reconcile",
+  "description": "Kampala Uganda Temple — the end-to-end lifecycle reconcile that joins the four systems keyed off the same Revit element: SpecLink/CSI (specified) → BOQ (measured/priced) → Fohlio (procured) → Niagara (commissioned). Pulls the latest Fohlio FF&E procurement data in, assigns CSI sections, rebuilds the priced BOQ, reconciles spec ↔ cost gaps, exports + reconciles the BMS point list, joins all four ledgers into the unified asset register, and finishes on the KUT KPI dashboard which now headlines the cross-ledger join metrics. File-dependent steps (Fohlio export, SpecLink ToC, Niagara station export) are optional — Cancel skips that step without failing the run.",
+  "rollback_on_failure": false,
+  "rollback_on_optional_failure": false,
+  "steps": [
+    { "commandTag": "SpecLink_ImportFolder", "label": "1. Import the SpecLink project manual from _BIM_COORD/speclink/ (spec → bill)", "optional": true },
+    { "commandTag": "Fohlio_Import", "label": "2. Pull Fohlio FF&E procurement (ref + unit cost + currency)", "optional": true },
+    { "commandTag": "CSI_Assign", "label": "3. Assign CSI MasterFormat sections (specified)" },
+    { "commandTag": "BOQRefresh", "label": "4. Rebuild the priced BOQ from the live model (spec-sourced descriptions + PC sums)" },
+    { "commandTag": "SpecLink_Reconcile", "label": "5. Spec ↔ cost gaps (priced-unspecified / specified-unpriced)", "optional": true },
+    { "commandTag": "Niagara_ExportPoints", "label": "6. Export the Niagara BMS point list (controls submittal)" },
+    { "commandTag": "Niagara_Reconcile", "label": "7. Reconcile model BMS devices vs the station export", "optional": true },
+    { "commandTag": "KUT_ValuationFromBms", "label": "8. Live BMS read-back → commissioning valuation % (5D)", "optional": true },
+    { "commandTag": "KUT_LifecycleReconcile", "label": "9. Four-ledger join — unified asset register + commissioning gaps", "optional": true },
+    { "commandTag": "KUT_PushLifecycleGapsToAcc", "label": "10. Push priced-unspecified / priced-no-BMS gaps to ACC Issues (idempotent)", "optional": true },
+    { "commandTag": "Owner_KpiDashboard", "label": "11. Owner KPI dashboard — four-ledger join metrics (HTML + CSV)" }
+  ]
+}

--- a/StingTools/ExLink/FohlioCommands.cs
+++ b/StingTools/ExLink/FohlioCommands.cs
@@ -128,8 +128,19 @@ namespace StingTools.ExLink
             }
 
             var writeCols = map.Columns.Where(c => c.WriteBack && !FohlioMap.IsPseudo(c.Param)).ToList();
+
+            // Phase C (KUT lifecycle) — pull the procurement cost columns. The numeric
+            // unit cost is written via SetDouble (not the text-diff path), so exclude it
+            // from writeCols. Headers resolved by Param so the map controls the names.
+            string costHeader = map.Columns.FirstOrDefault(c => string.Equals(c.Param, ParamRegistry.FOHLIO_UNIT_COST, StringComparison.OrdinalIgnoreCase))?.Header;
+            string curHeader  = map.Columns.FirstOrDefault(c => string.Equals(c.Param, ParamRegistry.FOHLIO_CURRENCY, StringComparison.OrdinalIgnoreCase))?.Header;
+            string qtyHeader  = map.Columns.FirstOrDefault(c => string.Equals(c.Param, "$FohlioQty", StringComparison.OrdinalIgnoreCase))?.Header;
+            string leadHeader = map.Columns.FirstOrDefault(c => string.Equals(c.Param, "$FohlioLeadDays", StringComparison.OrdinalIgnoreCase))?.Header;
+            writeCols = writeCols.Where(c => !string.Equals(c.Param, ParamRegistry.FOHLIO_UNIT_COST, StringComparison.OrdinalIgnoreCase)).ToList();
+
             var changes = new List<ProposedChange>();
             var snapshots = new Dictionary<long, (string fref, Dictionary<string, string> snap)>();
+            var costData = new Dictionary<long, (double cost, string cur, double qty, int lead)>();
             int matched = 0, unmatched = 0;
 
             foreach (var row in rows)
@@ -150,38 +161,53 @@ namespace StingTools.ExLink
                 }
                 row.TryGetValue("Fohlio Ref", out string fref);
                 snapshots[el.Id.Value] = (snap.TryGetValue(ParamRegistry.FOHLIO_REF, out var fr) ? fr : (fref ?? ""), snap);
+
+                // Procurement cost (optional columns)
+                double cost = ParseNum(costHeader, row);
+                string cur = (curHeader != null && row.TryGetValue(curHeader, out string cv)) ? (cv ?? "").Trim() : "";
+                double qty = ParseNum(qtyHeader, row);
+                int lead = (int)ParseNum(leadHeader, row);
+                costData[el.Id.Value] = (cost, cur, qty, lead);
             }
 
-            if (changes.Count == 0)
+            bool anyCost = costData.Values.Any(c => c.cost > 0);
+            if (changes.Count == 0 && !anyCost)
             {
                 TaskDialog.Show("Fohlio Import",
-                    $"Matched {matched} row(s), {unmatched} unmatched. No field changes to write.");
+                    $"Matched {matched} row(s), {unmatched} unmatched. No field or cost changes to write.");
                 return Result.Succeeded;
             }
 
-            // Preview / diff before any write.
-            var preview = new StringBuilder();
-            preview.AppendLine($"Matched {matched} row(s) by Item Tag — {unmatched} unmatched.");
-            preview.AppendLine($"{changes.Count} field change(s) proposed across {changes.Select(c => c.El.Id.Value).Distinct().Count()} element(s).");
-            preview.AppendLine();
-            foreach (var c in changes.Take(15))
-                preview.AppendLine($"  {c.El.Id} {c.Header}: '{c.Old}' → '{c.New}'");
-            if (changes.Count > 15) preview.AppendLine($"  … +{changes.Count - 15} more");
-
-            var confirm = new TaskDialog("Fohlio Import — preview")
+            // Preview / diff before any write. Skipped when only cost (no text field
+            // changes) is being imported — cost is numeric, not a text diff.
+            bool overwrite = true;
+            if (changes.Count > 0)
             {
-                MainInstruction = "Review before writing to the model",
-                MainContent = preview.ToString(),
-                CommonButtons = TaskDialogCommonButtons.Cancel,
-                AllowCancellation = true
-            };
-            confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Apply — fill empty only", "Write only where the model value is currently blank");
-            confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Apply — overwrite", "Overwrite existing model values with the Fohlio values");
-            var choice = confirm.Show();
-            if (choice == TaskDialogResult.Cancel) return Result.Cancelled;
-            bool overwrite = choice == TaskDialogResult.CommandLink2;
+                var preview = new StringBuilder();
+                preview.AppendLine($"Matched {matched} row(s) by Item Tag — {unmatched} unmatched.");
+                preview.AppendLine($"{changes.Count} field change(s) proposed across {changes.Select(c => c.El.Id.Value).Distinct().Count()} element(s).");
+                if (anyCost) preview.AppendLine($"Procurement cost on {costData.Values.Count(c => c.cost > 0)} item(s) will also be written.");
+                preview.AppendLine();
+                foreach (var c in changes.Take(15))
+                    preview.AppendLine($"  {c.El.Id} {c.Header}: '{c.Old}' → '{c.New}'");
+                if (changes.Count > 15) preview.AppendLine($"  … +{changes.Count - 15} more");
 
-            int written = 0;
+                var confirm = new TaskDialog("Fohlio Import — preview")
+                {
+                    MainInstruction = "Review before writing to the model",
+                    MainContent = preview.ToString(),
+                    CommonButtons = TaskDialogCommonButtons.Cancel,
+                    AllowCancellation = true
+                };
+                confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink1, "Apply — fill empty only", "Write only where the model value is currently blank");
+                confirm.AddCommandLink(TaskDialogCommandLinkId.CommandLink2, "Apply — overwrite", "Overwrite existing model values with the Fohlio values");
+                var choice = confirm.Show();
+                if (choice == TaskDialogResult.Cancel) return Result.Cancelled;
+                overwrite = choice == TaskDialogResult.CommandLink2;
+            }
+
+            string fxDate = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            int written = 0, costWritten = 0;
             using (var t = new Transaction(doc, "STING Fohlio Import"))
             {
                 t.Start();
@@ -193,25 +219,52 @@ namespace StingTools.ExLink
                         : ParameterHelpers.SetIfEmpty(c.El, c.Param, c.New);
                     if (ok) written++;
                 }
-                // Snapshot every matched element (for the staleness audit), even those with no change.
+                // Procurement cost — numeric unit cost + quote currency + FX-fixing
+                // date (decision #3, auditable at tender). Always overwrite (a fresh
+                // Fohlio export is authoritative for the price).
+                foreach (var kv in costData)
+                {
+                    if (kv.Value.cost <= 0) continue;
+                    var el = doc.GetElement(new ElementId(kv.Key));
+                    if (el == null || !TagPipelineHelper.IsEditableInWorksharing(doc, el)) continue;
+                    if (ParameterHelpers.SetDouble(el, ParamRegistry.FOHLIO_UNIT_COST, kv.Value.cost, overwrite: true))
+                        costWritten++;
+                    if (!string.IsNullOrEmpty(kv.Value.cur))
+                        ParameterHelpers.SetString(el, ParamRegistry.FOHLIO_CURRENCY, kv.Value.cur, overwrite: true);
+                    ParameterHelpers.SetString(el, "ASS_CST_FX_DATE_DT", fxDate, overwrite: true);
+                }
+                // Snapshot every matched element (for the staleness + cost audit), even
+                // those with no change. Carries the cost fields for the rate fallback.
                 foreach (var kv in snapshots)
                 {
                     var el = doc.GetElement(new ElementId(kv.Key));
                     if (el == null) continue;
+                    costData.TryGetValue(kv.Key, out var cd);
                     StingFohlioSnapshotSchema.Write(el, kv.Value.fref,
-                        JsonConvert.SerializeObject(kv.Value.snap), DateTime.UtcNow);
+                        JsonConvert.SerializeObject(kv.Value.snap), DateTime.UtcNow,
+                        cd.cost, cd.cur, cd.qty, cd.lead);
                 }
                 t.Commit();
             }
 
             new TaskDialog("Fohlio Import")
             {
-                MainInstruction = $"Wrote {written} field value(s) ({(overwrite ? "overwrite" : "fill empty")})",
-                MainContent = $"Matched: {matched}\nUnmatched: {unmatched}\nSnapshots stored: {snapshots.Count}\n\n" +
-                              "FOHLIO_REF_TXT now links each item to Fohlio; the ES snapshot powers the currency audit."
+                MainInstruction = $"Wrote {written} field value(s) + {costWritten} cost(s)",
+                MainContent = $"Matched: {matched}\nUnmatched: {unmatched}\nSnapshots stored: {snapshots.Count}\n" +
+                              $"Procurement costs written: {costWritten}\n\n" +
+                              "FOHLIO_REF_TXT links each item to Fohlio; FOHLIO_UNIT_COST_NR feeds the BOQ " +
+                              "(FohlioRateProvider), and ASS_CST_FX_DATE_DT records the FX-fixing date."
             }.Show();
-            StingLog.Info($"Fohlio_Import: matched={matched} wrote={written} snapshots={snapshots.Count}");
+            StingLog.Info($"Fohlio_Import: matched={matched} wrote={written} costs={costWritten} snapshots={snapshots.Count}");
             return Result.Succeeded;
+        }
+
+        // Phase C — parse an optional numeric column from a row; 0 when absent/blank.
+        private static double ParseNum(string header, Dictionary<string, string> row)
+        {
+            if (header == null || !row.TryGetValue(header, out string s) || string.IsNullOrWhiteSpace(s)) return 0;
+            return double.TryParse(s.Trim(), System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out double v) ? v : 0;
         }
 
         private static List<Dictionary<string, string>> ReadRows(string path, FohlioMap map)

--- a/StingTools/ExLink/FohlioLink.cs
+++ b/StingTools/ExLink/FohlioLink.cs
@@ -53,6 +53,43 @@ namespace StingTools.ExLink
             new FohlioColumn { Header = "Fohlio Ref",    Param = "FOHLIO_REF_TXT",       WriteBack = true },
         };
 
+        // ---- FF&E BOQ treatment --------------------------------------------------
+        // How Fohlio FF&E is carried in the bill. An item is exactly ONE of these -
+        // never double-counted.
+        //   "ffe"                    DEFAULT - transparent Owner-procured FF&E category
+        //                            (NRM1 group 8 / ICMS): a visible model line, priced
+        //                            at cost from the Fohlio register, flagged so the
+        //                            spec gate does not chase a specification the
+        //                            contractor never writes
+        //   "measured"               contractor-supplied - a normal priced line
+        //   "ownerSupplied-excluded" out of this bill entirely (the element is skipped)
+        //   "pcSum"                  explicit contractual provisional / prime-cost sum
+        public string BoqTreatment { get; set; } = "ffe";
+        public Dictionary<string, string> BoqTreatmentByCategory { get; set; }
+
+        /// <summary>Canonical treatment for a category - delegates to the pure,
+        /// unit-tested <see cref="StingTools.BOQ.FfeTreatment"/>.</summary>
+        public string TreatmentFor(string category)
+            => StingTools.BOQ.FfeTreatment.Resolve(category, BoqTreatment, BoqTreatmentByCategory);
+
+        public bool IsFfeCategory(string category)
+        {
+            if (string.IsNullOrEmpty(category) || Categories == null) return false;
+            foreach (var c in Categories)
+                if (string.Equals(c, category, StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+
+        // Per-document cache: the BOQ build asks once per FF&E element, so the JSON must
+        // be read once per run. Cleared by Cost_ReloadRules alongside the rate registry.
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, FohlioMap> _cache
+            = new System.Collections.Concurrent.ConcurrentDictionary<string, FohlioMap>(StringComparer.OrdinalIgnoreCase);
+
+        public static FohlioMap Cached(Document doc)
+            => _cache.GetOrAdd(doc?.PathName ?? "default", _ => Load(doc));
+
+        public static void Invalidate() => _cache.Clear();
+
         public static FohlioMap Load(Document doc)
         {
             var map = new FohlioMap();

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -3814,6 +3814,9 @@ namespace StingTools.UI
                     case "Fohlio_ImportFinishes": RunCommand<ExLink.FohlioImportFinishesCommand>(app); break;
                     case "Niagara_ExportPoints": RunCommand<Commands.Twin.NiagaraPointListExportCommand>(app); break;
                     case "Niagara_Reconcile": RunCommand<Commands.Twin.NiagaraReconcileCommand>(app); break;
+                    case "KUT_ValuationFromBms": RunCommand<Commands.Twin.KutValuationFromBmsCommand>(app); break;
+                    case "KUT_LifecycleReconcile": RunCommand<Commands.Twin.KutLifecycleReconcileCommand>(app); break;
+                    case "KUT_PushLifecycleGapsToAcc": RunCommand<Commands.Twin.KutPushLifecycleGapsToAccCommand>(app); break;
                     // Owner_KpiDashboard is the name; KUT_KpiDashboard is kept as an
                     // alias so the existing button, WORKFLOW_KUT_MonthlyReport and any
                     // muscle memory keep working. The command derives its code from

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -3765,6 +3765,22 @@
                             </StackPanel>
                         </Border>
 
+                        <!-- LIFECYCLE JOIN (spec -> cost -> procurement -> commissioning) -->
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="LIFECYCLE JOIN"/>
+                        <Border Style="{StaticResource GroupBorder}" BorderBrush="#00897B">
+                            <StackPanel>
+                                <TextBlock Text="Joins the four ledgers keyed off the same element: SpecLink (specified) → BOQ (priced) → Fohlio (procured) → Niagara (commissioned)" FontSize="9" Foreground="#888" Margin="0,0,0,4"/>
+                                <WrapPanel>
+                                    <Button Style="{StaticResource BlueBtn}" Content="Lifecycle Reconcile" Tag="KUT_LifecycleReconcile" Click="Cmd_Click"
+                                            ToolTip="Read-only four-ledger join into one asset register (XLSX), surfacing the two gaps a single-ledger reconcile cannot see: priced assets with no BMS point, and station points with no priced line"/>
+                                    <Button Style="{StaticResource BlueBtn}" Content="BMS Valuation" Tag="KUT_ValuationFromBms" Click="Cmd_Click"
+                                            ToolTip="Read the Niagara station and report what share of the priced monitorable scope is live and therefore certifiable as commissioned. Falls back to the last cached read when the station is down, and says so"/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="Push Gaps to ACC" Tag="KUT_PushLifecycleGapsToAcc" Click="Cmd_Click"
+                                            ToolTip="Push the model-derivable lifecycle gaps (priced-unspecified, priced-no-BMS-point) to ACC Issues. Idempotent — re-runs skip anything already pushed"/>
+                                </WrapPanel>
+                            </StackPanel>
+                        </Border>
+
                         <!-- FOHLIO FF&amp;E (Phase 192 C1) -->
                         <TextBlock Style="{StaticResource SectionLabel}" Text="FOHLIO FF&amp;E"/>
                         <Border Style="{StaticResource GroupBorder}" BorderBrush="#00897B">

--- a/docs/PROMPT_KUT_LIFECYCLE_INTEGRATION.md
+++ b/docs/PROMPT_KUT_LIFECYCLE_INTEGRATION.md
@@ -1,0 +1,292 @@
+# KUT Lifecycle Integration (BOQ ⇄ Fohlio ⇄ SpecLink ⇄ Niagara) — design record
+
+> **STATUS — this is a RECORD, not outstanding work.** It was written as a build
+> brief and is kept for the part that does not expire: the external facts in §1
+> (Fohlio ships its own Revit add-in; RIB SpecLink has no public REST API; Niagara
+> exposes points over the JSON Toolkit / oBIX), the reasoning behind the phase
+> split, and the decisions in §5. Re-deriving those costs a day of research each
+> time someone asks why STING consumes these systems instead of syncing them.
+>
+> **What actually shipped, and where.** Phases A, B and H landed as the BOQ spec
+> store, the CSI→NRM2 bridge and the tender spec gate. Phase C landed as
+> `FohlioRateProvider` + the FF&E treatment. Phase D landed as
+> `KUT_LifecycleReconcile`, `KUT_ValuationFromBms` and
+> `KUT_PushLifecycleGapsToAcc`. Phase E landed as
+> `WORKFLOW_KUT_LifecycleReconcile.json`, on top of `OwnerKpiDashboardCommand` —
+> the KUT-specific dashboard this brief calls for was **not** built, because a
+> project-agnostic one already exists and reads its code from
+> `PRJ_ORG_PROJECT_CODE_TXT`. Phase F (live read-back) shipped as the optional
+> `CommissioningSource` lane rather than behind a flag.
+>
+> Where this file and the code disagree, **the code is right**. Phase-by-phase
+> history lives in `docs/CHANGELOG.md`; open gaps live in `docs/ROADMAP.md`.
+
+---
+
+## 0. Your role & the one-paragraph goal
+
+You are extending the **StingTools** Revit plugin (C# / .NET 8 / `net8.0-windows`,
+Revit 2025/2026/2027) for the **KUT** project (Kampala Uganda Temple — Owner: The
+Church; Lead Appointed Party: Symbion Consulting; Information Manager: Planscape /
+Mayanja Davis). STING already links four systems to the model **but they never
+meet**: the **BOQ/cost** engine, **Fohlio** (FF&E procurement), **CSI
+MasterFormat / RIB SpecLink** (specifications) and **Niagara** (the Owner's BMS).
+Your job is to **join all four on the Revit element** so KUT gets one
+cost + spec + procurement + commissioning picture, where each system stays
+authoritative for its own column. **Do not rebuild any sync — STING's value is
+the join, the bill, and the gap reports, not re-implementing a vendor's plugin.**
+
+The lifecycle spine (all four keys already live on the same element):
+
+```
+   SpecLink ──►   BOQ      ──►  Fohlio   ──►  Niagara
+   specified     measured       procured      commissioned
+   CSI_SECTION   NRM2 + rate    FOHLIO_REF    ICT_HEALTHIOT_DEVICE_ID
+        └────────────── same Revit element ──────────────┘
+```
+
+---
+
+## 1. Critical external facts (already researched — do not re-litigate)
+
+- **Fohlio has an OFFICIAL Revit add-in.** It exports rooms/elements/quantities/
+  parameters → Fohlio and imports spec data + product images + URLs back into
+  Revit; it maps Revit families/params → Fohlio columns and uses **a chosen Revit
+  parameter as the unique key (update-not-duplicate)**. That key should be set to
+  STING's `ASS_TAG_1_TXT`. **Therefore STING must COEXIST, not duplicate**: let the
+  official plugin (or STING's existing CSV round-trip as fallback) own Revit⇄Fohlio
+  sync; STING only **consumes** the result (the link + the cost) and pulls FF&E cost
+  into the BOQ. (Refs: fohlio.com Revit integration pages.)
+- **RIB SpecLink / Deltek Specpoint** integrates via a Revit plugin + Word/PDF/CSV
+  exports; there is **no clean public REST API**. STING's CSV-ToC reconcile is the
+  correct lightweight lane — keep it. Do not attempt a live SpecLink API.
+- **Niagara 4** exposes live point data via the **JSON Toolkit** (point name/status/
+  present-value as JSON over HTTP GET) and **oBIX** (REST). Live read-back is an
+  *optional* upgrade behind `TwinReadbackBase`; the shipped/default lane is CSV
+  point-list export + station reconcile.
+- **There is no published CSI→NRM2 crosswalk.** Build a small custom mapping (STING
+  already computes both keys per element, so the join is local).
+
+---
+
+## 2. The existing code you build ON (read these first)
+
+**BOQ / cost (just hardened in Phase 195 — reuse it, don't fight it):**
+- `StingTools/BOQ/BoqTotals.cs` — single source of truth for summary maths (NRM
+  cascade + VAT + contract sum). Pure, host-free, unit-tested.
+- `StingTools/BOQ/BoqUnits.cs` — pure unit normalisation. Unit-tested.
+- `StingTools/BOQ/Rates/IRateProvider.cs` — `RateRequest` / `RateLookup`
+  (`RateLookup` now carries `RateIncludesOhp`). **You will add a provider here.**
+- `StingTools/BOQ/Rates/RateProviders.cs` — concrete providers.
+- `StingTools/BOQ/Rates/RateProviderRegistry.cs` — `Build(...)` registers providers
+  in priority order: `param-override(100)` → `es-override(95)` →
+  `material-library(95)` → `csv(90/85/80)` → `cobie(75)` → `default(60)`.
+  Has a currency adapter (UGX/USD/GBP). **You register `FohlioRateProvider` here.**
+- `StingTools/BOQ/BOQModels.cs` — `BOQLineItem` (fields incl. `QuantityMeasured`,
+  `RateIncludesOhp`), `BOQDocument` (`OhpBaseWorksUGX`, `Totals()`, `GrandTotalUGX`,
+  `VatUGX`, `ContractSumUGX`).
+- `StingTools/BOQ/BOQCostManager.cs` — `BuildLineItemFromElement(...)` is the
+  per-element pipeline (rate → quantity → NRM2 paragraph → carbon → line). It already
+  computes the element's **NRM2 section** (`DeriveNrm2Section`). `ResolveRate(...)`
+  drives the provider chain.
+- `StingTools/BOQ/BOQExportCommand.cs` (basic XLSX) + `BOQProfessionalExportCommand.cs`
+  (tender) — both totals route through `BoqTotals`. You add a **Spec ref** column.
+- `StingTools/Data/cost_rates_5d.csv` — baseline rates (placeholders).
+- Tests: `StingTools.Boq.Tests/` (xUnit). Pure helpers are linked in via
+  `<Compile Include="..\StingTools\BOQ\X.cs" Link="X.cs"/>`. **Follow this pattern:
+  extract any new pure maths into a host-free file and unit-test it.**
+
+**Fohlio (FF&E):**
+- `StingTools/ExLink/FohlioLink.cs` — `FohlioConnection.Load(doc)` reads
+  `_BIM_COORD/fohlio_connection.json`; `FohlioRestTransport` is a **stub
+  (`NotImplementedException`, "Tier 2, not yet wired")**.
+- `StingTools/ExLink/FohlioCommands.cs` — `Fohlio_Export` / `Fohlio_Import` /
+  `Fohlio_Audit`. Matching key `ASS_TAG_1_TXT`; writes back `ASS_MANUFACTURER_TXT`,
+  `ASS_MODEL_REF_TXT`, `FOHLIO_REF_TXT`. **No cost field today.**
+- `StingTools/ExLink/FohlioFinishesCommands.cs` — room-finish round-trip (BuiltIn
+  room finish params, keyed on Room Number).
+- `StingTools/Core/Storage/StingFohlioSnapshotSchema.cs` — ES schema
+  GUID `E1A7B2C4-1011-1245-8411-F6E5D4C3B2CD`, fields `FohlioRef`, `SnapshotJson`,
+  `CapturedUtcTicks`. **You extend this with cost.**
+- `project-templates/KUT/_BIM_COORD/fohlio_map.json` — `{ Categories[], Columns[] }`.
+  FF&E categories: Furniture, Furniture Systems, Casework, Plumbing Fixtures,
+  Lighting Fixtures, Specialty Equipment.
+- Param `FOHLIO_REF_TXT` GUID `0ecf2056-1239-52bc-87f8-17c281e67209`.
+
+**CSI / SpecLink:**
+- `StingTools/Commands/Classification/CsiCommands.cs` — `CSI_Assign`
+  (writes `CSI_SECTION_TXT` + `CSI_TITLE_TXT`), `SpecLink_Reconcile` (XLSX diff:
+  `SPEC_GAP` / `OVER_SPEC` / `TITLE_MISMATCH`).
+- `StingTools/Core/Classification/CsiMasterFormat.cs` — rule resolve + section
+  normalisation.
+- `StingTools/Data/STING_CSI_MASTERFORMAT_MAP.csv` — columns
+  `Category, FamilyRegex, TypeRegex, Sys, Section, Title`. Project overlay
+  `_BIM_COORD/csi_map.csv`. **You add an `Nrm2` column.**
+- Params `CSI_SECTION_TXT` (`3c2c7d9d-93e2-5f95-a002-69b17450efe6`),
+  `CSI_TITLE_TXT` (`160a2335-1886-5503-b569-28d9e63f5a75`).
+- Fixture `Tests/fixtures/kut/speclink_toc_sample.csv` (cols `Section,Title`).
+
+**Niagara (BMS):**
+- `StingTools/Commands/Twin/NiagaraCommands.cs` — `Niagara_ExportPoints`
+  (`NiagaraPointListExportCommand`, CSV point list from `IoTDeviceRegistry`) and
+  `Niagara_Reconcile` (`NiagaraReconcileCommand`, station CSV/XLSX vs model →
+  `STATION_ONLY` / `MODEL_ONLY` / `MATCHED_COUNT`).
+- `StingTools/Core/Twin/IoTDeviceRegistry.cs` — devices = elements carrying
+  `ICT_HEALTHIOT_DEVICE_ID_TXT` (+ `_PROTOCOL_TXT` / `_ENDPOINT_TXT` /
+  `_ALERT_BAND_TXT`). Live read-back parked behind `TwinReadbackBase`.
+
+**KUT KPI + workflows:**
+- `StingTools/Commands/Kpi/KutKpiDashboardCommand.cs` — `KutKpiSnapshot` already has
+  `FfeTotal/FfeLinked/FfeStale`, `SpecTotal/SpecAssigned`, `BmsPoints/BmsNoEndpoint`.
+  `KutKpiEngine.Gather(doc)` + `WriteHtml`. **You add the join metrics here.**
+- `StingTools/Data/WORKFLOW_KUT_FFESync.json`, `_CoordinationCycle.json`,
+  `_DeliverableD.json`, `_MonthlyReport.json`, `_Mobilisation.json`.
+- KUT MIDP rows: Z-212 BOQ (prelim), Z-310 BOQ (tender), FF-600 FF&E schedule.
+
+---
+
+## 3. The work — five phases, each independently shippable
+
+> Build phases in order. Each compiles, is verified, and delivers value alone.
+> After each phase: build against Revit 2025 and (where pure logic was added) run
+> the BOQ tests. Log each phase in `docs/CHANGELOG.md`.
+
+### Phase A — Spec ref on every BOQ line + CSI↔NRM2 bridge (pure-internal, smallest)
+1. Add an `Nrm2` column to `STING_CSI_MASTERFORMAT_MAP.csv` (+ the project overlay
+   reader in `CsiMasterFormat.cs`) so one rule resolves both CSI **and** the NRM2
+   section consistently. Author the ~40 KUT categories; leave blank = fall back to
+   the BOQ's existing `DeriveNrm2Section`.
+2. In `BOQCostManager.BuildLineItemFromElement`, read `CSI_SECTION_TXT` /
+   `CSI_TITLE_TXT` off the element and stamp new `BOQLineItem.CsiSection` /
+   `CsiTitle` fields (update `Clone()`).
+3. Add a **"Spec ref"** column to both exports (`BOQExportCommand`,
+   `BOQProfessionalExportCommand` item schedules).
+4. **Acceptance:** a priced bill shows the CSI section per line; an element with a
+   CSI rule gets a consistent NRM2 section.
+
+### Phase B — Two cost↔spec gap rows in `SpecLink_Reconcile`
+1. Extend `SpecLink_Reconcile` to also emit, using the BOQ document join:
+   - `PRICED_UNSPECIFIED` — a BOQ line with cost (`TotalUGX > 0`) but **no** CSI
+     section / not in the SpecLink ToC. Carry the value-at-risk (UGX).
+   - `SPECIFIED_UNPRICED` — a CSI section in the SpecLink ToC with **zero** measured
+     BOQ value.
+2. **Acceptance:** XLSX report gains the two row types; the priced-unspecified UGX
+   total is reported.
+
+### Phase C — Fohlio cost → BOQ via a new rate provider (the cost integration)
+1. Add params `FOHLIO_UNIT_COST_NR` (number) + `FOHLIO_CURRENCY_TXT` (text) to
+   `MR_PARAMETERS.txt` + `.csv` (stable UUIDv5 GUIDs, namespace
+   `a7c0b2e4-4d91-4a55-9c7e-7f6e5d4c3b2a`, like `FOHLIO_REF_TXT`).
+2. Extend `StingFohlioSnapshotSchema` with `UnitCost` (double), `Currency` (string),
+   `QtyFromFohlio` (double), `LeadTimeDays` (int). Populate on `Fohlio_Import` (and
+   document the official-plugin column mapping that writes `FOHLIO_UNIT_COST_NR`).
+3. Add `FohlioRateProvider : IRateProvider` in `Rates/RateProviders.cs`:
+   - Reads the element's `FOHLIO_UNIT_COST_NR` (+ `FOHLIO_CURRENCY_TXT`), else the
+     ES snapshot `UnitCost`/`Currency`.
+   - Returns `RateLookup { UnitRate, CurrencyCode, Confidence = 95,
+     SourceId = "fohlio", RateIncludesOhp = false, Provenance = "Fohlio FF&E
+     procurement" }`. The registry's currency adapter handles USD→UGX.
+   - Register in `RateProviderRegistry.Build` at **priority 96** (above
+     material-library/CSV, below the deliberate `param-override(100)`). Confirm this
+     priority with the user (see §5).
+   - Map `"fohlio"` → legacy source label `"Fohlio"` in
+     `BOQCostManager.MapProviderIdToLegacySource`.
+4. Add a per-category **FF&E treatment toggle** to `fohlio_map.json`:
+   `"boqTreatment": "measured" | "pcSum" | "ownerSupplied-excluded"`. In
+   `BuildLineItemFromElement`, `pcSum` → set `BOQRowSource.ProvisionalSum` with the
+   Fohlio total as the PC value; `ownerSupplied-excluded` → skip the line.
+5. **Acceptance:** FF&E rows priced from Fohlio carry `RateSource = "Fohlio"`,
+   confidence 95, correct UGX after FX; `pcSum` items appear as provisional sums.
+
+### Phase D — Niagara join: two commissioning-gap rows + the unified register
+1. Add a cross-ledger reconcile (extend `Niagara_Reconcile` or add
+   `KUT_LifecycleReconcile`): using the BOQ document + `IoTDeviceRegistry`, emit:
+   - `PRICED_NO_BMS_POINT` — a priced MEP/equipment BOQ line whose element has **no**
+     `ICT_HEALTHIOT_DEVICE_ID_TXT`/endpoint (handover gap). Scope to monitorable
+     categories only (don't flag a door).
+   - `COMMISSIONED_UNPRICED` — a Niagara/station point with **no** BOQ line
+     (asset-register gap).
+2. Emit a **unified KUT register** (XLSX): one row per asset, columns
+   `Element | CSI section | NRM2 + UGX | Fohlio ref | BMS device/endpoint` with
+   ✓/✗/⚠ per ledger.
+3. **Acceptance:** the register lists every asset with its four-ledger status; the
+   two new gap row types are produced.
+
+### Phase E — One KUT dashboard + the lifecycle workflow
+1. Extend `KutKpiSnapshot` with the **join** metrics no single ledger can produce:
+   `FfePricedFromFohlioPct`, `PricedUnspecifiedValueUGX`, `PricedNoBmsPointCount`,
+   `BoqVsFohlioVarianceUGX` (STING measured FF&E total vs Fohlio register total).
+   Render them in `KutKpiEngine.WriteHtml` with RAG bands.
+2. Add `StingTools/Data/WORKFLOW_KUT_LifecycleReconcile.json` chaining:
+   `Fohlio_Import → CSI_Assign → BOQ_Refresh → SpecLink_Reconcile →
+   Niagara_ExportPoints → Niagara_Reconcile → KUT_KpiDashboard`.
+   Reference it from `WORKFLOW_KUT_MonthlyReport.json`.
+3. **Acceptance:** one HTML board shows all four ledgers + the join metrics; the
+   workflow runs end-to-end.
+
+### Phase F (optional, behind a flag) — live read-back
+- Fohlio REST Tier-2: implement `FohlioRestTransport` (`GET {BaseUrl}/ping` with
+  `Authorization: Bearer {ApiKey}`; list/get items) for unattended monthly refresh.
+- Niagara live: implement a `TwinReadbackBase` subclass using the **Niagara JSON
+  Toolkit** (HTTP GET JSON of point status/present-value) or **oBIX**. Keep CSV as
+  default; live read-back is opt-in.
+
+---
+
+## 4. Conventions (from CLAUDE.md — follow exactly)
+- C#: PascalCase public, camelCase locals. State-changing commands
+  `[Transaction(TransactionMode.Manual)]`; read-only `[Transaction(ReadOnly)]`.
+  Use `TaskDialog` (not MessageBox), `StingLog.Info/Warn/Error` (no silent catch).
+- Reuse helpers: `ParameterHelpers`, `OutputLocationHelper`, `BoqTotals`, the
+  rate-provider chain. **Do not add a second markup/VAT path — everything goes
+  through `BoqTotals`.**
+- **Extract new pure maths into a host-free file** and link it into
+  `StingTools.Boq.Tests` with xUnit tests (mirror `BoqTotals`/`BoqUnits`).
+- New shared params: add to `MR_PARAMETERS.txt` **and** `.csv`, deterministic UUIDv5.
+- Build to verify (Revit IS installed on this machine):
+  `dotnet build StingTools/StingTools.csproj -p:RevitApiPath="C:/Program Files/Autodesk/Revit 2025"`
+  Tests: `dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj`
+- Branch off the current work; never commit to `main`. Log each phase in
+  `docs/CHANGELOG.md`.
+
+---
+
+## 5. Decisions to confirm with the user BEFORE coding
+1. **FF&E default treatment:** `measured` (priced in the contractor's bill) vs
+   `pcSum` (Provisional/Prime-Cost sum referencing the Fohlio register). For a temple
+   with heavy Owner-procured liturgical/specialty items, **PC-sum is the safer
+   default**; confirm per-category.
+2. **`FohlioRateProvider` priority:** 96 (proposed — Owner PO price beats
+   material-library/CSV but loses to a QS's explicit inline override at 100). Confirm.
+3. **Fohlio transport for KUT:** official Fohlio Revit plugin (recommended) vs
+   STING's CSV round-trip (fallback). If the plugin is used, set its unique key to
+   `ASS_TAG_1_TXT` and map a cost column to `FOHLIO_UNIT_COST_NR`.
+4. **Currency:** Fohlio quotes USD; KUT bill is UGX. Reuse the Phase 195 currency
+   adapter and stamp `ASS_CST_FX_DATE_DT` so FF&E FX is auditable at tender.
+5. **Budget basis:** `BudgetVarianceUGX` against works total (excl VAT) or contract
+   sum (incl VAT)?
+
+---
+
+## 6. Definition of done
+- All five core phases build against Revit 2025 with **0 errors**; new pure logic has
+  passing xUnit tests.
+- A KUT element that is specified + measured + procured + monitored shows ✓ across all
+  four ledgers in the unified register; broken chains are flagged.
+- FF&E rows are priced from Fohlio (or carried as PC sums) with correct UGX/FX and
+  `RateSource = "Fohlio"`.
+- The bill shows a Spec ref per line; `SpecLink_Reconcile` reports priced-unspecified
+  value; `KUT_KpiDashboard` shows the four-ledger join with RAG.
+- `docs/CHANGELOG.md` logs each phase; no second markup/VAT path was introduced.
+
+---
+
+## 7. Hard guardrails
+- **Do NOT** re-implement the Fohlio Revit plugin or a SpecLink API — coexist and
+  consume.
+- **Do NOT** double-count FF&E: an item is priced in the bill **or** a PC sum **or**
+  Owner-supplied-excluded — never two of these.
+- **Do NOT** bypass `BoqTotals` for any total, or invent a new confidence path —
+  unmeasured/low-provenance rows must still surface via the Phase 195 mechanisms.
+- Keep every external link **"link, never duplicate"**: the model references Fohlio/
+  SpecLink/Niagara by id; those systems stay authoritative for their own data.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,20 @@
 
 Open automation gaps, future-enhancement tables, and deep-review findings for the StingTools plugin. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`CHANGELOG.md`](CHANGELOG.md) for the history of closed items.
 
+## KUT lifecycle join — after the re-land from `claude/kut-lifecycle-integration` (2026-09-06)
+
+The four-ledger join (SpecLink → BOQ → Fohlio → Niagara) was recovered onto `main`
+in three PRs. These are the pieces that were deliberately left out or could not be
+covered, recorded so nobody reads their absence as an oversight.
+
+| ID | Item | Detail |
+|---|---|---|
+| LIFE-1 | **`NiagaraJsonClient.ParsePoints` and `CommissioningSource` have no tests** | Both are pure enough to test, but both log through `StingLog`, which the Revit-free test projects do not link (it carries a `StingTools.Core.Drawing` using and a Win32 P/Invoke). `ParsePoints` decides `hasValue`, which decides `IsCommissioned`, which decides whether a line is certified — so it is worth covering. The arithmetic on the other side of that decision (`BmsValuation`) IS tested. Closing this means either making `StingLog` linkable into a Revit-free test project, or moving the oBIX shape handling into a class that does not log. |
+| LIFE-2 | **The 34 site / civil / external-utility NRM2 codes in `STING_CSI_MASTERFORMAT_MAP.csv` have not had a QS's eye** | They carry the code implied by their CSI division and the file's existing convention, which is a strict improvement on the category-keyword fallback they had before (`Generic Models` and `Topography` landed in a bucket). They are data; changing one is a one-line edit. Flagged in the file header too. |
+| LIFE-3 | **Three accuracy fixes from the same branch were NOT recovered** | The branch carried a `kg_to_tonne` take-off conversion, a `RateIncludesOhp` flag excluding already-loaded rates from the document OH&P base, and an accuracy disclosure on `MeasurementStandards` (the standards re-classify rows, they do not re-measure; `ApplyDeductions` returns the quantity unchanged for NRM2/POMI/ICMS3/MMHW and the CESMM4 opening deduction is a stub returning 0). All three are outside the re-land's scope and none is on `main`. The disclosure in particular is cheap and worth landing: a user choosing a measurement standard may reasonably believe it changes the measurement. |
+| LIFE-4 | **`ASS_CST_FX_DATE_DT` is written by `Fohlio_Import` but nothing reads it** | The FX-fixing date is stamped so a tender is auditable, which is the right instinct, but no export or report surfaces it yet. Either surface it beside the Fohlio-sourced rate in the bill, or drop the write. |
+| LIFE-5 | **`FOHLIO_UNIT_COST_NR` / `FOHLIO_CURRENCY_TXT` need binding before the rate provider can fire** | The constants and GUIDs are registered, and `FohlioRateProvider` reads them, but the parameters have to be bound to the FF&E categories in a project for a value to exist. Until then the provider falls back to the ES import snapshot, and failing that returns null — correct, but silent. A binding-coverage line for the two would make the gap visible. |
+
 ## KUT mobilisation pack — after the Phase 243 hardening (2026-08-23)
 
 Numbered **MOB-n** because an older section further down this file, *KUT project-readiness — open after Phase 228*, already owns `KUT-1`…`KUT-11` for unrelated items. `KUT-OPEN-n` below does not collide and keeps its name.

--- a/project-templates/KUT/_BIM_COORD/fohlio_map.json
+++ b/project-templates/KUT/_BIM_COORD/fohlio_map.json
@@ -1,5 +1,9 @@
 {
-  "_comment": "Kampala Uganda Temple (KUT) Fohlio ExLink mapping. Deploy to <project>/_BIM_COORD/fohlio_map.json. Read by StingTools.ExLink.FohlioMap.Load on Fohlio_Export / Fohlio_Import. Link key is FOHLIO_REF_TXT (link, never duplicate). '$'-prefixed params are resolved at export time ($Family/$Type/$Category/$Room). WriteBack=true columns may be written back into the model on Fohlio_Import. Fohlio remains authoritative for FF&E/finishes/O&M.",
+  "_comment": "Kampala Uganda Temple (KUT) Fohlio ExLink mapping. Deploy to <project>/_BIM_COORD/fohlio_map.json. Read by StingTools.ExLink.FohlioMap.Load on Fohlio_Export / Fohlio_Import and (cached) by the BOQ engine. Link key is FOHLIO_REF_TXT (link, never duplicate). '$'-prefixed params are resolved at export time ($Family/$Type/$Category/$Room); $FohlioQty / $FohlioLeadDays are import-only and stored in the ES snapshot. WriteBack=true columns may be written back into the model on Fohlio_Import. Fohlio remains authoritative for FF&E/finishes/O&M.",
+  "_boqTreatmentComment": "How FF&E is carried in the bill. KUT default 'ffe' = a TRANSPARENT Owner-procured FF&E category (NRM1 Group 8 / ICMS): priced at cost from the Fohlio register, shown as its own subtotal, and EXCLUDED from the construction contractor's prelims / OH&P / contingency. Per-category override values: 'ffe' (default), 'measured' (contractor-supplied, priced from the Fohlio rate, full markups), 'ownerSupplied-excluded' (zero-cost in this bill), 'pcSum' (explicit contractual Provisional / Prime-Cost sum). An item is exactly one of these — never double-counted.",
+  "BoqTreatment": "ffe",
+  "BoqTreatmentByCategory": {
+  },
   "Categories": [
     "Furniture",
     "Furniture Systems",
@@ -16,6 +20,10 @@
     { "Header": "Manufacturer", "Param": "ASS_MANUFACTURER_TXT", "WriteBack": true },
     { "Header": "Model",        "Param": "ASS_MODEL_REF_TXT",    "WriteBack": true },
     { "Header": "Room",         "Param": "$Room",                "WriteBack": false },
-    { "Header": "Fohlio Ref",   "Param": "FOHLIO_REF_TXT",       "WriteBack": true }
+    { "Header": "Fohlio Ref",   "Param": "FOHLIO_REF_TXT",       "WriteBack": true },
+    { "Header": "Unit Cost",    "Param": "FOHLIO_UNIT_COST_NR",  "WriteBack": true },
+    { "Header": "Currency",     "Param": "FOHLIO_CURRENCY_TXT",  "WriteBack": true },
+    { "Header": "Qty",          "Param": "$FohlioQty",           "WriteBack": false },
+    { "Header": "Lead Days",    "Param": "$FohlioLeadDays",      "WriteBack": false }
   ]
 }


### PR DESCRIPTION
## What this adds

**The four ledgers meet.** SpecLink (specified), the BOQ (priced), Fohlio (procured) and Niagara (commissioned) all key off the same Revit element, and until now each reconcile could only see its own. The two gaps that exist only *between* them were therefore invisible:

- **`PRICED_NO_BMS_POINT`** — a priced, monitorable asset with no BMS device id or endpoint. A handover gap nobody finds until commissioning week.
- **`COMMISSIONED_UNPRICED`** — a station point with no priced BOQ line. An asset-register gap nobody finds until the O&M manual is due.

| Command | What it does |
|---|---|
| `KUT_LifecycleReconcile` | Read-only four-ledger join into one asset register (XLSX), with both gaps on their own sheet. The station export is optional — Cancel skips the commissioned-unpriced half rather than failing. |
| `KUT_ValuationFromBms` | What share of the priced **monitorable** scope is live on the station, and therefore certifiable as commissioned — the 5D signal for a payment certificate. Per-asset CSV. |
| `KUT_PushLifecycleGapsToAcc` | Pushes the model-derivable gaps to ACC Issues through the existing live client. Idempotent via a sidecar keyed on the gap signature, so re-runs skip what is already there. |
| `WORKFLOW_KUT_LifecycleReconcile.json` | The 11-step chain, spec import through KPI dashboard. File-dependent steps are `optional`. |

A point counts as **commissioned only when its status is in-service AND it reports a present value**. A configured-but-dead point answers with a status and no value; certifying that would certify money against equipment that is not working. The Baja `{ok}` decoration and the empty-status-object convention are both handled, and every non-live status is conservative.

`CommissioningSource` makes every consumer share one behaviour: live read when the station answers (persisting a snapshot), the **last good cached read** when it does not — and every report states which it used and how old it is. A valuation that silently ran on week-old data is worse than one that refuses.

## Fohlio v2

`FOHLIO_UNIT_COST_NR` / `FOHLIO_CURRENCY_TXT` carry the supplier's purchase-order price into the bill through a new **`FohlioRateProvider`** (priority 96 — above the material library and the CSV category rate, below an inline override), falling back to the import snapshot when the parameter is empty. That price is the truth for Owner-procured FF&E; a rate-book average is not.

The ES snapshot schema gains a **v2 GUID** for the cost fields — ExtensibleStorage schemas are immutable once registered in a document, so extending v1 in place is not possible — and the **v1 read path is preserved**, so elements snapshotted before this still read.

`fohlio_map.json` now decides how FF&E is carried: `ffe` (default, a transparent Owner-procured category), `measured` (a normal contractor line), `pcSum` (a contractual provisional sum), `ownerSupplied-excluded` (left out of the bill entirely rather than priced at zero, which would read as free work). An element gets exactly one, so nothing is double-counted.

## `BoqTotals` gains an optional markup-exempt base

Without it, "Owner-procured at cost" would be a label and a subtotal, not an arithmetic difference — and the treatment would be cosmetic.

A main contractor does not earn overhead, profit or contingency on goods the Owner buys direct, so `FfeOwnerProcuredUGX` comes out of the **OH&P and contingency base** while staying in the works total (it is real money the Owner spends). **Preliminaries keep the full works base** — site establishment, storage and handling are earned on Owner-supplied goods too.

The parameter **defaults to 0**, and a test pins that the default reproduces the previous arithmetic to six decimal places. Out-of-range values are clamped into `[0, works]` so no markup can go negative.

## Why it was worth recovering

The join is the thing STING is uniquely placed to do — every one of these four systems already sees the element, and none of them sees the others. The commands are ~650 lines and the arithmetic that decides whether a line is certifiable is ~90; that is not a lot of code for the difference between finding a missing BMS point during design and finding it during commissioning.

## Provenance

Ported from `claude/kut-lifecycle-integration` (cut 2026-06-21, never merged, 76 days behind). The branch is **not** merged. `KutKpiDashboardCommand` remains **deliberately excluded**, superseded by `OwnerKpiDashboardCommand` — and the new workflow's KPI step uses the canonical `Owner_KpiDashboard` tag rather than the retained `KUT_` alias.

## Drift repaired, and the judgement calls

**1. Path discipline.** `NiagaraConnection.Load`, `CommissioningSource` and the ACC sidecar all built `<dir>/_BIM_COORD/...` by hand. They now take an **already-resolved path** from a caller that holds the `Document` and asks `StingPaths` — which both keeps them host-free and stops them writing to the pre-consolidation sibling folder.

**2. Two branch changes deliberately left out.** The branch also lifted `es-override`'s priority 95 → 98 and added a `RateIncludesOhp` flag excluding already-loaded rates from the document OH&P base. Both are real improvements; both are outside this re-land's scope. They are recorded in `docs/ROADMAP.md` (LIFE-3) rather than smuggled in beside a new rate provider, where a silent priority change would be easy to miss in review.

**3. `docs/PROMPT_KUT_LIFECYCLE_INTEGRATION.md` is kept, but re-headed as a design record.** It was written as a build brief. What does not expire is §1: Fohlio ships its own Revit add-in (so STING must *coexist*, not duplicate), RIB SpecLink has no public REST API (so a CSV watch-folder is the correct lane, not a failed API attempt), Niagara exposes points over the JSON Toolkit / oBIX. Re-deriving that is a day of research each time someone asks why. The new header states what actually shipped, notes where the brief and the code disagree, and says the code wins.

**4. The shipped `fohlio_map` keys were renamed to the file's own PascalCase convention.** Newtonsoft matches either case, but a shipped template should not depend on that.

## Verified

- `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings**
- `dotnet test` → **916 Boq + 95 Cost + 38 Scheduling passed, 0 failed** (17 new)
- `tools/check_path_discipline.ps1` → Tier 1 = 0, Tier 2 = 0
- `tools/check_workflow_wiring.ps1` → **Tier 4 = 0**; 48 presets / 387 steps, all resolvable; all three commands dispatch from the button, the handler and `WorkflowEngine.ResolveCommand`
- `tools/check_kut_documents.py` → 80 assertions, green

The shipped Fohlio overlay is read by the real parser in a test — I confirmed that test fails when a cost column name is mistyped, which is exactly the silent-default failure a data file invites.

`niagara_connection.json` is gitignored: it carries a station base URL and either an API key or a username/password.

## Not verified — and this PR has more untested surface than the other two

**Nothing here was exercised inside Revit, and every network path needs a live endpoint I did not have.** Specifically untested at runtime: the Niagara station read, the ACC issue push and its idempotency sidecar, the four-ledger walk, the XLSX register, the FF&E treatment reaching a real priced line, and the v1 snapshot read fallback.

**One known test gap, logged rather than papered over.** `NiagaraJsonClient.ParsePoints` and `CommissioningSource` log through `StingLog`, which the Revit-free test projects cannot link (it carries a `StingTools.Core.Drawing` using and a Win32 P/Invoke). `ParsePoints` decides `hasValue`, which decides `IsCommissioned`, which decides whether money is certified — so this is a real gap, recorded as **ROADMAP LIFE-1**. The arithmetic on the other side of that decision, `BmsValuation`, **is** tested, including the Baja empty-status convention and the dead-point case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq1S3eCuoayfcdhoiXLsoc
