### PR TITLE
feat(matsched): tile size, the fourth member of a set that already had three

### DIFF
--- a/StingTools.Boq.Tests/TileSizeBandTests.cs
+++ b/StingTools.Boq.Tests/TileSizeBandTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// The fourth member of a set that already had three.
+    ///
+    /// Brick bond, block size and plaster type each resolve a BLE_* parameter
+    /// through a canonicaliser with an inference fallback, and each drives a
+    /// waste figure MATERIAL_LOOKUP bands for it. Tile size was the hole:
+    /// BLE_TILE_SIZE_TXT has been declared in MR_PARAMETERS.txt with a GUID all
+    /// along and read by NOTHING, so the supplier rule applied a flat 10% to a
+    /// mosaic splashback and a 600 mm porcelain floor alike — while the lookup
+    /// had banded it 20 / 12 / 10 / 8 since before this schedule existed.
+    ///
+    /// Adding a fifth mechanism would have been the mistake. This finishes an
+    /// existing one.
+    /// </summary>
+    public class TileSizeBandTests
+    {
+        // ── a stated band wins ──────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("MOSAIC", "MOSAIC")]
+        [InlineData("mosaic", "MOSAIC")]
+        [InlineData("Large format", "LARGE")]
+        [InlineData("  Small  ", "SMALL")]
+        public void A_Stated_Band_Is_Taken_Verbatim(string raw, string expected)
+        {
+            Assert.Equal(expected, MaterialKeyCanonicaliser.TileSize(raw));
+        }
+
+        // ── a dimension is banded on its SMALLER edge ───────────────────────
+
+        [Theory]
+        [InlineData("600x600", "LARGE")]
+        [InlineData("300x600", "MEDIUM")]   // banded on 300, not 600
+        [InlineData("300x300", "MEDIUM")]
+        [InlineData("200x200", "SMALL")]
+        [InlineData("50x50",   "MOSAIC")]
+        public void A_Dimension_Bands_On_The_EDGE_THAT_IS_CUT(string raw, string expected)
+        {
+            // A 300 x 600 plank is cut on its SHORT side, and that edge governs
+            // the cutting waste. Banding it on 600 would call a plank
+            // large-format and under-order it.
+            Assert.Equal(expected, MaterialKeyCanonicaliser.TileSize(raw));
+        }
+
+        [Theory]
+        [InlineData("Porcelain 300x600 Matt", "MEDIUM")]
+        [InlineData("Ceramic Wall Tile 250×400", "SMALL")]
+        [InlineData("Mosaic 25 x 25 glass", "MOSAIC")]
+        public void A_Dimension_Inside_A_Product_Name_Is_Found(string raw, string expected)
+        {
+            Assert.Equal(expected, MaterialKeyCanonicaliser.TileSize(raw));
+        }
+
+        [Theory]
+        [InlineData("600", "LARGE")]
+        [InlineData("100", "SMALL")]
+        public void A_Single_Dimension_Bands_On_Itself(string raw, string expected)
+        {
+            Assert.Equal(expected, MaterialKeyCanonicaliser.TileSize(raw));
+        }
+
+        // ── what it refuses to guess ────────────────────────────────────────
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(null)]
+        [InlineData("Ceramic Tile")]
+        [InlineData("Porcelain")]
+        public void A_Name_With_No_Size_In_It_Returns_NOTHING(string raw)
+        {
+            // Empty, not a default. InferOrCanon turns an empty result into the
+            // project default AND records it, so the export can say the band was
+            // never stated. Returning "MEDIUM" here would launder a guess into a
+            // stated fact.
+            Assert.Equal("", MaterialKeyCanonicaliser.TileSize(raw));
+        }
+
+        [Fact]
+        public void A_Zero_Dimension_Is_Not_A_Band()
+        {
+            Assert.Equal("", MaterialKeyCanonicaliser.TileSize("0x0"));
+        }
+
+        // ── the bands match the file that owns them ─────────────────────────
+
+        [Theory]
+        [InlineData("MOSAIC", 20.0)]
+        [InlineData("SMALL",  12.0)]
+        [InlineData("MEDIUM", 10.0)]
+        [InlineData("LARGE",   8.0)]
+        [InlineData("DEFAULT", 10.0)]
+        public void Every_Band_Has_A_Waste_Figure_In_MATERIAL_LOOKUP(string band, double expected)
+        {
+            // The canonicaliser's vocabulary and the lookup's keys have to be
+            // the same words, or a correctly-banded tile silently falls to
+            // DEFAULT. This is the pair that would drift.
+            double found = 0;
+            foreach (string raw in File.ReadAllLines(
+                         Path.Combine(AppContext.BaseDirectory, "Data", "MATERIAL_LOOKUP.csv")))
+            {
+                var p = (raw ?? "").Trim().Split(',');
+                if (p.Length >= 4 && p[0].Trim() == "TILE" && p[1].Trim() == band
+                    && p[2].Trim() == "WASTE_PCT"
+                    && double.TryParse(p[3].Trim(), System.Globalization.NumberStyles.Any,
+                                       System.Globalization.CultureInfo.InvariantCulture, out double v))
+                { found = v; break; }
+            }
+            Assert.Equal(expected, found);
+        }
+
+        // ── which lines carry the cutting waste ─────────────────────────────
+
+        [Fact]
+        public void ONLY_The_Tile_Line_Carries_The_Cutting_Waste()
+        {
+            // A mosaic's 20% is CUTTING waste: you cut tiles to fit and throw
+            // the offcuts away. Adhesive and grout are spread over the area and
+            // their own supplier rules own their allowances, so inflating them
+            // by the tile's cutting figure would buy half as much adhesive again
+            // for a splashback.
+            //
+            // This test exists because the mutation that puts the override on
+            // adhesive moved nothing — the claim was in a comment and in no
+            // assertion.
+            var lines = StingTools.BOQ.Takeoff.CompoundTakeoff.TiledFinish(
+                new StingTools.BOQ.Takeoff.TiledFinishInput
+                {
+                    AreaM2 = 10, IsWall = true, TileLabel = "Mosaic 25x25",
+                    AdhesiveKgPerM2 = 4, GroutKgPerM2 = 0.5,
+                    WastePctOverride = 20
+                });
+
+            var tile = lines.Single(l => l.Kind == "wall_tile");
+            Assert.Equal(20, tile.WastePctOverride);
+
+            foreach (string kind in new[] { "tile_adhesive", "tile_grout" })
+                Assert.Equal(-1, lines.Single(l => l.Kind == kind).WastePctOverride);
+        }
+
+        [Fact]
+        public void An_Unstated_Band_Leaves_The_Tile_Line_On_Its_Rules_Default()
+        {
+            // -1 means "the supplier rule decides", which is what every other
+            // constituent does. Writing 0 would mean "no waste at all".
+            var lines = StingTools.BOQ.Takeoff.CompoundTakeoff.TiledFinish(
+                new StingTools.BOQ.Takeoff.TiledFinishInput
+                {
+                    AreaM2 = 10, IsWall = false, TileLabel = "Ceramic",
+                    AdhesiveKgPerM2 = 4, WastePctOverride = -1
+                });
+
+            Assert.Equal(-1, lines.Single(l => l.Kind == "floor_tile").WastePctOverride);
+        }
+
+        [Fact]
+        public void A_Mosaic_Wastes_More_Than_A_Large_Format_Tile()
+        {
+            // The whole reason the band matters. If these were equal, a flat
+            // figure would have been defensible all along.
+            var bands = new[] { "MOSAIC", "SMALL", "MEDIUM", "LARGE" }
+                .Select(b => MaterialKeyCanonicaliser.TileSize(b)).ToArray();
+
+            Assert.Equal(new[] { "MOSAIC", "SMALL", "MEDIUM", "LARGE" }, bands);
+        }
+    }
+}

