### PR TITLE
fix(matsched): fasteners are counted per covering, because tiles are nailed

### DIFF
--- a/StingTools.Boq.Tests/ConsumablesTests.cs
+++ b/StingTools.Boq.Tests/ConsumablesTests.cs
@@ -637,6 +637,25 @@ namespace StingTools.Boq.Tests
         }
 
         [Fact]
+        public void Shipped_Covering_Densities_Stay_In_A_Believable_Band()
+        {
+            // The protection the perDriver band used to give, moved to where the
+            // number went. A SHEET fixed at every second corrugation on purlins
+            // at 0.9-1.2 m is roughly 4-14/m2; a TILE is nailed, so exactly 0 —
+            // and 0 is a real figure here, not an absent one, which is why it is
+            // asserted rather than skipped.
+            var units = Units();
+
+            foreach (string sheet in new[] { "roof-sheet", "roof-sheet-boxprofile" })
+                Assert.InRange(units.ResolveByCommodityKey(sheet).FastenersPerM2, 4.0, 14.0);
+
+            foreach (string tile in new[] { "roof-tile", "roof-tile-clay",
+                                            "roof-tile-concrete", "roof-tile-stonecoated",
+                                            "roof-shingle" })
+                Assert.Equal(0.0, units.ResolveByCommodityKey(tile).FastenersPerM2);
+        }
+
+        [Fact]
         public void The_Shipped_Ratios_Stay_In_A_Believable_Band()
         {
             // Not a rubber stamp: each band is the range a QS would argue inside,
@@ -650,8 +669,12 @@ namespace StingTools.Boq.Tests
             Assert.InRange(by["binding_wire"].PerDriver, 0.008, 0.02);
             // 0.15-0.25 kg/m² for sawn-timber formwork through several reuses.
             Assert.InRange(by["formwork_nails"].PerDriver, 0.1, 0.4);
-            // Every second corrugation on purlins at 0.9-1.2 m is roughly 8-14/m².
-            Assert.InRange(by["roof_fastener"].PerDriver, 6.0, 20.0);
+            // roof_fastener's ratio MOVED. The driver is now a count, produced
+            // per covering from each rule's own FastenersPerM2, so perDriver is
+            // 1 by construction and a band on it would assert nothing. The band
+            // that matters is on the densities themselves — see
+            // Shipped_Covering_Densities_Stay_In_A_Believable_Band below.
+            Assert.Equal(1.0, by["roof_fastener"].PerDriver);
         }
 
         [Fact]
@@ -679,7 +702,15 @@ namespace StingTools.Boq.Tests
             var lib = Consumables();
             var stages = Stages();
             var drivers = new ConsumableDrivers
-            { WalledAreaM2 = 564.22, RebarKg = 8000, FormworkM2 = 300, RoofCoveringM2 = 856 };
+            {
+                WalledAreaM2 = 564.22, RebarKg = 8000, FormworkM2 = 300, RoofCoveringM2 = 856,
+                // Fasteners are COUNTED per covering now rather than re-ratioed
+                // from the area, so the count driver has to be fed too: 856 m2
+                // of corrugated at 8/m2. Feeding only the area would leave
+                // roof_fastener producing nothing and this test asserting three
+                // rules where the library has four.
+                RoofFastenerNr = 856 * 8
+            };
 
             var rows = ConsumablesCalculator.Quantify(drivers, lib.Rules, new ConsumablesTally());
             Assert.Equal(lib.Rules.Count, rows.Count);
@@ -721,7 +752,14 @@ namespace StingTools.Boq.Tests
             var lib = Consumables();
             var stages = Stages();
             var rows = ConsumablesCalculator.Quantify(
-                new ConsumableDrivers { WalledAreaM2 = 500, RebarKg = 8000, FormworkM2 = 300, RoofCoveringM2 = 856 },
+                new ConsumableDrivers
+                {
+                    WalledAreaM2 = 500, RebarKg = 8000, FormworkM2 = 300, RoofCoveringM2 = 856,
+                    // Fasteners are COUNTED per covering now, not re-ratioed from
+                    // the area: 856 m2 of corrugated at 8/m2. The area driver
+                    // stays because the note still reports it.
+                    RoofFastenerNr = 856 * 8
+                },
                 lib.Rules, new ConsumablesTally());
 
             // Descriptions are BLANKED so that only the CONSTITUENT KIND can

