### PR TITLE
fix(baseline): a name is only wrong when NONE of its sizes is a size the type has

### DIFF
--- a/StingTools.Boq.Tests/HarvestDimensionTests.cs
+++ b/StingTools.Boq.Tests/HarvestDimensionTests.cs
@@ -123,6 +123,77 @@ namespace StingTools.Boq.Tests
         }
 
         [Fact]
+        public void A_Name_Carrying_An_EXTRA_Feature_Dimension_Is_NOT_Reported()
+        {
+            // Verbatim from the first real harvest. "900 x 2100 w 300 Vent" is a
+            // correctly named door: width and height both match, and the
+            // unmatched 300 is the VENT - a real feature that is not one of the
+            // dimensions harvested and was never meant to be.
+            //
+            // The original rule flagged any unmatched number and produced two
+            // findings of this shape out of seven. A name carrying an extra
+            // dimension is more informative than the parameter list, not in
+            // conflict with it.
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new[]
+            {
+                Observed("Doors", "900 x 2100 w 300 Vent", ("Width", 900), ("Height", 2100))
+            }, "PRJ", report);
+
+            Assert.Empty(report.NameDisagreesWithSize);
+        }
+
+        [Fact]
+        public void A_Name_Whose_Sizes_Are_ALL_Absent_Is_Still_Reported()
+        {
+            // The other real one: a door named 4200X2700 whose only harvested
+            // dimension is a 40 mm thickness. Nothing in the name is a size the
+            // type has, so the name describes a different product.
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new[]
+            {
+                Observed("Doors", "4200X2700", ("Thickness", 40))
+            }, "PRJ", report);
+
+            Assert.Single(report.NameDisagreesWithSize);
+        }
+
+        [Fact]
+        public void One_Matching_Dimension_Is_Enough_To_Clear_A_Name()
+        {
+            // The boundary the two rules disagree on, stated directly: under
+            // "any unmatched" this flags, under "none matched" it does not.
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new[]
+            {
+                Observed("Windows", "1200 x 9999", ("Width", 1200))
+            }, "PRJ", report);
+
+            Assert.Empty(report.NameDisagreesWithSize);
+        }
+
+        [Fact]
+        public void A_Name_Whose_Only_Number_Is_A_Dedup_Suffix_Is_Not_Reported()
+        {
+            // What the >= 10 filter still guards, now that the predicate is
+            // "none matched". Revit appends 2 / 3 to disambiguate a duplicated
+            // type name, and that digit is not a dimension. Without the filter
+            // this name has exactly one number, it matches nothing, and the type
+            // is flagged for a suffix Revit wrote itself.
+            //
+            // Every OTHER small-number case is now cleared by the predicate
+            // itself, which is why the mutation that drops the filter moves only
+            // this test.
+            var report = new TypeHarvestReport();
+            TypeHarvestBuilder.Build(new[]
+            {
+                Observed("Doors", "Flush Door 2", ("Width", 900), ("Height", 2100))
+            }, "PRJ", report);
+
+            Assert.Empty(report.NameDisagreesWithSize);
+        }
+
+        [Fact]
         public void A_Name_That_Matches_Its_Parameters_Is_Not_Reported()
         {
             var report = new TypeHarvestReport();

--- a/StingTools/Core/Baseline/TypeHarvest.cs
+++ b/StingTools/Core/Baseline/TypeHarvest.cs
@@ -204,10 +204,23 @@ namespace StingTools.Core.Baseline
                 .ToList();
             if (inName.Count == 0) return false;
 
-            // Every number in the name must be findable, to the millimetre, in
-            // some parameter. One that is not means the name is describing a
-            // size the type does not have.
-            return inName.Any(n => !parameters.Any(p => Math.Abs(p.ValueMm - n) < 0.5));
+            // NO number in the name is findable in any parameter.
+            //
+            // This was "ANY number unmatched" and the first real harvest showed
+            // that is too strict. `900 x 2100 w 300 Vent` is a correctly named
+            // door: its width and height both match, and the unmatched 300 is
+            // the VENT — a real feature of the product that is not one of the
+            // dimensions harvested, and was never meant to be. Two of seven
+            // findings were that shape.
+            //
+            // A name whose sizes are ALL absent is describing something the
+            // type is not: `200x200 with 12.5 plaster` measuring 450 square,
+            // `1740x2595mm` measuring 1500 x 2400. A name carrying an EXTRA
+            // dimension is simply more informative than the parameter list.
+            //
+            // Checked against all 16 types of that harvest, this keeps every
+            // genuine case and drops both vent doors.
+            return !inName.Any(n => parameters.Any(p => Math.Abs(p.ValueMm - n) < 0.5));
         }
 
         /// <summary>


### PR DESCRIPTION
fix(baseline): a name is only wrong when NONE of its sizes is a size the type has

#830's name check ran on a real model and found seven disagreements. Two
of them were mine.

    900 x 2100 w 300 Vent   Width=900  Height=2100
    750 x 2100w 600 Vent    Width=750  Height=2100

Both are correctly named doors. Width and height match; the unmatched
number is the VENT - a real feature of the product that is not one of
the dimensions harvested and was never meant to be. The rule was "flag
if ANY number in the name is unmatched", so a name that carries MORE
information than the parameter list was reported as contradicting it.

The five genuine ones share a different shape: nothing in the name is a
size the type has.

    200x200 with 12.5 plaster  x3   measuring 175 / 450 / 500 square
    4200X2700                       only harvested dimension: Thickness 40
    1740x2595mm                     measuring 1500 x 2400

So the predicate is now "NONE matched". Checked against all sixteen types
of that harvest it keeps every genuine case and drops both vent doors -
seven findings become five, and the two it loses are the two that were
not findings.

A name carrying an extra dimension is more informative than the
parameter list, not in conflict with it.

Boq tests 1205 -> 1209, build 0/0, all four gates pass.

Three mutations, all failing, each anchor asserted: reverting to
ANY-unmatched (2), never flagging anything (3), dropping the >= 10 filter
(1).

THE THIRD FIRST PROVED NOTHING, and finding out why was worth more than
the mutation. Under the old ANY-unmatched rule the filter mattered
everywhere; under NONE-matched almost every small-number case is cleared
by the predicate itself. It still guards exactly one: a name whose ONLY
number is Revit's own dedup suffix - "Flush Door 2" would otherwise be
flagged for a digit Revit wrote. One test now holds that, and the
mutation moves it and nothing else, which is the honest size of what the
filter still does.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
