### PR TITLE
fix(matsched): the bond's own cutting waste reaches the supplier rule

### DIFF
--- a/StingTools.Boq.Tests/BondWasteTests.cs
+++ b/StingTools.Boq.Tests/BondWasteTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.BOQ.Takeoff;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// MATERIAL_LOOKUP.csv has carried per-bond cutting waste all along —
+    /// stack 3%, stretcher and header 5, garden wall 6, English 7, Flemish 8.
+    /// CompoundTakeoffBuilder resolved it per wall into
+    /// MasonryWallInput.UnitWastePct, and NOTHING read it. Every wall got the
+    /// supplier rule's flat 5, so a Flemish bond was under-ordered by three
+    /// points and a stack bond over-ordered by two.
+    ///
+    /// The fix keeps wastage in exactly ONE place — the supplier rule still
+    /// applies it, and this only hands the rule a better number than its flat
+    /// default. Applying it in the take-off as well is the double-waste bug
+    /// that was removed earlier, and nothing here multiplies by it.
+    /// </summary>
+    public class BondWasteTests
+    {
+        private static SupplierUnitRule BrickRule() => new SupplierUnitRule
+        {
+            CommodityKey = "brick", SupplierUnit = "No.", SourceUnit = "nr",
+            SourceUnitsPerSupplierUnit = 1, RoundUpToWhole = true,
+            DefaultWastagePct = 5, MatchKinds = { "brick_units" }
+        };
+
+        private static AggregatorInputs Inputs(params ConstituentInput[] rows) => new AggregatorInputs
+        {
+            Constituents = rows.ToList(),
+            Units = new SupplierUnitTable { Rules = { BrickRule() } },
+            StageDefs = new List<StageDefinition>
+            { new StageDefinition { StageId = "superstructure", Title = "SUPER", Order = 10 } },
+            DefaultStageId = "superstructure",
+            Rates = new CommodityRateResolver(
+                new List<CommodityRate> { new CommodityRate { CommodityKey = "brick", RateUGX = 400 } }, null)
+        };
+
+        private static ConstituentInput Bricks(double nr, double waste) => new ConstituentInput
+        {
+            ConstituentKind = "brick_units", Category = "Walls", Unit = "nr",
+            Quantity = nr, Description = "Bricks", WastePctOverride = waste
+        };
+
+        private static MaterialCommodity Only(MaterialScheduleDocument d) =>
+            d.Stages.SelectMany(s => s.Commodities).Single(c => c.CommodityKey == "brick");
+
+        // ── the override reaches the conversion ─────────────────────────────
+
+        [Fact]
+        public void A_Flemish_Bond_Orders_Its_OWN_Eight_Percent_Not_The_Rules_Five()
+        {
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 8)));
+
+            Assert.Equal(8, Only(doc).WastagePct);
+            Assert.Equal(1080, Only(doc).OrderQuantity);
+        }
+
+        [Fact]
+        public void A_Stack_Bond_Orders_Three_Percent_Not_Five()
+        {
+            // The other direction: the flat default OVER-ordered this one.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 3)));
+
+            Assert.Equal(1030, Only(doc).OrderQuantity);
+        }
+
+        [Fact]
+        public void A_Row_With_No_Override_Still_Gets_The_Rules_Default()
+        {
+            // -1 means "the rule's default is fine", NOT "no waste". Conflating
+            // them would silently drop the allowance on every row with no
+            // variant to speak of, which is most rows.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, -1)));
+
+            Assert.Equal(5, Only(doc).WastagePct);
+            Assert.Equal(1050, Only(doc).OrderQuantity);
+        }
+
+        [Fact]
+        public void A_Zero_Override_Really_Means_Zero()
+        {
+            // Distinct from -1. A variant that genuinely wastes nothing must be
+            // able to say so.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 0)));
+
+            Assert.Equal(0, Only(doc).WastagePct);
+            Assert.Equal(1000, Only(doc).OrderQuantity);
+        }
+
+        // ── the blend, because rows merge ───────────────────────────────────
+
+        [Fact]
+        public void Two_Bonds_In_One_Commodity_Blend_By_QUANTITY()
+        {
+            // 1,000 bricks at 8% and 3,000 at 4% is not 6% — it is
+            // (8×1000 + 4×3000) / 4000 = 5%. The bigger wall moves the figure
+            // more, which is what a QS would do by hand.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 8), Bricks(3000, 4)));
+
+            Assert.Equal(5, Only(doc).WastagePct, 3);
+        }
+
+        [Fact]
+        public void A_Simple_Mean_Would_Be_Wrong_And_This_Proves_It()
+        {
+            // Same two bonds, sizes swapped. A simple mean gives 6% either way;
+            // weighting gives 7% here and 5% above, and only one of those pairs
+            // tracks the actual brick counts.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(3000, 8), Bricks(1000, 4)));
+
+            Assert.Equal(7, Only(doc).WastagePct, 3);
+        }
+
+        [Fact]
+        public void A_Row_Without_An_Override_Does_Not_Drag_The_Blend()
+        {
+            // Excluded from BOTH sides. Counting it at the rule's default would
+            // let one unstated row pull a stated blend toward a number nobody
+            // chose for it.
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 8), Bricks(9000, -1)));
+
+            Assert.Equal(8, Only(doc).WastagePct, 3);
+        }
+
+        [Fact]
+        public void A_Zero_Quantity_Row_Cannot_Skew_The_Blend()
+        {
+            var doc = CommodityAggregator.Build(Inputs(Bricks(1000, 8), Bricks(0, 40)));
+
+            Assert.Equal(8, Only(doc).WastagePct, 3);
+        }
+
+        // ── the converter, directly ─────────────────────────────────────────
+
+        [Fact]
+        public void The_Converter_Treats_Negative_As_Absent_And_Zero_As_Zero()
+        {
+            var rule = BrickRule();
+
+            Assert.Equal(5, SupplierUnitConverter.Convert(rule, 1000, -1).WastagePct);
+            Assert.Equal(0, SupplierUnitConverter.Convert(rule, 1000, 0).WastagePct);
+            Assert.Equal(8, SupplierUnitConverter.Convert(rule, 1000, 8).WastagePct);
+        }
+
+        [Fact]
+        public void The_Old_Two_Argument_Call_Still_Means_Use_The_Default()
+        {
+            Assert.Equal(5, SupplierUnitConverter.Convert(BrickRule(), 1000).WastagePct);
+        }
+
+        // ── the WIRING, not just the shape ──────────────────────────────────
+
+        [Fact]
+        public void MasonryWall_Puts_The_Bond_Waste_ON_The_Unit_Line()
+        {
+            // Every test above builds a ConstituentInput by hand, which proves
+            // the blend and the converter and NOTHING about whether the
+            // take-off ever sets the override. A mutation deleting that
+            // assignment moved no test until this one existed — the same gap
+            // found in the aggregator's category collection.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = true, UnitsPerM2 = 60, UnitWastePct = 8
+            });
+
+            var units = lines.Single(l => l.Kind == "brick_units");
+            Assert.Equal(8, units.WastePctOverride);
+        }
+
+        [Fact]
+        public void A_Wall_With_No_Stated_Bond_Waste_Leaves_The_Override_Absent()
+        {
+            // 0 from the lookup would mean "this bond wastes nothing", which is
+            // not what an unset input means. It must read as -1, so the rule's
+            // default applies rather than zero.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = false, UnitsPerM2 = 12.5, UnitWastePct = 0
+            });
+
+            Assert.Equal(-1, lines.Single(l => l.Kind == "block_units").WastePctOverride);
+        }
+
+        [Fact]
+        public void Other_Lines_Do_Not_Inherit_The_Unit_Waste()
+        {
+            // Cutting waste on bricks says nothing about mortar or plaster, and
+            // handing it to them would replace the cement rule's allowance with
+            // a number about a different material entirely.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = true, UnitsPerM2 = 60, UnitWastePct = 8,
+                MortarRatioM3PerM2 = 0.02, MortarCementBagsPerM3 = 6, MortarSandRatio = 1
+            });
+
+            foreach (var l in lines.Where(l => l.Kind != "brick_units"))
+                Assert.Equal(-1, l.WastePctOverride);
+        }
+
+        // ── the shipped lookup still states the bonds ───────────────────────
+
+        [Fact]
+        public void MATERIAL_LOOKUP_Still_Varies_Waste_By_Bond()
+        {
+            // If it stopped, the whole override path would be carrying a
+            // constant and should be deleted rather than left looking useful.
+            var waste = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            foreach (string raw in File.ReadAllLines(
+                         Path.Combine(AppContext.BaseDirectory, "Data", "MATERIAL_LOOKUP.csv")))
+            {
+                var p = (raw ?? "").Trim().Split(',');
+                if (p.Length < 4 || !p[0].Trim().Equals("BRICK_BOND", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!p[2].Trim().Equals("WASTE_PCT", StringComparison.OrdinalIgnoreCase)) continue;
+                if (double.TryParse(p[3].Trim(), out double v)) waste[p[1].Trim()] = v;
+            }
+
+            Assert.True(waste.Count >= 5, "the lookup should describe several bonds");
+            Assert.True(waste.Values.Distinct().Count() > 1,
+                        "if every bond wasted the same, the flat default would be right");
+            Assert.Equal(8, waste["FLEMISH"]);
+            Assert.Equal(3, waste["STACK"]);
+        }
+    }
+}