--- a/StingTools.Boq.Tests/FastenerPerCoveringTests.cs
+++ b/StingTools.Boq.Tests/FastenerPerCoveringTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// A tiled roof was being quoted screws it does not use.
+    ///
+    /// STING_CONSUMABLES applied a flat 11 fasteners per m² to every roof
+    /// covering. MATERIAL_LOOKUP.csv has said otherwise since long before the
+    /// material schedule existed — clay and concrete tile at ZERO, because
+    /// tiles are nailed every other course rather than screwed, and four sheet
+    /// profiles at four different densities.
+    ///
+    /// That is wrong by KIND, not by degree, and unlike the coverage figures
+    /// (PhysicalConstantDriftTests) it needed no supplier to settle: the data
+    /// was already in the repository, stating the opposite, unread.
+    /// </summary>
+    public class FastenerPerCoveringTests
+    {
+        private static SupplierUnitTable Shipped() =>
+            JsonConvert.DeserializeObject<SupplierUnitTable>(
+                File.ReadAllText(Path.Combine(AppContext.BaseDirectory,
+                                              "Data", "STING_SUPPLIER_UNITS.json")));
+
+        private static SupplierUnitRule Covering(string key, double density) =>
+            new SupplierUnitRule
+            {
+                CommodityKey = key, SupplierUnit = "No.", SourceUnit = "m2",
+                SourceUnitsPerSupplierUnit = 1, MatchCategories = { "Roofs" },
+                MatchTypePatterns = { key }, FeedsDriver = "roof_covering_m2",
+                FastenersPerM2 = density
+            };
+
+        private static ConstituentInput Row(string type, double m2, string unit = "m2") =>
+            new ConstituentInput
+            {
+                ConstituentKind = "", Category = "Roofs", TypeName = type,
+                Description = type, Unit = unit, Quantity = m2
+            };
+
+        // ── the count, per covering ─────────────────────────────────────────
+
+        [Fact]
+        public void A_Sheet_Roof_Counts_Its_Own_Density()
+        {
+            var d = ConsumableDrivers.From(new[] { Row("roof-sheet", 100) },
+                new SupplierUnitTable { Rules = { Covering("roof-sheet", 8) } });
+
+            Assert.Equal(800, d.RoofFastenerNr);
+        }
+
+        [Fact]
+        public void A_Tiled_Roof_Counts_ZERO_Because_Tiles_Are_Nailed()
+        {
+            var d = ConsumableDrivers.From(new[] { Row("roof-tile-clay", 100) },
+                new SupplierUnitTable { Rules = { Covering("roof-tile-clay", 0) } });
+
+            Assert.Equal(0, d.RoofFastenerNr);
+            // The AREA still counts — the covering is real and reported.
+            Assert.Equal(100, d.RoofCoveringM2);
+        }
+
+        [Fact]
+        public void A_MIXED_Roof_Is_The_Case_No_Flat_Ratio_Can_Express()
+        {
+            // 100 m² of sheet at 8 and 100 m² of tile at 0. A flat 11/m² over
+            // the combined 200 m² gives 2,200 fasteners; the truth is 800.
+            var table = new SupplierUnitTable
+            { Rules = { Covering("roof-sheet", 8), Covering("roof-tile-clay", 0) } };
+
+            var d = ConsumableDrivers.From(
+                new[] { Row("roof-sheet", 100), Row("roof-tile-clay", 100) }, table);
+
+            Assert.Equal(800, d.RoofFastenerNr);
+            Assert.Equal(200, d.RoofCoveringM2);
+        }
+
+        [Fact]
+        public void A_Covering_That_States_No_Density_Adds_NOTHING()
+        {
+            // Not zero-by-default: a roof nobody has measured fixings for is not
+            // a roof with zero fixings, and borrowing another covering's density
+            // would be a confident number for an unmeasured thing.
+            var d = ConsumableDrivers.From(new[] { Row("roof-x", 100) },
+                new SupplierUnitTable { Rules = { Covering("roof-x", -1) } });
+
+            Assert.Equal(0, d.RoofFastenerNr);
+            Assert.Equal(100, d.RoofCoveringM2);
+        }
+
+        [Fact]
+        public void The_Unit_Guard_Applies_To_The_Count_Too()
+        {
+            // 29 ridge caps measured in "each" must not be multiplied by a
+            // per-m² density.
+            var d = ConsumableDrivers.From(new[] { Row("roof-sheet", 29, "each") },
+                new SupplierUnitTable { Rules = { Covering("roof-sheet", 8) } });
+
+            Assert.Equal(0, d.RoofFastenerNr);
+            Assert.NotEmpty(d.UnitMismatches);
+        }
+
+        [Fact]
+        public void An_Unattributed_Covering_Contributes_No_Fasteners()
+        {
+            // Product unknown, so its density is unknown too. Counting it would
+            // pick a density for a covering nobody has identified.
+            var d = ConsumableDrivers.From(new[] { Row("Generic - 225mm", 610) },
+                new SupplierUnitTable { Rules = { Covering("roof-sheet", 8) } });
+
+            Assert.Equal(0, d.RoofFastenerNr);
+            Assert.Equal(610, d.RoofCoveringUnattributedM2);
+        }
+
+        // ── the shipped file matches MATERIAL_LOOKUP ────────────────────────
+
+        [Theory]
+        [InlineData("roof-sheet", 8.0)]              // ROOF_SHEET CORRUGATED
+        [InlineData("roof-sheet-boxprofile", 6.0)]   // ROOF_SHEET BOX_PROFILE
+        [InlineData("roof-tile-clay", 0.0)]          // ROOF_SHEET CLAY_TILE
+        [InlineData("roof-tile-concrete", 0.0)]      // ROOF_SHEET CONCRETE_TILE
+        public void The_Shipped_Densities_Agree_With_MATERIAL_LOOKUP(string key, double expected)
+        {
+            // The point of the whole exercise: two files stating the same
+            // physical fact and finally agreeing. PhysicalConstantDriftTests
+            // guards the coverage figures the same way.
+            Assert.Equal(expected, Shipped().ResolveByCommodityKey(key).FastenersPerM2);
+        }
+
+        [Fact]
+        public void Every_Nailed_Covering_Is_Zero_Not_Unstated()
+        {
+            // -1 (unstated) and 0 (nailed) mean different things and produce
+            // different notes. Tiles and shingles are KNOWN to take no screws,
+            // so they must say 0.
+            var units = Shipped();
+            foreach (string k in new[] { "roof-tile", "roof-tile-clay", "roof-tile-concrete",
+                                         "roof-tile-stonecoated", "roof-shingle" })
+                Assert.Equal(0.0, units.ResolveByCommodityKey(k).FastenersPerM2);
+        }
+
+        [Fact]
+        public void The_Consumable_Reads_The_COUNT_Not_The_Area()
+        {
+            var lib = JsonConvert.DeserializeObject<ConsumablesLibrary>(
+                File.ReadAllText(Path.Combine(AppContext.BaseDirectory,
+                                              "Data", "STING_CONSUMABLES.json")));
+
+            var rule = lib.Rules.Single(r =>
+                string.Equals(r.ConstituentKind, "roof_fastener", StringComparison.OrdinalIgnoreCase));
+
+            Assert.Equal("roof_fastener_nr", rule.Driver);
+            // 1 by construction: the driver is already the number of fasteners,
+            // so any other multiplier would re-ratio an already-counted figure.
+            Assert.Equal(1.0, rule.PerDriver);
+            Assert.Contains("nailed rather than screwed", rule.SourceNote);
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/ConsumablesCalculator.cs
+++ b/StingTools/Core/MaterialSchedule/ConsumablesCalculator.cs
@@ -44,6 +44,14 @@ namespace StingTools.Core.MaterialSchedule
         public double RoofCoveringM2;
 
         /// <summary>
+        /// Fasteners, already COUNTED per covering rather than derived by one
+        /// flat ratio over a mixed roof. A sheet roof and a tiled roof on the
+        /// same building need different numbers and one of them is zero, which
+        /// no single ratio over the combined area can express.
+        /// </summary>
+        public double RoofFastenerNr;
+
+        /// <summary>
         /// Roof covering that WAS measured but could not be attributed to a
         /// product: the category resolved to a roof commodity and the type name
         /// matched no pattern, so the supplier table refused to convert it.
@@ -75,6 +83,8 @@ namespace StingTools.Core.MaterialSchedule
             switch ((driver ?? "").Trim().ToLowerInvariant())
             {
                 case "rebar_kg": return "kg";
+                // Counted FROM an area, so the ROW that feeds it is in m2.
+                case "roof_fastener_nr": return "m2";
                 default:         return "m2";
             }
         }
@@ -89,6 +99,7 @@ namespace StingTools.Core.MaterialSchedule
                 case "rebar_kg":         RebarKg += quantity; break;
                 case "formwork_m2":      FormworkM2 += quantity; break;
                 case "roof_covering_m2": RoofCoveringM2 += quantity; break;
+                case "roof_fastener_nr": RoofFastenerNr += quantity; break;
             }
         }
 
