### PR TITLE
feat(matsched): Excel navigation and paste in the rate grid

### DIFF
--- a/StingTools.Boq.Tests/RatePasteParserTests.cs
+++ b/StingTools.Boq.Tests/RatePasteParserTests.cs
@@ -1,0 +1,188 @@
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Pasting a column out of a supplier's spreadsheet is the reason the rate
+    /// grid beats a form. Typing 58 numbers is the work the grid was meant to
+    /// remove, not preserve.
+    ///
+    /// The tests are mostly about alignment, because a paste that silently
+    /// shifts by one row puts every rate below the shift on the wrong
+    /// commodity — and each of those then looks like a deliberate figure.
+    /// </summary>
+    public class RatePasteParserTests
+    {
+        [Fact]
+        public void A_Plain_Column_Parses_In_Order()
+        {
+            var r = RatePasteParser.Parse("28000\r\n45000\r\n1400000");
+
+            Assert.Equal(new double?[] { 28000, 45000, 1400000 },
+                         r.Cells.Select(c => c.Value).ToArray());
+        }
+
+        [Fact]
+        public void Excels_Trailing_Newline_Does_Not_Become_A_Row()
+        {
+            // Copying a 3-cell range puts "a\r\nb\r\nc\r\n" on the clipboard.
+            var r = RatePasteParser.Parse("28000\r\n45000\r\n1400000\r\n");
+
+            Assert.Equal(3, r.Cells.Count);
+        }
+
+        [Fact]
+        public void An_INTERIOR_Blank_Keeps_Its_Place()
+        {
+            // The alignment rule. Dropping the gap would move 1400000 up onto
+            // whatever commodity the blank belonged to, and nothing on screen
+            // would say so.
+            var r = RatePasteParser.Parse("28000\r\n\r\n1400000");
+
+            Assert.Equal(3, r.Cells.Count);
+            Assert.Null(r.Cells[1].Value);
+            Assert.False(r.Cells[1].Unparseable);
+            Assert.Equal(1400000, r.Cells[2].Value);
+        }
+
+        [Fact]
+        public void A_Line_With_No_Number_Is_Rejected_Not_Zeroed()
+        {
+            // A pasted header row, or a "TBC". Treating either as zero prices
+            // the commodity at nothing and totals it as free.
+            var r = RatePasteParser.Parse("Rate\r\n28000\r\nTBC");
+
+            Assert.Equal(1, r.ValueCount);
+            Assert.Equal(2, r.Rejected.Count);
+            Assert.Contains("Rate", r.Rejected);
+            Assert.Contains("TBC", r.Rejected);
+        }
+
+        [Fact]
+        public void A_Rejected_Line_Still_Consumes_Its_Row()
+        {
+            // Same alignment rule as a blank: three lines in, three cells out.
+            var r = RatePasteParser.Parse("28000\r\nTBC\r\n45000");
+
+            Assert.Equal(3, r.Cells.Count);
+            Assert.True(r.Cells[1].Unparseable);
+            Assert.Equal(45000, r.Cells[2].Value);
+        }
+
+        [Theory]
+        [InlineData("28,000", 28000)]
+        [InlineData("UGX 28000", 28000)]
+        [InlineData("UGX 1,400,000", 1400000)]
+        [InlineData(" 28000 ", 28000)]
+        [InlineData("28000.50", 28000.50)]
+        [InlineData("$45", 45)]
+        public void Currency_And_Separators_Are_Decoration(string text, double expected)
+        {
+            Assert.Equal(expected, RatePasteParser.ParseNumber(text));
+        }
+
+        [Theory]
+        [InlineData("28k")]
+        [InlineData("TBC")]
+        [InlineData("n/a")]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Anything_That_Is_Not_A_Number_Stays_Not_A_Number(string text)
+        {
+            // "28k" must NOT read as 28. Stripping decoration is not the same
+            // as guessing at an abbreviation.
+            Assert.Null(RatePasteParser.ParseNumber(text));
+        }
+
+        [Fact]
+        public void A_Parenthesised_Negative_Stays_Negative()
+        {
+            // Accounting notation. Making it positive would turn a credit into
+            // a price; it is rejected downstream as negative, which is visible.
+            Assert.Equal(-500, RatePasteParser.ParseNumber("(500)"));
+        }
+
+        [Fact]
+        public void A_Two_Column_Paste_Takes_The_RATE_Not_The_Description()
+        {
+            var r = RatePasteParser.Parse("Cement\t28000\r\nSand\t1400000");
+
+            Assert.Equal(new double?[] { 28000, 1400000 }, r.Cells.Select(c => c.Value).ToArray());
+        }
+
+        [Fact]
+        public void A_Quantity_Column_Before_The_Rate_Does_Not_Win()
+        {
+            // The case that actually discriminates first-field from last-field.
+            // Copying Qty + Rate out of a working sheet is ordinary, and both
+            // fields are numeric — "first numeric wins" would price cement at
+            // 93 and nothing on screen would look wrong.
+            var r = RatePasteParser.Parse("93\t28000\r\n2\t1400000");
+
+            Assert.Equal(new double?[] { 28000, 1400000 }, r.Cells.Select(c => c.Value).ToArray());
+        }
+
+        [Fact]
+        public void A_Three_Column_Paste_Still_Takes_The_Rightmost_Number()
+        {
+            var r = RatePasteParser.Parse("Cement\tBags\t93\t28000");
+
+            Assert.Equal(28000, r.Cells.Single().Value);
+        }
+
+        [Fact]
+        public void A_Description_Containing_Digits_Does_Not_Win_Over_The_Rate()
+        {
+            // "8\" hollow block" has a number in it. Last-numeric-field is what
+            // stops it being read as the price.
+            var r = RatePasteParser.Parse("8 inch hollow block\t2500");
+
+            Assert.Equal(2500, r.Cells.Single().Value);
+        }
+
+        [Fact]
+        public void Empty_Clipboard_Produces_Nothing_And_Says_Nothing()
+        {
+            Assert.Empty(RatePasteParser.Parse("").Cells);
+            Assert.Empty(RatePasteParser.Parse(null).Cells);
+            Assert.Null(RatePasteParser.Parse("").Summary(0, 0));
+        }
+
+        // ── the report ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void The_Summary_Names_What_Was_Not_Applied()
+        {
+            var r = RatePasteParser.Parse("28000\r\nTBC\r\n\r\n45000");
+
+            string s = r.Summary(applied: 2, ranOutOfRows: 0);
+
+            Assert.Contains("Pasted 2 rate(s)", s);
+            Assert.Contains("1 blank line(s) left their row unchanged", s);
+            Assert.Contains("'TBC'", s);
+            Assert.Contains("not a rate of zero", s);
+        }
+
+        [Fact]
+        public void Running_Off_The_Bottom_Of_The_Grid_Is_Reported()
+        {
+            // Pasting 20 values starting 5 rows from the end must not silently
+            // drop 15 of them.
+            var r = RatePasteParser.Parse("1\r\n2\r\n3");
+
+            Assert.Contains("had no row left to land on", r.Summary(applied: 1, ranOutOfRows: 2));
+        }
+
+        [Fact]
+        public void A_Clean_Paste_Reports_Only_The_Count()
+        {
+            var r = RatePasteParser.Parse("28000\r\n45000");
+
+            string s = r.Summary(applied: 2, ranOutOfRows: 0);
+
+            Assert.Equal("Pasted 2 rate(s).", s);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesCalculator.cs" Link="MaterialSchedule\ConsumablesCalculator.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RateEditorSeed.cs" Link="MaterialSchedule\RateEditorSeed.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RateProvenanceLabel.cs" Link="MaterialSchedule\RateProvenanceLabel.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\RatePasteParser.cs" Link="MaterialSchedule\RatePasteParser.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/Core/MaterialSchedule/RatePasteParser.cs
+++ b/StingTools/Core/MaterialSchedule/RatePasteParser.cs
@@ -1,0 +1,166 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RatePasteParser.cs — turn a column copied out of Excel into rates.
+//
+//  This is the reason the editor is worth having rather than a form. A
+//  supplier quote arrives as a spreadsheet; pricing 58 commodities by typing
+//  58 numbers is the work the grid was supposed to remove, not preserve.
+//
+//  Three decisions here are load-bearing, and each is a way a paste could go
+//  wrong in silence:
+//
+//  * A BLANK line consumes a row without changing it. Copy a column with gaps
+//    and the gaps must stay aligned with the rows they came from — skipping
+//    them instead would shift every rate below the gap onto the wrong
+//    commodity, and every one of those would look like a deliberate figure.
+//
+//  * A line with NO number is reported, never treated as zero. A pasted
+//    header row ("Rate") or a "TBC" is a thing the user must see, not a free
+//    commodity.
+//
+//  * Multi-column paste takes the LAST numeric field, because Excel columns
+//    are copied left-to-right and the rate is conventionally rightmost — and
+//    when that is wrong the user sees a wrong number in a cell they can fix,
+//    rather than a silently skipped row they cannot notice.
+//
+//  Revit-free, so all of that is testable.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    /// <summary>One pasted cell: a value, or a reason there isn't one.</summary>
+    public sealed class PastedRate
+    {
+        /// <summary>The parsed rate, or NULL for a blank line (leave the row alone).</summary>
+        public double? Value;
+
+        /// <summary>The original text, for the report when it did not parse.</summary>
+        public string RawText = "";
+
+        /// <summary>True when the line held text but no number.</summary>
+        public bool Unparseable;
+    }
+
+    public sealed class RatePasteResult
+    {
+        public readonly List<PastedRate> Cells = new List<PastedRate>();
+
+        /// <summary>Lines that held text but no number, verbatim, for the report.</summary>
+        public readonly List<string> Rejected = new List<string>();
+
+        public int ValueCount => Cells.Count(c => c.Value.HasValue);
+        public int BlankCount => Cells.Count(c => !c.Value.HasValue && !c.Unparseable);
+
+        /// <summary>
+        /// What the paste did, or NULL when there was nothing on the clipboard
+        /// worth reporting.
+        /// </summary>
+        public string Summary(int applied, int ranOutOfRows)
+        {
+            if (Cells.Count == 0) return null;
+
+            string s = $"Pasted {applied} rate(s).";
+            if (BlankCount > 0)
+                s += $" {BlankCount} blank line(s) left their row unchanged — a gap in a copied "
+                   + "column keeps its place, so the rates below it stay on the right commodities.";
+            if (Rejected.Count > 0)
+                s += $" {Rejected.Count} line(s) held no number and were NOT applied: "
+                   + string.Join(", ", Rejected.Take(5).Select(r => "'" + r + "'"))
+                   + (Rejected.Count > 5 ? ", …" : "")
+                   + ". A line with no number is not a rate of zero.";
+            if (ranOutOfRows > 0)
+                s += $" {ranOutOfRows} value(s) had no row left to land on and were discarded — "
+                   + "the paste started too far down the grid.";
+            return s;
+        }
+    }
+
+    public static class RatePasteParser
+    {
+        /// <summary>
+        /// Parse clipboard text into one cell per line.
+        ///
+        /// Handles what Excel actually puts on the clipboard: CRLF line ends, a
+        /// trailing newline, tab-separated columns, thousands separators, a
+        /// currency prefix, and parentheses for negatives (which are rejected
+        /// downstream as negative, not silently made positive).
+        /// </summary>
+        public static RatePasteResult Parse(string clipboardText)
+        {
+            var result = new RatePasteResult();
+            if (string.IsNullOrEmpty(clipboardText)) return result;
+
+            string[] lines = clipboardText.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+            // Excel appends a trailing newline to a copied range. Dropping only
+            // the LAST empty line keeps interior blanks, which carry meaning.
+            int end = lines.Length;
+            if (end > 0 && lines[end - 1].Trim().Length == 0) end--;
+
+            for (int i = 0; i < end; i++)
+            {
+                string line = lines[i];
+                var cell = new PastedRate { RawText = line.Trim() };
+
+                if (cell.RawText.Length == 0) { result.Cells.Add(cell); continue; }
+
+                double? v = LastNumberIn(line);
+                if (v.HasValue) cell.Value = v;
+                else
+                {
+                    cell.Unparseable = true;
+                    result.Rejected.Add(cell.RawText.Length > 40
+                        ? cell.RawText.Substring(0, 40) + "…" : cell.RawText);
+                }
+                result.Cells.Add(cell);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// The last tab-separated field that parses as a number.
+        ///
+        /// Last rather than first: a two-column copy is conventionally
+        /// description-then-rate, and a wrong number in a visible cell is a
+        /// better failure than a skipped row nobody notices.
+        /// </summary>
+        private static double? LastNumberIn(string line)
+        {
+            var fields = (line ?? "").Split('\t');
+            for (int i = fields.Length - 1; i >= 0; i--)
+            {
+                double? v = ParseNumber(fields[i]);
+                if (v.HasValue) return v;
+            }
+            return null;
+        }
+
+        /// <summary>Parse one field, or null. Never throws, never guesses zero.</summary>
+        public static double? ParseNumber(string field)
+        {
+            string t = (field ?? "").Trim();
+            if (t.Length == 0) return null;
+
+            bool parenNegative = t.StartsWith("(") && t.EndsWith(")");
+            if (parenNegative) t = t.Substring(1, t.Length - 2).Trim();
+
+            // Strip currency and separators. Everything removed here is
+            // decoration; anything left that is not a number stays, so a value
+            // like "28k" is REJECTED rather than read as 28.
+            t = t.Replace("UGX", "", StringComparison.OrdinalIgnoreCase)
+                 .Replace("USh", "", StringComparison.OrdinalIgnoreCase)
+                 .Replace("$", "").Replace("£", "").Replace("€", "")
+                 .Replace(",", "").Replace(" ", "").Replace(" ", "");
+            if (t.Length == 0) return null;
+
+            if (!double.TryParse(t, NumberStyles.Any, CultureInfo.InvariantCulture, out double d)
+             && !double.TryParse(t, NumberStyles.Any, CultureInfo.CurrentCulture, out d))
+                return null;
+
+            return parenNegative ? -d : d;
+        }
+    }
+}

--- a/StingTools/UI/CommodityRateEditor.cs
+++ b/StingTools/UI/CommodityRateEditor.cs
@@ -107,6 +107,9 @@ namespace StingTools.UI
         private readonly DataGrid _grid;
         private readonly TextBlock _status;
         private readonly string _targetPath;
+        private readonly System.Collections.Generic.List<RateEditorRowVm> _all;
+        private readonly TextBox _filter;
+        private readonly CheckBox _unpricedOnly;
 
         public bool Saved { get; private set; }
 
@@ -117,7 +120,8 @@ namespace StingTools.UI
             _existingProject = existingProject ?? new List<CommodityRate>();
             _targetPath = targetPath;
 
-            foreach (var r in seed.Rows) _rows.Add(new RateEditorRowVm(r));
+            _all = seed.Rows.Select(r => new RateEditorRowVm(r)).ToList();
+            foreach (var r in _all) _rows.Add(r);
 
             Title = "STING — Price commodities";
             Width = 1080; Height = 660;
@@ -178,6 +182,55 @@ namespace StingTools.UI
             DockPanel.SetDock(footer, Dock.Bottom);
             root.Children.Add(footer);
 
+            // ── inline actions ──
+            //
+            // Every action that operates on the grid lives ON the grid, with
+            // the keyboard shortcut printed on it. The alternative - a dialog
+            // per action - is what made the editor's own button hard to find
+            // in the first place.
+            var bar = new WrapPanel { Margin = new Thickness(12, 10, 12, 0) };
+
+            bar.Children.Add(ToolButton("Paste column  (Ctrl+V)",
+                "Paste a column of rates copied from Excel, starting at the selected row. "
+              + "Blank lines keep their place so the rates below them stay on the right "
+              + "commodities; a line with no number is reported, never treated as zero.",
+                (a, b) => PasteColumn()));
+
+            bar.Children.Add(ToolButton("Fill down  (Ctrl+D)",
+                "Copy the rate in the row above into every selected row.",
+                (a, b) => FillDown()));
+
+            bar.Children.Add(ToolButton("Clear  (Del)",
+                "Clear the typed rate in the selected rows. The row keeps whatever rate it "
+              + "already had - clearing is not the same as pricing at zero.",
+                (a, b) => ClearSelected()));
+
+            bar.Children.Add(ToolButton("Copy keys",
+                "Copy Description and Unit for the visible rows to the clipboard, so a rate "
+              + "column can be built beside them in Excel and pasted straight back.",
+                (a, b) => CopyKeys()));
+
+            bar.Children.Add(new TextBlock
+            {
+                Text = "Find:", VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(14, 0, 4, 0), FontSize = 11.5
+            });
+            _filter = new TextBox { Width = 170, Height = 24, VerticalContentAlignment = VerticalAlignment.Center };
+            _filter.TextChanged += (a, b) => ApplyFilter();
+            bar.Children.Add(_filter);
+
+            _unpricedOnly = new CheckBox
+            {
+                Content = "Unpriced only", VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(12, 0, 0, 0), FontSize = 11.5
+            };
+            _unpricedOnly.Checked   += (a, b) => ApplyFilter();
+            _unpricedOnly.Unchecked += (a, b) => ApplyFilter();
+            bar.Children.Add(_unpricedOnly);
+
+            DockPanel.SetDock(bar, Dock.Top);
+            root.Children.Add(bar);
+
             // ── grid ──
             _grid = new DataGrid
             {
@@ -186,9 +239,33 @@ namespace StingTools.UI
                 CanUserAddRows = false, CanUserDeleteRows = false,
                 HeadersVisibility = DataGridHeadersVisibility.Column,
                 GridLinesVisibility = DataGridGridLinesVisibility.Horizontal,
-                Margin = new Thickness(12, 10, 12, 0),
-                RowBackground = Brushes.Transparent
+                Margin = new Thickness(12, 6, 12, 0),
+                RowBackground = Brushes.Transparent,
+
+                // Excel behaviour, deliberately:
+                //  * cell selection, not whole rows, so the rate column can be
+                //    navigated and pasted into like a spreadsheet column;
+                //  * Tab and Enter both commit and move on, Enter downwards,
+                //    which is what a hand pricing a column expects;
+                //  * one click into the cell rather than click-then-click.
+                SelectionUnit = DataGridSelectionUnit.Cell,
+                SelectionMode = DataGridSelectionMode.Extended,
+                CanUserSortColumns = true,
+                ClipboardCopyMode = DataGridClipboardCopyMode.IncludeHeader
             };
+            // Single click begins the edit. Without this the first click only
+            // selects, which reads as the cell being read-only.
+            _grid.PreparingCellForEdit += (s2, e2) =>
+            {
+                if (e2.EditingElement is TextBox tb)
+                { tb.SelectAll(); tb.Focus(); }
+            };
+            _grid.CurrentCellChanged += (s2, e2) =>
+            {
+                if (_grid.CurrentCell.Column != null && !_grid.CurrentCell.Column.IsReadOnly)
+                    _grid.BeginEdit();
+            };
+            _grid.PreviewKeyDown += Grid_PreviewKeyDown;
             var rowStyle = new Style(typeof(DataGridRow));
             rowStyle.Setters.Add(new Setter(DataGridRow.BackgroundProperty,
                 new System.Windows.Data.Binding(nameof(RateEditorRowVm.RowBrush))));
@@ -216,6 +293,206 @@ namespace StingTools.UI
             Content = root;
         }
 
+        private static Button ToolButton(string label, string tip, RoutedEventHandler onClick)
+        {
+            var b = new Button
+            {
+                Content = label, Height = 26, Padding = new Thickness(10, 0, 10, 0),
+                Margin = new Thickness(0, 0, 6, 0), ToolTip = tip, FontSize = 11.5
+            };
+            b.Click += onClick;
+            return b;
+        }
+
+        // ══ Excel keys ════════════════════════════════════════
+        private void Grid_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            bool ctrl = (System.Windows.Input.Keyboard.Modifiers
+                         & System.Windows.Input.ModifierKeys.Control) != 0;
+
+            if (ctrl && e.Key == System.Windows.Input.Key.V) { PasteColumn(); e.Handled = true; }
+            else if (ctrl && e.Key == System.Windows.Input.Key.D) { FillDown(); e.Handled = true; }
+            else if (e.Key == System.Windows.Input.Key.Delete && !IsEditing()) { ClearSelected(); e.Handled = true; }
+        }
+
+        private bool IsEditing() =>
+            _grid.CurrentCell.Column != null
+            && _grid.CurrentColumn != null
+            && System.Windows.Input.Keyboard.FocusedElement is TextBox;
+
+        private int SelectedIndex()
+        {
+            var vm = _grid.CurrentCell.Item as RateEditorRowVm;
+            int i = vm != null ? _rows.IndexOf(vm) : -1;
+            return i < 0 ? 0 : i;
+        }
+
+        /// <summary>
+        /// Paste a column from Excel over consecutive rows from the selection.
+        ///
+        /// The parsing, and every decision about blanks and unparseable lines,
+        /// lives in the Revit-free RatePasteParser where it is tested. This is
+        /// the part that moves values into rows and says what happened.
+        /// </summary>
+        private void PasteColumn()
+        {
+            string text;
+            try { text = Clipboard.GetText(); }
+            catch (Exception ex)
+            {
+                StingLog.Warn("RateEditor paste: " + ex.Message);
+                MessageBox.Show(this, "The clipboard could not be read.", Caption,
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var parsed = RatePasteParser.Parse(text);
+            if (parsed.Cells.Count == 0)
+            {
+                MessageBox.Show(this,
+                    "There is nothing on the clipboard to paste.\n\nCopy a column of rates in "
+                  + "Excel first — one per line, in the same order as the rows here. "
+                  + "Copy keys puts the descriptions on the clipboard so the column can be built "
+                  + "beside them.",
+                    Caption, MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            int start = SelectedIndex();
+            int applied = 0, ranOut = 0;
+
+            for (int i = 0; i < parsed.Cells.Count; i++)
+            {
+                int target = start + i;
+                if (target >= _rows.Count)
+                {
+                    if (parsed.Cells[i].Value.HasValue) ranOut++;
+                    continue;
+                }
+                var cell = parsed.Cells[i];
+                if (!cell.Value.HasValue) continue;      // blank or rejected: row untouched
+                _rows[target].NewRate = cell.Value.Value.ToString(
+                    System.Globalization.CultureInfo.InvariantCulture);
+                applied++;
+            }
+
+            CommitAndRefresh();
+            string summary = parsed.Summary(applied, ranOut);
+            _status.Text = summary ?? _status.Text;
+            if (parsed.Rejected.Count > 0 || ranOut > 0)
+                MessageBox.Show(this, summary, Caption, MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        /// <summary>Copy the rate above into every selected row.</summary>
+        private void FillDown()
+        {
+            var targets = _grid.SelectedCells
+                .Select(c => c.Item as RateEditorRowVm)
+                .Where(v => v != null).Distinct().ToList();
+            if (targets.Count == 0) { var v = _grid.CurrentCell.Item as RateEditorRowVm; if (v != null) targets.Add(v); }
+            if (targets.Count == 0) return;
+
+            int first = _rows.IndexOf(targets[0]);
+            if (first <= 0)
+            {
+                _status.Text = "Fill down needs a row above the selection to copy from.";
+                return;
+            }
+
+            string source = _rows[first - 1].NewRate;
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                _status.Text = "The row above has no typed rate to fill down.";
+                return;
+            }
+
+            foreach (var t in targets) t.NewRate = source;
+            CommitAndRefresh();
+            _status.Text = $"Filled {targets.Count} row(s) with {source}.";
+        }
+
+        /// <summary>
+        /// Clear the TYPED rate, not the rate in force.
+        ///
+        /// Clearing is "leave this one alone", which is exactly what an empty
+        /// cell means to the merge. It is not pricing at zero, and the tooltip
+        /// says so, because those two would look identical in the grid.
+        /// </summary>
+        private void ClearSelected()
+        {
+            var targets = _grid.SelectedCells
+                .Select(c => c.Item as RateEditorRowVm)
+                .Where(v => v != null).Distinct().ToList();
+            if (targets.Count == 0) return;
+
+            foreach (var t in targets) t.NewRate = "";
+            CommitAndRefresh();
+            _status.Text = $"Cleared the typed rate on {targets.Count} row(s) — each keeps the rate it already had.";
+        }
+
+        /// <summary>Description + unit for the VISIBLE rows, tab-separated.</summary>
+        private void CopyKeys()
+        {
+            var sb = new StringBuilder();
+            foreach (var r in _rows) sb.AppendLine(r.Description + "\t" + r.SupplierUnit);
+            try
+            {
+                Clipboard.SetText(sb.ToString());
+                _status.Text = $"Copied {_rows.Count} description(s) — paste into Excel, put rates "
+                             + "beside them, then copy that column back and press Ctrl+V here.";
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("RateEditor copy: " + ex.Message);
+                _status.Text = "The clipboard could not be written.";
+            }
+        }
+
+        /// <summary>
+        /// Filter the visible rows. Edits live on the underlying model, so a
+        /// row filtered out of sight keeps whatever was typed into it — hiding
+        /// a row must never discard the work done on it.
+        /// </summary>
+        private void ApplyFilter()
+        {
+            string q = (_filter?.Text ?? "").Trim();
+            bool unpricedOnly = _unpricedOnly?.IsChecked == true;
+
+            _rows.Clear();
+            foreach (var r in _all)
+            {
+                if (unpricedOnly && !r.Model.IsUnpriced) continue;
+                if (q.Length > 0 &&
+                    (r.Description ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) < 0 &&
+                    (r.SupplierUnit ?? "").IndexOf(q, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+                _rows.Add(r);
+            }
+            _status.Text = _rows.Count == _all.Count
+                ? "Writes " + (_targetPath ?? "(project not saved)")
+                : $"Showing {_rows.Count} of {_all.Count} row(s). Rates typed into hidden rows are kept.";
+        }
+
+        /// <summary>
+        /// Commit any open cell edit before refreshing.
+        ///
+        /// Items.Refresh() throws if the grid is mid-edit, and every one of
+        /// these actions can be triggered by a keyboard shortcut while a cell
+        /// is open — which is the normal way to use them.
+        /// </summary>
+        private void CommitAndRefresh()
+        {
+            try
+            {
+                _grid.CommitEdit(DataGridEditingUnit.Cell, true);
+                _grid.CommitEdit(DataGridEditingUnit.Row, true);
+            }
+            catch (Exception ex) { StingLog.Warn("RateEditor commit: " + ex.Message); }
+            _grid.Items.Refresh();
+        }
+
+        private const string Caption = "STING — Price commodities";
+
         private void AddReadOnly(string header, string path, double width) =>
             _grid.Columns.Add(new DataGridTextColumn
             {
@@ -240,7 +517,10 @@ namespace StingTools.UI
                 return false;
             }
 
-            var edited = _rows.Select(r => r.Model).ToList();
+            // _all, not _rows: a filtered-out row that was priced before the
+            // filter was applied must still be saved. Saving only what is on
+            // screen would silently discard work the user can no longer see.
+            var edited = _all.Select(r => r.Model).ToList();
 
             var problems = RateEditorSeed.Validate(edited);
             if (problems.Count > 0)


### PR DESCRIPTION
feat(matsched): Excel navigation and paste in the rate grid

Typing 58 numbers is the work the grid was meant to remove, not
preserve. A supplier quote arrives as a spreadsheet, so the grid now
takes one.

Inline on the grid, each with its shortcut printed on it: Paste column
(Ctrl+V), Fill down (Ctrl+D), Clear (Del), Copy keys, a Find box and an
"Unpriced only" toggle. Cell selection rather than row selection, single
click to edit, Enter commits and moves down.

Copy keys and Paste column are a pair: copy the descriptions out, build
a rate column beside them in Excel, copy that column, Ctrl+V back.

The parsing is Revit-free and tested, because three of its decisions are
each a way a paste could go wrong in silence:

  * A BLANK line consumes its row without changing it. Copy a column
    with gaps and the gaps must stay aligned with the rows they came
    from - skipping them shifts every rate below the gap onto the wrong
    commodity, and every one of those then looks deliberate.
  * A line with NO number is reported, never treated as zero. A pasted
    header row, or a "TBC", is a thing the user must see rather than a
    free commodity.
  * A multi-column paste takes the LAST numeric field. Copying Qty +
    Rate out of a working sheet is ordinary and both are numeric; first-
    numeric-wins would price cement at 93.

Clear empties the TYPED rate, not the rate in force - "leave this one
alone", which is what an empty cell already means to the merge. It is
not pricing at zero, and the tooltip says so, because in the grid those
two look identical.

Save reads the unfiltered set. Filtering the grid then saving must not
discard a rate typed into a row that is now hidden.

Items.Refresh() throws mid-edit and every one of these actions has a
keyboard shortcut, which is the normal way to reach them while a cell is
open - so each commits the edit first.

Boq tests 945 -> 947, build 0/0, all four gates pass.

Five mutations run, four failing: dropping interior blanks (2), an
unparseable line becoming zero (1), first-numeric-field (2), stripping
trailing letters so 28k reads as 28 (7).

TWO WERE FALSE RESULTS AND ARE CORRECTED HERE RATHER THAN COUNTED.

The 28k mutation first reported PASS. It had not applied: the source
strips a non-breaking space (U+00A0) and my mutation string carried an
ordinary one, so nothing was replaced and the suite was green for the
wrong reason. Checked the bytes rather than trusting the result; with
the edit actually applied it fails 7. A mutation that silently fails to
apply is indistinguishable from a test gap, which is the same failure
mode as an empty list standing in for an error.

The first-vs-last-field mutation genuinely proved nothing, and that was
a real gap: both existing tests had a non-numeric first field, so they
could not tell the two apart. Added a Qty+Rate case, which is what a
copy out of a working sheet looks like; it now fails 2.

The fifth (dropping ALL trailing blank lines rather than Excel's single
one) is behaviour-equivalent - trailing blanks land past the last row
and change nothing - so it is reported as equivalent rather than given a
test to satisfy it.

NOT verified: none of the grid behaviour has run in Revit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
