### PR TITLE
feat(matsched): map a model type to a commodity, in a file that cannot say more

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -65,6 +65,8 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\RateEditorSeed.cs" Link="MaterialSchedule\RateEditorSeed.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RateProvenanceLabel.cs" Link="MaterialSchedule\RateProvenanceLabel.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RatePasteParser.cs" Link="MaterialSchedule\RatePasteParser.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\SupplierUnitPatch.cs" Link="MaterialSchedule\SupplierUnitPatch.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\TypePatternPlanner.cs" Link="MaterialSchedule\TypePatternPlanner.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools.Boq.Tests/SupplierUnitPatchTests.cs
+++ b/StingTools.Boq.Tests/SupplierUnitPatchTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// A type mapping says "this model's `Generic - 225mm` is a roof tile". It
+    /// must not be able to say anything else.
+    ///
+    /// The existing project override replaces a rule WHOLESALE by CommodityKey,
+    /// so a file written to add one pattern also sets
+    /// SourceUnitsPerSupplierUnit to its default of 1.0 and DefaultWastagePct
+    /// to 0 — silently turning "2.4 m² per sheet, 10% waste" into "1 m² per
+    /// sheet, none", across the whole schedule, with nothing anywhere saying
+    /// why. These tests exist to keep that unrepresentable rather than merely
+    /// discouraged.
+    /// </summary>
+    public class SupplierUnitPatchTests
+    {
+        private static SupplierUnitTable Table() => new SupplierUnitTable
+        {
+            Rules =
+            {
+                new SupplierUnitRule
+                {
+                    CommodityKey = "roof-sheet", Description = "Corrugated iron sheet",
+                    SupplierUnit = "Sheets", SourceUnit = "m2",
+                    SourceUnitsPerSupplierUnit = 2.4, RoundUpToWhole = true, DefaultWastagePct = 10,
+                    MatchCategories = { "Roofs" }, MatchTypePatterns = { "IT4", "Corrugated" }
+                },
+                new SupplierUnitRule
+                {
+                    CommodityKey = "roof-tile", Description = "Clay roof tile",
+                    SupplierUnit = "No.", SourceUnit = "m2",
+                    SourceUnitsPerSupplierUnit = 0.1, RoundUpToWhole = true, DefaultWastagePct = 8,
+                    MatchCategories = { "Roofs" }, MatchTypePatterns = { "Tile" }
+                }
+            }
+        };
+
+        private static MaterialCommodity Roof(string desc, double net = 610.61, double order = 610.62) =>
+            new MaterialCommodity
+            {
+                CommodityKey = desc, Description = desc, SupplierUnit = "m2",
+                NetQuantity = net, OrderQuantity = order, ConversionBlocked = true,
+                Categories = { "Roofs" }, TypeNames = { desc }
+            };
+
+        // ── the file shape is the guarantee ─────────────────────────────────
+
+        [Fact]
+        public void A_Patch_Cannot_Express_A_Conversion_Factor()
+        {
+            // Not "does not" — CANNOT. The type has nowhere to put one, so a
+            // pricing dialog cannot restate a measurement rule by accident.
+            var fields = typeof(SupplierUnitPatch).GetFields()
+                            .Select(f => f.Name).ToArray();
+
+            Assert.DoesNotContain("SourceUnitsPerSupplierUnit", fields);
+            Assert.DoesNotContain("DefaultWastagePct", fields);
+            Assert.DoesNotContain("SupplierUnit", fields);
+            Assert.DoesNotContain("RoundUpToWhole", fields);
+        }
+
+        [Fact]
+        public void Applying_A_Patch_Leaves_Every_Measurement_Field_Untouched()
+        {
+            var table = Table();
+            var file = new SupplierUnitPatchFile
+            {
+                TypePatterns = { new SupplierUnitPatch { CommodityKey = "roof-sheet", Pattern = "Generic - 225" } }
+            };
+
+            SupplierUnitPatcher.Apply(table, file);
+
+            var rule = table.ResolveByCommodityKey("roof-sheet");
+            Assert.Equal(2.4, rule.SourceUnitsPerSupplierUnit);
+            Assert.Equal(10, rule.DefaultWastagePct);
+            Assert.Equal("Sheets", rule.SupplierUnit);
+            Assert.True(rule.RoundUpToWhole);
+        }
+
+        [Fact]
+        public void The_Pattern_Is_Added_To_The_Rule()
+        {
+            var table = Table();
+            var file = new SupplierUnitPatchFile
+            {
+                TypePatterns = { new SupplierUnitPatch { CommodityKey = "roof-tile", Pattern = "Generic - 225" } }
+            };
+
+            var applied = SupplierUnitPatcher.Apply(table, file);
+
+            Assert.Contains("Generic - 225", table.ResolveByCommodityKey("roof-tile").MatchTypePatterns);
+            Assert.Single(applied);
+        }
+
+        [Fact]
+        public void The_Corporate_Patterns_Survive()
+        {
+            // Additive, not replacing. IT4 roofs must keep converting.
+            var table = Table();
+            SupplierUnitPatcher.Apply(table, new SupplierUnitPatchFile
+            {
+                TypePatterns = { new SupplierUnitPatch { CommodityKey = "roof-sheet", Pattern = "Generic - 225" } }
+            });
+
+            Assert.Contains("IT4", table.ResolveByCommodityKey("roof-sheet").MatchTypePatterns);
+        }
+
+        [Fact]
+        public void Patching_The_Same_Pattern_Twice_Adds_It_Once()
+        {
+            var table = Table();
+            var file = new SupplierUnitPatchFile
+            {
+                TypePatterns =
+                {
+                    new SupplierUnitPatch { CommodityKey = "roof-tile", Pattern = "Generic - 225" },
+                    new SupplierUnitPatch { CommodityKey = "roof-tile", Pattern = "generic - 225" }
+                }
+            };
+
+            SupplierUnitPatcher.Apply(table, file);
+
+            Assert.Equal(2, table.ResolveByCommodityKey("roof-tile").MatchTypePatterns.Count);  // "Tile" + one
+        }
+
+        [Fact]
+        public void A_Patch_For_An_Unknown_Commodity_Changes_Nothing_And_Is_Reported()
+        {
+            var table = Table();
+            var file = new SupplierUnitPatchFile
+            {
+                TypePatterns = { new SupplierUnitPatch { CommodityKey = "roof-shet", Pattern = "Generic - 225" } }
+            };
+
+            Assert.Empty(SupplierUnitPatcher.Apply(table, file));
+            Assert.Contains(file.Validate(table), p => p.Contains("not a commodity"));
+        }
+
+        [Fact]
+        public void A_Pattern_Too_Short_To_Be_Safe_Is_Rejected()
+        {
+            // "22" would claim "Generic - 225mm" and every 2200-wide door.
+            var file = new SupplierUnitPatchFile
+            {
+                TypePatterns = { new SupplierUnitPatch { CommodityKey = "roof-tile", Pattern = "22" } }
+            };
+
+            Assert.Contains(file.Validate(Table()), p => p.Contains("too short"));
+        }
+
+        [Fact]
+        public void The_Summary_Says_Units_Change_But_Factors_Do_Not()
+        {
+            string s = SupplierUnitPatcher.Summary(new[] { "Generic - 225 → roof-tile" });
+
+            Assert.Contains("UNIT and quantity", s);
+            Assert.Contains("do not change any conversion factor", s);
+        }
+
+        [Fact]
+        public void A_Project_That_Maps_Nothing_Gets_No_Line()
+        {
+            Assert.Null(SupplierUnitPatcher.Summary(new string[0]));
+            Assert.Null(SupplierUnitPatcher.Summary(null));
+        }
+
+        // ── the preview ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void The_Plan_Shows_Before_And_After_In_BOTH_Units()
+        {
+            // 610.61 m² ÷ 2.4 m² per sheet, +10% waste, rounded up.
+            var plan = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") },
+                                               "roof-sheet", "Generic - 225");
+
+            var m = plan.Matches.Single();
+            Assert.Equal("m2", m.BeforeUnit);
+            Assert.Equal("Sheets", m.AfterUnit);
+            Assert.True(m.AfterQuantity > 0 && m.AfterQuantity < m.BeforeQuantity);
+        }
+
+        [Fact]
+        public void A_Substring_Pattern_Shows_EVERY_Row_It_Would_Claim()
+        {
+            // The point of the preview: "225" is a substring test and catches
+            // all three roofs, which the author may or may not have meant.
+            var plan = TypePatternPlanner.Plan(Table(),
+                new[] { Roof("Generic - 225mm"), Roof("Generic - 225mm 2"), Roof("Generic - 225mm 3") },
+                "roof-tile", "225mm");
+
+            Assert.Equal(3, plan.Matches.Count);
+            Assert.Contains("would claim 3 row(s)", plan.Summary());
+        }
+
+        [Fact]
+        public void A_Roof_Mapping_Always_Warns_That_Sheet_And_Tile_Both_Look_Right()
+        {
+            // Both convert from area and both look correct afterwards. This is
+            // the confident-wrong-number case, so it is named every time.
+            var plan = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") },
+                                               "roof-sheet", "Generic - 225");
+
+            Assert.Contains(plan.Warnings, w => w.Contains("Sheet and tile"));
+        }
+
+        [Fact]
+        public void A_Pattern_Matching_Nothing_Says_So_Rather_Than_Offering_To_Apply()
+        {
+            var plan = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") },
+                                               "roof-tile", "Corrugated");
+
+            Assert.False(plan.CanApply);
+            Assert.Contains("matches no commodity row", plan.Summary());
+        }
+
+        [Fact]
+        public void A_Short_Pattern_Blocks_Rather_Than_Warns()
+        {
+            var plan = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") }, "roof-tile", "22");
+
+            Assert.False(plan.CanApply);
+            Assert.Contains("cannot be applied", plan.Summary());
+        }
+
+        [Fact]
+        public void An_Unknown_Commodity_Blocks()
+        {
+            var plan = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") }, "nonsense", "Generic - 225");
+
+            Assert.False(plan.CanApply);
+            Assert.Contains(plan.Blockers, b => b.Contains("not a commodity"));
+        }
+
+        [Fact]
+        public void A_Memorandum_Is_Never_Matched()
+        {
+            // It carries no rate and no purchasable quantity; re-routing it
+            // would give the double-count a unit.
+            var memo = Roof("Generic - 225mm");
+            memo.IsMemorandum = true;
+
+            Assert.Empty(TypePatternPlanner.Plan(Table(), new[] { memo }, "roof-tile", "Generic - 225").Matches);
+        }
+
+        [Fact]
+        public void The_Commodity_List_Is_Offered_So_A_Key_Cannot_Be_Misspelt()
+        {
+            var keys = TypePatternPlanner.Candidates(Table()).Select(r => r.CommodityKey).ToArray();
+
+            Assert.Equal(new[] { "roof-sheet", "roof-tile" }, keys);
+        }
+
+        [Fact]
+        public void Both_Roof_Commodities_Are_Offered_For_The_Same_Row()
+        {
+            // The user asked for both: a roof can be mapped to sheeting OR to
+            // tiles, and the schedule cannot know which the building has.
+            var sheet = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") }, "roof-sheet", "Generic - 225");
+            var tile  = TypePatternPlanner.Plan(Table(), new[] { Roof("Generic - 225mm") }, "roof-tile",  "Generic - 225");
+
+            Assert.True(sheet.CanApply);
+            Assert.True(tile.CanApply);
+            Assert.NotEqual(sheet.Matches.Single().AfterQuantity, tile.Matches.Single().AfterQuantity);
+        }
+    }
+}

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -27,6 +27,15 @@ namespace StingTools.BOQ.MaterialSchedule
         public int ConstituentRowsSeen;
         public int RowsWithoutKind;
         public List<string> Warnings = new List<string>();
