### PR TITLE
fix(matsched): which commodities feed a consumable driver is DATA, not a hardcoded pair

### DIFF
--- a/StingTools.Boq.Tests/FeedsDriverTests.cs
+++ b/StingTools.Boq.Tests/FeedsDriverTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// Which commodities feed a consumable driver is DATA, not code.
+    ///
+    /// It used to be two hardcoded keys:
+    ///
+    ///     commodityKey == "roof-sheet" || commodityKey == "roof-tile"
+    ///
+    /// Five roofing commodities were then added to the data file, none of them
+    /// fed the fastener driver, and a real export reported the driver as zero
+    /// for a shingle roof that was measured, converted and priced three rows
+    /// above it. Two lists of roofing commodities — one in code, one in data —
+    /// drift the moment either is edited, and only the data one ever is.
+    /// </summary>
+    public class FeedsDriverTests
+    {
+        private static SupplierUnitTable Table(params SupplierUnitRule[] rules) =>
+            new SupplierUnitTable { Rules = rules.ToList() };
+
+        private static SupplierUnitRule Covering(string key, string driver = "roof_covering_m2") =>
+            new SupplierUnitRule
+            {
+                CommodityKey = key, SupplierUnit = "No.", SourceUnit = "m2",
+                SourceUnitsPerSupplierUnit = 1, MatchCategories = { "Roofs" },
+                MatchTypePatterns = { key }, FeedsDriver = driver
+            };
+
+        private static ConstituentInput Row(string type, double m2 = 100, string unit = "m2") =>
+            new ConstituentInput
+            {
+                ConstituentKind = "", Category = "Roofs", TypeName = type,
+                Description = type, Unit = unit, Quantity = m2
+            };
+
+        [Fact]
+        public void A_Commodity_That_Declares_The_Driver_Feeds_It()
+        {
+            var d = ConsumableDrivers.From(new[] { Row("roof-shingle") },
+                                           Table(Covering("roof-shingle")));
+
+            Assert.Equal(100, d.RoofCoveringM2);
+        }
+
+        [Theory]
+        [InlineData("roof-shingle")]
+        [InlineData("roof-tile-stonecoated")]
+        [InlineData("roof-tile-clay")]
+        [InlineData("roof-tile-concrete")]
+        [InlineData("roof-sheet-boxprofile")]
+        public void Every_Roofing_Commodity_Added_In_840_Feeds_It_Too(string key)
+        {
+            // The five that silently did not. Named individually so a future
+            // addition that forgets the declaration is a visible omission
+            // rather than a silent one.
+            var d = ConsumableDrivers.From(new[] { Row(key) }, Table(Covering(key)));
+
+            Assert.Equal(100, d.RoofCoveringM2);
+        }
+
+        [Fact]
+        public void A_Commodity_Declaring_Nothing_Feeds_Nothing()
+        {
+            var d = ConsumableDrivers.From(new[] { Row("roof-underlay") },
+                                           Table(Covering("roof-underlay", driver: "")));
+
+            Assert.Equal(0, d.RoofCoveringM2);
+        }
+
+        [Fact]
+        public void The_Unit_Guard_Survives_The_Change()
+        {
+            // A count is never added to an area total, whatever the rule says.
+            var d = ConsumableDrivers.From(new[] { Row("roof-shingle", 29, "each") },
+                                           Table(Covering("roof-shingle")));
+
+            Assert.Equal(0, d.RoofCoveringM2);
+            Assert.NotEmpty(d.UnitMismatches);
+        }
+
+        [Fact]
+        public void An_Unattributed_Covering_Is_Still_Tracked_Apart()
+        {
+            // Category matches a covering, type matches no pattern. The product
+            // is unknown, so the ratio for it is unknown — measured, not usable.
+            var d = ConsumableDrivers.From(new[] { Row("Generic - 225mm") },
+                                           Table(Covering("roof-shingle")));
+
+            Assert.Equal(0, d.RoofCoveringM2);
+            Assert.Equal(100, d.RoofCoveringUnattributedM2);
+        }
+
+        [Fact]
+        public void A_Rule_Naming_A_Driver_That_Does_Not_Exist_Adds_Nothing()
+        {
+            var d = ConsumableDrivers.From(new[] { Row("roof-shingle") },
+                                           Table(Covering("roof-shingle", driver: "invented_driver")));
+
+            Assert.Equal(0, d.RoofCoveringM2);
+            Assert.Equal(0, d.WalledAreaM2);
+            Assert.Equal(0, d.FormworkM2);
+        }
+
+        [Fact]
+        public void The_Material_Is_Used_When_Resolving_A_Driver_Row()
+        {
+            // The shingle roof in the real model: type "Generic - 225mm 2",
+            // material "Asphalt Shingle". Before this the driver pass resolved
+            // WITHOUT the material and would have missed it even though the
+            // schedule converted it.
+            var rule = Covering("roof-shingle");
+            rule.MatchTypePatterns.Clear();
+            rule.MatchMaterialPatterns.Add("shingle");
+
+            var row = Row("Generic - 225mm 2");
+            row.MaterialName = "Asphalt Shingle";
+
+            var d = ConsumableDrivers.From(new[] { row }, Table(rule));
+
+            Assert.Equal(100, d.RoofCoveringM2);
+        }
+
+        // ── the shipped file ────────────────────────────────────────────────
+
+        private static SupplierUnitTable Shipped() =>
+            JsonConvert.DeserializeObject<SupplierUnitTable>(
+                File.ReadAllText(Path.Combine(System.AppContext.BaseDirectory,
+                                              "Data", "STING_SUPPLIER_UNITS.json")));
+
+        [Fact]
+        public void Every_Shipped_Roof_COVERING_Declares_The_Driver()
+        {
+            // A covering that does not declare it produces no fasteners, and
+            // the export says the driver is zero while the covering sits priced
+            // three rows above — which is exactly what happened.
+            var coverings = Shipped().Rules.Where(r =>
+                r.CommodityKey.StartsWith("roof-")
+                && r.CommodityKey != "roof-underlay"      // goes UNDER a covering
+                && r.CommodityKey != "roof-fastener");    // is the OUTPUT
+
+            Assert.NotEmpty(coverings);
+            foreach (var r in coverings)
+                Assert.Equal("roof_covering_m2", r.FeedsDriver);
+        }
+
+        [Fact]
+        public void The_Fastener_Does_Not_Feed_The_Driver_It_Produces()
+        {
+            // Circular: fasteners are derived FROM covering area.
+            Assert.True(string.IsNullOrEmpty(
+                Shipped().ResolveByCommodityKey("roof-fastener")?.FeedsDriver));
+        }
+
+        [Fact]
+        public void Underlay_Does_Not_Feed_The_Covering_Driver()
+        {
+            // It goes under a covering; counting it would double the area.
+            Assert.True(string.IsNullOrEmpty(
+                Shipped().ResolveByCommodityKey("roof-underlay")?.FeedsDriver));
+        }
+
+        [Fact]
+        public void Every_Declared_Driver_In_The_Shipped_File_Is_A_Real_One()
+        {
+            var known = ConsumablesCalculator.AllDrivers;
+
+            foreach (var r in Shipped().Rules.Where(r => !string.IsNullOrWhiteSpace(r.FeedsDriver)))
+                Assert.Contains(r.FeedsDriver, known);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/UnattributedRoofDriverTests.cs
+++ b/StingTools.Boq.Tests/UnattributedRoofDriverTests.cs
@@ -29,7 +29,11 @@ namespace StingTools.Boq.Tests
                 {
                     CommodityKey = "roof-sheet",
                     MatchCategories = new List<string> { "Roofs" },
-                    MatchTypePatterns = new List<string> { "IT4", "Corrugated" }
+                    MatchTypePatterns = new List<string> { "IT4", "Corrugated" },
+                    // Which commodities feed a driver is DATA now, not a
+                    // hardcoded key list in ConsumableDrivers. A rule that
+                    // declares nothing feeds nothing — which is the point.
+                    FeedsDriver = "roof_covering_m2"
                 }
             }
         };