--- a/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoff.cs
@@ -126,6 +126,16 @@ namespace StingTools.BOQ.Takeoff
         public string TileLabel;         // material name, for the description
         public double AdhesiveKgPerM2;   // manufacturer spreading rate
         public double GroutKgPerM2;      // joint width / tile size dependent
+
+        /// <summary>
+        /// Cutting waste for this tile's SIZE band, or -1 when unstated.
+        ///
+        /// MATERIAL_LOOKUP has banded it 20 / 12 / 10 / 8 for mosaic / small /
+        /// medium / large since before this schedule existed; the supplier rule
+        /// applied a flat 10% to all of them, so a mosaic splashback was
+        /// under-ordered by half its cutting allowance.
+        /// </summary>
+        public double WastePctOverride;
     }
 
     /// <summary>
@@ -546,9 +556,14 @@ namespace StingTools.BOQ.Takeoff
             if (area <= 0) return lines;
 
             string label = string.IsNullOrWhiteSpace(t.TileLabel) ? "tiling" : t.TileLabel.Trim();
+            // The TILE row carries the size band's waste. Adhesive and grout
+            // do NOT: they are spread over the area and their own rules own
+            // their allowance, so a mosaic's cutting waste is not a reason to
+            // buy half as much adhesive again.
             lines.Add(new CompoundLine(t.IsWall ? "wall_tile" : "floor_tile",
                 t.IsWall ? $"Wall tiling — {label}" : $"Floor tiling — {label}",
-                "m2", area, SecPlaster));
+                "m2", area, SecPlaster)
+            { WastePctOverride = t.WastePctOverride > 0 ? t.WastePctOverride : -1 });
 
             if (t.AdhesiveKgPerM2 > 0)
                 lines.Add(new CompoundLine("tile_adhesive", "Tile adhesive", "kg",

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -1443,13 +1443,31 @@ namespace StingTools.BOQ.Takeoff
             if (measured <= 0) return empty;
 
             var cover = TileCoverages(found.Label);
+
+            // The fourth member of the set. BLE_TILE_SIZE_TXT has been declared
+            // in MR_PARAMETERS.txt with a GUID all along and read by nothing —
+            // parameter first, then an inference from the material name, then
+            // the project default, exactly as brick bond, block size and
+            // plaster type already resolve. The inference is RECORDED through
+            // Resolution, so a guessed band lowers row confidence and is named
+            // rather than passing as a stated fact.
+            var tileRes = new Resolution();
+            string sizeRaw = ParameterHelpers.GetString(el, "BLE_TILE_SIZE_TXT");
+            string tileSize = InferOrCanon("tile size",
+                Core.Materials.MaterialKeyCanonicaliser.TileSize(sizeRaw),
+                () => Core.Materials.MaterialKeyCanonicaliser.TileSize(found.Label),
+                tileRes, "DEFAULT");
+            double tileWaste = Resolve(tileRes, "tile size",
+                $"TILE {tileSize}", "WASTE_PCT", "TILE DEFAULT");
+
             return CompoundTakeoff.TiledFinish(new TiledFinishInput
             {
                 AreaM2 = areaM2 * measured,
                 IsWall = isWall,
                 TileLabel = found.Label,
                 AdhesiveKgPerM2 = cover.AdhesiveKgPerM2,
-                GroutKgPerM2 = cover.GroutKgPerM2
+                GroutKgPerM2 = cover.GroutKgPerM2,
+                WastePctOverride = tileWaste
             });
         }
 

--- a/StingTools/Core/Materials/MaterialKeyCanonicaliser.cs
+++ b/StingTools/Core/Materials/MaterialKeyCanonicaliser.cs
@@ -39,6 +39,57 @@ namespace StingTools.Core.Materials
             return s;
         }
 