+
+        /// <summary>
+        /// The merged, patched supplier-unit table this build used.
+        ///
+        /// Handed to the rate editor so its mapping preview and the schedule
+        /// cannot disagree about what converts — re-loading it there would be a
+        /// second copy of the same layering, and two copies of a merge drift.
+        /// </summary>
+        public SupplierUnitTable UnitsUsed = new SupplierUnitTable();
     }
 
     internal static class MaterialScheduleBuilder
@@ -54,6 +63,8 @@ namespace StingTools.BOQ.MaterialSchedule
                 StageDefs = new List<StageDefinition>(),
                 Options = options ?? new MaterialScheduleOptions()
             };
+
+            result.UnitsUsed = inputs.Units;
 
             var lib = LoadStages(doc);
             inputs.StageDefs = lib.Stages;
@@ -137,6 +148,13 @@ namespace StingTools.BOQ.MaterialSchedule
             // After every row exists and every rate is resolved, and after the
             // site-tools and manual rows are appended so their rates count too.
             // The column says it per row; this says it once.
+            // OUTSIDE the priced block. A type mapping changes a row's UNIT and
+            // QUANTITY, so it is exactly as relevant to a quantities-only
+            // buy-list as to a priced one — arguably more, since that list is
+            // what somebody orders against.
+            string mapped = SupplierUnitPatcher.Summary(LastPatchesApplied);
+            if (!string.IsNullOrEmpty(mapped)) msDoc.Warnings.Add(mapped);
+
             if (msDoc.Options.ShowPrices)
             {
                 string provenance = RateProvenanceLabel.Summary(
@@ -432,8 +450,30 @@ namespace StingTools.BOQ.MaterialSchedule
                     table.Rules.RemoveAll(x => string.Equals(x.CommodityKey, r.CommodityKey, StringComparison.OrdinalIgnoreCase));
                     table.Rules.Add(r);
                 }
+
+            // Type mappings, applied AFTER the wholesale override so a project
+            // that has both gets the patterns on top of its own rule.
+            //
+            // A separate file because the override above replaces a rule
+            // ENTIRELY: a file written to add one pattern would also reset
+            // SourceUnitsPerSupplierUnit to 1.0 and DefaultWastagePct to 0.
+            // A patch has nowhere to put either, so that is unrepresentable
+            // rather than merely discouraged.
+            var patches = ReadJson<SupplierUnitPatchFile>(
+                StingPaths.MetaFile(doc, "_BIM_COORD", "supplier_unit_patches.json"));
+            LastPatchesApplied = SupplierUnitPatcher.Apply(table, patches);
+            foreach (string problem in patches?.Validate(table) ?? new List<string>())
+                StingLog.Warn("supplier_unit_patches.json: " + problem);
+
             return table;
         }