--- a/StingTools/Core/MaterialSchedule/ConsumablesCalculator.cs
+++ b/StingTools/Core/MaterialSchedule/ConsumablesCalculator.cs
@@ -68,10 +68,29 @@ namespace StingTools.Core.MaterialSchedule
         public readonly SortedSet<string> UnitMismatches =
             new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        private static bool IsRoofCovering(string commodityKey) =>
-            !string.IsNullOrWhiteSpace(commodityKey)
-            && (commodityKey.Equals("roof-sheet", StringComparison.OrdinalIgnoreCase)
-             || commodityKey.Equals("roof-tile", StringComparison.OrdinalIgnoreCase));
+        /// <summary>The unit a driver is counted in. A quantity measured in
+        /// another dimension is never added to it.</summary>
+        internal static string UnitFor(string driver)
+        {
+            switch ((driver ?? "").Trim().ToLowerInvariant())
+            {
+                case "rebar_kg": return "kg";
+                default:         return "m2";
+            }
+        }
+
+        /// <summary>Add to a driver by name. An unknown name adds nothing —
+        /// the rule declaring it is reported by Validate, not healed here.</summary>
+        public void Add(string driver, double quantity)
+        {
+            switch ((driver ?? "").Trim().ToLowerInvariant())
+            {
+                case "walled_area_m2":   WalledAreaM2 += quantity; break;
+                case "rebar_kg":         RebarKg += quantity; break;
+                case "formwork_m2":      FormworkM2 += quantity; break;
+                case "roof_covering_m2": RoofCoveringM2 += quantity; break;
+            }
+        }
 
         public double Value(string driver)
         {
@@ -133,21 +152,28 @@ namespace StingTools.Core.MaterialSchedule
                     continue;
                 }
 