+        /// <summary>
+        /// Tile size → MOSAIC / SMALL / MEDIUM / LARGE, the keys
+        /// MATERIAL_LOOKUP already bands waste by.
+        ///
+        /// The fourth member of a set that already had three: brick bond, block
+        /// size and plaster type all resolve a BLE_* parameter through a
+        /// canonicaliser with an inference fallback. Tile size was the hole —
+        /// BLE_TILE_SIZE_TXT has been declared in MR_PARAMETERS.txt with a GUID
+        /// all along and read by nothing, so waste was flat at 10% for a mosaic
+        /// splashback and a 600 mm porcelain floor alike. The lookup has banded
+        /// it 20 / 12 / 10 / 8 since before the schedule existed.
+        ///
+        /// Accepts both the band name and a dimension: "MOSAIC", "600x600",
+        /// "600", "Porcelain 300x600". A dimension is banded on its SMALLER
+        /// side, because that is the edge that governs cutting waste.
+        /// </summary>
+        public static string TileSize(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return "";
+            string s = raw.Trim().ToUpperInvariant();
+
+            // A stated band wins over anything parsed out of the text.
+            foreach (string band in new[] { "MOSAIC", "SMALL", "MEDIUM", "LARGE" })
+                if (s.Contains(band)) return band;
+
+            string t = Regex.Replace(s.Replace('×', 'x').Replace('X', 'x').Replace('*', 'x'),
+                                     @"\s+", "");
+
+            // "300x600" → band on the SMALLER edge: a long thin tile is cut on
+            // its short side, and that is where the waste comes from.
+            var two = Regex.Match(t, @"(\d+)x(\d+)");
+            if (two.Success
+                && int.TryParse(two.Groups[1].Value, out int a1)
+                && int.TryParse(two.Groups[2].Value, out int b1))
+                return Band(Math.Min(a1, b1));
+
+            var one = Regex.Match(t, @"(\d+)");
+            if (one.Success && int.TryParse(one.Groups[1].Value, out int only))
+                return Band(only);
+
+            return "";
+        }
+
+        /// <summary>The bands MATERIAL_LOOKUP's own comments describe.</summary>
+        private static string Band(int mm) =>
+            mm <= 0   ? ""
+          : mm < 100  ? "MOSAIC"
+          : mm < 300  ? "SMALL"
+          : mm < 600  ? "MEDIUM"
+                      : "LARGE";
+
         /// <summary>Mortar mix → "1:N" with whitespace around ':' collapsed
         /// ("1 : 6" → "1:6"). cement:lime:sand designations pass through upper-cased.</summary>
         public static string MortarMix(string raw)


