### PR TITLE
feat(matsched): the rate grid says what each row IS, not only what it costs

### DIFF
--- a/StingTools.Boq.Tests/CommodityAggregatorTests.cs
+++ b/StingTools.Boq.Tests/CommodityAggregatorTests.cs
@@ -58,6 +58,41 @@ namespace StingTools.Boq.Tests
         };
 
         [Fact]
+        public void An_Aggregated_Commodity_Remembers_Every_Category_It_Came_From()
+        {
+            // The wiring, not the shape. Setting Categories on a MaterialCommodity
+            // by hand in a test proves the editor renders it and nothing about
+            // whether aggregation ever fills it — a mutation deleting the
+            // collection line moved no test until this one existed.
+            var doc = CommodityAggregator.Build(Inputs(
+                new ConstituentInput { ConstituentKind = "mortar_cement", Unit = "bag", Quantity = 120,
+                                       Category = "Walls",  TypeName = "Blockwork 200" },
+                new ConstituentInput { ConstituentKind = "mortar_cement", Unit = "bag", Quantity = 230,
+                                       Category = "Floors", TypeName = "RC Slab 150" }));
+
+            var cement = doc.Stages.Single(s => s.StageId == "superstructure")
+                            .Commodities.Single(c => c.CommodityKey == "cement");
+
+            Assert.Equal(new[] { "Floors", "Walls" }, cement.Categories.ToArray());
+            Assert.Contains("Blockwork 200", cement.TypeNames);
+            Assert.Contains("RC Slab 150", cement.TypeNames);
+        }
+
+        [Fact]
+        public void A_Row_With_No_Category_Adds_No_Empty_Entry()
+        {
+            var doc = CommodityAggregator.Build(Inputs(
+                new ConstituentInput { ConstituentKind = "mortar_cement", Unit = "bag", Quantity = 10,
+                                       Category = "  ", TypeName = "" }));
+
+            var cement = doc.Stages.Single(s => s.StageId == "superstructure")
+                            .Commodities.Single(c => c.CommodityKey == "cement");
+
+            Assert.Empty(cement.Categories);
+            Assert.Empty(cement.TypeNames);
+        }
+
+        [Fact]
         public void Rows_Of_The_Same_Commodity_In_The_Same_Stage_Merge_Into_One_Line()
         {
             var doc = CommodityAggregator.Build(Inputs(

--- a/StingTools.Boq.Tests/RateEditorSeedTests.cs
+++ b/StingTools.Boq.Tests/RateEditorSeedTests.cs
@@ -218,5 +218,124 @@ namespace StingTools.Boq.Tests
         {
             Assert.Empty(RateEditorSeed.Validate(new[] { Edit("cement", 28000), Edit("sand", 1400000) }));
         }
-    }
+    
+        // ── origin, sort order and stakes ───────────────────────────────────
+
+        [Fact]
+        public void A_Row_Carries_The_Categories_It_Was_Measured_From()
+        {
+            // "Generic - 225mm, 610 m2, unpriced" gave a QS no way to tell it
+            // was a ROOF — the one fact needed to price it.
+            var c = C("Generic - 225mm", qty: 610);
+            c.Categories = new List<string> { "Roofs" };
+
+            Assert.Equal("Roofs", RateEditorSeed.Build(Doc(c)).Rows.Single().Origin);
+        }
+
+        [Fact]
+        public void A_Commodity_From_Several_Categories_Names_Them_All()
+        {
+            // Cement comes from walls AND floors. Collapsing that to "the first
+            // one" would name a source that is only part of the truth.
+            var c = C("cement", rate: 28000, source: "baseline");
+            c.Categories = new List<string> { "Floors", "Walls" };
+
+            Assert.Equal("Floors, Walls", RateEditorSeed.Build(Doc(c)).Rows.Single().Origin);
+        }
+
+        [Fact]
+        public void Quantities_Are_Never_Sorted_Across_Units()
+        {
+            // 610 m2 sorted above 29 each said the roof mattered more than the
+            // ridge caps. Those two numbers cannot support that comparison.
+            var m2 = C("roof", qty: 610); m2.SupplierUnit = "m2";
+            var each = C("caps", qty: 29); each.SupplierUnit = "each";
+            var m2small = C("small-roof", qty: 21); m2small.SupplierUnit = "m2";
+
+            var rows = RateEditorSeed.Build(Doc(m2, each, m2small)).Rows;
+
+            // Grouped by unit first: both "each" rows together, both m2 together.
+            Assert.Equal(new[] { "caps", "roof", "small-roof" },
+                         rows.Select(r => r.CommodityKey).ToArray());
+        }
+
+        [Fact]
+        public void Within_A_Unit_The_Largest_Quantity_Still_Leads()
+        {
+            var big = C("big", qty: 610); big.SupplierUnit = "m2";
+            var small = C("small", qty: 21); small.SupplierUnit = "m2";
+
+            var rows = RateEditorSeed.Build(Doc(small, big)).Rows;
+
+            Assert.Equal("big", rows[0].CommodityKey);
+        }
+
+        [Fact]
+        public void The_Stakes_Line_Says_The_Priced_Total_Is_Short_Not_Complete()
+        {
+            var priced = C("cement", qty: 93, rate: 28000, source: "baseline");
+            var seed = RateEditorSeed.Build(Doc(priced, C("roof", qty: 610)));
+
+            string s = seed.Stakes();
+
+            Assert.Contains("2,604,000", s);
+            Assert.Contains("1 row(s) still unpriced", s);
+            Assert.Contains("short by whatever they are worth, not by zero", s);
+        }
+
+        [Fact]
+        public void A_Fully_Priced_Schedule_Says_So_Without_A_Warning()
+        {
+            string s = RateEditorSeed.Build(Doc(C("cement", qty: 93, rate: 28000, source: "baseline"))).Stakes();
+
+            Assert.Contains("every commodity carries a rate", s);
+            Assert.DoesNotContain("still unpriced", s);
+        }
+
+        // ── the identification detail ───────────────────────────────────────
+
+        [Fact]
+        public void A_Row_Backed_By_One_Element_Names_It()
+        {
+            var c = C("gate", qty: 1);
+            c.TraceRefs = new List<string> { "E-16438" };
+
+            var row = RateEditorSeed.Build(Doc(c)).Rows.Single();
+
+            Assert.Equal(1, row.ContributingRows);
+            Assert.Equal("E-16438", row.SingleTraceRef);
+        }
+
+        [Fact]
+        public void A_Row_Backed_By_Many_Names_None_Of_Them()
+        {
+            // A commodity is an aggregate. "The first of 40" would be a
+            // confident label for something untrue of the row.
+            var c = C("cement", rate: 28000, source: "baseline");
+            c.TraceRefs = new List<string> { "W1", "W2", "F1" };
+
+            var row = RateEditorSeed.Build(Doc(c)).Rows.Single();
+
+            Assert.Equal(3, row.ContributingRows);
+            Assert.Equal("", row.SingleTraceRef);
+        }
+
+        [Fact]
+        public void The_Reason_A_Row_Stayed_In_Measured_Units_Is_Carried()
+        {
+            var c = C("Generic - 225mm", qty: 610);
+            c.ConversionNote = "category 'Roofs' maps to 'roof-sheet', but type matches no pattern";
+
+            Assert.Contains("roof-sheet", RateEditorSeed.Build(Doc(c)).Rows.Single().ConversionNote);
+        }
+
+        [Fact]
+        public void The_Constituent_Kind_Is_Carried()
+        {
+            var c = C("cement", rate: 28000, source: "baseline");
+            c.SourceKind = "mortar_cement";
+
+            Assert.Equal("mortar_cement", RateEditorSeed.Build(Doc(c)).Rows.Single().SourceKind);
+        }
+}
 }

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -163,6 +163,8 @@ namespace StingTools.Core.MaterialSchedule
                 }
                 a.SourceQuantity += row.Quantity;
                 if (!string.IsNullOrWhiteSpace(row.TraceRef)) a.TraceRefs.Add(row.TraceRef);
