### PR TITLE
fix(ui): put Price Commodities where a QS actually works

### DIFF
--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -1327,9 +1327,21 @@ namespace StingTools.UI
 
             sp.Children.Add(BuildActionGroup("Procurement (Material Schedule)",
                 "The buy-list, not the bill. Converts measured work into commodities in supplier " +
-                "units — bags of cement, trips of sand, No. of blocks — sectioned by construction stage.",
+                "units — bags of cement, trips of sand, No. of blocks — sectioned by construction stage. " +
+                "Price the commodities first; the schedule reads those rates.",
                 new[]
                 {
+                    // Beside the export, not on the dock panel alone. A QS lives
+                    // in this window, and the first run of the editor was missed
+                    // entirely because its only button was on the other surface.
+                    // It is listed FIRST because it is the prerequisite: an
+                    // unpriced commodity totals zero in the schedule below it.
+                    ("Price Commodities", "MaterialSchedule_PriceCommodities",
+                     "Price the material schedule in a grid, seeded from the schedule itself so no commodity " +
+                     "key is ever retyped — most of them contain characters that cannot be typed reliably. " +
+                     "Unpriced rows sort first. A blank cell leaves that rate alone and a zero is never " +
+                     "written. Saves to the project's commodity_rates.csv; the shipped corporate baseline is " +
+                     "never touched.", false),
                     ("★ Material Schedule", "MaterialSchedule_Export",
                      "Export a stage-sectioned material schedule as XLSX. Commodities are aggregated across " +
                      "the project, converted to supplier units with a visible wastage step, and priced from the " +


### PR DESCRIPTION
fix(ui): put Price Commodities where a QS actually works

The rate editor shipped with exactly one button, on the dock panel. A QS
pricing a job is in the BOQ & Cost Manager window, which has its own
Actions tab and its own Procurement (Material Schedule) group holding
the export the editor feeds. The first person to look for it did not
find it, which is a fair verdict on the placement rather than on them.

So it now sits inline beside the export it is a prerequisite for, and
listed FIRST: an unpriced commodity totals zero in the schedule below
it, so pricing is the step that comes before exporting, not after.

The group blurb says so too. The dock-panel button stays - two surfaces,
one registered tag, and the tag was already registered in #821, so this
is placement only. Tier 4 confirms it dispatches.

Build 0/0, gates pass, Tier 4: 1,671 buttons, 0 dispatching to nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