@@ -100,6 +111,7 @@ namespace StingTools.Core.MaterialSchedule
                 case "rebar_kg":         return RebarKg;
                 case "formwork_m2":      return FormworkM2;
                 case "roof_covering_m2": return RoofCoveringM2;
+                case "roof_fastener_nr": return RoofFastenerNr;
                 default:                 return 0;
             }
         }
@@ -160,7 +172,20 @@ namespace StingTools.Core.MaterialSchedule
                     var res = units.Resolve(r.ConstituentKind, r.Category, r.TypeName, r.MaterialName);
                     if (res.Rule != null && !string.IsNullOrWhiteSpace(res.Rule.FeedsDriver))
                     {
-                        if (Is(UnitFor(res.Rule.FeedsDriver))) d.Add(res.Rule.FeedsDriver, r.Quantity);
+                        if (Is(UnitFor(res.Rule.FeedsDriver)))
+                        {
+                            d.Add(res.Rule.FeedsDriver, r.Quantity);
+
+                            // The fastener count, per covering, in the same
+                            // pass. A covering that states no density adds
+                            // NOTHING rather than borrowing another's — a roof
+                            // nobody has measured fixings for is not a roof
+                            // with zero fixings, and those are different facts.
+                            if (res.Rule.FastenersPerM2 >= 0
+                                && string.Equals(res.Rule.FeedsDriver, "roof_covering_m2",
+                                                 StringComparison.OrdinalIgnoreCase))
+                                d.RoofFastenerNr += r.Quantity * res.Rule.FastenersPerM2;
+                        }
                         else d.UnitMismatches.Add($"{res.Rule.CommodityKey} in '{r.Unit}'");
                     }
                     else if (res.Match == SupplierUnitMatch.CategoryTypeMismatch)