--- a/StingTools/BOQ/BOQModels.cs
+++ b/StingTools/BOQ/BOQModels.cs
@@ -292,6 +292,10 @@ namespace StingTools.BOQ
         /// </summary>
         public string MaterialName;
 
+        /// <summary>Wastage this row's variant implies, or -1 for the supplier
+        /// rule's default. See CompoundLine.WastePctOverride.</summary>
+        public double WastePctOverride = -1;
+
         // ── P1 aggregation ─────────────────────────────────────────────────
         // When several near-identical modelled elements collapse into one BOQ
         // row, SimilarCount holds the element count and ConstituentElementIds
@@ -415,6 +419,7 @@ namespace StingTools.BOQ
                 CarbonQuality = this.CarbonQuality,
                 CarbonMaterial = this.CarbonMaterial,
                 MaterialName = this.MaterialName,
+                WastePctOverride = this.WastePctOverride,
                 SimilarCount = this.SimilarCount,
                 ConstituentElementIds = this.ConstituentElementIds != null
                     ? new List<long>(this.ConstituentElementIds) : new List<long>(),

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -86,6 +86,7 @@ namespace StingTools.BOQ.MaterialSchedule
                     Category = item.Category ?? "",
                     TypeName = item.TypeName ?? "",
                     MaterialName = item.MaterialName ?? "",