-                // The roof covering has no kind of its own — the supplier table
-                // matches it by category and type pattern.
+                // A covering has no kind of its own — the supplier table matches
+                // it by category, material or type pattern, and the RULE says
+                // which driver it feeds. Nothing here names a commodity.
                 if (units != null && string.IsNullOrEmpty(kind))
                 {
-                    var res = units.Resolve(r.ConstituentKind, r.Category, r.TypeName);
-                    if (res.Rule != null && IsRoofCovering(res.Rule.CommodityKey))
+                    var res = units.Resolve(r.ConstituentKind, r.Category, r.TypeName, r.MaterialName);
+                    if (res.Rule != null && !string.IsNullOrWhiteSpace(res.Rule.FeedsDriver))
                     {
-                        if (Is("m2")) d.RoofCoveringM2 += r.Quantity;
+                        if (Is(UnitFor(res.Rule.FeedsDriver))) d.Add(res.Rule.FeedsDriver, r.Quantity);
                         else d.UnitMismatches.Add($"{res.Rule.CommodityKey} in '{r.Unit}'");
                     }
-                    else if (res.Match == SupplierUnitMatch.CategoryTypeMismatch
-                             && IsRoofCovering(res.CandidateCommodityKey) && Is("m2"))
+                    else if (res.Match == SupplierUnitMatch.CategoryTypeMismatch)
                     {
-                        // A roof whose product is unknown. Measured, not usable.
-                        d.RoofCoveringUnattributedM2 += r.Quantity;
+                        // Measured, but the product is unknown, so the ratio for
+                        // it is unknown too. Tracked apart from the real driver
+                        // and never added to it.
+                        var candidate = units.ResolveByCommodityKey(res.CandidateCommodityKey);
+                        if (candidate != null
+                            && string.Equals(candidate.FeedsDriver, "roof_covering_m2",
+                                             StringComparison.OrdinalIgnoreCase)
+                            && Is("m2"))
+                            d.RoofCoveringUnattributedM2 += r.Quantity;
                     }
                 }
             }

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -74,6 +74,26 @@ namespace StingTools.Core.MaterialSchedule
         public string SourceNote = "";
 
         /// <summary>
+        /// The consumable driver this commodity contributes to, e.g.
+        /// "roof_covering_m2". Empty for most commodities.
+        ///
+        /// This used to be a hardcoded pair of keys inside ConsumableDrivers:
+        ///
+        ///     commodityKey == "roof-sheet" || commodityKey == "roof-tile"
+        ///
+        /// Five roofing commodities were then added to the DATA file, none of
+        /// them fed the fastener driver, and a real export reported the driver
+        /// as zero for a shingle roof that was measured, converted and priced
+        /// three rows above. Two lists of roofing commodities — one in code,
+        /// one in data — drift the moment either is edited, and only the data
+        /// one is ever edited.
+        ///
+        /// Declaring it here means adding a sixth roofing type needs no code
+        /// change, and a commodity that feeds nothing simply says nothing.
+        /// </summary>
+        public string FeedsDriver = "";
+
+        /// <summary>
         /// The construction stage this commodity belongs to, overriding whatever
         /// stage the ELEMENT's category routes to. Required on any category rule.
         ///

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -147,7 +147,8 @@
     "it4",
     "it5"
    ],
-   "sourceNote": "IT4/IT5 corrugated at 2.4 m2 effective cover per standard sheet after side and end laps. NOMINAL COVER - confirm against the product's own coverage table before ordering; cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "IT4/IT5 corrugated at 2.4 m2 effective cover per standard sheet after side and end laps. NOMINAL COVER - confirm against the product's own coverage table before ordering; cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "roof-tile",
@@ -171,7 +172,8 @@
     "roof tile",
     "tile - roof"
    ],
-   "sourceNote": "0.09 m2 per tile is roughly 11 tiles per m2, a mid-range figure across Max-pan and clay profiles which run 10 to 16. NOMINAL COVER - confirm against the product's own coverage table before ordering."
+   "sourceNote": "0.09 m2 per tile is roughly 11 tiles per m2, a mid-range figure across Max-pan and clay profiles which run 10 to 16. NOMINAL COVER - confirm against the product's own coverage table before ordering.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "paint-interior",
@@ -433,7 +435,8 @@
     "shingle"
    ],
    "stageId": "roof",