@@ -214,7 +239,7 @@ namespace StingTools.Core.MaterialSchedule
     {
         private static readonly HashSet<string> KnownDrivers =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { "walled_area_m2", "rebar_kg", "formwork_m2", "roof_covering_m2" };
+            { "walled_area_m2", "rebar_kg", "formwork_m2", "roof_covering_m2", "roof_fastener_nr" };
 
         public static IReadOnlyCollection<string> AllDrivers => KnownDrivers;
 

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -94,6 +94,30 @@ namespace StingTools.Core.MaterialSchedule
         public string FeedsDriver = "";
 
         /// <summary>
+        /// Fasteners per m2 of THIS covering. -1 means not stated.
+        ///
+        /// STING_CONSUMABLES applied a flat 11/m2 to every roof covering. For
+        /// tiles that is wrong by KIND rather than by degree, and
+        /// MATERIAL_LOOKUP.csv has said so since long before the material
+        /// schedule existed:
+        ///
+        ///     CLAY_TILE      0     CORRUGATED     8
+        ///     CONCRETE_TILE  0     BOX_PROFILE    6
+        ///                          STANDING_SEAM  4
+        ///                          FIBRE_CEMENT  10
+        ///
+        /// Tiles are nailed every other course, not screwed, so a tiled roof
+        /// was being quoted a pack count for fixings it does not use. Four
+        /// profiles with four densities also means one flat number cannot be
+        /// right for all of them.
+        ///
+        /// Unlike the COVERAGE figures (see PhysicalConstantDriftTests) this
+        /// needed no supplier to settle: the data was already in the repository
+        /// stating the opposite, and unread.
+        /// </summary>
+        public double FastenersPerM2 = -1;
+
+        /// <summary>
         /// The construction stage this commodity belongs to, overriding whatever
         /// stage the ELEMENT's category routes to. Required on any category rule.
         ///

--- a/StingTools/Data/STING_CONSUMABLES.json
+++ b/StingTools/Data/STING_CONSUMABLES.json
@@ -1,39 +1,39 @@
 {
-  "schemaVersion": "1.0",
-  "note": "PRACTICE HEURISTICS, NOT A STANDARD. Nothing in a Revit model states how much hoop iron a wall carries, how much wire ties a tonne of steel, how many nails a square metre of formwork takes or how many screws fix a square metre of sheeting. No measurement standard publishes any of these either — NRM2 treats them as part of the item they serve. Every figure below is contractor practice, is stated with its derivation in sourceNote, and is emitted only when its measured driver is non-zero. With no driver, NOTHING is emitted: a default quantity would be a fabricated number wearing the costume of a calculation. Project override: <project>/_data/coord/consumables.json (merged by constituentKind).",
-  "drivers": "walled_area_m2 | rebar_kg | formwork_m2 | roof_covering_m2 — all taken from the constituent rows the bill itself is built from, NET of wastage.",
-  "rules": [
-    {
-      "constituentKind": "hoop_iron",
-      "description": "Hoop iron (masonry reinforcement)",
-      "driver": "walled_area_m2",
-      "perDriver": 1.2,
-      "unit": "m",
-      "sourceNote": "ONE strip laid in every 4th course of 200 mm blockwork. A course is 200 mm block + 10 mm bed = 210 mm, so every 4th course is one 1 m run per 0.84 m of wall height = 1.19 m per m2 of wall face, taken as 1.2. DOUBLE IT if the specification calls for a strip near each face, and scale it if the course interval differs. East African contractor practice; no measurement standard publishes it."
-    },
-    {
-      "constituentKind": "binding_wire",
-      "description": "Binding wire (rebar tying)",
-      "driver": "rebar_kg",
-      "perDriver": 0.0125,
-      "unit": "kg",
-      "sourceNote": "1.25% of reinforcement mass — the midpoint of the 1.0-1.5% range used in East African and Indian practice for tying bars at every intersection. Heavily congested sections and small-diameter mesh-like cages run higher. No measurement standard publishes it."
-    },
-    {
-      "constituentKind": "formwork_nails",
-      "description": "Nails (formwork)",
-      "driver": "formwork_m2",
-      "perDriver": 0.2,
-      "unit": "kg",
-      "sourceNote": "0.20 kg of nails per m2 of formwork CONTACT AREA, mid-range of the 0.15-0.25 kg/m2 commonly allowed for sawn-timber formwork taken through three to four reuses. A single-use shutter or a heavily propped soffit runs higher. No measurement standard publishes it."
-    },
-    {
-      "constituentKind": "roof_fastener",
-      "description": "Roofing screws / nails",
-      "driver": "roof_covering_m2",
-      "perDriver": 11.0,
-      "unit": "nr",
-      "sourceNote": "11 fasteners per m2 of roof covering — IT4 / corrugated sheeting fixed at every second corrugation on each purlin, with purlins at 900 mm centres. Count the SPECIFIED fixing pattern for a firm figure; this is a starting point, not a take-off. No measurement standard publishes it."
-    }
-  ]
+ "schemaVersion": "1.0",
+ "note": "PRACTICE HEURISTICS, NOT A STANDARD. Nothing in a Revit model states how much hoop iron a wall carries, how much wire ties a tonne of steel, how many nails a square metre of formwork takes or how many screws fix a square metre of sheeting. No measurement standard publishes any of these either — NRM2 treats them as part of the item they serve. Every figure below is contractor practice, is stated with its derivation in sourceNote, and is emitted only when its measured driver is non-zero. With no driver, NOTHING is emitted: a default quantity would be a fabricated number wearing the costume of a calculation. Project override: <project>/_data/coord/consumables.json (merged by constituentKind).",
+ "drivers": "walled_area_m2 | rebar_kg | formwork_m2 | roof_covering_m2 — all taken from the constituent rows the bill itself is built from, NET of wastage.",
+ "rules": [
+  {
+   "constituentKind": "hoop_iron",
+   "description": "Hoop iron (masonry reinforcement)",
+   "driver": "walled_area_m2",
+   "perDriver": 1.2,
+   "unit": "m",
+   "sourceNote": "ONE strip laid in every 4th course of 200 mm blockwork. A course is 200 mm block + 10 mm bed = 210 mm, so every 4th course is one 1 m run per 0.84 m of wall height = 1.19 m per m2 of wall face, taken as 1.2. DOUBLE IT if the specification calls for a strip near each face, and scale it if the course interval differs. East African contractor practice; no measurement standard publishes it."
+  },
+  {
+   "constituentKind": "binding_wire",
+   "description": "Binding wire (rebar tying)",
+   "driver": "rebar_kg",
+   "perDriver": 0.0125,
+   "unit": "kg",
+   "sourceNote": "1.25% of reinforcement mass — the midpoint of the 1.0-1.5% range used in East African and Indian practice for tying bars at every intersection. Heavily congested sections and small-diameter mesh-like cages run higher. No measurement standard publishes it."
+  },
+  {
+   "constituentKind": "formwork_nails",
+   "description": "Nails (formwork)",
+   "driver": "formwork_m2",
+   "perDriver": 0.2,
+   "unit": "kg",
+   "sourceNote": "0.20 kg of nails per m2 of formwork CONTACT AREA, mid-range of the 0.15-0.25 kg/m2 commonly allowed for sawn-timber formwork taken through three to four reuses. A single-use shutter or a heavily propped soffit runs higher. No measurement standard publishes it."
+  },
+  {
+   "constituentKind": "roof_fastener",
+   "description": "Roofing screws / nails",
+   "driver": "roof_fastener_nr",
+   "perDriver": 1.0,
+   "unit": "nr",
+   "sourceNote": "Counted per covering from MATERIAL_LOOKUP's FASTENERS_PER_M2, not from one flat ratio over the whole roof: corrugated 8/m2, box profile 6, standing seam 4, fibre cement 10, and ZERO for tiles and shingles, which are nailed rather than screwed. The previous flat 11/m2 quoted a tiled roof a pack count for fixings it does not use. Count the SPECIFIED fixing pattern for a firm figure; these are starting points."
+  }
+ ]
 }

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -148,7 +148,8 @@
     "it5"
    ],
    "sourceNote": "IT4/IT5 corrugated at 2.4 m2 effective cover per standard sheet after side and end laps. NOMINAL COVER - confirm against the product's own coverage table before ordering; cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 8.0
   },
   {
    "commodityKey": "roof-tile",
@@ -173,7 +174,8 @@
     "tile - roof"
    ],
    "sourceNote": "0.09 m2 per tile is roughly 11 tiles per m2, a mid-range figure across Max-pan and clay profiles which run 10 to 16. NOMINAL COVER - confirm against the product's own coverage table before ordering.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 0.0
   },
   {
    "commodityKey": "paint-interior",
@@ -436,7 +438,8 @@
    ],
    "stageId": "roof",
    "sourceNote": "3 bundles per roofing square (9.29 m2) is the near-universal packing, so ~3.1 m2 per bundle. 10% covers hip/ridge cutting and the starter course. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 0.0
   },
   {
    "commodityKey": "roof-tile-stonecoated",
@@ -469,7 +472,8 @@
    ],
    "stageId": "roof",
    "sourceNote": "Nominal sheet 1330 x 420 mm with side and head laps gives roughly 0.47 m2 of cover, about 2.1 sheets per m2 — suppliers commonly quote 2.2 to 2.3 per m2 depending on pitch. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 0.0
   },
   {
    "commodityKey": "roof-tile-clay",
@@ -496,7 +500,8 @@
    ],
    "stageId": "roof",
    "sourceNote": "13 tiles per m2 (0.077 m2 each) is the usual Marseille-profile gauge; Roman and pantile profiles run 10 to 16. Breakage is why the waste allowance is higher than for steel. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 0.0
   },
   {
    "commodityKey": "roof-tile-concrete",
@@ -520,7 +525,8 @@
    ],
    "stageId": "roof",
    "sourceNote": "10 tiles per m2 (0.10 m2 each) at the common 300 mm gauge. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 0.0
   },
   {
    "commodityKey": "roof-sheet-boxprofile",
@@ -550,7 +556,8 @@
    ],
    "stageId": "roof",
    "sourceNote": "Nominal 1 m sheet with one-rib side lap covers about 0.86 m. Sold by LENGTH, so the order quantity here is running metres of sheet, not a sheet count — lengths are cut to the rafter run. NOMINAL COVER — confirm against the product's own coverage table before ordering. Cover varies by profile, pitch and lap, and this number multiplies the whole roof area.",