### PR DESCRIPTION
feat(matsched): tile size, the fourth member of a set that already had three

Brick bond, block size and plaster type each resolve a BLE_* parameter
through a canonicaliser, fall back to an inference, and drive a waste
figure MATERIAL_LOOKUP bands for them. Tile size was the hole in that
set - and BLE_TILE_SIZE_TXT has been declared in MR_PARAMETERS.txt with
a GUID all along, read by NOTHING.

So the supplier rule applied a flat 10% to a mosaic splashback and a
600 mm porcelain floor alike, while the lookup had banded it
20 / 12 / 10 / 8 since before this schedule existed. A mosaic was
under-ordered by half its cutting allowance.

Adding a fifth mechanism would have been the mistake. This finishes an
existing one: parameter first, then an inference from the material name,
then the project default - and the inference goes through InferOrCanon
like its three siblings, so a guessed band lowers row confidence and is
NAMED rather than passing as a stated fact.

A dimension bands on its SMALLER edge. A 300x600 plank is cut on its
short side and that edge governs the waste; banding on 600 would call a
plank large-format and under-order it. The mutation that bands on the
larger edge fails three tests.

A name with no size in it returns EMPTY, not MEDIUM. Empty becomes the
project default through InferOrCanon and is recorded; returning a band
directly would launder a guess into a stated fact. That mutation fails
two.

ONLY the tile line carries the cutting waste. Adhesive and grout are
spread over the area and their own rules own their allowances - a
mosaic's 20% is offcuts thrown away, not half as much adhesive again.

ADOPTING THIS CHANGES NO EXISTING NUMBER. Nothing in a model states a
tile size yet, so every tile falls to DEFAULT at 10%, which is exactly
the flat figure it replaces. The value arrives as projects fill the
parameter, and until then the export says the band was inferred or
defaulted rather than stated.

Boq tests 1177 -> 1205, build 0/0, all four gates pass.

Three mutations, all failing, each anchor asserted: banding on the
larger edge (3), defaulting a nameless tile to MEDIUM (2), putting the
cutting waste on adhesive and grout (1).

THE THIRD FIRST PROVED NOTHING. The claim that adhesive must not take the
tile's waste was in a COMMENT and in no assertion, so moving the override
onto it moved no test. Two tests now hold it. A comment is not a test,
and a mutation is how you find out which one you wrote.

NOT verified in Revit: the test project has no tiling at all - its only
finish material is Gypsum Wall Board - so this changes nothing visible
there and needs a tiled model to exercise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