-   "sourceNote": "3 bundles per roofing square (9.29 m2) is the near-universal packing, so ~3.1 m2 per bundle. 10% covers hip/ridge cutting and the starter course. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "3 bundles per roofing square (9.29 m2) is the near-universal packing, so ~3.1 m2 per bundle. 10% covers hip/ridge cutting and the starter course. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "roof-tile-stonecoated",
@@ -465,7 +468,8 @@
     "stonecoat"
    ],
    "stageId": "roof",
-   "sourceNote": "Nominal sheet 1330 x 420 mm with side and head laps gives roughly 0.47 m2 of cover, about 2.1 sheets per m2 — suppliers commonly quote 2.2 to 2.3 per m2 depending on pitch. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "Nominal sheet 1330 x 420 mm with side and head laps gives roughly 0.47 m2 of cover, about 2.1 sheets per m2 — suppliers commonly quote 2.2 to 2.3 per m2 depending on pitch. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "roof-tile-clay",
@@ -491,7 +495,8 @@
     "marseille"
    ],
    "stageId": "roof",
-   "sourceNote": "13 tiles per m2 (0.077 m2 each) is the usual Marseille-profile gauge; Roman and pantile profiles run 10 to 16. Breakage is why the waste allowance is higher than for steel. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "13 tiles per m2 (0.077 m2 each) is the usual Marseille-profile gauge; Roman and pantile profiles run 10 to 16. Breakage is why the waste allowance is higher than for steel. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "roof-tile-concrete",
@@ -514,7 +519,8 @@
     "concrete tile"
    ],
    "stageId": "roof",
-   "sourceNote": "10 tiles per m2 (0.10 m2 each) at the common 300 mm gauge. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "10 tiles per m2 (0.10 m2 each) at the common 300 mm gauge. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "roof-sheet-boxprofile",
@@ -543,7 +549,8 @@
     "kliplok"
    ],
    "stageId": "roof",
-   "sourceNote": "Nominal 1 m sheet with one-rib side lap covers about 0.86 m. Sold by LENGTH, so the order quantity here is running metres of sheet, not a sheet count — lengths are cut to the rafter run. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area."
+   "sourceNote": "Nominal 1 m sheet with one-rib side lap covers about 0.86 m. Sold by LENGTH, so the order quantity here is running metres of sheet, not a sheet count — lengths are cut to the rafter run. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
+   "feedsDriver": "roof_covering_m2"
   },
   {
    "commodityKey": "fascia-board",


### PR DESCRIPTION
fix(matsched): which commodities feed a consumable driver is DATA, not a hardcoded pair

The 01:05 export proved material matching works end to end: a roof typed
"Generic - 225mm 2" and materialled "Asphalt Shingle" converted to 80
bundles at the indicative rate, 224.44 / 3.1 = 72.40 x 1.10 = 79.64,
rounded up. ROOF went 2,790,000 to 11,590,000.

And the fastener driver still read ZERO, three rows below a shingle roof
that was measured, converted and priced. Cause:

    commodityKey == "roof-sheet" || commodityKey == "roof-tile"

Two hardcoded keys. #840 added five roofing commodities to the DATA file
and none of them fed the driver, because the code's list was never
touched. Two lists of roofing commodities - one in code, one in data -
drift the moment either is edited, and only the data one is ever edited.

So the RULE declares it: feedsDriver: "roof_covering_m2". Nothing in
ConsumableDrivers names a commodity any more, and adding a sixth roofing
type needs no code change. A commodity that feeds nothing simply says
nothing, which is most of them.

Three declarations are deliberately absent and each has a test:
  * roof-fastener does not feed the driver it is DERIVED FROM - circular;
  * roof-underlay does not either, because it goes UNDER a covering and
    counting it would double the area;
  * a rule naming a driver that does not exist adds to nothing, rather
    than falling through to whichever total is nearest in the switch.

The driver pass also now resolves WITH the material, which it did not.
Without that it would have missed the shingle roof even after #840 -
resolving one way for the schedule and another for the drivers is two
answers to the same question.

Three existing tests failed on this change and were right to: their
fixtures declared no driver, and under the new scheme that means they
feed none. Fixtures updated to declare what the shipped data declares.

Boq tests 1091 -> 1106, build 0/0, all four gates pass.

Four mutations, all failing, each with its anchor ASSERTED before the
edit was accepted: the fastener declaring the driver it produces (1),
underlay declaring it (1), dropping the unit guard (1), an invented
driver name falling through to roof covering (1).

One of those first failed to COMPILE rather than to fail - removing an
`if` left a dangling `else`. A mutation that does not build proves
nothing, exactly like one that does not apply; re-run so it compiles, it
fails. That is the third variant of this trap tonight, after a
non-breaking space and a shell-escaped &&.

NOT verified in Revit: no export has been produced with the declaration
in it. The next one should show roof_fastener firing off 224.44 m2 of
shingle - not the full 856, because two of the three roofs carry the
material "Default Roof" and are correctly still unattributed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