-   "feedsDriver": "roof_covering_m2"
+   "feedsDriver": "roof_covering_m2",
+   "fastenersPerM2": 6.0
   },
   {
    "commodityKey": "fascia-board",


### PR DESCRIPTION
fix(matsched): fasteners are counted per covering, because tiles are nailed

A flat 11 fasteners per m2 was applied to every roof covering.
MATERIAL_LOOKUP.csv has said otherwise since long before the material
schedule existed:

    CLAY_TILE      0     CORRUGATED     8
    CONCRETE_TILE  0     BOX_PROFILE    6
                         STANDING_SEAM  4
                         FIBRE_CEMENT  10

Tiles are nailed every other course, not screwed, so a tiled roof was
being quoted a pack count for fixings it does not use. Wrong by KIND
rather than by degree - and unlike the coverage figures in #846 this
needed no supplier to settle, because the data was already in the
repository stating the opposite, unread.

The mixed case is the one no flat ratio can express: 100 m2 of sheet at
8 plus 100 m2 of tile at 0 is 800 fasteners, and a flat 11 over the
combined 200 m2 gives 2,200. A test holds exactly that.

So the covering RULE states its own density and the driver is a COUNT
rather than an area to be re-ratioed. roof_fastener now reads
roof_fastener_nr at perDriver 1.0 - 1 by construction, since any other
multiplier would re-ratio an already-counted figure.

-1 (unstated) and 0 (nailed) are kept distinct. A roof nobody has
measured fixings for is not a roof with zero fixings; an unstated
density contributes NOTHING rather than borrowing another covering's.
Both mutations fail.

Three existing tests failed on this and were right to. Two built
ConsumableDrivers by hand and fed only the area, so roof_fastener
produced nothing and the library's four rules became three. The third
asserted a believable band on roof_fastener.PerDriver, which is now 1 by
construction - so the band MOVED to where the number went: sheets 4-14
per m2, tiles exactly 0. A band on a constructed 1.0 would assert
nothing.

Boq tests 1134 -> 1146, build 0/0, all four gates pass.

Three mutations, all failing, each anchor asserted before the edit:
treating an unstated density as zero-and-counted (1), giving tiles
screws again (3), dropping the unit guard from the count (2).

NOT verified in Revit. On the test project the two Default Roof roofs
stay unattributed, so the visible change should be roof_fastener finally
appearing for the 224 m2 of shingle - at ZERO, because shingles are
nailed, which is the correct answer and not an absent one.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