+                if (!string.IsNullOrWhiteSpace(row.Category)) a.Categories.Add(row.Category.Trim());
+                if (!string.IsNullOrWhiteSpace(row.TypeName)) a.TypeNames.Add(row.TypeName.Trim());
             }
 
             // Materialise stages in definition order, dropping empties.
@@ -203,6 +205,8 @@ namespace StingTools.Core.MaterialSchedule
                         RateUGX = rate.RateUGX,
                         RateSource = rate.Source,
                         TraceRefs = a.TraceRefs,
+                        Categories = a.Categories.ToList(),
+                        TypeNames = a.TypeNames.Take(8).ToList(),
                         SourceKind = a.SourceKind,
                         ConversionBlocked = a.ConversionBlocked,
                         ConversionNote = a.ConversionNote
@@ -246,6 +250,10 @@ namespace StingTools.Core.MaterialSchedule
             public bool ConversionBlocked;
             public string ConversionNote = "";
             public List<string> TraceRefs = new List<string>();
+            public readonly SortedSet<string> Categories =
+                new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            public readonly SortedSet<string> TypeNames =
+                new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
+++ b/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
@@ -29,6 +29,27 @@ namespace StingTools.Core.MaterialSchedule
         public List<string> TraceRefs = new List<string>();
 
         /// <summary>
