### PR TITLE
fix(matsched): four structural defects a second project exposed

### DIFF
--- a/StingTools.Boq.Tests/MaterialMatchTallyTests.cs
+++ b/StingTools.Boq.Tests/MaterialMatchTallyTests.cs
@@ -121,6 +121,41 @@ namespace StingTools.Boq.Tests
         }
 
         [Fact]
+        public void A_Category_NO_Commodity_Rule_Names_Is_Not_Inspected()
+        {
+            // A second project reported "200 rows could be identified by
+            // material, 3 matched" and listed 56 unplaced materials led by
+            // '911 CARRERA S - BODY COLOR' - a Porsche in the entourage.
+            //
+            // A car's paint is never a building commodity. Counting it made a
+            // working feature read as a 1.5% success rate and buried the
+            // materials that DO need a pattern.
+            var inputs = Inputs(new ConstituentInput
+            {
+                ConstituentKind = "", Category = "Furniture", TypeName = "Sofa",
+                Description = "Sofa", MaterialName = "911 CARRERA S - BODY COLOR",
+                Unit = "each", Quantity = 1
+            });
+
+            CommodityAggregator.Build(inputs);
+
+            Assert.Equal(0, inputs.MaterialScan.RowsInspected);
+            Assert.Empty(inputs.MaterialScan.UnplacedMaterials);
+        }
+
+        [Fact]
+        public void A_Category_A_Rule_DOES_Name_Is_Still_Inspected()
+        {
+            // The other half: scoping must not quietly stop looking at roofs.
+            var inputs = Inputs(Roof("Generic - 225mm", "Woven Papyrus Thatch"));
+
+            CommodityAggregator.Build(inputs);
+
+            Assert.Equal(1, inputs.MaterialScan.RowsInspected);
+            Assert.True(inputs.MaterialScan.UnplacedMaterials.Contains("Woven Papyrus Thatch"));
+        }
+
+        [Fact]
         public void A_Scan_That_Inspected_Nothing_Reports_Nothing()
         {
             Assert.Null(new MaterialMatchTally().Summary());

--- a/StingTools.Boq.Tests/PatternMatchTests.cs
+++ b/StingTools.Boq.Tests/PatternMatchTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    /// <summary>
+    /// A pattern matches a WORD, not a run of letters.
+    ///
+    /// Found by running the schedule over a second project. An oil painting
+    /// arrived in ELEMENT 03: ROOF —
+    ///
+    ///     Art_Piece_-_Draw_Bridge_at_Arles_-_Van_Gogh_5866
+    ///
+    /// — because the roof stage lists the type pattern "ridge" and "bRIDGEe"
+    /// contains it. Every bridge, cartridge and porridge in every future
+    /// project routed to the roof.
+    ///
+    /// The same bug sat in the wall take-off: `material.Contains("rc")` decides
+    /// a wall is reinforced concrete, and "poRCelain" contains "rc" — so a
+    /// porcelain-tiled surface would decompose into concrete, rebar and
+    /// formwork.
+    ///
+    /// Neither produced an error. Both produced a confident wrong row in a
+    /// section a reader has no reason to question.
+    /// </summary>
+    public class PatternMatchTests
+    {
+        // ── the two that were live ──────────────────────────────────────────
+
+        [Fact]
+        public void BRIDGE_Does_Not_Match_RIDGE()
+        {
+            Assert.False(PatternMatch.Contains("Art_Piece_-_Draw_Bridge_at_Arles_-_Van_Gogh_5866",
+                                               "ridge"));
+        }
+
+        [Fact]
+        public void But_A_REAL_Ridge_Still_Matches()
+        {
+            // The pattern has to keep working, or the fix trades one silent
+            // wrong for another.
+            Assert.True(PatternMatch.Contains("Roof ridge capping", "ridge"));
+            Assert.True(PatternMatch.Contains("RIDGE-TILE", "ridge"));
+            Assert.True(PatternMatch.Contains("ridge", "ridge"));
+        }
+
+        [Fact]
+        public void PORCELAIN_Does_Not_Match_RC()
+        {
+            Assert.False(PatternMatch.Contains("STING RC Slab 200 - Porcelain Tiled".ToLowerInvariant()
+                                                   .Replace("rc slab", "x slab"),
+                                               "rc"));
+            Assert.False(PatternMatch.Contains("porcelain tiled", "rc"));
+        }
+
+        [Fact]
+        public void But_A_REAL_RC_Still_Matches()
+        {
+            Assert.True(PatternMatch.Contains("rc slab 150", "rc"));
+            Assert.True(PatternMatch.Contains("200mm RC wall", "rc"));
+        }
+
+        // ── the boundary rule ───────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("roof-cap", "cap", true)]      // hyphen is a boundary
+        [InlineData("roof cap", "cap", true)]      // space is a boundary
+        [InlineData("roof_cap", "cap", true)]      // underscore is a boundary
+        [InlineData("capping", "cap", false)]      // letter is not
+        [InlineData("handicap", "cap", false)]
+        public void A_Boundary_Is_Anything_That_Is_Not_A_Letter_Or_Digit(
+            string text, string pattern, bool expected)
+        {
+            Assert.Equal(expected, PatternMatch.Contains(text, pattern));
+        }
+
+        [Fact]
+        public void A_Digit_Counts_As_Part_Of_A_Word()
+        {
+            // A gauge is not a prefix of another gauge: g28 sheeting and g285
+            // are different products.
+            Assert.True(PatternMatch.Contains("sheet g28 corrugated", "g28"));
+            Assert.False(PatternMatch.Contains("sheet g285 corrugated", "g28"));
+        }
+
+        [Fact]
+        public void A_Multi_Word_Pattern_Is_Bounded_At_Both_Ends()
+        {
+            Assert.True(PatternMatch.Contains("Steel barge board 150", "barge board"));
+            Assert.False(PatternMatch.Contains("barge boarding", "barge board"));
+        }
+
+        [Theory]
+        [InlineData(null, "ridge")]
+        [InlineData("", "ridge")]
+        [InlineData("anything", null)]
+        [InlineData("anything", "")]
+        [InlineData("anything", "   ")]
+        public void Nothing_Matches_Nothing(string text, string pattern)
+        {
+            Assert.False(PatternMatch.Contains(text, pattern));
+        }
+
+        [Fact]
+        public void An_Inner_Hit_Does_Not_Stop_The_Search()
+        {
+            // "bridge" first, a real "ridge" after. Returning on the first
+            // occurrence would miss it.
+            Assert.True(PatternMatch.Contains("Bridge detail and ridge capping", "ridge"));
+        }
+
+        // ── the shipped patterns, against the names that broke them ─────────
+
+        [Fact]
+        public void No_Shipped_Stage_Pattern_Claims_The_Van_Gogh()
+        {
+            var lib = JsonConvert.DeserializeObject<StageLibrary>(
+                File.ReadAllText(Path.Combine(System.AppContext.BaseDirectory,
+                                              "Data", "STING_MATERIAL_STAGES.json")));
+
+            const string painting = "Art_Piece_-_Draw_Bridge_at_Arles_-_Van_Gogh_5866";
+
+            foreach (var st in lib.Stages)
+                foreach (string p in st.TypePatterns ?? new List<string>())
+                    Assert.False(PatternMatch.Contains(painting, p),
+                                 $"stage '{st.StageId}' pattern '{p}' claims a painting");
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\TypePatternPlanner.cs" Link="MaterialSchedule\TypePatternPlanner.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\MaterialMatchTally.cs" Link="MaterialSchedule\MaterialMatchTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\CommodityTypeBreakdown.cs" Link="MaterialSchedule\CommodityTypeBreakdown.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\PatternMatch.cs" Link="MaterialSchedule\PatternMatch.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ConsumablesTally.cs" Link="MaterialSchedule\ConsumablesTally.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\RoofAccessoryTally.cs" Link="MaterialSchedule\RoofAccessoryTally.cs" />
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
+++ b/StingTools/BOQ/MaterialSchedule/MaterialScheduleBuilder.cs
@@ -128,6 +128,7 @@ namespace StingTools.BOQ.MaterialSchedule
                 var drivers = ConsumableDrivers.From(inputs.Constituents, inputs.Units);
                 foreach (string m in drivers.UnitMismatches) consumablesTally.UnitMismatches.Add(m);
                 consumablesTally.RoofCoveringUnattributedM2 = drivers.RoofCoveringUnattributedM2;
+                consumablesTally.RoofCoveringMeasuredM2 = drivers.RoofCoveringM2;
                 inputs.Constituents.AddRange(
                     ConsumablesCalculator.Quantify(drivers, conLib.Rules, consumablesTally));
             }

--- a/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
+++ b/StingTools/BOQ/Takeoff/CompoundTakeoffBuilder.cs
@@ -165,7 +165,7 @@ namespace StingTools.BOQ.Takeoff
 
             string material = (GetPrimaryMaterialName(doc, el) ?? "").ToLowerInvariant();
             bool isBrick = IsBrickWall(doc, el, material);
-            bool isRc = material.Contains("concrete") || material.Contains("rc") || material.Contains("reinforced");
+            bool isRc = material.Contains("concrete") || Core.MaterialSchedule.PatternMatch.Contains(material, "rc") || material.Contains("reinforced");
             var res = new Resolution();
 
             // Units per m² + cutting waste + mortar-per-m² from bond/block tables.
@@ -247,7 +247,7 @@ namespace StingTools.BOQ.Takeoff
             bool requireExplicitConcrete = false, bool hostIsRoof = false)
         {
             string material = (GetPrimaryMaterialName(doc, el) ?? "").ToLowerInvariant();
-            bool isConcrete = material.Contains("concrete") || material.Contains("rc");
+            bool isConcrete = material.Contains("concrete") || Core.MaterialSchedule.PatternMatch.Contains(material, "rc");
             // Blank material reads as concrete for a FLOOR and as unknown for a
             // roof — see the Roofs branch in TryBuild.
             bool isRc = isConcrete || !(requireExplicitConcrete || material.Length != 0);
@@ -1005,7 +1005,7 @@ namespace StingTools.BOQ.Takeoff
                 // footprint, because a concrete roof usually HAS one and would
                 // otherwise produce a confident fascia run for a parapet.
                 string material = (GetPrimaryMaterialName(doc, el) ?? "").ToLowerInvariant();
-                if (material.Contains("concrete") || material.Contains("rc")
+                if (material.Contains("concrete") || Core.MaterialSchedule.PatternMatch.Contains(material, "rc")
                  || material.Contains("reinforced"))
                 {
                     RoofAccessoryScan.Tally.ConcreteRoofsSkipped++;

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -166,7 +166,15 @@ namespace StingTools.Core.MaterialSchedule
                 // their own could ever be decided by material, so those are the
                 // denominator — counting the rest would report a coverage the
                 // feature was never asked for.
-                if (string.IsNullOrWhiteSpace(row.ConstituentKind) && input.MaterialScan != null)
+                // Only categories some rule could ever claim. A second project
+                // reported "200 rows could be identified by material, 3
+                // matched" and listed 56 unplaced materials led by
+                // '911 CARRERA S - BODY COLOR' - a Porsche in the entourage.
+                // A car's paint is never a building commodity, and counting it
+                // made a working feature read as a 1.5% success rate while
+                // burying the materials that DO need a pattern.
+                if (string.IsNullOrWhiteSpace(row.ConstituentKind) && input.MaterialScan != null
+                    && CategoryCouldConvert(input.Units, row.Category))
                 {
                     var scan = input.MaterialScan;
                     scan.RowsInspected++;
@@ -294,6 +302,34 @@ namespace StingTools.Core.MaterialSchedule
             return string.Equals(StingTools.BOQ.BoqUnits.Normalise(measured),
                                  StingTools.BOQ.BoqUnits.Normalise(ruleSource),
                                  StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True when ANY rule in the table names this category. Furniture,
+        /// entourage and casework are named by none, so a material on them can
+        /// never become a commodity and counting it only dilutes the scan.
+        ///
+        /// A rule with no categories at all (matched by kind or material alone)
+        /// makes every category a candidate - which is correct, because such a
+        /// rule really could claim anything.
+        /// </summary>
+        private static bool CategoryCouldConvert(SupplierUnitTable units, string category)
+        {
+            if (units?.Rules == null) return true;
+            if (string.IsNullOrWhiteSpace(category)) return true;
+            string c = category.Trim();
+            foreach (var r in units.Rules)
+            {
+                if (r?.MatchCategories == null || r.MatchCategories.Count == 0)
+                {
+                    if (r?.MatchMaterialPatterns != null && r.MatchMaterialPatterns.Count > 0)
+                        return true;   // material-only rule: any category could carry it
+                    continue;
+                }
+                foreach (string mc in r.MatchCategories)
+                    if (string.Equals(mc, c, StringComparison.OrdinalIgnoreCase)) return true;
+            }
+            return false;
         }
 
         private sealed class Accum

--- a/StingTools/Core/MaterialSchedule/ConsumablesTally.cs
+++ b/StingTools/Core/MaterialSchedule/ConsumablesTally.cs
@@ -68,6 +68,20 @@ namespace StingTools.Core.MaterialSchedule
         /// </summary>
         public double RoofCoveringUnattributedM2;
 
+        /// <summary>
+        /// Roof covering that was measured AND identified, in m2.
+        ///
+        /// Separates two zeros that read identically. On a second project the
+        /// fastener driver was zero and the note said "with no driver the
+        /// quantity would be invented" - while 437 m2 of shingle and clay tile
+        /// sat priced above it. Both are NAILED, so zero screws is the right
+        /// answer, not a missing one.
+        ///
+        /// Same failure as the unattributed case one level down: the number is
+        /// correct and the sentence explaining it is not.
+        /// </summary>
+        public double RoofCoveringMeasuredM2;
+
         /// <summary>Driver rows skipped because their measured unit disagreed
         /// with the unit the driver is counted in. Carried through from
         /// ConsumableDrivers so one line reports the whole source.</summary>
@@ -84,6 +98,7 @@ namespace StingTools.Core.MaterialSchedule
             UnusableRules.Clear();
             UnitMismatches.Clear();
             RoofCoveringUnattributedM2 = 0;
+            RoofCoveringMeasuredM2 = 0;
         }
 
         public void Consider(string kind) { RulesConsidered++; }
@@ -135,6 +150,18 @@ namespace StingTools.Core.MaterialSchedule
 
                 // ... unless the driver is zero because nothing could be
                 // IDENTIFIED, which is a different fact with a different fix.
+                // A covering that is nailed rather than screwed. The count is
+                // zero because it SHOULD be, and saying "no driver" invites
+                // somebody to go looking for a fault that is not there.
+                if (RoofCoveringMeasuredM2 > 0
+                    && DriversAbsent.ContainsKey("roof_fastener_nr"))
+                {
+                    s += $" The roof fastener count is zero because the {RoofCoveringMeasuredM2:N0} m² "
+                       + "of covering measured here is NAILED, not screwed — tiles and shingles are "
+                       + "fixed every other course. That is the right answer for this roof, not a "
+                       + "missing measurement.";
+                }
+
                 if (RoofCoveringUnattributedM2 > 0
                     && DriversAbsent.ContainsKey("roof_covering_m2"))
                 {

--- a/StingTools/Core/MaterialSchedule/PatternMatch.cs
+++ b/StingTools/Core/MaterialSchedule/PatternMatch.cs
@@ -1,0 +1,70 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  PatternMatch.cs — a pattern matches a WORD, not a run of letters.
+//
+//  Found by running the schedule over a second project. An oil painting
+//  arrived in ELEMENT 03: ROOF —
+//
+//      Art_Piece_-_Draw_Bridge_at_Arles_-_Van_Gogh_5866
+//
+//  — because the roof stage lists the type pattern "ridge", and "bRIDGEe"
+//  contains it. Every bridge, cartridge, porridge and Aldridge in every
+//  future project routes to the roof.
+//
+//  The same class of bug sat in the wall take-off: `material.Contains("rc")`
+//  decides a wall is reinforced concrete, and "poRCelain" contains "rc". A
+//  porcelain-tiled surface would have decomposed into concrete, rebar and
+//  formwork.
+//
+//  Neither produces an error. Both produce a confident wrong row in a
+//  section a reader has no reason to question — which is why this is a
+//  matcher rather than a longer list of exceptions.
+//
+//  A boundary is anything that is not a letter or a digit, so "roof-cap",
+//  "roof cap" and "roof_cap" all match the pattern "roof cap" once their
+//  separators are normalised by the caller, while "bridge" never matches
+//  "ridge". Patterns that are themselves multi-word are matched as a run
+//  with the same boundary rule at each end.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+
+namespace StingTools.Core.MaterialSchedule
+{
+    public static class PatternMatch
+    {
+        /// <summary>
+        /// True when <paramref name="pattern"/> appears in <paramref name="text"/>
+        /// as a whole word — bounded at both ends by a non-alphanumeric
+        /// character or the end of the string.
+        ///
+        /// Case-insensitive, like every other match in this file.
+        /// </summary>
+        public static bool Contains(string text, string pattern)
+        {
+            if (string.IsNullOrEmpty(text) || string.IsNullOrWhiteSpace(pattern)) return false;
+            string pat = pattern.Trim();
+
+            int i = 0;
+            while (true)
+            {
+                i = text.IndexOf(pat, i, StringComparison.OrdinalIgnoreCase);
+                if (i < 0) return false;
+                if (IsBoundedAt(text, i, pat.Length)) return true;
+                i++;   // an inner hit; keep looking for a bounded one
+            }
+        }
+
+        /// <summary>
+        /// A digit counts as part of a word, so "g28" does not match inside
+        /// "g285" — a gauge is not a prefix of another gauge.
+        /// </summary>
+        private static bool IsBoundedAt(string text, int start, int length)
+        {
+            bool leftOk = start == 0 || !IsWordChar(text[start - 1]);
+            int end = start + length;
+            bool rightOk = end >= text.Length || !IsWordChar(text[end]);
+            return leftOk && rightOk;
+        }
+
+        private static bool IsWordChar(char c) => char.IsLetterOrDigit(c);
+    }
+}

--- a/StingTools/Core/MaterialSchedule/StageMapper.cs
+++ b/StingTools/Core/MaterialSchedule/StageMapper.cs
@@ -159,7 +159,7 @@ namespace StingTools.Core.MaterialSchedule
             if (!string.IsNullOrWhiteSpace(typeText) && _byTypePattern.Count > 0)
             {
                 foreach (var kv in _byTypePattern)
-                    if (typeText.IndexOf(kv.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    if (PatternMatch.Contains(typeText, kv.Key))
                         return kv.Value;
             }
 

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -347,9 +347,22 @@
    "matchKinds": [
     "roof_underlay"
    ],
-   "matchCategories": [],
-   "matchTypePatterns": [],
-   "stageId": ""
+   "matchCategories": [
+    "Roofs"
+   ],
+   "matchTypePatterns": [
+    "felt",
+    "underlay",
+    "sarking"
+   ],
+   "stageId": "roof",
+   "matchMaterialPatterns": [
+    "felt",
+    "underlay",
+    "sarking",
+    "breather membrane"
+   ],
+   "sourceNote": "45 m2 per 1 x 45 m roll, 15% for laps and cutting. Until now this commodity matched NOTHING: it listed the constituent kind 'roof_underlay', which nothing emits, and no category, material or type pattern - so a real 1,608 m2 of ROOFING FELT 1MM reached a schedule as an unpriced area. NOMINAL COVER - confirm the roll size before ordering."
   },
   {
    "commodityKey": "hoop-iron",


### PR DESCRIPTION
fix(matsched): four structural defects a second project exposed

Running the schedule over a lodge project - different building types,
different materials - surfaced four things that were wrong for EVERY
future project, not just that one.

1. A PATTERN MATCHED A RUN OF LETTERS, NOT A WORD.

An oil painting arrived in ELEMENT 03: ROOF:

    Art_Piece_-_Draw_Bridge_at_Arles_-_Van_Gogh_5866

The roof stage lists the type pattern "ridge", and "bRIDGEe" contains
it. Every bridge, cartridge and porridge in every project routed to the
roof.

The same bug sat in the wall take-off, unfired: material.Contains("rc")
decides a wall is reinforced concrete, and "poRCelain" contains "rc" -
so a porcelain-tiled surface would have decomposed into concrete, rebar
and formwork. The shipped baseline literally contains a type called
"STING RC Slab 200 - Porcelain Tiled".

Neither produces an error. Both produce a confident wrong row in a
section a reader has no reason to question. PatternMatch requires a
non-alphanumeric boundary at both ends, so a real ridge still matches
and a bridge never does. A digit counts as part of a word, so g28 does
not match inside g285 - a gauge is not a prefix of another gauge. One
test walks every shipped stage pattern against the painting.

2. roof-underlay COULD NEVER MATCH ANYTHING.

The commodity had a rate, a roll size and a wastage figure, and matched
on the constituent kind "roof_underlay" - which nothing emits. No
category, no material pattern, no type pattern. So 1,608 m2 of
ROOFING FELT 1MM reached a schedule as an unpriced area while a
commodity for exactly that sat unreachable. It now matches felt /
underlay / sarking by material and type.

An existing gate caught the fix mid-flight: a commodity matching by
CATEGORY must declare its own stageId, and this one still said "". That
gate was written for a different reason and did its job here.

3. A ZERO THAT IS THE RIGHT ANSWER READ AS A MISSING ONE.

    roof_fastener_nr (would have given roof_fastener). That is the
    intended behaviour - with no driver the quantity would be invented.

437 m2 of shingle and clay tile sat priced three rows above. Both are
NAILED, correctly at 0/m2 since #848, so zero screws is right - and the
note framed it as nothing having been measured. Identical to the
roof_covering_m2 message fixed in #820, one level down. The tally now
distinguishes measured-and-nailed from nothing-measured and says which.

4. THE MATERIAL SCAN WAS DROWNING IN ENTOURAGE.

    200 row(s) could be identified by material, 3 matched.
    56 unplaced: '911 CARRERA S - BODY COLOR', 'CARPET TILE LOOP-BLUE'...

A Porsche's paint is never a building commodity. Counting furniture and
entourage made a working feature read as a 1.5% success rate and buried
the materials that DO need a pattern. The denominator is now categories
some rule could actually claim.

Boq tests 1209 -> 1225, build 0/0, all four gates pass.

Four mutations, all failing, each anchor asserted: plain substring
matching (7), a digit as a boundary (1), stopping at the first inner hit
(1), counting every category in the scan (1).

THE LAST FIRST PROVED NOTHING - no test covered the scan's denominator,
so removing the scoping moved nothing. Two tests now hold it: a Porsche
on Furniture is not inspected, and a roof still is. The second matters
as much as the first, because scoping must not quietly stop looking at
roofs.

NOT verified in Revit. The next export of that lodge should show the
painting leave the roof section, ROOFING FELT convert to ~41 rolls, the
fastener note explain its zero, and the scan denominator fall from 200
to something close to the rows that could ever convert.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
