### PR TITLE
feat(matsched): match a covering by its MATERIAL, and add the East African roofing family

### DIFF
--- a/StingTools.Boq.Tests/MaterialMatchTests.cs
+++ b/StingTools.Boq.Tests/MaterialMatchTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Matching on the MATERIAL, because type names lie and materials mostly do
+    /// not.
+    ///
+    /// A real roof in a delivered model: type "Generic - 225mm", total thickness
+    /// 25 mm, one Structure layer of "Asphalt Shingle". The name was wrong by a
+    /// factor of ten and the material was exactly right — and every layer reader
+    /// filters on Finish1/Finish2/Substrate/Membrane, so a covering on a
+    /// STRUCTURE layer was invisible to all of them and the row fell back to
+    /// being named after the type.
+    /// </summary>
+    public class MaterialMatchTests
+    {
+        private static SupplierUnitTable Table() => new SupplierUnitTable
+        {
+            Rules =
+            {
+                new SupplierUnitRule
+                {
+                    CommodityKey = "roof-shingle", SupplierUnit = "Bundles", SourceUnit = "m2",
+                    SourceUnitsPerSupplierUnit = 3.1, RoundUpToWhole = true, DefaultWastagePct = 10,
+                    MatchCategories = { "Roofs" },
+                    MatchMaterialPatterns = { "asphalt shingle", "shingle" }
+                },
+                new SupplierUnitRule
+                {
+                    CommodityKey = "roof-sheet", SupplierUnit = "No.", SourceUnit = "m2",
+                    SourceUnitsPerSupplierUnit = 2.4, RoundUpToWhole = true, DefaultWastagePct = 10,
+                    MatchCategories = { "Roofs" },
+                    MatchTypePatterns = { "IT4", "corrugat" },
+                    MatchMaterialPatterns = { "corrugat" }
+                }
+            }
+        };
+
+        [Fact]
+        public void A_Correctly_Materialled_Roof_Converts_Despite_A_Nonsense_Type_Name()
+        {
+            // The whole point. "Generic - 225mm" matches no pattern anywhere.
+            var res = Table().Resolve("", "Roofs", "Generic - 225mm", "Asphalt Shingle");
+
+            Assert.Equal("roof-shingle", res.Rule?.CommodityKey);
+        }
+
+        [Fact]
+        public void Without_The_Material_That_Same_Roof_Still_Cannot_Convert()
+        {
+            // Proves the material is what did it, not something else.
+            var res = Table().Resolve("", "Roofs", "Generic - 225mm", null);
+
+            Assert.Null(res.Rule);
+            Assert.Equal(SupplierUnitMatch.CategoryTypeMismatch, res.Match);
+        }
+
+        [Fact]
+        public void A_Material_Match_Does_Not_Also_Require_A_Type_Match()
+        {
+            // Requiring both would leave a correctly-materialled roof with a bad
+            // name exactly as stuck as before.
+            var res = Table().Resolve("", "Roofs", "nothing matches this", "asphalt shingle roofing");
+
+            Assert.Equal("roof-shingle", res.Rule?.CommodityKey);
+        }
+
+        [Fact]
+        public void The_Constituent_Kind_Still_Wins_Over_The_Material()
+        {
+            // A kind is emitted by our own take-off; a material is chosen by
+            // whoever built the model. Decreasing reliability, in that order.
+            var t = Table();
+            t.Rules.Add(new SupplierUnitRule
+            {
+                CommodityKey = "by-kind", SupplierUnit = "Bags", SourceUnit = "bag",
+                SourceUnitsPerSupplierUnit = 1, MatchKinds = { "mortar_cement" }
+            });
+
+            var res = t.Resolve("mortar_cement", "Roofs", "x", "Asphalt Shingle");
+
+            Assert.Equal("by-kind", res.Rule?.CommodityKey);
+        }
+
+        [Fact]
+        public void A_Material_Rule_Bound_To_A_Category_Does_Not_Escape_It()
+        {
+            // "Asphalt Shingle" on a WALL is not a roof covering.
+            var res = Table().Resolve("", "Walls", "x", "Asphalt Shingle");
+
+            Assert.Null(res.Rule);
+        }
+
+        [Fact]
+        public void A_Material_Rule_With_No_Category_Applies_Anywhere()
+        {
+            var t = new SupplierUnitTable
+            {
+                Rules =
+                {
+                    new SupplierUnitRule
+                    {
+                        CommodityKey = "anywhere", SupplierUnit = "No.", SourceUnit = "m2",
+                        SourceUnitsPerSupplierUnit = 1,
+                        MatchMaterialPatterns = { "special-product" }
+                    }
+                }
+            };
+
+            Assert.Equal("anywhere", t.Resolve("", "Anything", "x", "Special-Product 900").Rule?.CommodityKey);
+        }
+
+        [Fact]
+        public void A_Blank_Material_Changes_Nothing()
+        {
+            var res = Table().Resolve("", "Roofs", "IT4 sheeting", "");
+
+            Assert.Equal("roof-sheet", res.Rule?.CommodityKey);   // still matched on type
+        }
+
+        // ── the arithmetic, stated ──────────────────────────────────────────
+
+        [Theory]
+        // 856.28 m² of roof, by covering. Net = area ÷ cover, order = net × (1+waste), rounded up.
+        [InlineData("roof-shingle", 3.1,  10.0,  304)]   // 276.2 bundles + 10%
+        [InlineData("roof-sheet",   2.4,  10.0,  393)]   // 356.8 sheets  + 10%
+        public void The_Conversion_Is_Area_Over_Cover_Plus_Waste(string key, double cover,
+                                                                double waste, int expected)
+        {
+            var rule = new SupplierUnitRule
+            {
+                CommodityKey = key, SupplierUnit = "No.", SourceUnit = "m2",
+                SourceUnitsPerSupplierUnit = cover, RoundUpToWhole = true, DefaultWastagePct = waste
+            };
+
+            var r = SupplierUnitConverter.Convert(rule, 856.28);
+
+            Assert.Equal(expected, r.OrderQuantity);
+        }
+
+        // ── the shipped file ────────────────────────────────────────────────
+
+        private static SupplierUnitTable Shipped() =>
+            JsonConvert.DeserializeObject<SupplierUnitTable>(
+                File.ReadAllText(Path.Combine(System.AppContext.BaseDirectory,
+                                              "Data", "STING_SUPPLIER_UNITS.json")));
+
+        [Theory]
+        [InlineData("Asphalt Shingle",            "roof-shingle")]
+        [InlineData("Harvey Tile - Charcoal",     "roof-tile-stonecoated")]
+        [InlineData("Decra Roman",                "roof-tile-stonecoated")]
+        [InlineData("Clay Tile - Marseille",      "roof-tile-clay")]
+        [InlineData("Concrete Tile",              "roof-tile-concrete")]
+        [InlineData("Box Profile Steel G28",      "roof-sheet-boxprofile")]
+        [InlineData("Corrugated Iron Sheet",      "roof-sheet")]
+        public void The_Shipped_Table_Recognises_East_African_Roofing_By_Material(
+            string material, string expectedKey)
+        {
+            // Every one of these is a material a delivered model actually
+            // carries. The type name is deliberately absent from the call: the
+            // material alone has to be enough.
+            var res = Shipped().Resolve("", "Roofs", "Generic - 225mm", material);
+
+            Assert.Equal(expectedKey, res.Rule?.CommodityKey);
+        }
+
+        [Fact]
+        public void Every_New_Roofing_Rule_Says_Where_Its_Cover_Came_From()
+        {
+            // A conversion factor multiplies the whole roof. One that cannot say
+            // where it came from is a guess wearing a standard's clothes.
+            var roofing = Shipped().Rules
+                .Where(r => r.CommodityKey.StartsWith("roof-") && r.MatchMaterialPatterns.Count > 0)
+                .ToList();
+
+            Assert.NotEmpty(roofing);
+            foreach (var r in roofing)
+                Assert.False(string.IsNullOrWhiteSpace(r.SourceNote),
+                             $"{r.CommodityKey} has no sourceNote");
+        }
+
+        [Fact]
+        public void Every_New_Roofing_Rule_Tells_The_Reader_To_Confirm_The_Cover()
+        {
+            var roofing = Shipped().Rules
+                .Where(r => r.CommodityKey.StartsWith("roof-") && r.MatchMaterialPatterns.Count > 0
+                            && r.SourceUnitsPerSupplierUnit != 1.0);
+
+            foreach (var r in roofing)
+                Assert.True(r.SourceNote.IndexOf("confirm", System.StringComparison.OrdinalIgnoreCase) >= 0,
+                            $"{r.CommodityKey} does not tell the reader to confirm its cover");
+        }
+    }
+}

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -281,6 +281,21 @@ namespace StingTools.BOQ
             return single != null ? new List<BOQLineItem> { single } : new List<BOQLineItem>();
         }
 
