### PR TITLE
fix(matsched): the plaster coat's allowance governs its cement and sand

### DIFF
--- a/StingTools.Boq.Tests/BondWasteTests.cs
+++ b/StingTools.Boq.Tests/BondWasteTests.cs
@@ -203,6 +203,89 @@ namespace StingTools.Boq.Tests
                 Assert.Equal(-1, l.WastePctOverride);
         }
 
+        // ── plaster: the coat's allowance GOVERNS, it does not add ──────────
+
+        [Fact]
+        public void The_Plaster_Coat_Waste_Rides_The_DERIVED_Lines()
+        {
+            // 15-25% is material lost mixing and applying plaster. The cement
+            // rule's 2.5% is bag handling. The coat allowance is the larger,
+            // governing one for plaster-derived cement and sand — it replaces
+            // the rule's default rather than stacking on it, which is the
+            // decision this encodes.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = false, UnitsPerM2 = 12.5,
+                PlasterFaces = 2, PlasterThicknessM = 0.015, PlasterWastePct = 20,
+                PlasterCementBagsPerM3 = 6, PlasterSandRatio = 1
+            });
+
+            Assert.Equal(20, lines.Single(l => l.Kind == "plaster_cement").WastePctOverride);
+            Assert.Equal(20, lines.Single(l => l.Kind == "plaster_sand").WastePctOverride);
+        }
+
+        [Fact]
+        public void The_Plaster_AREA_Line_Takes_No_Material_Allowance()
+        {
+            // Measured work a QS prices by m². It is not bought, so a material
+            // wastage on it would be an allowance on a rate, not on a quantity.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = false, UnitsPerM2 = 12.5,
+                PlasterFaces = 2, PlasterThicknessM = 0.015, PlasterWastePct = 20,
+                PlasterCementBagsPerM3 = 6, PlasterSandRatio = 1
+            });
+
+            Assert.Equal(-1, lines.Single(l => l.Kind == "plaster").WastePctOverride);
+        }
+
+        [Fact]
+        public void An_Unstated_Coat_Waste_Falls_Back_To_The_Rule()
+        {
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = false, UnitsPerM2 = 12.5,
+                PlasterFaces = 1, PlasterThicknessM = 0.015, PlasterWastePct = 0,
+                PlasterCementBagsPerM3 = 6, PlasterSandRatio = 1
+            });
+
+            Assert.Equal(-1, lines.Single(l => l.Kind == "plaster_cement").WastePctOverride);
+        }
+
+        [Fact]
+        public void Plaster_Waste_Is_Applied_ONCE_Not_Folded_Into_The_Volume()
+        {
+            // The double-waste bug this replaces: the volume used to be
+            // multiplied by (1 + waste) here AND wasted again by the rule.
+            // 10 m² × 2 faces × 0.015 m = 0.30 m³ × 6 bags = 1.80 bags, NET.
+            var lines = CompoundTakeoff.MasonryWall(new MasonryWallInput
+            {
+                FaceAreaM2 = 10, IsBrick = false, UnitsPerM2 = 12.5,
+                PlasterFaces = 2, PlasterThicknessM = 0.015, PlasterWastePct = 20,
+                PlasterCementBagsPerM3 = 6, PlasterSandRatio = 1
+            });
+
+            Assert.Equal(1.8, lines.Single(l => l.Kind == "plaster_cement").Quantity, 3);
+        }
+
+        [Fact]
+        public void MATERIAL_LOOKUP_Still_Varies_Plaster_Waste_By_Coat()
+        {
+            var waste = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+            foreach (string raw in File.ReadAllLines(
+                         Path.Combine(AppContext.BaseDirectory, "Data", "MATERIAL_LOOKUP.csv")))
+            {
+                var p = (raw ?? "").Trim().Split(',');
+                if (p.Length < 4 || !p[0].Trim().Equals("PLASTER", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!p[2].Trim().Equals("WASTE_PCT", StringComparison.OrdinalIgnoreCase)) continue;
+                if (double.TryParse(p[3].Trim(), out double v)) waste[p[1].Trim()] = v;
+            }
+
+            Assert.Equal(15, waste["THIN_COAT"]);
+            Assert.Equal(20, waste["STANDARD"]);
+            Assert.Equal(25, waste["THICK"]);
+        }
+
         // ── the shipped lookup still states the bonds ───────────────────────
 
         [Fact]

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -69,7 +69,22 @@ namespace StingTools.BOQ.Takeoff
         public double UnitWastePct;      // cutting waste on the units
         public int PlasterFaces;         // 0 / 1 / 2 plastered faces
         public double PlasterThicknessM; // plaster coat thickness
-        /// <summary>RETIRED — see UnitWastePct.</summary>
+
+        /// <summary>
+        /// The coat's application waste, from PLASTER {type} WASTE_PCT — thin 15%,
+        /// standard and lime 20, thick 25.
+        ///
+        /// It was RETIRED because applying it in the take-off AND letting the
+        /// supplier rule apply its own wasted the cement twice. It is live again
+        /// on the other side of that fix: nothing here multiplies by it, it is
+        /// handed to the supplier rule as the allowance to use INSTEAD of the
+        /// rule's default.
+        ///
+        /// That substitution is the decision. The cement rule's 2.5% is bag
+        /// handling and spillage; plaster's 15-25% is material lost in mixing
+        /// and application, and it is the larger, governing allowance for
+        /// plaster-derived cement and sand rather than an addition to it.
+        /// </summary>
         public double PlasterWastePct;
         public double MortarRatioM3PerM2;     // mortar volume per m² of wall
         public double MortarCementBagsPerM3;  // from MORTAR mix (MAT-2)
@@ -338,12 +353,18 @@ namespace StingTools.BOQ.Takeoff
                 // used to multiply by PlasterWastePct (20%), so the cement and
                 // sand derived from it were wasted twice.
                 double plasterVol = plasterArea * Math.Max(0, m.PlasterThicknessM);
+                // The coat's application allowance rides on the DERIVED lines
+                // only. The plaster m2 above is measured work a QS prices by
+                // area — it is not bought, so it takes no material allowance.
+                double coatWaste = m.PlasterWastePct > 0 ? m.PlasterWastePct : -1;
                 if (plasterVol > 0 && m.PlasterCementBagsPerM3 > 0)
                     lines.Add(new CompoundLine("plaster_cement", "Plaster — cement", "bag",
-                        plasterVol * m.PlasterCementBagsPerM3, SecPlaster));
+                        plasterVol * m.PlasterCementBagsPerM3, SecPlaster)
+                    { WastePctOverride = coatWaste });
                 if (plasterVol > 0 && m.PlasterSandRatio > 0)
                     lines.Add(new CompoundLine("plaster_sand", "Plaster — sand", "m3",
-                        plasterVol * m.PlasterSandRatio, SecPlaster));
+                        plasterVol * m.PlasterSandRatio, SecPlaster)
+                    { WastePctOverride = coatWaste });
 
                 // Painted area IS the plastered face area — no new measurement,
                 // just the quantity already derived above given its own kind so