+        /// The Revit categories this commodity was measured FROM, sorted.
+        ///
+        /// Aggregation groups by commodity key and had been dropping this, so a
+        /// row reading "Generic - 225mm, 610 m2, unpriced" gave a QS no way to
+        /// tell it was a ROOF — the one fact needed to price it. Cement comes
+        /// from several categories at once, so it is a set rather than a single
+        /// value; collapsing it to "the first one" would name a source that is
+        /// only part of the truth.
+        /// </summary>
+        public List<string> Categories = new List<string>();
+
+        /// <summary>
+        /// The model TYPE names behind this row, sorted, capped at a few.
+        ///
+        /// For an unmatched row the key IS the type name and this adds nothing;
+        /// for cement it says which walls and slabs produced it, which is what
+        /// makes a rate checkable rather than merely enterable.
+        /// </summary>
+        public List<string> TypeNames = new List<string>();
+
+        /// <summary>
         /// True when a supplier-unit rule matched this row's CATEGORY but not its
         /// type, so the quantity stayed in measured units rather than being
         /// converted on a guess. Surfaced by reconciler rule R5 — a wrong trade

--- a/StingTools/Core/MaterialSchedule/RateEditorSeed.cs
+++ b/StingTools/Core/MaterialSchedule/RateEditorSeed.cs
@@ -38,6 +38,39 @@ namespace StingTools.Core.MaterialSchedule
         /// <summary>"baseline" / "project" / "unpriced" — where CurrentRateUGX came from.</summary>
         public string CurrentSource = "";
 
+        /// <summary>Categories this row was measured from, e.g. "Roofs".</summary>
+        public string Origin = "";
+
+        /// <summary>Model type names behind it, for the tooltip.</summary>
+        public string TypeDetail = "";
+
+        /// <summary>The constituent kind, e.g. "mortar_cement". Says WHY the row exists.</summary>
+        public string SourceKind = "";
+
+        /// <summary>
+        /// How many measured rows fed this commodity.
+        ///
+        /// A confidence signal a rate cannot carry: 93 bags of cement from 40
+        /// walls is a different kind of number from 93 bags from one, and the
+        /// second is worth looking at before pricing it.
+        /// </summary>
+        public int ContributingRows;
+
+        /// <summary>
+        /// Why the quantity stayed in measured units, when it did — the same
+        /// text reconciler rule R5 reports.
+        /// </summary>
+        public string ConversionNote = "";
+
+        /// <summary>
+        /// Element / BOQ references behind the row, but ONLY when there is one.
+        ///
+        /// A commodity is an aggregate: cement comes from dozens of walls, and
+        /// no single element identifies it. Showing "the first of 40" would be
+        /// a confident label for something that is not true of the row.
+        /// </summary>
+        public string SingleTraceRef = "";
+
         /// <summary>
         /// What the user typed. NULL means "left alone", which is NOT the same
         /// as 0. A blank cell must never delete a rate already in force — that
