### PR TITLE
feat(matsched): the export says whether the material reached the resolver

### DIFF
--- a/StingTools.Boq.Tests/MaterialMatchTallyTests.cs
+++ b/StingTools.Boq.Tests/MaterialMatchTallyTests.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Material matching arrived with a failure mode that looks exactly like
+    /// success-minus-one-pattern: the row still reads "Generic - 225mm, 610 m²,
+    /// unpriced", precisely as it did before. Three different causes produce
+    /// that same output, and reading a log to tell them apart is a round trip.
+    ///
+    /// So the scan publishes its own denominator, the way the tiling, screed,
+    /// membrane and room-finish scans already do.
+    /// </summary>
+    public class MaterialMatchTallyTests
+    {
+        private static SupplierUnitTable Units() => new SupplierUnitTable
+        {
+            Rules =
+            {
+                new SupplierUnitRule
+                {
+                    CommodityKey = "roof-shingle", SupplierUnit = "Bundles", SourceUnit = "m2",
+                    SourceUnitsPerSupplierUnit = 3.1, RoundUpToWhole = true,
+                    MatchCategories = { "Roofs" },
+                    MatchMaterialPatterns = { "shingle" }, MatchTypePatterns = { "shingle" }
+                },
+                new SupplierUnitRule
+                {
+                    CommodityKey = "cement", SupplierUnit = "Bags", SourceUnit = "bag",
+                    SourceUnitsPerSupplierUnit = 1, MatchKinds = { "mortar_cement" }
+                }
+            }
+        };
+
+        private static AggregatorInputs Inputs(params ConstituentInput[] rows) => new AggregatorInputs
+        {
+            Constituents = rows.ToList(),
+            Units = Units(),
+            StageDefs = new List<StageDefinition>
+            {
+                new StageDefinition { StageId = "roof", Title = "ROOF", Order = 10 }
+            },
+            DefaultStageId = "roof",
+            Rates = new CommodityRateResolver(
+                new List<CommodityRate> { new CommodityRate { CommodityKey = "roof-shingle", RateUGX = 110000 } },
+                null)
+        };
+
+        private static ConstituentInput Roof(string type, string material, double m2 = 610.61) =>
+            new ConstituentInput
+            {
+                ConstituentKind = "", Category = "Roofs", TypeName = type,
+                Description = type, MaterialName = material, Unit = "m2", Quantity = m2
+            };
+
+        // ── the three outcomes that look identical on the sheet ─────────────
+
+        [Fact]
+        public void A_Material_That_Matches_Is_Counted_As_Matched()
+        {
+            var inputs = Inputs(Roof("Generic - 225mm", "Asphalt Shingle"));
+
+            CommodityAggregator.Build(inputs);
+
+            var s = inputs.MaterialScan;
+            Assert.Equal(1, s.RowsInspected);
+            Assert.Equal(1, s.RowsWithMaterial);
+            Assert.Equal(1, s.MatchedByMaterial);
+            Assert.Empty(s.UnplacedMaterials);
+        }
+
+        [Fact]
+        public void A_Material_That_Matches_Nothing_Is_NAMED()
+        {
+            // The actionable half. Each name is a pattern worth adding.
+            var inputs = Inputs(Roof("Generic - 225mm", "Woven Papyrus Thatch"));
+
+            CommodityAggregator.Build(inputs);
+
+            Assert.True(inputs.MaterialScan.UnplacedMaterials.Contains("Woven Papyrus Thatch"));
+            Assert.True(inputs.MaterialScan.UnplacedCategories.Contains("Roofs"));
+            Assert.Contains("'Woven Papyrus Thatch'", inputs.MaterialScan.Summary());
+        }
+
+        [Fact]
+        public void NO_Material_At_All_Is_Called_Out_As_Plumbing_Not_Naming()
+        {
+            // The case that reads as a broken feature and is not. The material
+            // is read off the element, so an empty column means the element has
+            // none — or it is not reaching the schedule.
+            var inputs = Inputs(Roof("Generic - 225mm", ""));
+
+            CommodityAggregator.Build(inputs);
+
+            string s = inputs.MaterialScan.Summary();
+            Assert.Equal(0, inputs.MaterialScan.RowsWithMaterial);
+            Assert.Contains("NO row carried a material name at all", s);
+            Assert.Contains("not a naming problem", s);
+            Assert.Contains("Check one element", s);
+        }
+
+        // ── the denominator ─────────────────────────────────────────────────
+
+        [Fact]
+        public void A_Row_With_Its_Own_Constituent_Kind_Is_Not_Inspected()
+        {
+            // Cement is decided by kind. Counting it would report a coverage
+            // the feature was never asked for, and make the ratio meaningless.
+            var inputs = Inputs(new ConstituentInput
+            {
+                ConstituentKind = "mortar_cement", Unit = "bag", Quantity = 10, MaterialName = "Cement"
+            });
+
+            CommodityAggregator.Build(inputs);
+
+            Assert.Equal(0, inputs.MaterialScan.RowsInspected);
+            Assert.Null(inputs.MaterialScan.Summary());
+        }
+
+        [Fact]
+        public void A_Scan_That_Inspected_Nothing_Reports_Nothing()
+        {
+            Assert.Null(new MaterialMatchTally().Summary());
+        }
+
+        [Fact]
+        public void A_Well_Named_Model_Says_Material_Matching_Changed_Nothing()
+        {
+            // Matched on TYPE, not material — the expected outcome when the
+            // model is named properly, and worth saying so it does not read as
+            // a failure.
+            var inputs = Inputs(Roof("Shingle roof 25mm", "Some Unlisted Backing"));
+
+            CommodityAggregator.Build(inputs);
+
+            var s = inputs.MaterialScan;
+            Assert.Equal(0, s.MatchedByMaterial);
+            Assert.Empty(s.UnplacedMaterials);
+            Assert.Contains("material matching changed nothing here", s.Summary());
+        }
+
+        [Fact]
+        public void The_Counts_Read_As_A_Ratio_Somebody_Can_Act_On()
+        {
+            var inputs = Inputs(
+                Roof("Generic - 225mm", "Asphalt Shingle"),
+                Roof("Generic - 225mm 2", "Woven Papyrus Thatch"),
+                Roof("Generic - 225mm 3", ""));
+
+            CommodityAggregator.Build(inputs);
+
+            string s = inputs.MaterialScan.Summary();
+            Assert.Contains("3 row(s) could be identified by material", s);
+            Assert.Contains("2 carried a material name", s);
+            Assert.Contains("1 matched a commodity by it", s);
+        }
+
+        [Fact]
+        public void Reset_Clears_Everything_So_A_Second_Build_Does_Not_Accumulate()
+        {
+            var t = new MaterialMatchTally { RowsInspected = 5, RowsWithMaterial = 4, MatchedByMaterial = 3 };
+            t.UnplacedMaterials.Add("x");
+            t.UnplacedCategories.Add("Roofs");
+
+            t.Reset();
+
+            Assert.Equal(0, t.RowsInspected);
+            Assert.Empty(t.UnplacedMaterials);
+            Assert.Null(t.Summary());
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\RatePasteParser.cs" Link="MaterialSchedule\RatePasteParser.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\SupplierUnitPatch.cs" Link="MaterialSchedule\SupplierUnitPatch.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\TypePatternPlanner.cs" Link="MaterialSchedule\TypePatternPlanner.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\MaterialMatchTally.cs" Link="MaterialSchedule\MaterialMatchTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -156,6 +156,12 @@ namespace StingTools.BOQ.MaterialSchedule
             string mapped = SupplierUnitPatcher.Summary(LastPatchesApplied);
             if (!string.IsNullOrEmpty(mapped)) msDoc.Warnings.Add(mapped);
 
+            // Alongside the tiling / screed / membrane / room-finish scans, and
+            // outside the priced block for the same reason: a material match
+            // decides a row's UNIT, which a quantities-only buy-list needs too.
+            string matScan = inputs.MaterialScan?.Summary();
+            if (!string.IsNullOrEmpty(matScan)) msDoc.Warnings.Add(matScan);
+
             if (msDoc.Options.ShowPrices)
             {
                 string provenance = RateProvenanceLabel.Summary(

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -35,6 +35,8 @@ namespace StingTools.Core.MaterialSchedule
         public string DefaultStageId = "";
         /// <summary>Categories that are not materials — see StageLibrary.ExcludedCategories.</summary>
         public List<string> ExcludedCategories = new List<string>();
+        /// <summary>Filled during the pass, for the export note. See MaterialMatchTally.</summary>
+        public MaterialMatchTally MaterialScan = new MaterialMatchTally();
         /// <summary>Description/type substrings that are never materials.</summary>
         public List<string> ExcludedDescriptionPatterns = new List<string>();
         /// <summary>Categories no description pattern may exclude — see StageLibrary.</summary>
@@ -156,6 +158,25 @@ namespace StingTools.Core.MaterialSchedule
                 // A category hit whose type did not match is NOT converted. Record
                 // why, so the reconciler can name it and the QS can either fix the
                 // rule or price the measured row by hand.
+                // The material scan. Only rows with no constituent kind of
+                // their own could ever be decided by material, so those are the
+                // denominator — counting the rest would report a coverage the
+                // feature was never asked for.
+                if (string.IsNullOrWhiteSpace(row.ConstituentKind) && input.MaterialScan != null)
+                {
+                    var scan = input.MaterialScan;
+                    scan.RowsInspected++;
+                    bool hasMaterial = !string.IsNullOrWhiteSpace(row.MaterialName);
+                    if (hasMaterial) scan.RowsWithMaterial++;
+                    if (res.Match == SupplierUnitMatch.ByMaterial) scan.MatchedByMaterial++;
+                    else if (hasMaterial && res.Rule == null)
+                    {
+                        scan.UnplacedMaterials.Add(row.MaterialName.Trim());
+                        if (!string.IsNullOrWhiteSpace(row.Category))
+                            scan.UnplacedCategories.Add(row.Category.Trim());
+                    }
+                }
+
                 if (res.Match == SupplierUnitMatch.CategoryTypeMismatch)
                 {
                     a.ConversionBlocked = true;

--- a/StingTools/Core/MaterialSchedule/MaterialMatchTally.cs
+++ b/StingTools/Core/MaterialSchedule/MaterialMatchTally.cs
@@ -1,0 +1,98 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialMatchTally.cs — did the element's MATERIAL reach the resolver,
+//  and did it match anything?
+//
+//  Material matching landed with a failure mode that looks identical to
+//  success-minus-one-pattern: the row still reads "Generic - 225mm, 610 m²,
+//  unpriced", exactly as it did before. Three very different causes produce
+//  that same output —
+//
+//    * GetMaterialIds returned nothing, so no material ever reached the
+//      resolver (plumbing);
+//    * the material arrived and no rule's patterns fit it (data);
+//    * the row was never a candidate for material matching at all (fine).
+//
+//  Reading a log to tell them apart is a round trip. The four scans already
+//  in this export — tiling, screed, membrane, room finishes — each publish
+//  their own denominator for the same reason: an absent result never explains
+//  itself, and the commonest wrong conclusion is that the feature is broken
+//  when the model is simply silent.
+//
+//  So this counts what it saw, and NAMES the materials it could not place —
+//  the one output that turns "it didn't work" into a list of patterns to add.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public sealed class MaterialMatchTally
+    {
+        /// <summary>Rows whose commodity could be decided by material — i.e. rows
+        /// carrying no constituent kind of their own.</summary>
+        public int RowsInspected;
+
+        /// <summary>Of those, how many actually carried a material name.</summary>
+        public int RowsWithMaterial;
+
+        /// <summary>How many resolved through the MATERIAL path specifically.</summary>
+        public int MatchedByMaterial;
+
+        /// <summary>Distinct material names on rows that still did not convert.
+        /// This is the actionable half: each one is a pattern worth adding.</summary>
+        public readonly SortedSet<string> UnplacedMaterials =
+            new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Categories those unplaced rows sat in, so the reader knows
+        /// which rule family to extend.</summary>
+        public readonly SortedSet<string> UnplacedCategories =
+            new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        public void Reset()
+        {
+            RowsInspected = RowsWithMaterial = MatchedByMaterial = 0;
+            UnplacedMaterials.Clear();
+            UnplacedCategories.Clear();
+        }
+
+        private const int MaxNamesShown = 8;
+
+        /// <summary>
+        /// The note line, or NULL when no row could have been decided by
+        /// material — a scan that inspected nothing is not a finding.
+        /// </summary>
+        public string Summary()
+        {
+            if (RowsInspected == 0) return null;
+
+            string s = $"Material scan: {RowsInspected} row(s) could be identified by material, "
+                     + $"{RowsWithMaterial} carried a material name, {MatchedByMaterial} matched a "
+                     + "commodity by it.";
+
+            // The plumbing case, stated as such. This is the one that reads as a
+            // broken feature and is not.
+            if (RowsWithMaterial == 0)
+                s += " NO row carried a material name at all. That is not a naming problem — the "
+                   + "material is read off the element itself, so either these elements have no "
+                   + "material assigned, or it is not reaching the schedule. Check one element's "
+                   + "Material before adding any pattern.";
+
+            if (UnplacedMaterials.Count > 0)
+                s += $" {UnplacedMaterials.Count} material(s) were found but match no commodity: "
+                   + string.Join(", ", UnplacedMaterials.Take(MaxNamesShown).Select(m => "'" + m + "'"))
+                   + (UnplacedMaterials.Count > MaxNamesShown ? ", …" : "")
+                   + (UnplacedCategories.Count > 0
+                        ? " (in " + string.Join(", ", UnplacedCategories.Take(4)) + ")" : "")
+                   + ". Each is a pattern worth adding to STING_SUPPLIER_UNITS.json — or, for one "
+                   + "project only, a mapping via Price Commodities → Map to commodity.";
+
+            if (RowsWithMaterial > 0 && UnplacedMaterials.Count == 0 && MatchedByMaterial == 0)
+                s += " Every material found was already handled by a constituent kind or a type "
+                   + "pattern, so material matching changed nothing here — which is the expected "
+                   + "outcome on a well-named model.";
+
+            return s;
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -91,6 +91,7 @@ namespace StingTools.Core.MaterialSchedule
         None,                   // nothing matched — row keeps its measured unit, silently
         ByKind,                 // matched a CompoundTakeoff constituent kind
         ByCategory,             // matched a category (and its type pattern, if any)
+        ByMaterial,             // matched the element's MATERIAL name
         CategoryTypeMismatch    // category matched but the type did not — DO NOT convert
     }
 
@@ -144,7 +145,7 @@ namespace StingTools.Core.MaterialSchedule
                     if (!CategoryAllows(r, category)) continue;
                     if (r.MatchMaterialPatterns.Any(p => !string.IsNullOrWhiteSpace(p)
                             && mat.IndexOf(p.Trim(), StringComparison.OrdinalIgnoreCase) >= 0))
-                        return new SupplierUnitResolution { Rule = r, Match = SupplierUnitMatch.ByCategory };
+                        return new SupplierUnitResolution { Rule = r, Match = SupplierUnitMatch.ByMaterial };
                 }
 
             // PERF: single pass, no LINQ closure and no candidates List per row.


### PR DESCRIPTION
feat(matsched): the export says whether the material reached the resolver

Material matching (#840) shipped with a failure mode indistinguishable
from success-minus-one-pattern: the row still reads "Generic - 225mm,
610 m2, unpriced", exactly as it did before. Three different causes give
that same output —

  * GetMaterialIds returned nothing, so no material ever reached the
    resolver (plumbing);
  * the material arrived and no rule's patterns fit it (data);
  * the row was never a candidate for material matching (fine).

Telling them apart meant reading a log, which is a round trip. The four
scans already in this export - tiling, screed, membrane, room finishes -
each publish their own denominator for exactly this reason.

So a fifth: "Material scan: 22 row(s) could be identified by material,
22 carried a material name, 22 matched a commodity by it."

Two of the three cases get their own sentence rather than a number to
interpret. Nothing carrying a material at all says so and says it is NOT
a naming problem - the material is read off the element, so either these
elements have none or it is not reaching the schedule, and the reader is
told to check one element before adding any pattern. Materials found but
unplaced are NAMED, with their categories, because each one is a pattern
worth adding and a list beats a count.

A model where nothing needed material matching says so too, so a row of
zeros does not read as a failure on a well-named model.

The denominator is rows with NO constituent kind of their own - the only
rows a material could ever decide. Counting cement, which is decided by
kind, would report a coverage the feature was never asked for and make
the ratio meaningless. That mutation fails.

SupplierUnitMatch gained ByMaterial so the tally can tell a material
match from a type match. Nothing switches exhaustively on that enum;
every existing use compares against a specific member or tests Rule for
null, so the new member is additive.

Boq tests 1083 -> 1091, build 0/0, all four gates pass.

Four mutations, all failing: dropping the no-material-at-all message (1),
not naming the unplaced materials (1), counting kind-matched rows in the
denominator (1), emitting a line when nothing was inspected (3).

ONE OF THOSE FIRST REPORTED PASS AND HAD NOT APPLIED. A shell-escaped &&
broke the anchor, nothing was replaced, and the suite was green for the
wrong reason - the same shape as the U+00A0 incident in #828. Re-run from
a file with the match asserted, it fails. A mutation that silently fails
to apply is indistinguishable from a test gap.

NOT verified in Revit. The scan's whole purpose is to answer that on the
next export without another round trip.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