### PR DESCRIPTION
fix(matsched): the plaster coat's allowance governs its cement and sand

PLASTER {type} WASTE_PCT — thin 15%, standard and lime 20, thick 25 —
was resolved per wall into MasonryWallInput.PlasterWastePct and read by
nothing. The field was marked RETIRED, because applying it in the
take-off AND letting the supplier rule apply its own wasted the cement
twice.

It is live again on the other side of that fix. Nothing here multiplies
by it; it is handed to the supplier rule as the allowance to use INSTEAD
of the rule's default.

THE DECISION THIS ENCODES. The cement rule's 2.5% is bag handling and
spillage. Plaster's 15-25% is material lost mixing and applying. They
are different allowances covering different losses, and the coat's is
the larger and governing one for plaster-derived cement and sand rather
than an addition to it. Using the standard allowance, as asked.

It rides the DERIVED lines only. The plaster m2 line is measured work a
QS prices by area — it is not bought, so a material wastage on it would
be an allowance on a rate rather than on a quantity. A mutation putting
it there fails.

The volume stays NET: 10 m2 x 2 faces x 0.015 m = 0.30 m3 x 6 bags =
1.80 bags, asserted to three places. Restoring the old
volume x (1 + waste) fails five tests, which is the double-waste bug
this replaces.

Boq tests 1147 -> 1165, build 0/0, all four gates pass.

Three mutations, all failing, each anchor asserted and each restored
from a BACKUP rather than git checkout — the mistake in #850 that
reverted a whole feature while the suite stayed green, because the test
project does not compile the Revit-bound builder. The plugin build runs
after every restore now.

With this, the two lookup waste models that were computed and discarded
are both live: BRICK_BOND in #850 and PLASTER here. TILE waste remains
inert, and deliberately so — it keys on tile SIZE, which nothing in a
Revit model states, and inferring it from a material name is the
inference #710 withdrew.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