+
+        /// <summary>
+        /// Mappings the last build applied, for the export notes. A mapping
+        /// changes a row's UNIT and quantity, so a reader comparing two exports
+        /// needs to know one was in force.
+        /// </summary>
+        internal static List<string> LastPatchesApplied = new List<string>();
 
         private static StageLibrary LoadStages(Document doc)
         {

--- a/StingTools/Commands/MaterialSchedule/MaterialScheduleCommands.cs
+++ b/StingTools/Commands/MaterialSchedule/MaterialScheduleCommands.cs
@@ -238,8 +238,13 @@ namespace StingTools.Commands.MaterialSchedule
                           + "\n\nCancel and fix them by hand if they matter.");
                 }
 
+                // The same table the build used, so the editor's mapping preview
+                // and the schedule can never disagree about what converts.
+                var units = built.UnitsUsed;
+                string patchPath = StingPaths.MetaFile(doc, "_BIM_COORD", "supplier_unit_patches.json");
+
                 bool saved = StingTools.UI.CommodityRateEditor.ShowDialog(
-                    doc, built.Document, existing, target);
+                    doc, built.Document, existing, target, units, patchPath);
 
                 return saved ? Result.Succeeded : Result.Cancelled;
             }

--- a/StingTools/Core/MaterialSchedule/SupplierUnitPatch.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitPatch.cs
@@ -1,0 +1,159 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SupplierUnitPatch.cs — say which commodity a model TYPE belongs to,
+//  without being able to say anything else.
+//
+//  WHY A SEPARATE FILE RATHER THAN THE EXISTING OVERRIDE. The project
+//  override at _data/coord/supplier_units.json replaces a rule WHOLESALE by
+//  CommodityKey:
+//
+//      table.Rules.RemoveAll(x => x.CommodityKey == r.CommodityKey);
+//      table.Rules.Add(r);
+//
+//  So a file written to add one type pattern —
+//      { "CommodityKey": "roof-sheet", "MatchTypePatterns": ["Generic - 225"] }
+//  — also silently sets SourceUnitsPerSupplierUnit to its default of 1.0 and
+//  DefaultWastagePct to 0, turning "2.4 m2 per sheet, 10% waste" into "1 m2
+//  per sheet, none". The quantities change across the whole schedule and
+//  nothing anywhere says why. A UI promising not to do that is a promise; a
+//  file shape that cannot express it is a guarantee.
+//
+//  A patch therefore carries a commodity key and a pattern and NOTHING ELSE.
+//  There is nowhere to put a conversion factor, so a pricing dialog cannot
+//  restate a measurement rule by accident — and a corporate change to
+//  sheets-per-m2 still reaches every project, because the rule itself is
+//  never copied.
+//
+//  Mapping is a PROJECT fact: "Generic - 225mm" is a name in one model.
+//  Measurement is a STANDARD. This file holds only the first.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    /// <summary>One statement: "this type name belongs to that commodity".</summary>
+    public sealed class SupplierUnitPatch
+    {
+        public string CommodityKey = "";
+
+        /// <summary>A substring matched against the model type name.</summary>
+        public string Pattern = "";
+
+        /// <summary>Why, in the author's words. Required — see Validate.</summary>
+        public string Why = "";
+
+        public string AddedBy = "";
+        public string AddedUtc = "";
+    }
+
+    public sealed class SupplierUnitPatchFile
+    {
+        public string SchemaVersion = "1.0";
+
+        public string Note =
+            "Type-to-commodity mappings for THIS project. Each entry says which commodity a model "
+          + "type name belongs to, and can say nothing else — conversion factors and wastage are "
+          + "measurement standards and live in STING_SUPPLIER_UNITS.json, so a change there still "
+          + "reaches this project. Safe to edit by hand; safe to copy to another project only if "
+          + "its type names are the same.";
+
+        public List<SupplierUnitPatch> TypePatterns = new List<SupplierUnitPatch>();
+
+        /// <summary>
+        /// Problems in the file itself. A pattern is a SUBSTRING test, so a
+        /// short one matches far more than its author intends.
+        /// </summary>
+        public List<string> Validate(SupplierUnitTable table)
+        {
+            var problems = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var p in TypePatterns ?? new List<SupplierUnitPatch>())
+            {
+                if (p == null) continue;
+                string pat = (p.Pattern ?? "").Trim();
+                string key = (p.CommodityKey ?? "").Trim();
+
+                if (key.Length == 0) { problems.Add("a mapping has no commodity key"); continue; }
+                if (pat.Length == 0) { problems.Add($"'{key}' has an empty pattern"); continue; }
+
+                if (pat.Length < MinPatternLength)
+                    problems.Add($"pattern '{pat}' is too short to be safe — it is matched as a "
+                               + "SUBSTRING of every type name, so a fragment this small will claim "
+                               + "types nobody meant it to");
+
+                if (table != null && table.ResolveByCommodityKey(key) == null)
+                    problems.Add($"'{key}' is not a commodity in the supplier-unit table — check the "
+                               + "spelling against STING_SUPPLIER_UNITS.json");
+
+                if (!seen.Add(key + "|" + pat))
+                    problems.Add($"'{pat}' is mapped to '{key}' more than once");
+            }
+            return problems;
+        }
+
+        /// <summary>
+        /// Three characters. Two ("22") would match "Generic - 225mm" and also
+        /// every 2200-wide door in the model.
+        /// </summary>
+        public const int MinPatternLength = 3;
+    }
+
+    public static class SupplierUnitPatcher
+    {
+        /// <summary>
+        /// Add each patch's pattern to its commodity's rule, in place.
+        ///
+        /// ADDITIVE only. A pattern is appended to MatchTypePatterns and no
+        /// other field of the rule is read or written, so this cannot change
+        /// what a commodity IS — only which types reach it.
+        ///
+        /// A patch naming a commodity that does not exist is REPORTED, not
+        /// dropped: silently ignoring a typo leaves somebody believing they
+        /// mapped a type they did not.
+        /// </summary>
+        public static List<string> Apply(SupplierUnitTable table, SupplierUnitPatchFile patches)
+        {
+            var applied = new List<string>();
+            if (table?.Rules == null || patches?.TypePatterns == null) return applied;
+
+            foreach (var p in patches.TypePatterns)
+            {
+                if (p == null) continue;
+                string key = (p.CommodityKey ?? "").Trim();
+                string pat = (p.Pattern ?? "").Trim();
+                if (key.Length == 0 || pat.Length == 0) continue;
+
+                var rule = table.ResolveByCommodityKey(key);
+                if (rule == null) continue;   // reported by Validate, not silently healed here
+
+                if (rule.MatchTypePatterns == null)
+                    rule.MatchTypePatterns = new List<string>();
+
+                if (!rule.MatchTypePatterns.Any(x =>
+                        string.Equals(x, pat, StringComparison.OrdinalIgnoreCase)))
+                {
+                    rule.MatchTypePatterns.Add(pat);
+                    applied.Add($"{pat} → {key}");
+                }
+            }
+            return applied;
+        }
+
+        /// <summary>
+        /// The line for the export notes, or NULL when the project patches
+        /// nothing — which is the default and not worth a line.
+        /// </summary>
+        public static string Summary(IReadOnlyCollection<string> applied)
+        {
+            if (applied == null || applied.Count == 0) return null;
+            return $"Type mappings: {applied.Count} model type name(s) are mapped to a commodity by "
+                 + "this project — " + string.Join("; ", applied.Take(6))
+                 + (applied.Count > 6 ? ", …" : "")
+                 + ". These change which commodity a row converts to, and therefore its UNIT and "
+                 + "quantity. They do not change any conversion factor: those stay in the shipped "
+                 + "table, so a corporate correction still reaches this project.";
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/TypePatternPlanner.cs
+++ b/StingTools/Core/MaterialSchedule/TypePatternPlanner.cs
@@ -1,0 +1,176 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypePatternPlanner.cs — what a proposed type mapping would actually do.
+//
+//  Mapping a type to a commodity is not a labelling change. It converts the
+//  row from measured units into supplier units: 610.62 m2 of roof becomes
+//  N sheets, at a different rate, in a different unit. That is the number
+//  somebody buys against.
+//
+//  So no mapping is written without this. It answers three questions the
+//  author cannot answer from the pattern alone:
+//
+//    * which rows would it claim — a pattern is a SUBSTRING test, so "225"
+//      catches every 225-anything in the model, not just the roof;
+//    * what does each row become — before and after, both units named;
+//    * is the commodity even plausible — a tiled roof mapped to roof-sheet
+//      converts cleanly and prices sheeting for a tile roof, which is a
+//      confident wrong number and the exact failure this schedule keeps
+//      being audited for.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public sealed class PatternMatchRow
+    {
+        public string Description = "";
+        public double BeforeQuantity;
+        public string BeforeUnit = "";
+        public double AfterQuantity;
+        public string AfterUnit = "";
+
+        /// <summary>True when this row already converts — the mapping is not needed for it.</summary>
+        public bool AlreadyConverted;
+    }
+
+    public sealed class TypePatternPlan
+    {
+        public string CommodityKey = "";
+        public string Pattern = "";
+        public readonly List<PatternMatchRow> Matches = new List<PatternMatchRow>();
+
+        /// <summary>Reasons this must not be written at all.</summary>
+        public readonly List<string> Blockers = new List<string>();
+
+        /// <summary>Reasons to look twice before writing it.</summary>
+        public readonly List<string> Warnings = new List<string>();
+
+        public bool CanApply => Blockers.Count == 0 && Matches.Count > 0;
+
+        public string Summary()
+        {
+            if (Blockers.Count > 0)
+                return "This mapping cannot be applied:\n  • " + string.Join("\n  • ", Blockers);
+
+            if (Matches.Count == 0)
+                return $"'{Pattern}' matches no commodity row in this schedule, so mapping it would "
+                     + "change nothing. Check the spelling against the Description column — the "
+                     + "pattern is matched against the model TYPE name.";
+
+            var s = new System.Text.StringBuilder();
+            s.AppendLine($"'{Pattern}' → {CommodityKey} would claim {Matches.Count} row(s):");
+            foreach (var m in Matches.Take(12))
+                s.AppendLine($"  • {m.Description}"
+                           + $"\n      {m.BeforeQuantity:N2} {m.BeforeUnit}"
+                           + $"  →  {m.AfterQuantity:N2} {m.AfterUnit}"
+                           + (m.AlreadyConverted ? "   (already converts — unchanged by this)" : ""));
+            if (Matches.Count > 12) s.AppendLine($"  … and {Matches.Count - 12} more.");
+
+            if (Warnings.Count > 0)
+                s.AppendLine().AppendLine("Look twice:\n  • " + string.Join("\n  • ", Warnings));
+
+            return s.ToString().TrimEnd();
+        }
+    }
+
+    public static class TypePatternPlanner
+    {
+        /// <summary>
+        /// Work out what mapping <paramref name="pattern"/> to
+        /// <paramref name="commodityKey"/> would do to the rows in this schedule.
+        ///
+        /// Never writes. The caller decides whether the result is acceptable,
+        /// and it is shown before it is offered.
+        /// </summary>
+        public static TypePatternPlan Plan(SupplierUnitTable table,
+                                           IEnumerable<MaterialCommodity> commodities,
+                                           string commodityKey, string pattern)
+        {
+            var plan = new TypePatternPlan
+            {
+                CommodityKey = (commodityKey ?? "").Trim(),
+                Pattern = (pattern ?? "").Trim()
+            };
+
+            if (plan.Pattern.Length == 0) { plan.Blockers.Add("the pattern is empty"); return plan; }
+            if (plan.CommodityKey.Length == 0) { plan.Blockers.Add("no commodity was chosen"); return plan; }
+
+            if (plan.Pattern.Length < SupplierUnitPatchFile.MinPatternLength)
+                plan.Blockers.Add($"'{plan.Pattern}' is shorter than "
+                    + $"{SupplierUnitPatchFile.MinPatternLength} characters. A pattern is matched as a "
+                    + "SUBSTRING of every type name, so a fragment this small claims types nobody "
+                    + "meant it to.");
+
+            var rule = table?.ResolveByCommodityKey(plan.CommodityKey);
+            if (rule == null)
+            {
+                plan.Blockers.Add($"'{plan.CommodityKey}' is not a commodity in the supplier-unit table");
+                return plan;
+            }
+
+            foreach (var c in commodities ?? Enumerable.Empty<MaterialCommodity>())
+            {
+                if (c == null || c.IsMemorandum) continue;
+
+                // The pattern is matched against the model TYPE names behind the
+                // row, and against the description, which for an unconverted row
+                // IS the type name.
+                bool hit = Contains(c.Description, plan.Pattern)
+                        || (c.TypeNames ?? new List<string>()).Any(t => Contains(t, plan.Pattern));
+                if (!hit) continue;
+
+                var conv = SupplierUnitConverter.Convert(rule, c.NetQuantity);
+                plan.Matches.Add(new PatternMatchRow
+                {
+                    Description = c.Description,
+                    BeforeQuantity = c.OrderQuantity,
+                    BeforeUnit = c.SupplierUnit,
+                    AfterQuantity = conv.OrderQuantity,
+                    AfterUnit = conv.SupplierUnit,
+                    AlreadyConverted = !c.ConversionBlocked
+                                       && !string.Equals(c.SupplierUnit, c.CommodityKey,
+                                                         StringComparison.OrdinalIgnoreCase)
+                });
+            }
+
+            AddWarnings(plan, rule);
+            return plan;
+        }
+
+        private static void AddWarnings(TypePatternPlan plan, SupplierUnitRule rule)
+        {
+            int already = plan.Matches.Count(m => m.AlreadyConverted);
+            if (already > 0)
+                plan.Warnings.Add($"{already} of the matched row(s) already convert to a commodity. "
+                    + "This mapping would re-route them, changing their unit and quantity.");
+
+            // The roof case, generalised: two commodities in the same family
+            // convert equally cleanly and only one is right for the building.
+            if (rule.CommodityKey.IndexOf("roof", StringComparison.OrdinalIgnoreCase) >= 0)
+                plan.Warnings.Add("Sheet and tile roofs both convert from area and both look correct "
+                    + "afterwards. Check which this roof actually is — the fastener and covering "
+                    + "rates differ, and a wrong choice here prices confidently for the other one.");
+
+            if (plan.Matches.Count > 8)
+                plan.Warnings.Add($"{plan.Matches.Count} rows is a lot for one pattern. A longer, "
+                    + "more specific pattern usually means you meant fewer.");
+        }
+
+        private static bool Contains(string haystack, string needle) =>
+            !string.IsNullOrEmpty(haystack)
+            && haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+
+        /// <summary>
+        /// Commodities a row could sensibly be mapped to: everything the table
+        /// can convert an AREA or a COUNT into. Offered as a list rather than a
+        /// free-text key so the commodity can never be misspelt.
+        /// </summary>
+        public static List<SupplierUnitRule> Candidates(SupplierUnitTable table) =>
+            (table?.Rules ?? new List<SupplierUnitRule>())
+                .Where(r => r != null && !string.IsNullOrWhiteSpace(r.CommodityKey))
+                .OrderBy(r => r.CommodityKey, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+    }
+}

--- a/StingTools/UI/CommodityRateEditor.cs
+++ b/StingTools/UI/CommodityRateEditor.cs
@@ -152,12 +152,20 @@ namespace StingTools.UI
         private readonly string _seedStakes;
         private Button _detailsButton;
         private bool _detailsShown;
+        private readonly SupplierUnitTable _units;
+        private readonly string _patchPath;
+        private readonly MaterialScheduleDocument _schedule;
 
         public bool Saved { get; private set; }
 
         private CommodityRateEditor(Document doc, RateSeedResult seed,
-                                    List<CommodityRate> existingProject, string targetPath)
+                                    List<CommodityRate> existingProject, string targetPath,
+                                    SupplierUnitTable units, string patchPath,
+                                    MaterialScheduleDocument schedule)
         {
+            _units = units;
+            _patchPath = patchPath;
+            _schedule = schedule;
             _doc = doc;
             _existingProject = existingProject ?? new List<CommodityRate>();
             _targetPath = targetPath;
@@ -248,6 +256,13 @@ namespace StingTools.UI
                 "Clear the typed rate in the selected rows. The row keeps whatever rate it "
               + "already had - clearing is not the same as pricing at zero.",
                 (a, b) => ClearSelected()));