+                    WastePctOverride = item.WastePctOverride,
                     Description = item.ItemName ?? "",
                     Unit = BoqUnits.Normalise(item.Unit),
                     Quantity = item.Quantity,

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -34,8 +34,29 @@ namespace StingTools.BOQ.Takeoff
         public double Quantity;
         public string Nrm2Section;
 
+        /// <summary>
+        /// The wastage this line's own VARIANT implies, or -1 for "the supplier
+        /// rule's default is fine".
+        ///
+        /// Wastage still lives in exactly one place — the supplier rule applies
+        /// it, and this only tells the rule a better number than its flat
+        /// default. Applying it here as well is the double-waste bug that was
+        /// removed earlier; nothing multiplies by this.
+        ///
+        /// MATERIAL_LOOKUP has carried per-bond cutting waste all along (stack
+        /// 3%, stretcher 5, garden wall 6, English 7, Flemish 8). It was
+        /// resolved per wall into UnitWastePct and read by NOTHING, so every
+        /// wall got the rule's flat 5 and a Flemish bond was under-ordered by
+        /// three points.
+        /// </summary>
+        public double WastePctOverride;
+
         public CompoundLine(string kind, string description, string unit, double quantity, string nrm2)
-        { Kind = kind; Description = description; Unit = unit; Quantity = Math.Round(quantity, 4); Nrm2Section = nrm2; }
+        {
+            Kind = kind; Description = description; Unit = unit;
+            Quantity = Math.Round(quantity, 4); Nrm2Section = nrm2;
+            WastePctOverride = -1;
+        }
     }
 
     public struct MasonryWallInput