@@ -59,6 +92,31 @@ namespace StingTools.Core.MaterialSchedule
         public int MemorandaExcluded;
 
         public int UnpricedCount => Rows.Count(r => r.IsUnpriced);
+
+        /// <summary>
+        /// What is currently priced, and what is not.
+        ///
+        /// The grid shows 25 rows reading "—" and gives no sense of what that
+        /// costs, because an unpriced row's contribution is unknowable until it
+        /// has a rate. So this says what IS known — the priced total — and
+        /// names the unpriced count as a hole in it rather than implying the
+        /// figure is complete.
+        /// </summary>
+        public string Stakes()
+        {
+            if (Rows.Count == 0) return "";
+
+            double priced = Rows.Where(r => !r.IsUnpriced).Sum(r => r.CurrentAmountUGX);
+            int unpriced = UnpricedCount;
+
+            string s = $"Priced so far: UGX {priced:N0}";
+            if (unpriced > 0)
+                s += $"  ·  {unpriced} row(s) still unpriced and contributing nothing — the total "
+                   + "above is short by whatever they are worth, not by zero.";
+            else
+                s += "  ·  every commodity carries a rate.";
+            return s;
+        }
 
         public string Summary()
         {
@@ -113,15 +171,31 @@ namespace StingTools.Core.MaterialSchedule
                     SupplierUnit   = c.SupplierUnit ?? "",
                     OrderQuantity  = c.OrderQuantity,
                     CurrentRateUGX = c.RateUGX,
-                    CurrentSource  = c.RateSource ?? ""
+                    CurrentSource  = c.RateSource ?? "",
+                    Origin         = string.Join(", ", c.Categories ?? new List<string>()),
+                    TypeDetail     = string.Join("\n", c.TypeNames ?? new List<string>()),
+                    SourceKind     = c.SourceKind ?? "",
+                    ContributingRows = (c.TraceRefs ?? new List<string>()).Count,
+                    ConversionNote = c.ConversionNote ?? "",
+                    SingleTraceRef = (c.TraceRefs ?? new List<string>()).Count == 1
+                                     ? c.TraceRefs[0] : ""
                 });
             }
 
             // Unpriced first, then largest quantity — the order somebody pricing
             // a job actually works in.