+        /// <summary>First material on the element, or "". Never throws.</summary>
+        private static string SafePrimaryMaterialName(Document doc, Element el)
+        {
+            try
+            {
+                var ids = el?.GetMaterialIds(false);
+                if (ids != null)
+                    foreach (var id in ids)
+                        if (id != null && id.Value > 0)
+                            return doc.GetElement(id)?.Name ?? "";
+            }
+            catch (Exception ex) { StingLog.WarnRateLimited("BoqMat", "SafePrimaryMaterialName: " + ex.Message); }
+            return "";
+        }
+
         private static void StoreHostCache(string key, List<BOQLineItem> items, HostIncrementalState st)
         {
             // Store an isolated clone so a later caller mutating the returned rows
@@ -819,6 +834,11 @@ namespace StingTools.BOQ
                 ItemName = GetElementDisplayName(el),
                 FamilyName = GetFamilyName(el),
                 TypeName = el.Name ?? "",
+                // The material, for supplier-unit matching. This is the row that
+                // produced "Generic - 225mm" for a roof whose material said
+                // "Asphalt Shingle" — the type name was wrong by a factor of
+                // ten and the material was exactly right.
+                MaterialName = SafePrimaryMaterialName(doc, el),
                 Quantity = quantity,
                 Unit = unit,
                 GrossQuantity = grossQty,

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -263,6 +263,15 @@ namespace StingTools.BOQ
         public string CarbonQuality;
         public string CarbonMaterial;
 
+        /// <summary>
+        /// The element's primary material name, for supplier-unit matching.
+        ///
+        /// A material is chosen deliberately; a type name is free text. One
+        /// delivered roof was typed "Generic - 225mm", measured 25 mm, and was
+        /// correctly materialled "Asphalt Shingle".
+        /// </summary>
+        public string MaterialName;
+
         // ── P1 aggregation ─────────────────────────────────────────────────
         // When several near-identical modelled elements collapse into one BOQ
         // row, SimilarCount holds the element count and ConstituentElementIds
@@ -385,6 +394,7 @@ namespace StingTools.BOQ
                 CarbonSource = this.CarbonSource,
                 CarbonQuality = this.CarbonQuality,
                 CarbonMaterial = this.CarbonMaterial,
+                MaterialName = this.MaterialName,
                 SimilarCount = this.SimilarCount,
                 ConstituentElementIds = this.ConstituentElementIds != null
                     ? new List<long>(this.ConstituentElementIds) : new List<long>(),

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -85,6 +85,7 @@ namespace StingTools.BOQ.MaterialSchedule
                     ConstituentKind = item.ConstituentKind ?? "",
                     Category = item.Category ?? "",
                     TypeName = item.TypeName ?? "",
+                    MaterialName = item.MaterialName ?? "",
                     Description = item.ItemName ?? "",
                     Unit = BoqUnits.Normalise(item.Unit),
                     Quantity = item.Quantity,

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -403,6 +403,7 @@ namespace StingTools.BOQ.Takeoff
                     ItemName = c.Description,
                     FamilyName = GetFamilyName(doc, el),
                     TypeName = el.Name ?? "",
+                    MaterialName = GetPrimaryMaterialName(doc, el) ?? "",
                     Quantity = Math.Round(c.Quantity, 3),
                     Unit = c.Unit,
                     ConstituentKind = c.Kind,

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -17,6 +17,9 @@ namespace StingTools.Core.MaterialSchedule
         public string ConstituentKind = "";
         public string Category = "";
         public string TypeName = "";    // narrows a category match (MAT-SCHED trade units)
+        /// <summary>The element's material name. Matched BEFORE the type name —
+        /// see SupplierUnitRule.MatchMaterialPatterns for why.</summary>
+        public string MaterialName = "";
         public string Description = "";
         public string Unit = "";        // source unit as measured
         public double Quantity;
@@ -102,7 +105,7 @@ namespace StingTools.Core.MaterialSchedule
 
                 // Constituent kind first, then category (+ optional type pattern).
                 var res = input.Units != null
-                    ? input.Units.Resolve(row.ConstituentKind, row.Category, row.TypeName)
+                    ? input.Units.Resolve(row.ConstituentKind, row.Category, row.TypeName, row.MaterialName)
                     : new SupplierUnitResolution { Match = SupplierUnitMatch.None };
                 var rule = res.Rule;
 

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -45,6 +45,35 @@ namespace StingTools.Core.MaterialSchedule
         public List<string> MatchTypePatterns = new List<string>();
 
         /// <summary>
+        /// Substrings matched against the element's MATERIAL name.
+        ///
+        /// Added because type names lie and material names mostly do not. A real
+        /// roof in a delivered model was typed "Generic - 225mm", was 25 mm
+        /// thick, and carried the material "Asphalt Shingle" — the name was
+        /// wrong by a factor of ten and the material was exactly right.
+        ///
+        /// Material also survives the thing that defeated every type pattern
+        /// here: nobody renames a material to make a schedule work, whereas
+        /// type names are whatever somebody typed at 5pm.
+        ///
+        /// Checked BEFORE type patterns, and on its own — a material match does
+        /// not also require a type match, or a correctly-materialled roof with a
+        /// nonsense name would still fail.
+        /// </summary>
+        public List<string> MatchMaterialPatterns = new List<string>();
+
+        /// <summary>
+        /// Where the conversion factor came from, and what to check before
+        /// trusting it.
+        ///
+        /// A cover figure multiplies the WHOLE roof area, so one that cannot say
+        /// where it came from is a guess wearing a standard's clothes. Nominal
+        /// cover varies by profile, pitch and lap, and the difference between
+        /// 0.47 and 0.42 m² per sheet is 12% of the order.
+        /// </summary>
+        public string SourceNote = "";
+
+        /// <summary>
         /// The construction stage this commodity belongs to, overriding whatever
         /// stage the ELEMENT's category routes to. Required on any category rule.
         ///
@@ -84,6 +113,18 @@ namespace StingTools.Core.MaterialSchedule
         /// converted on a guess and never dropped.
         /// </summary>
         public SupplierUnitResolution Resolve(string constituentKind, string category, string typeName)
+            => Resolve(constituentKind, category, typeName, null);
+
+        /// <summary>
+        /// As above, with the element's material name.
+        ///
+        /// Order is kind → material → type, because that is decreasing
+        /// reliability: a constituent kind is emitted by our own take-off, a
+        /// material is chosen deliberately by whoever built the model, and a
+        /// type name is free text.
+        /// </summary>
+        public SupplierUnitResolution Resolve(string constituentKind, string category,
+                                              string typeName, string materialName)
         {
             var byKind = ResolveByKind(constituentKind);
             if (byKind != null)
@@ -91,6 +132,20 @@ namespace StingTools.Core.MaterialSchedule
 
             if (string.IsNullOrWhiteSpace(category))
                 return new SupplierUnitResolution { Match = SupplierUnitMatch.None };
+
+            // Material first among the category-scoped tests. A roof whose
+            // material says "Asphalt Shingle" is a shingle roof whatever its
+            // type is called.
+            string mat = (materialName ?? "").Trim();
+            if (mat.Length > 0)
+                foreach (var r in Rules)
+                {
+                    if (r?.MatchMaterialPatterns == null || r.MatchMaterialPatterns.Count == 0) continue;
+                    if (!CategoryAllows(r, category)) continue;
+                    if (r.MatchMaterialPatterns.Any(p => !string.IsNullOrWhiteSpace(p)
+                            && mat.IndexOf(p.Trim(), StringComparison.OrdinalIgnoreCase) >= 0))
+                        return new SupplierUnitResolution { Rule = r, Match = SupplierUnitMatch.ByCategory };
+                }
 
             // PERF: single pass, no LINQ closure and no candidates List per row.
             string cat = category.Trim();
@@ -106,8 +161,18 @@ namespace StingTools.Core.MaterialSchedule
                 if (firstCategoryHit == null) firstCategoryHit = r;
 
                 // No patterns ⇒ the whole category converts.
+                //
+                // UNLESS the rule discriminates by MATERIAL. A material-matched
+                // rule that also swallowed its whole category would claim every
+                // roof in the model the moment it was added — the material
+                // patterns are its discriminator, and having them means the
+                // category alone is not enough. Without this, adding one
+                // shingle rule silently re-routes every roof.
                 if (r.MatchTypePatterns == null || r.MatchTypePatterns.Count == 0)
+                {
+                    if (r.MatchMaterialPatterns != null && r.MatchMaterialPatterns.Count > 0) continue;
                     return new SupplierUnitResolution { Rule = r, Match = SupplierUnitMatch.ByCategory };
+                }
 
                 // A blank type name can never satisfy a pattern. Guarding this
                 // explicitly because "".IndexOf(p) is -1 but p.IndexOf("") is 0 —
@@ -127,6 +192,20 @@ namespace StingTools.Core.MaterialSchedule
                 Match = SupplierUnitMatch.CategoryTypeMismatch,
                 CandidateCommodityKey = firstCategoryHit.CommodityKey
             };
+        }
+
+        /// <summary>
+        /// True when the rule's categories permit this one. An EMPTY category
+        /// list means the material pattern stands on its own — some materials
+        /// (a specific shingle, a named tile) identify a commodity wherever
+        /// they appear.
+        /// </summary>
+        private static bool CategoryAllows(SupplierUnitRule r, string category)
+        {
+            if (r.MatchCategories == null || r.MatchCategories.Count == 0) return true;
+            if (string.IsNullOrWhiteSpace(category)) return false;
+            return r.MatchCategories.Any(c =>
+                string.Equals(c, category.Trim(), StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>First rule listing this constituent kind, or null.</summary>

--- a/StingTools/Data/STING_COMMODITY_RATES.csv
+++ b/StingTools/Data/STING_COMMODITY_RATES.csv
@@ -44,4 +44,9 @@ hoop-iron,Rolls,35000,Hoop iron 30 m roll
 binding-wire,Rolls,90000,Binding wire 20 kg roll
 formwork-nails,Kg,7000,Wire nails for formwork per kg
 roof-fastener,Packs,25000,Roofing screws / nails pack of 100
+roof-shingle,Bundles,110000,Asphalt shingle bundle (~3.1 m2 cover) INDICATIVE - re-price
+roof-tile-stonecoated,No.,26000,Stone-coated steel tile sheet (Harvey / Decra type) INDICATIVE - re-price
+roof-tile-clay,No.,3000,Clay roof tile Marseille profile INDICATIVE - re-price
+roof-tile-concrete,No.,2500,Concrete roof tile INDICATIVE - re-price
+roof-sheet-boxprofile,m,21000,Box-profile steel sheet per running metre gauge 28 INDICATIVE - re-price
 fascia-board,Lengths,45000,Fascia board 4.2 m length (timber / fibre-cement as specified)

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -1,415 +1,565 @@
 {
-  "schemaVersion": "1.0",
-  "note": "Corporate baseline. Project override: <project>/_data/coord/supplier_units.json (merged by commodityKey).",
-  "rules": [
-    {
-      "commodityKey": "cement",
-      "description": "Cement (OPC 42.5N)",
-      "supplierUnit": "Bags",
-      "sourceUnit": "bag",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 2.5,
-      "matchKinds": [
-        "mortar_cement",
-        "plaster_cement",
-        "screed_cement"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "sand",
-      "description": "River and pit sand",
-      "supplierUnit": "Trips (Sino Truck)",
-      "sourceUnit": "m3",
-      "sourceUnitsPerSupplierUnit": 12.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "mortar_sand",
-        "plaster_sand",
-        "screed_sand"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "block",
-      "description": "Hollow blocks 8\"",
-      "supplierUnit": "No.",
-      "sourceUnit": "nr",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "block_units"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "brick",
-      "description": "Bricks",
-      "supplierUnit": "No.",
-      "sourceUnit": "nr",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "brick_units"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "rebar",
-      "description": "Steel reinforcement bars",
-      "supplierUnit": "Kg",
-      "sourceUnit": "kg",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 7.5,
-      "matchKinds": [
-        "rebar",
-        "mesh"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "formwork-timber",
-      "description": "Sawn timber for formwork",
-      "supplierUnit": "m²",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": false,
-      "defaultWastagePct": 15.0,
-      "matchKinds": [
-        "formwork"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "concrete-ready",
-      "description": "In-situ concrete",
-      "supplierUnit": "m³",
-      "sourceUnit": "m3",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": false,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "concrete",
-        "precast_rib"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "roof-sheet",
-      "description": "Roofing sheets (corrugated / IT4)",
-      "supplierUnit": "No.",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 2.4,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [],
-      "matchCategories": [
-        "Roofs"
-      ],
-      "matchTypePatterns": [
-        "sheet",
-        "it4",
-        "it5",
-        "corrugat",
-        "profil",
-        "metal",
-        "gauge",
-        "g28",
-        "g30"
-      ],
-      "stageId": "roof"
-    },
-    {
-      "commodityKey": "roof-tile",
-      "description": "Roof tiles",
-      "supplierUnit": "No.",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 0.09,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 7.5,
-      "matchKinds": [],
-      "matchCategories": [
-        "Roofs"
-      ],
-      "matchTypePatterns": [
-        "tile",
-        "clay",
-        "concrete tile"
-      ],
-      "stageId": "roof"
-    },
-    {
-      "commodityKey": "paint-interior",
-      "description": "Interior paint (silk, incl. undercoat)",
-      "supplierUnit": "Bkts",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 60.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [
-        "paint_interior"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "paint-exterior",
-      "description": "Exterior paint (weather-guard, incl. undercoat)",
-      "supplierUnit": "Bkts",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 50.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [
-        "paint_exterior"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "floor-tile",
-      "description": "Floor tiles",
-      "spec": "600x600 (4 pcs = 1.44 m2 per box)",
-      "supplierUnit": "Boxes",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 1.44,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10,
-      "matchKinds": [
-        "floor_tile"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "wall-tile",
-      "description": "Wall tiles",
-      "spec": "300x600 (8 pcs = 1.44 m2 per box)",
-      "supplierUnit": "Boxes",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 1.44,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10,
-      "matchKinds": [
-        "wall_tile"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "tile-adhesive",
-      "description": "Tile adhesive",
-      "spec": "cementitious, 20 kg bag",
-      "supplierUnit": "Bags",
-      "sourceUnit": "kg",
-      "sourceUnitsPerSupplierUnit": 20.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 0,
-      "matchKinds": [
-        "tile_adhesive"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "tile-grout",
-      "description": "Tile grout",
-      "spec": "5 kg bag",
-      "supplierUnit": "Bags",
-      "sourceUnit": "kg",
-      "sourceUnitsPerSupplierUnit": 5.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 0,
-      "matchKinds": [
-        "tile_grout"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "skirting",
-      "description": "Skirting",
-      "spec": "per linear metre, as scheduled",
-      "supplierUnit": "m",
-      "sourceUnit": "m",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": false,
-      "defaultWastagePct": 5,
-      "matchKinds": [
-        "skirting"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "ceiling-board",
-      "description": "Ceiling board (gypsum / plasterboard)",
-      "spec": "1200x2400 sheet = 2.88 m2",
-      "supplierUnit": "Sheets",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 2.88,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [
-        "ceiling_board"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "ceiling-furring",
-      "description": "Ceiling furring / suspension grid (DERIVED from area by a practice ratio - not measured)",
-      "spec": "3.6 m length",
-      "supplierUnit": "Lengths",
-      "sourceUnit": "m",
-      "sourceUnitsPerSupplierUnit": 3.6,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [
-        "ceiling_furring"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "dpm",
-      "description": "Damp-proof membrane (polythene sheet)",
-      "spec": "1000 gauge, 4 m x 25 m roll = 100 m2",
-      "supplierUnit": "Rolls",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 100.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 15.0,
-      "matchKinds": [
-        "dpm"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "roof-underlay",
-      "description": "Roof underlay / sarking membrane",
-      "spec": "1 m x 45 m roll = 45 m2",
-      "supplierUnit": "Rolls",
-      "sourceUnit": "m2",
-      "sourceUnitsPerSupplierUnit": 45.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 15.0,
-      "matchKinds": [
-        "roof_underlay"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "hoop-iron",
-      "description": "Hoop iron (DERIVED from walled area by a practice ratio - not measured)",
-      "spec": "30 m roll",
-      "supplierUnit": "Rolls",
-      "sourceUnit": "m",
-      "sourceUnitsPerSupplierUnit": 30.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "hoop_iron"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "binding-wire",
-      "description": "Binding wire (DERIVED from rebar mass by a practice ratio - not measured)",
-      "spec": "20 kg roll",
-      "supplierUnit": "Rolls",
-      "sourceUnit": "kg",
-      "sourceUnitsPerSupplierUnit": 20.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "binding_wire"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "formwork-nails",
-      "description": "Nails for formwork (DERIVED from contact area by a practice ratio - not measured)",
-      "spec": "sold by the kilogram",
-      "supplierUnit": "Kg",
-      "sourceUnit": "kg",
-      "sourceUnitsPerSupplierUnit": 1.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "formwork_nails"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "roof-fastener",
-      "description": "Roofing screws / nails (DERIVED from covering area by a practice ratio - not measured)",
-      "spec": "pack of 100",
-      "supplierUnit": "Packs",
-      "sourceUnit": "nr",
-      "sourceUnitsPerSupplierUnit": 100.0,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 5.0,
-      "matchKinds": [
-        "roof_fastener"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    },
-    {
-      "commodityKey": "fascia-board",
-      "description": "Fascia board (measured along the eaves)",
-      "spec": "4.2 m length, sold whole",
-      "supplierUnit": "Lengths",
-      "sourceUnit": "m",
-      "sourceUnitsPerSupplierUnit": 4.2,
-      "roundUpToWhole": true,
-      "defaultWastagePct": 10.0,
-      "matchKinds": [
-        "fascia_board"
-      ],
-      "matchCategories": [],
-      "matchTypePatterns": [],
-      "stageId": ""
-    }
-  ]
+ "schemaVersion": "1.0",
+ "note": "Corporate baseline. Project override: <project>/_data/coord/supplier_units.json (merged by commodityKey).",
+ "rules": [
+  {
+   "commodityKey": "cement",
+   "description": "Cement (OPC 42.5N)",
+   "supplierUnit": "Bags",
+   "sourceUnit": "bag",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 2.5,
+   "matchKinds": [
+    "mortar_cement",
+    "plaster_cement",
+    "screed_cement"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "sand",
+   "description": "River and pit sand",
+   "supplierUnit": "Trips (Sino Truck)",
+   "sourceUnit": "m3",
+   "sourceUnitsPerSupplierUnit": 12.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "mortar_sand",
+    "plaster_sand",
+    "screed_sand"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "block",
+   "description": "Hollow blocks 8\"",
+   "supplierUnit": "No.",
+   "sourceUnit": "nr",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "block_units"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "brick",
+   "description": "Bricks",
+   "supplierUnit": "No.",
+   "sourceUnit": "nr",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "brick_units"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "rebar",
+   "description": "Steel reinforcement bars",
+   "supplierUnit": "Kg",
+   "sourceUnit": "kg",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 7.5,
+   "matchKinds": [
+    "rebar",
+    "mesh"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "formwork-timber",
+   "description": "Sawn timber for formwork",
+   "supplierUnit": "m²",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": false,
+   "defaultWastagePct": 15.0,
+   "matchKinds": [
+    "formwork"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "concrete-ready",
+   "description": "In-situ concrete",
+   "supplierUnit": "m³",
+   "sourceUnit": "m3",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": false,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "concrete",
+    "precast_rib"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "roof-sheet",
+   "description": "Roofing sheets (corrugated / IT4)",
+   "supplierUnit": "No.",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 2.4,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchTypePatterns": [
+    "sheet",
+    "it4",
+    "it5",
+    "corrugat",
+    "profil",
+    "metal",
+    "gauge",
+    "g28",
+    "g30"
+   ],
+   "stageId": "roof",
+   "matchMaterialPatterns": [
+    "corrugat",
+    "galvanis",
+    "galvaniz",
+    "iron sheet",
+    "metal deck",
+    "metal - roof",
+    "it4",
+    "it5"
+   ],
+   "sourceNote": "IT4/IT5 corrugated at 2.4 m2 effective cover per standard sheet after side and end laps. NOMINAL COVER - confirm against the product's own coverage table before ordering; cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "roof-tile",
+   "description": "Roof tiles",
+   "supplierUnit": "No.",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 0.09,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 7.5,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchTypePatterns": [
+    "tile",
+    "clay",
+    "concrete tile"
+   ],
+   "stageId": "roof",
+   "matchMaterialPatterns": [
+    "roof tile",
+    "tile - roof"
+   ],
+   "sourceNote": "0.09 m2 per tile is roughly 11 tiles per m2, a mid-range figure across Max-pan and clay profiles which run 10 to 16. NOMINAL COVER - confirm against the product's own coverage table before ordering."
+  },
+  {
+   "commodityKey": "paint-interior",
+   "description": "Interior paint (silk, incl. undercoat)",
+   "supplierUnit": "Bkts",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 60.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [
+    "paint_interior"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "paint-exterior",
+   "description": "Exterior paint (weather-guard, incl. undercoat)",
+   "supplierUnit": "Bkts",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 50.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [
+    "paint_exterior"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "floor-tile",
+   "description": "Floor tiles",
+   "spec": "600x600 (4 pcs = 1.44 m2 per box)",
+   "supplierUnit": "Boxes",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 1.44,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10,
+   "matchKinds": [
+    "floor_tile"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "wall-tile",
+   "description": "Wall tiles",
+   "spec": "300x600 (8 pcs = 1.44 m2 per box)",
+   "supplierUnit": "Boxes",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 1.44,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10,
+   "matchKinds": [
+    "wall_tile"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "tile-adhesive",
+   "description": "Tile adhesive",
+   "spec": "cementitious, 20 kg bag",
+   "supplierUnit": "Bags",
+   "sourceUnit": "kg",
+   "sourceUnitsPerSupplierUnit": 20.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 0,
+   "matchKinds": [
+    "tile_adhesive"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "tile-grout",
+   "description": "Tile grout",
+   "spec": "5 kg bag",
+   "supplierUnit": "Bags",
+   "sourceUnit": "kg",
+   "sourceUnitsPerSupplierUnit": 5.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 0,
+   "matchKinds": [
+    "tile_grout"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "skirting",
+   "description": "Skirting",
+   "spec": "per linear metre, as scheduled",
+   "supplierUnit": "m",
+   "sourceUnit": "m",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": false,
+   "defaultWastagePct": 5,
+   "matchKinds": [
+    "skirting"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "ceiling-board",
+   "description": "Ceiling board (gypsum / plasterboard)",
+   "spec": "1200x2400 sheet = 2.88 m2",
+   "supplierUnit": "Sheets",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 2.88,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [
+    "ceiling_board"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "ceiling-furring",
+   "description": "Ceiling furring / suspension grid (DERIVED from area by a practice ratio - not measured)",
+   "spec": "3.6 m length",
+   "supplierUnit": "Lengths",
+   "sourceUnit": "m",
+   "sourceUnitsPerSupplierUnit": 3.6,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [
+    "ceiling_furring"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "dpm",
+   "description": "Damp-proof membrane (polythene sheet)",
+   "spec": "1000 gauge, 4 m x 25 m roll = 100 m2",
+   "supplierUnit": "Rolls",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 100.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 15.0,
+   "matchKinds": [
+    "dpm"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "roof-underlay",
+   "description": "Roof underlay / sarking membrane",
+   "spec": "1 m x 45 m roll = 45 m2",
+   "supplierUnit": "Rolls",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 45.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 15.0,
+   "matchKinds": [
+    "roof_underlay"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "hoop-iron",
+   "description": "Hoop iron (DERIVED from walled area by a practice ratio - not measured)",
+   "spec": "30 m roll",
+   "supplierUnit": "Rolls",
+   "sourceUnit": "m",
+   "sourceUnitsPerSupplierUnit": 30.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "hoop_iron"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "binding-wire",
+   "description": "Binding wire (DERIVED from rebar mass by a practice ratio - not measured)",
+   "spec": "20 kg roll",
+   "supplierUnit": "Rolls",
+   "sourceUnit": "kg",
+   "sourceUnitsPerSupplierUnit": 20.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "binding_wire"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "formwork-nails",
+   "description": "Nails for formwork (DERIVED from contact area by a practice ratio - not measured)",
+   "spec": "sold by the kilogram",
+   "supplierUnit": "Kg",
+   "sourceUnit": "kg",
+   "sourceUnitsPerSupplierUnit": 1.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "formwork_nails"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "roof-fastener",
+   "description": "Roofing screws / nails (DERIVED from covering area by a practice ratio - not measured)",
+   "spec": "pack of 100",
+   "supplierUnit": "Packs",
+   "sourceUnit": "nr",
+   "sourceUnitsPerSupplierUnit": 100.0,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 5.0,
+   "matchKinds": [
+    "roof_fastener"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  },
+  {
+   "commodityKey": "roof-shingle",
+   "description": "Asphalt / bitumen shingles",
+   "spec": "bundle covers ~3.1 m2 (3 bundles = 1 square = 9.29 m2)",
+   "supplierUnit": "Bundles",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 3.1,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchMaterialPatterns": [
+    "asphalt shingle",
+    "bitumen shingle",
+    "shingle"
+   ],
+   "matchTypePatterns": [
+    "shingle"
+   ],
+   "stageId": "roof",
+   "sourceNote": "3 bundles per roofing square (9.29 m2) is the near-universal packing, so ~3.1 m2 per bundle. 10% covers hip/ridge cutting and the starter course. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "roof-tile-stonecoated",
+   "description": "Stone-coated steel roof tiles (Harvey / Decra / Versatile type)",
+   "spec": "sheet nominal 1330 x 420 mm; effective cover ~0.47 m2",
+   "supplierUnit": "No.",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 0.47,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 7.5,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchMaterialPatterns": [
+    "stone coated",
+    "stone-coated",
+    "harvey",
+    "decra",
+    "versatile",
+    "roman tile",
+    "milano"
+   ],
+   "matchTypePatterns": [
+    "harvey",
+    "decra",
+    "versatile",
+    "stone coat",
+    "stonecoat"
+   ],
+   "stageId": "roof",
+   "sourceNote": "Nominal sheet 1330 x 420 mm with side and head laps gives roughly 0.47 m2 of cover, about 2.1 sheets per m2 — suppliers commonly quote 2.2 to 2.3 per m2 depending on pitch. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "roof-tile-clay",
+   "description": "Clay roof tiles (Marseille / Roman profile)",
+   "spec": "~13 tiles per m2 at standard gauge",
+   "supplierUnit": "No.",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 0.077,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 8.0,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchMaterialPatterns": [
+    "clay tile",
+    "clay roof",
+    "marseille",
+    "terracotta"
+   ],
+   "matchTypePatterns": [
+    "clay tile",
+    "marseille"
+   ],
+   "stageId": "roof",
+   "sourceNote": "13 tiles per m2 (0.077 m2 each) is the usual Marseille-profile gauge; Roman and pantile profiles run 10 to 16. Breakage is why the waste allowance is higher than for steel. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "roof-tile-concrete",
+   "description": "Concrete roof tiles",
+   "spec": "~10 tiles per m2 at standard gauge",
+   "supplierUnit": "No.",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 0.1,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 7.5,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchMaterialPatterns": [
+    "concrete tile",
+    "concrete roof tile"
+   ],
+   "matchTypePatterns": [
+    "concrete tile"
+   ],
+   "stageId": "roof",
+   "sourceNote": "10 tiles per m2 (0.10 m2 each) at the common 300 mm gauge. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "roof-sheet-boxprofile",
+   "description": "Box-profile / trapezoidal steel roofing sheet",
+   "spec": "1 m nominal width, ~0.86 m effective cover; sold by the running metre of length",
+   "supplierUnit": "m",
+   "sourceUnit": "m2",
+   "sourceUnitsPerSupplierUnit": 0.86,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [],
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchMaterialPatterns": [
+    "box profile",
+    "box-profile",
+    "trapezoidal",
+    "kliplok",
+    "klip lok"
+   ],
+   "matchTypePatterns": [
+    "box profile",
+    "boxprofile",
+    "trapezoid",
+    "kliplok"
+   ],
+   "stageId": "roof",
+   "sourceNote": "Nominal 1 m sheet with one-rib side lap covers about 0.86 m. Sold by LENGTH, so the order quantity here is running metres of sheet, not a sheet count — lengths are cut to the rafter run. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+  },
+  {
+   "commodityKey": "fascia-board",
+   "description": "Fascia board (measured along the eaves)",
+   "spec": "4.2 m length, sold whole",
+   "supplierUnit": "Lengths",
+   "sourceUnit": "m",
+   "sourceUnitsPerSupplierUnit": 4.2,
+   "roundUpToWhole": true,
+   "defaultWastagePct": 10.0,
+   "matchKinds": [
+    "fascia_board"
+   ],
+   "matchCategories": [],
+   "matchTypePatterns": [],
+   "stageId": ""
+  }
+ ]
 }


### PR DESCRIPTION
feat(matsched): match a covering by its MATERIAL, and add the East African roofing family

A delivered roof, opened in Revit: type "Generic - 225mm", total thickness
25.0 mm, one layer - Structure, "Asphalt Shingle". The type name was wrong
by a factor of ten. The material was exactly right.

WHY THE LAYER WAS INVISIBLE. Every layer reader filters on Finish1,
Finish2, Substrate, Membrane or Insulation. None accepts STRUCTURE. So a
covering sitting on a structure layer was seen by no reader, the element
fell through to the composite fallback, and the fallback names its row
after the TYPE. That is the whole path from "the model is correct" to
"610 m2 of unpriceable Generic - 225mm".

So rules can now match on MatchMaterialPatterns, checked before type
patterns and standing on their own. Order is kind -> material -> type,
which is decreasing reliability: a kind is emitted by our own take-off, a
material is chosen deliberately by whoever built the model, a type name
is free text at 5pm. Nobody renames a material to make a schedule work.

A HAZARD FOUND WHILE TESTING, not after. "No type patterns => the whole
category converts" is existing and correct behaviour, but combined with a
material rule it means adding ONE shingle rule silently re-routes every
roof in the model. A rule that declares material patterns no longer falls
through to whole-category matching - the material IS its discriminator,
and having one means the category alone was never enough. That mutation
fails two tests.

FIVE EAST AFRICAN ROOFING COMMODITIES, each with the arithmetic stated
and each told to confirm it:

  roof-shingle            3.1 m2/bundle   (3 bundles = 1 square = 9.29 m2)
  roof-tile-stonecoated   0.47 m2/sheet   (Harvey / Decra / Versatile)
  roof-tile-clay          0.077 m2/tile   (~13/m2, Marseille profile)
  roof-tile-concrete      0.10 m2/tile    (~10/m2)
  roof-sheet-boxprofile   0.86 m2/m       (sold by the running metre)

The two shipped roof rules gained material patterns and the sourceNotes
they never had. Every cover figure multiplies the WHOLE roof area, so a
new SourceNote field carries where it came from, and a test asserts every
roofing rule has one and tells the reader to confirm it. 0.47 versus 0.42
m2 per sheet is 12% of the order.

Rates are indicative and say so in their own description, matching the
file's existing contract - the shipped rates file already states that a
live project must re-price before tender. The shipped-data gate caught
the commodities before the rates existed, which is the gate doing its
job: a commodity that cannot be priced is not a commodity.

For the roof in question, 856.28 m2 now reads:
  shingle 304 bundles · stone-coated 1,959 · clay 12,011 · concrete 9,206
  sheet 393 · box profile 1,096 m
None of which is square metres, which was the ask.

Boq tests 1065 -> 1083, build 0/0, all four gates pass.

Four mutations, all failing, each verified to have applied: a material
rule also claiming its whole category (2), a material match also
requiring a type match (3), material escaping its category binding (1),
material beating constituent kind (13).

NOT verified in Revit: no export has been produced with material matching
in it. The specific thing to watch is whether "Asphalt Shingle" reaches
the resolver at all - the material is read via Element.GetMaterialIds,
which is new on this path.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