@@ -286,7 +307,12 @@ namespace StingTools.BOQ.Takeoff
             {
                 double units = area * m.UnitsPerM2;
                 lines.Add(new CompoundLine(m.IsBrick ? "brick_units" : "block_units",
-                    m.IsBrick ? "Bricks" : "Blocks", "nr", units, SecMasonry));
+                    m.IsBrick ? "Bricks" : "Blocks", "nr", units, SecMasonry)
+                {
+                    // The BOND's cutting waste, handed to the supplier rule
+                    // rather than applied here.
+                    WastePctOverride = m.UnitWastePct > 0 ? m.UnitWastePct : -1
+                });
             }
 
             // 3. Mortar m³ and its cement (bags) + sand (m³) from the MAT-2 mix.

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -404,6 +404,7 @@ namespace StingTools.BOQ.Takeoff
                     FamilyName = GetFamilyName(doc, el),
                     TypeName = el.Name ?? "",
                     MaterialName = GetPrimaryMaterialName(doc, el) ?? "",
+                    WastePctOverride = c.WastePctOverride,
                     Quantity = Math.Round(c.Quantity, 3),
                     Unit = c.Unit,
                     ConstituentKind = c.Kind,

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -20,6 +20,10 @@ namespace StingTools.Core.MaterialSchedule
         /// <summary>The element's material name. Matched BEFORE the type name —
         /// see SupplierUnitRule.MatchMaterialPatterns for why.</summary>
         public string MaterialName = "";
+
+        /// <summary>Wastage this row's variant implies, or -1 for the rule's
+        /// default. Blended across rows that merge — see the accumulator.</summary>
+        public double WastePctOverride = -1;
         public string Description = "";
         public string Unit = "";        // source unit as measured
         public double Quantity;
@@ -189,6 +193,11 @@ namespace StingTools.Core.MaterialSchedule
                 if (!string.IsNullOrWhiteSpace(row.TraceRef)) a.TraceRefs.Add(row.TraceRef);
                 if (!string.IsNullOrWhiteSpace(row.Category)) a.Categories.Add(row.Category.Trim());
                 if (!string.IsNullOrWhiteSpace(row.TypeName)) a.TypeNames.Add(row.TypeName.Trim());
+                if (row.WastePctOverride >= 0 && row.Quantity > 0)
+                {
+                    a.WasteWeighted += row.WastePctOverride * row.Quantity;
+                    a.WasteWeight += row.Quantity;
+                }
             }
 
             // Materialise stages in definition order, dropping empties.
@@ -212,7 +221,8 @@ namespace StingTools.Core.MaterialSchedule
                 foreach (var kv in mine)
                 {
                     var a = kv.Value;
-                    var conv = SupplierUnitConverter.Convert(a.Rule, a.SourceQuantity);
+                    double blendedWaste = a.WasteWeight > 0 ? a.WasteWeighted / a.WasteWeight : -1;
+                    var conv = SupplierUnitConverter.Convert(a.Rule, a.SourceQuantity, blendedWaste);
                     var rate = input.Rates?.Resolve(kv.Key.key)
                                ?? new CommodityRate { RateUGX = 0, Source = "unpriced" };
 
@@ -276,6 +286,22 @@ namespace StingTools.Core.MaterialSchedule
             public List<string> TraceRefs = new List<string>();
             public readonly SortedSet<string> Categories =
                 new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            /// <summary>
+            /// Quantity-weighted numerator for the blended waste, and the
+            /// quantity that carried an override at all.
+            ///
+            /// Rows merge by commodity, so a wall in Flemish bond (8%) and one
+            /// in stack bond (3%) become ONE order line and cannot both have
+            /// their own allowance. Weighting by quantity is the only blend
+            /// that keeps the total right: the bigger wall moves the figure
+            /// more, which is what a QS would do by hand.
+            ///
+            /// Rows with NO override are excluded from both sides rather than
+            /// counted at the rule's default — that would let one unstated row
+            /// drag a stated blend back toward a number nobody chose.
+            /// </summary>
+            public double WasteWeighted, WasteWeight;
+
             public readonly SortedSet<string> TypeNames =
                 new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
         }

--- a/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
+++ b/StingTools/Core/MaterialSchedule/SupplierUnitConverter.cs
@@ -273,6 +273,18 @@ namespace StingTools.Core.MaterialSchedule
             => Math.Ceiling(v * 100.0 - 1e-9) / 100.0;
 
         public static SupplierUnitResult Convert(SupplierUnitRule rule, double sourceQuantity)