+            // Unpriced first — those are the rows totalling zero.
+            //
+            // Then by UNIT, and only then by quantity. Sorting 610 m2 above
+            // 29 each said the roof mattered more than the ridge caps, which is
+            // not a comparison those two numbers can support: they measure
+            // different things in different dimensions. Grouping by unit first
+            // means every quantity a reader compares is comparable.
             result.Rows.Sort((a, b) =>
             {
                 if (a.IsUnpriced != b.IsUnpriced) return a.IsUnpriced ? -1 : 1;
+                int u = string.Compare(a.SupplierUnit, b.SupplierUnit, StringComparison.OrdinalIgnoreCase);
+                if (u != 0) return u;
                 int q = b.OrderQuantity.CompareTo(a.OrderQuantity);
                 return q != 0 ? q
                     : string.Compare(a.Description, b.Description, StringComparison.OrdinalIgnoreCase);

--- a/StingTools/UI/BOQCostManagerPanel.cs
+++ b/StingTools/UI/BOQCostManagerPanel.cs
@@ -5075,6 +5075,35 @@ namespace StingTools.UI
             DockPanel.SetDock(btn, Dock.Right);
             row.Children.Add(Guarded(btn));
 
+            // Second entry point to the SAME editor. It exists on the Actions
+            // tab too, and that was still one tab away from where a QS reading
+            // materials actually is — the first person to look for it did not
+            // find it at all. Placed LEFT of the export because it is the step
+            // before: an unpriced commodity totals zero in the schedule.
+            var priceBtn = new Button
+            {
+                Content = "Price Commodities",
+                Tag = "MaterialSchedule_PriceCommodities",
+                FontSize = 11,
+                MinHeight = 30,
+                Padding = new Thickness(12, 5, 12, 5),
+                Margin = new Thickness(12, 0, 0, 0),
+                Cursor = Cursors.Hand,
+                ToolTip = "Price the material schedule in a grid seeded from the schedule itself, so no "
+                        + "commodity key is ever retyped. Paste a rate column straight out of Excel "
+                        + "(Ctrl+V). Saves to this project's commodity_rates.csv; the shipped corporate "
+                        + "baseline is never touched."
+            };
+            try
+            {
+                var pstyle = TryFindResource("BlueBtn") as Style;
+                if (pstyle != null) { priceBtn.Style = pstyle; priceBtn.FontSize = 11; priceBtn.MinHeight = 30; }
+            }
+            catch (Exception ex) { StingLog.Warn($"BuildMaterialScheduleBar price style: {ex.Message}"); }
+            priceBtn.Click += (s, e) => DispatchAction("MaterialSchedule_PriceCommodities");
+            DockPanel.SetDock(priceBtn, Dock.Right);
+            row.Children.Add(Guarded(priceBtn));
+
             row.Children.Add(new TextBlock
             {
                 Text = "This tab is what you MODELLED, by category. A material schedule is what you BUY — "

--- a/StingTools/UI/CommodityRateEditor.cs
+++ b/StingTools/UI/CommodityRateEditor.cs
@@ -56,8 +56,45 @@ namespace StingTools.UI
             ? "—"
             : _row.CurrentRateUGX.ToString("N0", CultureInfo.CurrentCulture);
 
-        /// <summary>"unpriced" reads as a state; the others say where the number came from.</summary>
-        public string Source => string.IsNullOrWhiteSpace(_row.CurrentSource) ? "—" : _row.CurrentSource;
+        /// <summary>
+        /// The SAME wording the export uses.
+        ///
+        /// This read "baseline" while the schedule the user reads next said
+        /// "Indicative" for the identical row. Two names for one fact, in two
+        /// places a QS compares, is how a shipped guess comes to be trusted as
+        /// a corporate rate.
+        /// </summary>
+        public string Source => RateProvenanceLabel.For(new MaterialCommodity
+        {
+            RateUGX = _row.CurrentRateUGX, RateSource = _row.CurrentSource
+        });
+
+        /// <summary>Where the quantity was measured from, e.g. "Roofs".</summary>
+        public string Origin => string.IsNullOrWhiteSpace(_row.Origin) ? "—" : _row.Origin;
+
+        /// <summary>The exact key written to commodity_rates.csv.</summary>
+        public string Key => _row.CommodityKey;
+
+        public string Kind => string.IsNullOrWhiteSpace(_row.SourceKind) ? "—" : _row.SourceKind;
+
+        /// <summary>
+        /// How many measured rows fed this commodity, or the single element
+        /// reference when there is exactly one.
+        ///
+        /// A commodity is an aggregate. Naming "the first of 40" elements would
+        /// be a confident label for something untrue of the row, so a count is
+        /// shown instead and a reference only when it identifies the whole row.
+        /// </summary>
+        public string Backing => _row.ContributingRows == 1 && _row.SingleTraceRef.Length > 0
+            ? _row.SingleTraceRef
+            : _row.ContributingRows.ToString(CultureInfo.CurrentCulture);
+
+        public string Note => string.IsNullOrWhiteSpace(_row.ConversionNote) ? "" : _row.ConversionNote;
+
+        /// <summary>The model types behind the row, for the row tooltip.</summary>
+        public string TypeDetail => string.IsNullOrWhiteSpace(_row.TypeDetail)
+            ? "No model type recorded for this row."
+            : "Measured from:\n" + _row.TypeDetail;
 
         public string Amount => _row.IsUnpriced
             ? "—"
@@ -110,6 +147,11 @@ namespace StingTools.UI
         private readonly System.Collections.Generic.List<RateEditorRowVm> _all;
         private readonly TextBox _filter;
         private readonly CheckBox _unpricedOnly;
+        private readonly System.Collections.Generic.List<DataGridColumn> _detailColumns =
+            new System.Collections.Generic.List<DataGridColumn>();
+        private readonly string _seedStakes;
+        private Button _detailsButton;
+        private bool _detailsShown;
 
         public bool Saved { get; private set; }
 
@@ -119,6 +161,7 @@ namespace StingTools.UI
             _doc = doc;
             _existingProject = existingProject ?? new List<CommodityRate>();
             _targetPath = targetPath;
+            _seedStakes = seed.Stakes();
 
             _all = seed.Rows.Select(r => new RateEditorRowVm(r)).ToList();
             foreach (var r in _all) _rows.Add(r);
@@ -157,9 +200,10 @@ namespace StingTools.UI
             var footer = new DockPanel { Margin = new Thickness(12, 8, 12, 12) };
             _status = new TextBlock
             {
-                Text = "Writes " + (_targetPath ?? "(project not saved)"),
+                Text = seed.Stakes(),
                 VerticalAlignment = VerticalAlignment.Center, FontSize = 11,
-                Foreground = Brushes.DimGray, TextTrimming = TextTrimming.CharacterEllipsis
+                Foreground = Brushes.DimGray, TextTrimming = TextTrimming.CharacterEllipsis,
+                ToolTip = "Writes " + (targetPath ?? "(project not saved)")
             };
             var buttons = new StackPanel { Orientation = Orientation.Horizontal };
             DockPanel.SetDock(buttons, Dock.Right);
@@ -204,6 +248,13 @@ namespace StingTools.UI
                 "Clear the typed rate in the selected rows. The row keeps whatever rate it "
               + "already had - clearing is not the same as pricing at zero.",
                 (a, b) => ClearSelected()));
+
+            _detailsButton = ToolButton("Show detail",
+                "Show the columns that identify a row rather than price it: the exact key written to "
+              + "commodity_rates.csv, the constituent kind behind it, how many measured rows back it, "
+              + "and why a row stayed in measured units.",
+                (a, b) => ToggleDetailColumns());
+            bar.Children.Add(_detailsButton);
 
             bar.Children.Add(ToolButton("Copy keys",
                 "Copy Description and Unit for the visible rows to the clipboard, so a rate "
@@ -269,14 +320,30 @@ namespace StingTools.UI
             var rowStyle = new Style(typeof(DataGridRow));
             rowStyle.Setters.Add(new Setter(DataGridRow.BackgroundProperty,
                 new System.Windows.Data.Binding(nameof(RateEditorRowVm.RowBrush))));
+            rowStyle.Setters.Add(new Setter(DataGridRow.ToolTipProperty,
+                new System.Windows.Data.Binding(nameof(RateEditorRowVm.TypeDetail))));
             _grid.RowStyle = rowStyle;
 
-            AddReadOnly("Description", nameof(RateEditorRowVm.Description), 300);
-            AddReadOnly("Unit", nameof(RateEditorRowVm.SupplierUnit), 130);
+            AddReadOnly("Description", nameof(RateEditorRowVm.Description), 290);
+            // "Generic - 225mm, 610 m2, unpriced" told a QS nothing about what
+            // it was. Naming the category is what makes the row priceable.
+            AddReadOnly("From", nameof(RateEditorRowVm.Origin), 110);
+            AddReadOnly("Unit", nameof(RateEditorRowVm.SupplierUnit), 120);
             AddReadOnly("Order qty", nameof(RateEditorRowVm.Quantity), 90);
             AddReadOnly("Rate now", nameof(RateEditorRowVm.CurrentRate), 90);
             AddReadOnly("Source", nameof(RateEditorRowVm.Source), 80);
             AddReadOnly("Amount", nameof(RateEditorRowVm.Amount), 110);
+            // Detail columns, COLLAPSED by default.
+            //
+            // Every one of these identifies a row rather than pricing it, and a
+            // grid wide enough to show them all at once is a grid nobody reads.
+            // They are kept together so one toggle reveals the whole set.
+            _detailColumns.Add(AddReadOnly("Key", nameof(RateEditorRowVm.Key), 220));
+            _detailColumns.Add(AddReadOnly("Kind", nameof(RateEditorRowVm.Kind), 120));
+            _detailColumns.Add(AddReadOnly("Backing", nameof(RateEditorRowVm.Backing), 80));
+            _detailColumns.Add(AddReadOnly("Why measured units", nameof(RateEditorRowVm.Note), 280));
+            foreach (var c in _detailColumns) c.Visibility = System.Windows.Visibility.Collapsed;
+
             _grid.Columns.Add(new DataGridTextColumn
             {
                 Header = "New rate UGX",
@@ -493,14 +560,34 @@ namespace StingTools.UI
 
         private const string Caption = "STING — Price commodities";
 
-        private void AddReadOnly(string header, string path, double width) =>
-            _grid.Columns.Add(new DataGridTextColumn
+        private DataGridColumn AddReadOnly(string header, string path, double width)
+        {
+            var col = new DataGridTextColumn
             {
                 Header = header,
                 Binding = new System.Windows.Data.Binding(path),
                 Width = width,
                 IsReadOnly = true
-            });
+            };
+            _grid.Columns.Add(col);
+            return col;
+        }
+
+        /// <summary>Show or hide the identification columns as one set.</summary>
+        private void ToggleDetailColumns()
+        {
+            _detailsShown = !_detailsShown;
+            foreach (var c in _detailColumns)
+                c.Visibility = _detailsShown ? System.Windows.Visibility.Visible
+                                             : System.Windows.Visibility.Collapsed;
+            if (_detailsButton != null)
+                _detailsButton.Content = _detailsShown ? "Hide detail" : "Show detail";
+            _status.Text = _detailsShown
+                ? "Detail columns: the exact CSV key, the constituent kind that produced the row, how "
+                + "many measured rows back it (or the element reference when only one does), and why a "
+                + "row stayed in measured units."
+                : _seedStakes;
+        }
 
         // ══════════════════════════════════════════════════════════════════
         private bool Save()


### PR DESCRIPTION
feat(matsched): the rate grid says what each row IS, not only what it costs

The first real run of the editor showed 25 rows reading

    Generic - 225mm   m2   610.62   -   unpriced   -

and nothing on the row said it was a ROOF, which is the one fact needed
to price it. ConstituentInput carried Category and TypeName all along;
aggregation grouped by commodity key and dropped both. They are carried
through now, as SETS - cement comes from walls AND floors, and naming
only the first would name a source that is only part of the truth.

  * A "From" column names the categories a row was measured from.
  * The row tooltip lists the model types behind it.
  * "Show detail" reveals four more columns as one set: the exact key
    written to commodity_rates.csv, the constituent kind that produced
    the row, how many measured rows back it, and why a row stayed in
    measured units. Collapsed by default - a grid wide enough to show
    everything at once is a grid nobody reads.

There is deliberately NO tag column. A commodity is an aggregate: 93
bags of cement come from dozens of walls and no single ISO 19650 tag
identifies the row. Where exactly one measured row backs a commodity its
reference is shown; where several do, the COUNT is shown instead.
"The first of 40" would be a confident label for something untrue of the
row, and this schedule has spent sixteen fixes removing exactly that.

Two alignment defects fixed alongside:

  * The Source column read "baseline" while the export the user reads
    next said "Indicative" for the identical row. Two names for one fact
    in two places a QS compares is how a shipped guess comes to be
    trusted as a corporate rate. Both now use RateProvenanceLabel.
  * Sorting put 610 m2 above 29 each, which said the roof mattered more
    than the ridge caps - not a comparison those numbers can support.
    Rows group by UNIT first, so every quantity a reader compares is
    comparable.

The footer now carries the priced total and says the unpriced rows make
it SHORT rather than complete.

Second entry point on the Materials tab, beside Export Material
Schedule. It was already on the Actions tab and that was still one tab
away from where a QS reading materials actually is.

Boq tests 959 -> 1023, build 0/0, all four gates pass.

Six mutations, all failing: sorting across units (1), collapsing
categories to the first (1), a stakes line implying completeness (1),
the aggregator not collecting categories (1), naming the first element
of an aggregate (1), plus the earlier set.

ONE MUTATION PROVED NOTHING FIRST AND THE GAP IT FOUND IS CLOSED. Deleting
the aggregator's category-collection line moved no test, because every
test set Categories on a MaterialCommodity by hand - proving the editor
RENDERS it and nothing about whether aggregation ever FILLS it. Two
tests now drive CommodityAggregator.Build itself, and that mutation
fails.

NOT verified: none of the new columns has been seen in Revit.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
