### PR TITLE
feat(matsched): a By Type sheet — the sheets and tiles for EACH roof

### DIFF
--- a/StingTools.Boq.Tests/CommodityTypeBreakdownTests.cs
+++ b/StingTools.Boq.Tests/CommodityTypeBreakdownTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// "We need the number of sheets/tiles for each type of roof."
+    ///
+    /// The schedule aggregates by commodity because that is what you BUY:
+    /// three shingle roofs become one pile of bundles, and ordering three
+    /// separate piles would be wrong. But aggregation destroys the three other
+    /// things a quantity gets used for — checking a number against the model,
+    /// phasing a delivery, and dividing work between subcontractors. "80
+    /// bundles" cannot be traced back to a roof, and a wrong roof cannot be
+    /// found inside it.
+    ///
+    /// So the breakdown is ADDITIVE: the order line is untouched and this says
+    /// what went into it.
+    /// </summary>
+    public class CommodityTypeBreakdownTests
+    {
+        private static MaterialCommodity Commodity(string key, double order, string unit = "Bundles") =>
+            new MaterialCommodity
+            {
+                CommodityKey = key, Description = key, SupplierUnit = unit, OrderQuantity = order
+            };
+
+        private static Dictionary<string, Dictionary<string, double>> Source(
+            string key, params (string type, double qty)[] parts) =>
+            new Dictionary<string, Dictionary<string, double>>
+            {
+                [key] = parts.ToDictionary(p => p.type, p => p.qty)
+            };
+
+        [Fact]
+        public void An_Order_Is_Split_By_Each_Types_Measured_Share()
+        {
+            // 856 m² of roof over three types, ordered as 304 bundles.
+            var b = CommodityTypeBreakdown.Build(
+                new[] { Commodity("roof-shingle", 304) },
+                Source("roof-shingle",
+                       ("Generic - 225mm", 610.61),
+                       ("Generic - 225mm 2", 224.44),
+                       ("Generic - 225mm 3", 21.23))).Single();
+
+            Assert.Equal(3, b.Parts.Count);
+            // Largest first — the order somebody checking a roof works in.
+            Assert.Equal("Generic - 225mm", b.Parts[0].TypeName);
+            Assert.Equal(304, b.Parts.Sum(p => p.OrderQuantity), 1);
+        }
+
+        [Fact]
+        public void The_Parts_Never_Exceed_The_Order_Line()
+        {
+            // THE reason this apportions rather than re-converts. Converting
+            // each type separately and rounding each UP to whole bundles would
+            // order more than the schedule says, and two documents in one
+            // workbook disagreeing about a total is worse than no breakdown.
+            var b = CommodityTypeBreakdown.Build(
+                new[] { Commodity("roof-shingle", 304) },
+                Source("roof-shingle", ("A", 100), ("B", 100), ("C", 100))).Single();
+
+            Assert.True(b.Parts.Sum(p => p.OrderQuantity) <= 304.01,
+                        "the split must never order more than the line it splits");
+        }
+
+        [Fact]
+        public void Shares_Are_Fractions_Of_The_MEASURED_Total()
+        {
+            var b = CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) },
+                Source("x", ("A", 75), ("B", 25))).Single();
+
+            Assert.Equal(0.75, b.Parts[0].Share, 4);
+            Assert.Equal(0.25, b.Parts[1].Share, 4);
+        }
+
+        [Fact]
+        public void A_Single_Type_Commodity_Is_Marked_As_Adding_Nothing()
+        {
+            var b = CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) }, Source("x", ("Only", 50))).Single();
+
+            Assert.True(b.IsSingleType);
+        }
+
+        [Fact]
+        public void A_Memorandum_Is_Never_Broken_Down()
+        {
+            // It carries no purchasable quantity; splitting it would give the
+            // double-count a per-type shape.
+            var memo = Commodity("blockwork-area", 174);
+            memo.IsMemorandum = true;
+
+            Assert.Empty(CommodityTypeBreakdown.Build(
+                new[] { memo }, Source("blockwork-area", ("A", 100), ("B", 74))));
+        }
+
+        [Fact]
+        public void A_Commodity_With_No_Recorded_Source_Is_OMITTED_Not_Invented()
+        {
+            // Showing it whole under a made-up type name would be a breakdown
+            // that invents its own source.
+            Assert.Empty(CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) },
+                new Dictionary<string, Dictionary<string, double>>()));
+        }
+
+        [Fact]
+        public void A_Commodity_Appearing_In_Two_Stages_Is_Broken_Down_Once()
+        {
+            var c = Commodity("cement", 93);
+            Assert.Single(CommodityTypeBreakdown.Build(
+                new[] { c, Commodity("cement", 93) },
+                Source("cement", ("Wall", 60), ("Slab", 33))));
+        }
+
+        [Fact]
+        public void Zero_And_Negative_Parts_Are_Dropped()
+        {
+            var b = CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) },
+                Source("x", ("Real", 50), ("Zero", 0), ("Negative", -5))).Single();
+
+            Assert.Single(b.Parts);
+            Assert.Equal("Real", b.Parts[0].TypeName);
+        }
+
+        // ── the note ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void The_Note_Says_The_Order_Line_Is_Unchanged()
+        {
+            var bs = CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) }, Source("x", ("A", 60), ("B", 40)));
+
+            string s = CommodityTypeBreakdown.Summary(bs);
+
+            Assert.Contains("what you BUY and is unchanged", s);
+            Assert.Contains("APPORTIONED by measured share, not re-converted", s);
+        }
+
+        [Fact]
+        public void Nothing_Split_Says_The_Sheet_Would_Repeat_The_Schedule()
+        {
+            var bs = CommodityTypeBreakdown.Build(
+                new[] { Commodity("x", 100) }, Source("x", ("Only", 50)));
+
+            Assert.Contains("adds nothing this time", CommodityTypeBreakdown.Summary(bs));
+        }
+
+        [Fact]
+        public void No_Commodities_At_All_Gets_No_Note()
+        {
+            Assert.Null(CommodityTypeBreakdown.Summary(new List<CommodityBreakdown>()));
+            Assert.Null(CommodityTypeBreakdown.Summary(null));
+        }
+
+        // ── the wiring, not the shape ───────────────────────────────────────
+
+        [Fact]
+        public void The_Aggregator_Records_Which_Type_Contributed_What()
+        {
+            // Setting SourceByType by hand in the tests above proves the split
+            // arithmetic and nothing about whether aggregation ever FILLS it —
+            // the same gap a mutation found in #833.
+            var inputs = new AggregatorInputs
+            {
+                Constituents =
+                {
+                    new ConstituentInput { ConstituentKind = "mortar_cement", Unit = "bag",
+                                           Quantity = 60, TypeName = "Blockwork 200" },
+                    new ConstituentInput { ConstituentKind = "mortar_cement", Unit = "bag",
+                                           Quantity = 33, TypeName = "Brickwork 230" },
+                },
+                Units = new SupplierUnitTable
+                {
+                    Rules =
+                    {
+                        new SupplierUnitRule
+                        {
+                            CommodityKey = "cement", SupplierUnit = "Bags", SourceUnit = "bag",
+                            SourceUnitsPerSupplierUnit = 1, RoundUpToWhole = true,
+                            MatchKinds = { "mortar_cement" }
+                        }
+                    }
+                },
+                StageDefs = { new StageDefinition { StageId = "s", Title = "S", Order = 1 } },
+                DefaultStageId = "s"
+            };
+
+            var doc = CommodityAggregator.Build(inputs);
+
+            Assert.True(doc.SourceByType.ContainsKey("cement"));
+            Assert.Equal(60, doc.SourceByType["cement"]["Blockwork 200"]);
+            Assert.Equal(33, doc.SourceByType["cement"]["Brickwork 230"]);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\SupplierUnitPatch.cs" Link="MaterialSchedule\SupplierUnitPatch.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\TypePatternPlanner.cs" Link="MaterialSchedule\TypePatternPlanner.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\MaterialMatchTally.cs" Link="MaterialSchedule\MaterialMatchTally.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\CommodityTypeBreakdown.cs" Link="MaterialSchedule\CommodityTypeBreakdown.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -163,6 +163,11 @@ namespace StingTools.BOQ.MaterialSchedule
             string matScan = inputs.MaterialScan?.Summary();
             if (!string.IsNullOrEmpty(matScan)) msDoc.Warnings.Add(matScan);
 
+            string byType = CommodityTypeBreakdown.Summary(
+                CommodityTypeBreakdown.Build(
+                    msDoc.Stages.SelectMany(st => st.Commodities), msDoc.SourceByType));
+            if (!string.IsNullOrEmpty(byType)) msDoc.Warnings.Add(byType);
+
             if (msDoc.Options.ShowPrices)
             {
                 string provenance = RateProvenanceLabel.Summary(

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleXlsxWriter.cs
@@ -26,6 +26,7 @@ namespace StingTools.BOQ.MaterialSchedule
             {
                 WriteScheduleSheet(wb.Worksheets.Add("Material Schedule"), doc);
                 WriteSummarySheet(wb.Worksheets.Add("Summary"), doc);
+                WriteByTypeSheet(wb, doc);
                 WriteValidationSheet(wb.Worksheets.Add("Validation"), doc);
 
                 string dir = Path.GetDirectoryName(path);
@@ -197,6 +198,68 @@ namespace StingTools.BOQ.MaterialSchedule
             if (bold) ws.Range(row, 1, row, 3).Style.Fill.BackgroundColor = BoqXlsxStyle.HeaderFill;
             if (bold) ws.Range(row, 1, row, 3).Style.Font.FontColor = XLColor.White;
             BoqXlsxStyle.MoneyFormat(ws.Range(row, 3, row, 3));
+        }
+
+        /// <summary>
+        /// Each commodity split across the model TYPES that produced it.
+        ///
+        /// The schedule aggregates because that is what you BUY — three shingle
+        /// roofs are one pile of bundles. This is for the three things a
+        /// quantity gets used for that aggregation destroys: checking a number
+        /// against the model, phasing a delivery, and dividing work between
+        /// subcontractors.
+        ///
+        /// NOT written when nothing was split. A sheet of single-type rows
+        /// repeats the schedule, and a second document that merely restates the
+        /// first is one more place for the two to disagree.
+        /// </summary>
+        private static void WriteByTypeSheet(XLWorkbook wb, MaterialScheduleDocument doc)
+        {
+            var breakdowns = CommodityTypeBreakdown.Build(
+                doc.Stages.SelectMany(st => st.Commodities), doc.SourceByType);
+
+            if (breakdowns.All(b => b.IsSingleType)) return;
+
+            var ws = wb.Worksheets.Add("By Type");
+            BoqXlsxStyle.BannerRow(ws, "BY TYPE — what produced each commodity");
+
+            int row = 3;
+            ws.Cell(row, 1).Value =
+                "The ORDER line in the schedule is what you buy and is unchanged. Each part below is "
+              + "that order APPORTIONED by measured share — not re-converted, because rounding each "
+              + "type up to whole units separately would order more than the schedule says.";
+            ws.Cell(row, 1).Style.Font.Italic = true;
+            ws.Range(row, 1, row, 6).Merge();
+            row += 2;
+
+            BoqXlsxStyle.WriteHeader(ws, row,
+                new[] { "Commodity", "Model type", "Measured", "Share", "Order qty", "Unit" });
+            row++;
+
+            foreach (var b in breakdowns.Where(x => !x.IsSingleType))
+            {
+                var head = ws.Cell(row, 1);
+                head.Value = b.Description;
+                head.Style.Font.Bold = true;
+                ws.Cell(row, 5).Value = b.OrderQuantity;
+                ws.Cell(row, 6).Value = DisplayUnit(b.SupplierUnit);
+                ws.Cell(row, 5).Style.Font.Bold = true;
+                row++;
+
+                foreach (var part in b.Parts)
+                {
+                    ws.Cell(row, 2).Value = part.TypeName;
+                    ws.Cell(row, 3).Value = Math.Round(part.SourceQuantity, 2);
+                    ws.Cell(row, 4).Value = Math.Round(part.Share * 100.0, 1) / 100.0;
+                    ws.Cell(row, 4).Style.NumberFormat.Format = "0.0%";
+                    ws.Cell(row, 5).Value = part.OrderQuantity;
+                    ws.Cell(row, 6).Value = DisplayUnit(b.SupplierUnit);
+                    row++;
+                }
+                row++;
+            }
+
+            foreach (var c in ws.ColumnsUsed()) c.AdjustToContents();
         }
 
         private static void WriteValidationSheet(IXLWorksheet ws, MaterialScheduleDocument doc)

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -193,6 +193,12 @@ namespace StingTools.Core.MaterialSchedule
                 if (!string.IsNullOrWhiteSpace(row.TraceRef)) a.TraceRefs.Add(row.TraceRef);
                 if (!string.IsNullOrWhiteSpace(row.Category)) a.Categories.Add(row.Category.Trim());
                 if (!string.IsNullOrWhiteSpace(row.TypeName)) a.TypeNames.Add(row.TypeName.Trim());
+                if (!string.IsNullOrWhiteSpace(row.TypeName) && row.Quantity > 0)
+                {
+                    string tn = row.TypeName.Trim();
+                    a.SourceByType.TryGetValue(tn, out double prev);
+                    a.SourceByType[tn] = prev + row.Quantity;
+                }
                 if (row.WastePctOverride >= 0 && row.Quantity > 0)
                 {
                     a.WasteWeighted += row.WastePctOverride * row.Quantity;
@@ -240,6 +246,7 @@ namespace StingTools.Core.MaterialSchedule
                         RateSource = rate.Source,
                         TraceRefs = a.TraceRefs,
                         Categories = a.Categories.ToList(),
+                        // (the per-type source is published on the DOCUMENT, below)
                         TypeNames = a.TypeNames.Take(8).ToList(),
                         SourceKind = a.SourceKind,
                         ConversionBlocked = a.ConversionBlocked,
@@ -248,6 +255,22 @@ namespace StingTools.Core.MaterialSchedule
                 }
 
                 doc.Stages.Add(section);
+            }
+
+            // One entry per commodity, merged across stages — the breakdown is
+            // about which TYPE produced a commodity, not which section it was
+            // printed in.
+            foreach (var kv in acc)
+            {
+                if (kv.Value.SourceByType.Count == 0) continue;
+                if (!doc.SourceByType.TryGetValue(kv.Key.key, out var byType))
+                    doc.SourceByType[kv.Key.key] =
+                        byType = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+                foreach (var t in kv.Value.SourceByType)
+                {
+                    byType.TryGetValue(t.Key, out double prev);
+                    byType[t.Key] = prev + t.Value;
+                }
             }
 
             StageMapper.AssignLetters(doc.Stages);
@@ -301,6 +324,16 @@ namespace StingTools.Core.MaterialSchedule
             /// drag a stated blend back toward a number nobody chose.
             /// </summary>
             public double WasteWeighted, WasteWeight;
+
+            /// <summary>
+            /// Measured source per model type, for the by-type breakdown.
+            ///
+            /// The aggregator's own numerator, so a share computed from it
+            /// cannot disagree with the order line it came from — the same
+            /// reason the breakdown apportions rather than re-converts.
+            /// </summary>
+            public readonly Dictionary<string, double> SourceByType =
+                new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
 
             public readonly SortedSet<string> TypeNames =
                 new SortedSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/StingTools/Core/MaterialSchedule/CommodityTypeBreakdown.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityTypeBreakdown.cs
@@ -1,0 +1,149 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  CommodityTypeBreakdown.cs — the same commodity, split by the model TYPES
+//  that produced it.
+//
+//  The schedule aggregates by commodity because that is what you BUY: three
+//  shingle roofs become one pile of bundles, and ordering three separate
+//  piles would be wrong. But it is useless for the other three things a
+//  quantity gets used for — checking a number against the model, phasing a
+//  delivery, and splitting work between subcontractors. "80 bundles" cannot
+//  be traced back to a roof, and a wrong roof cannot be found in it.
+//
+//  So the breakdown is ADDITIVE and separate: the order line stays exactly as
+//  it was, and this says what went into it.
+//
+//  THE ARITHMETIC IS DELIBERATELY NOT RE-DERIVED. Each part is the order
+//  quantity apportioned by its share of the measured source, because
+//  converting each type separately and rounding each up would order MORE than
+//  the single line says — three roofs rounding up to whole bundles is up to
+//  three extra bundles that the order line does not contain, and two
+//  documents in one workbook disagreeing about a total is worse than no
+//  breakdown at all.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    /// <summary>One type's share of a commodity.</summary>
+    public sealed class CommodityTypePart
+    {
+        public string TypeName = "";
+
+        /// <summary>What this type measured, in the SOURCE unit (m², nr, m³…).</summary>
+        public double SourceQuantity;
+
+        /// <summary>Its share of the order, in supplier units. Apportioned, not re-converted.</summary>
+        public double OrderQuantity;
+
+        /// <summary>Share of the commodity's measured total, 0..1.</summary>
+        public double Share;
+    }
+
+    public sealed class CommodityBreakdown
+    {
+        public string CommodityKey = "";
+        public string Description = "";
+        public string SupplierUnit = "";
+        public double OrderQuantity;
+        public readonly List<CommodityTypePart> Parts = new List<CommodityTypePart>();
+
+        /// <summary>
+        /// True when one type produced everything, so the breakdown repeats the
+        /// order line and adds nothing.
+        /// </summary>
+        public bool IsSingleType => Parts.Count <= 1;
+    }
+
+    public static class CommodityTypeBreakdown
+    {
+        /// <summary>
+        /// Apportion each commodity's order across the types that fed it.
+        ///
+        /// <paramref name="sourceByType"/> is the measured quantity per
+        /// (commodityKey, typeName) — the aggregator's own numerator, so the
+        /// shares cannot disagree with the line they came from.
+        ///
+        /// Commodities whose parts are unknown are OMITTED rather than shown
+        /// whole under a made-up type name: a breakdown that invents a source
+        /// is worse than one that admits it has none.
+        /// </summary>
+        public static List<CommodityBreakdown> Build(
+            IEnumerable<MaterialCommodity> commodities,
+            IReadOnlyDictionary<string, Dictionary<string, double>> sourceByType)
+        {
+            var outList = new List<CommodityBreakdown>();
+            if (commodities == null || sourceByType == null) return outList;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var c in commodities)
+            {
+                if (c == null || c.IsMemorandum) continue;
+                if (string.IsNullOrWhiteSpace(c.CommodityKey)) continue;
+                if (!seen.Add(c.CommodityKey)) continue;
+                if (!sourceByType.TryGetValue(c.CommodityKey, out var byType)) continue;
+
+                var parts = (byType ?? new Dictionary<string, double>())
+                    .Where(kv => !string.IsNullOrWhiteSpace(kv.Key) && kv.Value > 0)
+                    .ToList();
+                if (parts.Count == 0) continue;
+
+                double total = parts.Sum(kv => kv.Value);
+                if (total <= 0) continue;
+
+                var b = new CommodityBreakdown
+                {
+                    CommodityKey = c.CommodityKey,
+                    Description = c.Description ?? "",
+                    SupplierUnit = c.SupplierUnit ?? "",
+                    OrderQuantity = c.OrderQuantity
+                };
+
+                foreach (var kv in parts.OrderByDescending(kv => kv.Value)
+                                        .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    double share = kv.Value / total;
+                    b.Parts.Add(new CommodityTypePart
+                    {
+                        TypeName = kv.Key,
+                        SourceQuantity = Math.Round(kv.Value, 3),
+                        // Apportioned from the ORDER, never re-converted: three
+                        // roofs each rounded up to whole bundles would exceed
+                        // the order line by up to three bundles.
+                        OrderQuantity = Math.Round(c.OrderQuantity * share, 2),
+                        Share = share
+                    });
+                }
+                outList.Add(b);
+            }
+
+            return outList
+                .OrderBy(b => b.Description, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// The note for the export, or NULL when nothing was split — a sheet of
+        /// single-type rows repeats the schedule and is worth saying so once
+        /// rather than printing twice.
+        /// </summary>
+        public static string Summary(IReadOnlyCollection<CommodityBreakdown> breakdowns)
+        {
+            if (breakdowns == null || breakdowns.Count == 0) return null;
+
+            int split = breakdowns.Count(b => !b.IsSingleType);
+            if (split == 0)
+                return "By-type breakdown: every commodity came from a single model type, so the "
+                     + "breakdown repeats the schedule and adds nothing this time.";
+
+            return $"By-type breakdown: {split} of {breakdowns.Count} commodity row(s) came from more "
+                 + "than one model type and are split on their own sheet. The order line is what you "
+                 + "BUY and is unchanged; the split is for checking a number against the model, "
+                 + "phasing a delivery, or dividing work between subcontractors. Each part is the "
+                 + "order APPORTIONED by measured share, not re-converted — converting each type "
+                 + "separately and rounding each up would order more than the schedule says.";
+        }
+    }
+}

--- a/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
+++ b/StingTools/Core/MaterialSchedule/MaterialScheduleModel.cs
@@ -180,6 +180,14 @@ namespace StingTools.Core.MaterialSchedule
         /// </summary>
         public string ProjectRatesPath = "";
 
+        /// <summary>
+        /// Measured source per (commodityKey, typeName), for the by-type sheet.
+        /// Carried on the document because the breakdown must be computed from
+        /// the SAME numerator the order lines were, not from a second pass.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, double>> SourceByType =
+            new Dictionary<string, Dictionary<string, double>>(StringComparer.OrdinalIgnoreCase);
+
         public List<string> Warnings = new List<string>();
 
         /// <summary>MAT-SCHED-8 — model rows dropped as not-a-material, by category.


### PR DESCRIPTION
feat(matsched): a By Type sheet — the sheets and tiles for EACH roof

"We need the number of sheets/tiles for each type of roof."

The schedule aggregates by commodity because that is what you BUY: three
shingle roofs become one pile of bundles, and ordering three separate
piles would be wrong. But aggregation destroys the three other things a
quantity is used for - checking a number against the model, phasing a
delivery, and dividing work between subcontractors. "80 bundles" cannot
be traced back to a roof, and a wrong roof cannot be found inside it.

So the sheet is ADDITIVE. The order line is untouched; this says what
went into it.

THE ARITHMETIC IS APPORTIONED, NOT RE-DERIVED, and that is the whole
design. Converting each type separately and rounding each UP to whole
units would order more than the schedule says - three roofs rounding up
is up to three extra bundles the order line does not contain. Two
documents in one workbook disagreeing about a total is worse than no
breakdown at all. A test asserts the parts never exceed the line they
split, and the mutation that re-converts fails it.

Each part's share comes from the AGGREGATOR'S OWN numerator - the same
per-type measured quantities the order line was built from - so a share
cannot disagree with the row it came from. A second pass over the model
could.

Refusals with tests: a memorandum is never split (it carries no
purchasable quantity, and splitting it would give the double-count a
per-type shape); a commodity with no recorded source is OMITTED rather
than shown whole under a made-up type name; zero and negative parts are
dropped; a commodity appearing in two stages is broken down once.

The sheet is NOT WRITTEN when nothing was split. A page of single-type
rows repeats the schedule, and a second document that merely restates
the first is one more place for the two to disagree - the note says so
instead.

Boq tests 1165 -> 1177, build 0/0, all four gates pass.

Three mutations, all failing, each anchor asserted before the edit:
re-converting instead of apportioning (2), breaking down memoranda (1),
the aggregator no longer recording per-type source (1).

The third is there because of the gap a mutation found in #833: setting
SourceByType by hand in a test proves the split arithmetic and nothing
about whether aggregation ever fills it. One test drives
CommodityAggregator.Build itself.

NOT verified in Revit: no export has been produced with the sheet in it.
On the test project only ONE roof converts, so the sheet should not
appear at all yet - which is the correct behaviour and worth confirming
rather than reading as a failure.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