+            => Convert(rule, sourceQuantity, -1);
+
+        /// <summary>
+        /// As above, with the wastage the row's own variant implies.
+        ///
+        /// A NEGATIVE override means "use the rule's default" — not "no waste".
+        /// Those are different, and conflating them would silently drop the
+        /// allowance on every row that has no variant to speak of, which is
+        /// most of them.
+        /// </summary>
+        public static SupplierUnitResult Convert(SupplierUnitRule rule, double sourceQuantity,
+                                                 double wastePctOverride)
         {
             if (rule == null)
                 return new SupplierUnitResult
@@ -287,7 +299,9 @@ namespace StingTools.Core.MaterialSchedule
             if (factor <= 0 || double.IsNaN(factor) || double.IsInfinity(factor)) factor = 1.0;
 
             double net = sourceQuantity / factor;
-            double waste = Math.Max(0, rule.DefaultWastagePct);
+            double waste = wastePctOverride >= 0
+                ? wastePctOverride
+                : Math.Max(0, rule.DefaultWastagePct);
             double order = net * (1.0 + waste / 100.0);
             // Countable units round UP — you cannot buy 2.08 truck trips.
             // Divisible units round UP to 2 dp: order quantity is what someone


### PR DESCRIPTION
fix(matsched): the bond's own cutting waste reaches the supplier rule

MATERIAL_LOOKUP.csv has carried per-bond cutting waste all along — stack
3%, stretcher and header 5, garden wall 6, English 7, Flemish 8.
CompoundTakeoffBuilder resolved it per wall into
MasonryWallInput.UnitWastePct, and NOTHING read it. Every wall got the
supplier rule's flat 5, so a Flemish bond was under-ordered by three
points and a stack bond over-ordered by two. PlasterWastePct is the same
story and is even marked RETIRED in the source.

Dead data of the same class as ViewStylePack.Checksum: computed from real
input, assigned, never consumed.

WASTAGE STILL LIVES IN EXACTLY ONE PLACE. The supplier rule applies it;
this only hands the rule a better number than its flat default. Applying
it in the take-off as well is the double-waste bug removed earlier, and
nothing on this path multiplies by it.

-1 and 0 are kept distinct. -1 means "the rule's default is fine"; 0
means "this variant wastes nothing". Conflating them would silently drop
the allowance on every row with no variant to speak of, which is most
rows — that mutation fails 9 tests.

THE BLEND. Rows merge by commodity, so a Flemish wall and a stack wall
become ONE order line and cannot both keep their own allowance.
Quantity-weighted is the only blend that keeps the total right: 1,000
bricks at 8% and 3,000 at 4% is 5%, not 6%. Two tests hold that,
including the size-swapped case where a simple mean gives 6% either way
and weighting gives 7% and 5% — only one of those pairs tracks the brick
counts. Rows with NO override are excluded from both sides rather than
counted at the default, or one unstated row would drag a stated blend
toward a number nobody chose.

PLASTER IS DELIBERATELY NOT INCLUDED. Its 15-25% is application waste on
the mortar; the cement rule's 2.5% is bag handling. They are different
allowances, and substituting one for the other is a QS decision rather
than a like-for-like resolution improvement. Bond waste IS like-for-like
— cutting waste on units, replacing a flat cutting-waste default.

Boq tests 1134 -> 1147, build 0/0, all four gates pass.

Four mutations, all failing: negative treated as zero waste (9), a
simple mean instead of quantity-weighted (2), rows without an override
dragging the blend (1), the take-off never setting the override (1).

THE LAST ONE FIRST PROVED NOTHING, AND RESTORING IT BROKE THE BUILD.
Every test built a ConstituentInput by hand, so nothing exercised the
wiring from MasonryWallInput to the line; three tests now drive
CompoundTakeoff.MasonryWall directly. Worse, I restored that mutation
with `git checkout` rather than from a backup, which reverted the whole
feature — and the suite stayed GREEN because the test project does not
compile the Revit-bound CompoundTakeoffBuilder where the break was. Only
building the plugin caught it. A test suite that cannot see half the
compilation unit is not a build check, and mutations get restored from
backups from here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