+
+            bar.Children.Add(ToolButton("Map to commodity…",
+                "Say which commodity the selected row's model type belongs to — a roof named "
+              + "'Generic - 225mm' can be sheeting or tiles, and the schedule cannot tell. Shows "
+              + "every row the mapping would claim and what each becomes BEFORE writing anything. "
+              + "Writes only the mapping; conversion factors and wastage stay in the shipped table.",
+                (a, b) => MapToCommodity()));
 
             _detailsButton = ToolButton("Show detail",
                 "Show the columns that identify a row rather than price it: the exact key written to "
@@ -558,6 +573,99 @@ namespace StingTools.UI
             _grid.Items.Refresh();
         }
 
+        /// <summary>
+        /// Map the selected row's model type to a commodity.
+        ///
+        /// Two things happen before anything is written: the RENAME is offered
+        /// first, and the mapping is previewed.
+        ///
+        /// The rename comes first because it is the better fix and the mapping
+        /// is the escape hatch. Calling a roof "IT4 Corrugated Sheet Roof 225"
+        /// matches the shipped pattern with no override at all, and the name
+        /// then means something to the schedule, the bill, the drawings and the
+        /// next consultant. A mapping fixes one project and leaves the name
+        /// wrong everywhere else — which is right when the type is in a linked
+        /// model, a vendor family or somebody else's file, and those are common
+        /// enough that the escape hatch has to exist.
+        /// </summary>
+        private void MapToCommodity()
+        {
+            var vm = _grid.CurrentCell.Item as RateEditorRowVm;
+            if (vm == null) { _status.Text = "Select a row first."; return; }
+            if (_units == null || _schedule == null)
+            {
+                MessageBox.Show(this, "The supplier-unit table was not loaded, so nothing can be mapped.",
+                    Caption, MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var candidates = TypePatternPlanner.Candidates(_units);
+            if (candidates.Count == 0)
+            {
+                MessageBox.Show(this, "The supplier-unit table declares no commodities to map to.",
+                    Caption, MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            var dlg = new TypeMappingDialog(vm.Description, candidates, _units, _schedule) { Owner = this };
+            if (dlg.ShowDialog() != true || dlg.Chosen == null) return;
+
+            try
+            {
+                var file = LoadPatches(_patchPath);
+                file.TypePatterns.Add(new SupplierUnitPatch
+                {
+                    CommodityKey = dlg.Chosen.CommodityKey,
+                    Pattern = dlg.ChosenPattern,
+                    Why = dlg.Why,
+                    AddedBy = Environment.UserName ?? "",
+                    AddedUtc = DateTime.UtcNow.ToString("u")
+                });
+
+                string dir = Path.GetDirectoryName(_patchPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                string tmp = _patchPath + ".tmp";
+                File.WriteAllText(tmp,
+                    Newtonsoft.Json.JsonConvert.SerializeObject(file, Newtonsoft.Json.Formatting.Indented),
+                    new UTF8Encoding(false));
+                if (File.Exists(_patchPath))
+                {
+                    string bak = _patchPath + ".bak";
+                    if (File.Exists(bak)) File.Delete(bak);
+                    File.Replace(tmp, _patchPath, bak);
+                }
+                else File.Move(tmp, _patchPath);
+
+                StingLog.Info($"CommodityRateEditor: mapped '{dlg.ChosenPattern}' -> {dlg.Chosen.CommodityKey}");
+                MessageBox.Show(this,
+                    $"'{dlg.ChosenPattern}' is now mapped to {dlg.Chosen.CommodityKey}.\n\n"
+                  + _patchPath
+                  + "\n\nRe-run the material schedule to see the converted quantities. The rows in "
+                  + "this grid still show the OLD unit — the mapping is applied when the schedule is "
+                  + "rebuilt, not here.",
+                    Caption, MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Error("CommodityRateEditor.MapToCommodity", ex);
+                MessageBox.Show(this, "The mapping could not be written:\n\n" + ex.Message,
+                    Caption, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private static SupplierUnitPatchFile LoadPatches(string path)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                    return Newtonsoft.Json.JsonConvert
+                               .DeserializeObject<SupplierUnitPatchFile>(File.ReadAllText(path))
+                           ?? new SupplierUnitPatchFile();
+            }
+            catch (Exception ex) { StingLog.Warn("LoadPatches: " + ex.Message); }
+            return new SupplierUnitPatchFile();
+        }
+
         private const string Caption = "STING — Price commodities";
 
         private DataGridColumn AddReadOnly(string header, string path, double width)
@@ -681,7 +789,8 @@ namespace StingTools.UI
 
         /// <summary>Open the editor over a built schedule. Returns true if rates were written.</summary>
         public static bool ShowDialog(Document doc, MaterialScheduleDocument schedule,
-                                      List<CommodityRate> existingProject, string targetPath)
+                                      List<CommodityRate> existingProject, string targetPath,
+                                      SupplierUnitTable units, string patchPath)
         {
             var seed = RateEditorSeed.Build(schedule);
             if (seed.Rows.Count == 0)
@@ -691,7 +800,8 @@ namespace StingTools.UI
                 return false;
             }
 
-            var w = new CommodityRateEditor(doc, seed, existingProject, targetPath);
+            var w = new CommodityRateEditor(doc, seed, existingProject, targetPath,
+                                            units, patchPath, schedule);
             w.ShowDialog();
             return w.Saved;
         }

--- a/StingTools/UI/TypeMappingDialog.cs
+++ b/StingTools/UI/TypeMappingDialog.cs
@@ -1,0 +1,202 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeMappingDialog.cs — choose the commodity a model type belongs to, and
+//  see what that does before it is written.
+//
+//  THE RENAME IS OFFERED FIRST, and not as politeness. Renaming the Revit
+//  type to something the shipped patterns already match — "IT4 Corrugated
+//  Sheet Roof 225" — fixes the cause: the name then means the same thing to
+//  the schedule, the bill, the drawings and the next consultant, and no
+//  project carries a private patch for it. A mapping fixes one project and
+//  leaves the name wrong everywhere else.
+//
+//  The mapping exists because renaming is often impossible: a linked model, a
+//  vendor family, a file somebody else owns. That is common enough that the
+//  escape hatch must exist — but a dialog that offered only the escape hatch
+//  would have every project accumulate patches instead of fixing anything
+//  once.
+//
+//  Nothing is written until the preview has been seen. A mapping changes the
+//  row's UNIT and quantity, and both roof commodities convert equally
+//  cleanly, so "it worked" is not evidence it was right.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using StingTools.Core.MaterialSchedule;
+
+namespace StingTools.UI
+{
+    public sealed class TypeMappingDialog : Window
+    {
+        private readonly SupplierUnitTable _units;
+        private readonly MaterialScheduleDocument _schedule;
+        private readonly ComboBox _commodity;
+        private readonly TextBox _pattern;
+        private readonly TextBox _why;
+        private readonly TextBox _preview;
+        private readonly Button _apply;
+
+        public SupplierUnitRule Chosen { get; private set; }
+        public string ChosenPattern { get; private set; } = "";
+        public string Why { get; private set; } = "";
+
+        public TypeMappingDialog(string rowDescription, List<SupplierUnitRule> candidates,
+                                 SupplierUnitTable units, MaterialScheduleDocument schedule)
+        {
+            _units = units;
+            _schedule = schedule;
+
+            Title = "STING — Map a type to a commodity";
+            Width = 760; Height = 640;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            Background = Brushes.White;
+
+            var root = new DockPanel { Margin = new Thickness(14) };
+
+            // ── the rename, first ──
+            var advice = new Border
+            {
+                Background = new SolidColorBrush(Color.FromRgb(0xFF, 0xF8, 0xE1)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0xCC, 0x80)),
+                BorderThickness = new Thickness(1),
+                Padding = new Thickness(10),
+                Margin = new Thickness(0, 0, 0, 12),
+                Child = new TextBlock
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    FontSize = 11.5,
+                    Text = "Consider renaming the Revit type first. A type called "
+                         + "\"IT4 Corrugated Sheet Roof 225\" matches the shipped patterns with no "
+                         + "mapping at all, and the name then means the same thing to the schedule, "
+                         + "the bill, the drawings and the next consultant.\n\n"
+                         + "Map it here when you cannot rename it — a linked model, a vendor family, "
+                         + "or a file somebody else owns. The mapping applies to THIS project only."
+                }
+            };
+            DockPanel.SetDock(advice, Dock.Top);
+            root.Children.Add(advice);
+
+            // ── the choice ──
+            var form = new Grid { Margin = new Thickness(0, 0, 0, 10) };
+            form.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(110) });
+            form.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+            for (int i = 0; i < 3; i++) form.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            AddLabel(form, 0, "Commodity");
+            _commodity = new ComboBox { Margin = new Thickness(0, 3, 0, 3), Height = 26 };
+            foreach (var r in candidates)
+                _commodity.Items.Add(new ComboBoxItem
+                {
+                    Content = $"{r.CommodityKey}  —  {r.Description}  ({r.SupplierUnit})",
+                    Tag = r
+                });
+            _commodity.SelectionChanged += (a, b) => Refresh();
+            Grid.SetRow(_commodity, 0); Grid.SetColumn(_commodity, 1);
+            form.Children.Add(_commodity);
+
+            AddLabel(form, 1, "Type pattern");
+            _pattern = new TextBox
+            {
+                Text = rowDescription ?? "", Margin = new Thickness(0, 3, 0, 3), Height = 26,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                ToolTip = "Matched as a SUBSTRING of the model type name. Longer is safer."
+            };
+            _pattern.TextChanged += (a, b) => Refresh();
+            Grid.SetRow(_pattern, 1); Grid.SetColumn(_pattern, 1);
+            form.Children.Add(_pattern);
+
+            AddLabel(form, 2, "Why");
+            _why = new TextBox
+            {
+                Margin = new Thickness(0, 3, 0, 3), Height = 26,
+                VerticalContentAlignment = VerticalAlignment.Center,
+                ToolTip = "Recorded in the file. The next reader needs to know why this project "
+                        + "differs from the shipped table."
+            };
+            Grid.SetRow(_why, 2); Grid.SetColumn(_why, 1);
+            form.Children.Add(_why);
+
+            DockPanel.SetDock(form, Dock.Top);
+            root.Children.Add(form);
+
+            // ── buttons ──
+            var buttons = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 10, 0, 0)
+            };
+            var cancel = new Button { Content = "Cancel", Width = 96, Height = 30, Margin = new Thickness(6, 0, 0, 0) };
+            cancel.Click += (a, b) => { DialogResult = false; Close(); };
+            _apply = new Button
+            {
+                Content = "Apply mapping", Width = 140, Height = 30, Margin = new Thickness(6, 0, 0, 0),
+                IsEnabled = false
+            };
+            _apply.Click += (a, b) => Accept();
+            buttons.Children.Add(cancel);
+            buttons.Children.Add(_apply);
+            DockPanel.SetDock(buttons, Dock.Bottom);
+            root.Children.Add(buttons);
+
+            // ── the preview fills what is left ──
+            _preview = new TextBox
+            {
+                IsReadOnly = true, TextWrapping = TextWrapping.NoWrap,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                FontFamily = new FontFamily("Consolas"), FontSize = 11.5,
+                Background = new SolidColorBrush(Color.FromRgb(0xFA, 0xFA, 0xFA))
+            };
+            root.Children.Add(_preview);
+
+            Content = root;
+            if (_commodity.Items.Count > 0) _commodity.SelectedIndex = 0;
+        }
+
+        private static void AddLabel(Grid g, int row, string text)
+        {
+            var t = new TextBlock
+            {
+                Text = text, VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 3, 8, 3), FontSize = 11.5
+            };
+            Grid.SetRow(t, row); Grid.SetColumn(t, 0);
+            g.Children.Add(t);
+        }
+
+        /// <summary>
+        /// Re-plan on every keystroke. The preview is the whole point — Apply
+        /// stays disabled until a plan says it can be applied.
+        /// </summary>
+        private void Refresh()
+        {
+            var rule = (_commodity.SelectedItem as ComboBoxItem)?.Tag as SupplierUnitRule;
+            if (rule == null) { _preview.Text = ""; _apply.IsEnabled = false; return; }
+
+            var plan = TypePatternPlanner.Plan(_units,
+                (_schedule?.Stages ?? new List<StageSection>()).SelectMany(st => st.Commodities),
+                rule.CommodityKey, _pattern.Text);
+
+            _preview.Text = plan.Summary();
+            _apply.IsEnabled = plan.CanApply;
+        }
+
+        private void Accept()
+        {
+            var rule = (_commodity.SelectedItem as ComboBoxItem)?.Tag as SupplierUnitRule;
+            if (rule == null) return;
+
+            Chosen = rule;
+            ChosenPattern = (_pattern.Text ?? "").Trim();
+            Why = (_why.Text ?? "").Trim();
+            if (Why.Length == 0)
+                Why = "no reason recorded";   // never blank: the file is read by somebody else later
+            DialogResult = true;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
feat(matsched): map a model type to a commodity, in a file that cannot say more

Generic - 225mm is unpriced AND unconverted: it stays in m2 because it
matches no supplier type pattern. Pricing it per-m2 gets a number;
telling the schedule what it IS converts it to sheets or tiles, prices
it per unit, and releases the roof_fastener consumable that has reported
a zero driver since T4. One edit, three symptoms.

WHY A NEW FILE RATHER THAN THE EXISTING OVERRIDE. supplier_units.json
replaces a rule WHOLESALE by CommodityKey:

    table.Rules.RemoveAll(x => x.CommodityKey == r.CommodityKey);
    table.Rules.Add(r);

So a file written to add one type pattern would also set
SourceUnitsPerSupplierUnit to its default of 1.0 and DefaultWastagePct
to 0 - turning "2.4 m2 per sheet, 10% waste" into "1 m2 per sheet, none"
across the whole schedule, with nothing anywhere saying why. A UI
promising not to do that is a promise. A file shape that cannot express
it is a guarantee.

supplier_unit_patches.json therefore carries a commodity key, a pattern
and a reason, and NOTHING else. A test asserts by reflection that the
type has no conversion field, so the guarantee cannot be edited away
without that test failing. Corporate corrections to sheets-per-m2 still
reach every project, because the rule is never copied - only appended
to.

Mapping is a PROJECT fact: "Generic - 225mm" is a name in one model.
Measurement is a STANDARD. The split is now structural.

BOTH roof commodities are offered, because the schedule cannot know
which the building has - and both convert equally cleanly, so "it
worked" is not evidence it was right. Every roof mapping warns about
exactly that.

The preview is not optional. Apply stays disabled until a plan says it
can be applied, and the plan shows every row the pattern would claim
(it is a SUBSTRING test - "225" catches all three roofs) with before
and after in both units. A pattern under three characters BLOCKS: "22"
would claim Generic - 225mm and every 2200-wide door.

THE RENAME IS OFFERED FIRST, and not as politeness. Renaming the type to
"IT4 Corrugated Sheet Roof 225" matches the shipped patterns with no
mapping at all, and the name then means the same thing to the schedule,
the bill, the drawings and the next consultant. The mapping is the
escape hatch for a linked model, a vendor family or somebody else's
file - common enough to need one, but a dialog offering only the escape
hatch would have every project accumulate patches instead of fixing
anything once.

The export names every mapping in force, OUTSIDE the priced-only block:
a mapping changes a row's unit and quantity, so it matters as much to a
quantities-only buy-list as to a priced schedule.

Boq tests 1023 -> 1051, build 0/0, all four gates pass.

Five mutations, all failing, each verified to have applied: a patch
replacing the rule's patterns instead of appending (2), allowing a
1-character pattern (2), dropping the sheet-vs-tile warning (1),
re-routing a memorandum (1), silently ignoring an unknown commodity (1).

NOT verified: the mapping dialog has never opened in Revit, and no
mapping has been written.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
