### PR TITLE
fix(prod): the specific rule wins, and a stem matches a word

### DIFF
--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// The shipped PROD data, asserted. The RESOLVER had fifteen tests; the two CSVs it
+    /// reads had none — the same asymmetry the material schedule carried until a drift
+    /// gate was put over its constants.
+    ///
+    /// <para>Three defects were sitting in the data, and every one of them resolved to a
+    /// confident wrong code rather than to an error:</para>
+    ///
+    /// <list type="number">
+    /// <item><b>Ten rules were shadowed.</b> <c>*Boiler Feed*</c> sat below
+    /// <c>*Boiler*</c>, <c>*Fire Damper*</c> below <c>*Damper*</c>, <c>*Fume Hood*</c>
+    /// below <c>*Hood*</c>, <c>*Mop Sink*</c> below <c>*Sink*</c>. Three could never fire
+    /// at all. Ten different authors made the same mistake, which is what says the file —
+    /// which reads like a dictionary of independent rules — was behaving like an ordered
+    /// chain. Fixed in the matcher (most specific wins), not by reordering rows.</item>
+    ///
+    /// <item><b>Unanchored material stems matched inside longer words.</b>
+    /// "Sh<b>eeps</b> Wool Insulation" took the EPS code: a real insulation handed a
+    /// different insulation's code. Fixed in the data, because only the author knows that
+    /// <c>galv</c> is a deliberate prefix and <c>eps</c> is not.</item>
+    ///
+    /// <item><b>One PROD code declared two disciplines.</b> VIE / ZVB / AAP each said P
+    /// in one row and MG in another, so a tag's discipline would depend on which category
+    /// somebody modelled the thing in.</item>
+    /// </list>
+    ///
+    /// <para>Only columns 0-2 of STING_PROD_CODES.csv are read by the plugin today, so
+    /// finding 3 is currently inert. It is asserted anyway: an inert disagreement is a
+    /// live one the day someone wires the DISCIPLINE column, and it costs nothing to
+    /// keep the file honest until then.</para>
+    /// </summary>
+    public class ProdCodeDataTests
+    {
+        // ── the shipped files, read from source rather than a copy ──────────────
+        // Deliberately NOT copied to the output directory: a stale copy passing while
+        // the shipped file is wrong is the exact failure this class exists to stop.
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_PROD_CODES.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private sealed class Row
+        {
+            public int Line;
+            public string Code = "", Category = "", Pattern = "", Discipline = "";
+            public override string ToString() => $"line {Line} [{Category}] '{Pattern}' -> {Code}";
+        }
+
+        private static List<Row> ProdRows()
+        {
+            var rows = new List<Row>();
+            var lines = File.ReadAllLines(Path.Combine(DataDir(), "STING_PROD_CODES.csv"));
+            for (int i = 1; i < lines.Length; i++)
+            {
+                string line = (lines[i] ?? "").Trim();
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+                var c = line.Split(',');
+                if (c.Length < 3) continue;
+                string code = c[0].Trim(), cat = c[1].Trim(), pat = c[2].Trim().ToUpperInvariant();
+                if (code.Length == 0 || cat.Length == 0 || pat.Length == 0) continue;
+                rows.Add(new Row
+                {
+                    Line = i + 1,
+                    Code = code,
+                    Category = cat,
+                    Pattern = pat,
+                    Discipline = c.Length > 4 ? c[4].Trim() : "",
+                });
+            }
+            Assert.True(rows.Count > 100, "STING_PROD_CODES.csv looks empty: " + rows.Count + " rows");
+            return rows;
+        }
+
+        /// <summary>The alternatives of a glob cell, and the shortest name each was
+        /// written to catch (its literal, wildcards stripped).</summary>
+        private static IEnumerable<string> Literals(string pattern)
+            => pattern.Split('|')
+                      .Select(a => a.Trim().Replace("*", "").Replace("?", "").Trim())
+                      .Where(a => a.Length > 0);
+
+        private static List<(string Pattern, string ProdCode)> ForCategory(List<Row> rows, string cat)
+            => rows.Where(r => string.Equals(r.Category, cat, StringComparison.OrdinalIgnoreCase))
+                   .Select(r => (r.Pattern, r.Code)).ToList();
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. No rule is unreachable
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Every shipped rule wins on a name written to satisfy it.
+        ///
+        /// <para>This is the whole of finding 1, made executable: feed each alternative
+        /// the literal it was authored for, resolve it through the REAL resolver against
+        /// the REAL category rule list, and require the authoring row to be the one that
+        /// answers. Before the specificity change, ten rows failed here.</para>
+        /// </summary>
+        [Fact]
+        public void Every_Shipped_Rule_Wins_On_Its_Own_Name()
+        {
+            var rows = ProdRows();
+            var byCat = rows.GroupBy(r => r.Category, StringComparer.OrdinalIgnoreCase)
+                            .ToDictionary(g => g.Key, g => g.Select(r => (r.Pattern, r.Code)).ToList(),
+                                          StringComparer.OrdinalIgnoreCase);
+
+            var dead = new List<string>();
+            foreach (var row in rows)
+                foreach (string lit in Literals(row.Pattern))
+                {
+                    // The one exclusion, named rather than tolerated. BHD and BHT are two
+                    // codes for ONE product and both spell "*Bedhead*", so they tie on
+                    // specificity and the tie correctly falls to file order — no ranking
+                    // can separate them because there is nothing to separate. Retiring one
+                    // is a healthcare-catalogue decision (E vs H discipline), not a
+                    // mechanical one. KnownUnresolved_Bedhead_Trunking_Has_Two_Codes fails
+                    // the day it is settled, so this cannot outlive the problem.
+                    if (row.Code == "BHT" && lit == "BEDHEAD") continue;
+
+                    string got = ProdResolver.Resolve(
+                        familyName: "F", typeName: lit, categoryName: row.Category,
+                        projRulesForCategory: null, corpRulesForCategory: byCat[row.Category],
+                        prodMap: null, source: out _);
+
+                    if (!string.Equals(got, row.Code, StringComparison.Ordinal))
+                        dead.Add($"{row}  — the name '{lit}' it was written for resolves to {got}");
+                }
+
+            Assert.True(dead.Count == 0,
+                "Shipped PROD rules that a more general rule in the same category swallows. " +
+                "A name the author wrote a rule for resolves to somebody else's code, silently:\n  "
+                + string.Join("\n  ", dead));
+        }
+
+        /// <summary>The guard above is only worth having if it fires. This is the exact
+        /// pair that was live in the file — a general rule, then a specific one — with
+        /// the specificity ranking removed by hand.</summary>
+        [Fact]
+        public void The_Unreachable_Guard_Actually_Fires_Under_First_Match_Wins()
+        {
+            var rules = new List<(string, string)>
+            {
+                ("*DAMPER*", "DMP"),        // general, first
+                ("*FIRE DAMPER*", "FSD"),   // specific, second — the shipped order
+            };
+
+            // What the resolver does NOW: the specific rule wins wherever it applies.
+            Assert.Equal("FSD", ProdResolver.Resolve("F", "FIRE DAMPER", "Ducts",
+                                                     null, rules, null, out _));
+            Assert.Equal("DMP", ProdResolver.Resolve("F", "VOLUME DAMPER", "Ducts",
+                                                     null, rules, null, out _));
+
+            // What plain first-match-wins did: the general rule ate it. Kept as a literal
+            // so this test states the defect rather than describing it in prose.
+            string firstMatch = rules.First(r => ProdPatternMatcher.Matches("FIRE DAMPER", r.Item1)).Item2;
+            Assert.Equal("DMP", firstMatch);
+        }
+
+        /// <summary>Ties keep file order, so nothing that used to resolve one way starts
+        /// resolving the other for want of a tie-break.</summary>
+        [Fact]
+        public void Equally_Specific_Rules_Keep_File_Order()
+        {
+            var rules = new List<(string, string)> { ("*PUMP*", "AAA"), ("*PUMP*", "BBB") };
+            Assert.Equal("AAA", ProdResolver.Resolve("F", "PUMP 01", "Mechanical Equipment",
+                                                     null, rules, null, out _));
+        }
+
+        /// <summary>A project overlay still beats corporate even when the corporate rule
+        /// is the more specific of the two — the tiers are a chain, only the rules WITHIN
+        /// a tier are peers.</summary>
+        [Fact]
+        public void A_Vaguer_Project_Rule_Still_Beats_A_Sharper_Corporate_One()
+        {
+            string got = ProdResolver.Resolve(
+                "F", "FIRE DAMPER", "Ducts",
+                projRulesForCategory: new List<(string, string)> { ("*DAMPER*", "PRJ") },
+                corpRulesForCategory: new List<(string, string)> { ("*FIRE DAMPER*", "FSD") },
+                prodMap: null, source: out string source);
+
+            Assert.Equal("PRJ", got);
+            Assert.Equal(ProdResolver.Sources.Project, source);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. One code, one discipline
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// A PROD code may appear in several categories — a zone valve box is modelled as
+        /// Pipe Accessories on one job and Specialty Equipment on the next, and both rows
+        /// are wanted. What it may NOT do is declare a different discipline in each, or
+        /// the tag's discipline segment depends on how somebody chose to model it.
+        /// </summary>
+        [Fact]
+        public void No_Prod_Code_Declares_Two_Disciplines()
+        {
+            var split = ProdRows()
+                .Where(r => r.Discipline.Length > 0)
+                .GroupBy(r => r.Code, StringComparer.Ordinal)
+                .Where(g => g.Select(r => r.Discipline).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1)
+                .Select(g => $"{g.Key} -> " + string.Join(" / ", g.Select(r => $"{r.Discipline} (line {r.Line}, {r.Category})")))
+                .ToList();
+
+            Assert.True(split.Count == 0,
+                "One PROD code, two disciplines. The DISCIPLINE column is not read by the " +
+                "plugin today, so this is documentation — but it is documentation the next " +
+                "person will wire up:\n  " + string.Join("\n  ", split));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. Material stems match words, not runs of letters
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static List<MaterialProdRule> MaterialRules()
+        {
+            var warnings = new List<string>();
+            var rules = MaterialProdOverrideRules.Parse(
+                File.ReadAllLines(Path.Combine(DataDir(), "STING_MATERIAL_PROD_OVERRIDES.csv")), warnings);
+            Assert.True(warnings.Count == 0, "Unparseable rows: " + string.Join("; ", warnings));
+            Assert.True(rules.Count > 20, "Override table looks empty: " + rules.Count);
+            return rules;
+        }
+
+        /// <summary>
+        /// The four misfires found by running the shipped table over real material names.
+        /// Sheep's wool is the one worth remembering: a genuine insulation being handed a
+        /// DIFFERENT insulation's code reads as a fact, not as a fault.
+        /// </summary>
+        [Theory]
+        [InlineData("Sheeps Wool Insulation")]     // matched (?i)eps
+        [InlineData("Acoustic Spiral Liner")]      // matched (?i)pir
+        [InlineData("Respirator Filter Housing")]  // matched (?i)pir
+        [InlineData("Prefabricated Ductwork")]     // matched (?i)fabric
+        [InlineData("Aspirating Detector Housing")]
+        [InlineData("Empire Panelling")]
+        public void A_Stem_Inside_A_Longer_Word_Is_Not_A_Material(string materialName)
+        {
+            string suffix = MaterialProdOverrideRules.ResolveSuffix(MaterialRules(), materialName, "Generic Models");
+            Assert.True(suffix == null,
+                $"'{materialName}' took the material suffix -{suffix} from a stem buried inside " +
+                "one of its words. Anchor that alternative in STING_MATERIAL_PROD_OVERRIDES.csv.");
+        }
+
+        /// <summary>
+        /// The other half, and the reason this is curated data rather than an inferred
+        /// rule: several stems are DELIBERATE prefixes. Anchoring both ends of every
+        /// alternative would have traded one silent wrong answer for another.
+        /// </summary>
+        [Theory]
+        // Neither of these names contains ANY other stem from its row, so only the
+        // open-ended prefix can answer them. "Galvanised Steel Sheet" would not do:
+        // it also contains "Steel", so it passes whether or not \bgalv still works,
+        // and a mutation over-anchoring galv sailed straight through it.
+        [InlineData("Galvanised Finish", "STL")]        // \bgalv is meant to be open-ended
+        [InlineData("Cementitious Screed", "CON")]      // so is \bcement
+        [InlineData("Steelwork", "STL")]
+        [InlineData("Plasterboard 12.5mm", "GYP")]
+        [InlineData("Blockwork 200", "MAS")]
+        [InlineData("Stonework Cladding", "STN")]
+        [InlineData("uPVC Window Frame", "PLA")]        // leading edge deliberately open
+        [InlineData("cPVC Pipe", "PLA")]
+        [InlineData("EPS Insulation Board", "INS-EPS")]
+        [InlineData("PIR Board 100mm", "INS-PIR")]
+        [InlineData("Rigid Polyurethane", "INS-PIR")]
+        [InlineData("Fabrics - Upholstery", "FAB")]
+        [InlineData("Porcelain 600x600", "TIL")]
+        [InlineData("Concrete C25/30", "CON")]
+        [InlineData("Mineral Wool Quilt", "INS-MW")]
+        [InlineData("EPDM Membrane", "RBR")]
+        [InlineData("Lead Sheet Code 5", "PB")]
+        public void A_Real_Material_Still_Resolves(string materialName, string expected)
+        {
+            Assert.Equal(expected,
+                MaterialProdOverrideRules.ResolveSuffix(MaterialRules(), materialName, "Structural Framing"));
+        }
+
+        /// <summary>
+        /// Known-unresolved, named rather than quietly tolerated.
+        ///
+        /// <para>"Lead-Free Solder" still takes -PB. That is not a boundary problem — the
+        /// word IS "lead", correctly bounded — it is a NEGATION the table has no way to
+        /// express, and inventing a <c>(?!-free)</c> special case invites tin-free,
+        /// chrome-free and every other one after it. It is recorded here so the next
+        /// reader meets it as a known limit rather than as a fresh surprise; the test
+        /// fails if it is ever fixed, so the note cannot rot.</para>
+        /// </summary>
+        [Fact]
+        public void KnownUnresolved_A_Negated_Material_Name_Still_Matches_The_Material()
+        {
+            Assert.Equal("PB",
+                MaterialProdOverrideRules.ResolveSuffix(MaterialRules(), "Lead-Free Solder", "Pipe Fittings"));
+        }
+
+        /// <summary>
+        /// Known-unresolved: BHD and BHT are two PROD codes for one product (bedhead
+        /// trunking), under two disciplines (E and H). Which survives is a standards call
+        /// for whoever owns the healthcare catalogue, not a mechanical one — so it is
+        /// named here instead of being decided quietly in a commit.
+        /// </summary>
+        [Fact]
+        public void KnownUnresolved_Bedhead_Trunking_Has_Two_Codes()
+        {
+            var codes = ProdRows()
+                .Where(r => r.Pattern.Contains("BEDHEAD"))
+                .Select(r => r.Code).Distinct().OrderBy(c => c).ToList();
+
+            Assert.Equal(new[] { "BHD", "BHT" }, codes);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -73,6 +73,10 @@
     <Compile Include="..\StingTools\Core\ScopeBoxLoc.cs" Link="Core\ScopeBoxLoc.cs" />
     <Compile Include="..\StingTools\Core\ProdPatternMatcher.cs" Link="Core\ProdPatternMatcher.cs" />
     <Compile Include="..\StingTools\Core\ProdResolver.cs" Link="Core\ProdResolver.cs" />
+    <!-- The Revit-free half of the material-driven PROD suffix. Split out of
+         MaterialProdOverrideRegistry (which needs an Element) so the SHIPPED rule
+         table is assertable: an unanchored stem handed sheep's wool an EPS code. -->
+    <Compile Include="..\StingTools\Core\MaterialProdOverrideRules.cs" Link="Core\MaterialProdOverrideRules.cs" />
     <!-- IM-15: config-driven revision scheme. Kept Revit-free so the P→C default and the
          per-appointment override are provable without a Revit host. -->
     <Compile Include="..\StingTools\Docs\Templates\RevisionScheme.cs" Link="Docs\Templates\RevisionScheme.cs" />

--- a/StingTools/Core/MaterialProdOverrideRegistry.cs
+++ b/StingTools/Core/MaterialProdOverrideRegistry.cs
@@ -26,15 +26,12 @@ namespace StingTools.Core
     /// </summary>
     public static class MaterialProdOverrideRegistry
     {
-        private static List<Rule> _rules;
+        // Parsing and matching live in the Revit-free MaterialProdOverrideRules so
+        // the SHIPPED rule table can be asserted outside Revit — an unanchored
+        // pattern handing sheep's wool an EPS code is a data defect, and a data
+        // defect needs a data gate. This class keeps only what needs an Element.
+        private static List<MaterialProdRule> _rules;
         private static readonly object _lock = new object();
-
-        private class Rule
-        {
-            public string Category;            // category name; "*" wildcard
-            public System.Text.RegularExpressions.Regex MaterialPattern;
-            public string Suffix;
-        }
 
         public static void Reload()
         {
@@ -50,17 +47,11 @@ namespace StingTools.Core
                 if (_rules == null || _rules.Count == 0) return null;
                 string matName = ReadPrimaryMaterialName(el);
                 if (string.IsNullOrEmpty(matName)) return null;
-                foreach (var r in _rules)
+                try
                 {
-                    if (!string.IsNullOrEmpty(r.Category) && r.Category != "*" &&
-                        !string.Equals(r.Category, categoryName, StringComparison.OrdinalIgnoreCase))
-                        continue;
-                    try
-                    {
-                        if (r.MaterialPattern.IsMatch(matName)) return r.Suffix;
-                    }
-                    catch (Exception ex) { StingLog.Warn($"MaterialProdOverride match: {ex.Message}"); }
+                    return MaterialProdOverrideRules.ResolveSuffix(_rules, matName, categoryName);
                 }
+                catch (Exception ex) { StingLog.Warn($"MaterialProdOverride match: {ex.Message}"); }
             }
             return null;
         }
@@ -95,7 +86,7 @@ namespace StingTools.Core
             lock (_lock)
             {
                 if (_rules != null) return;
-                _rules = new List<Rule>();
+                _rules = new List<MaterialProdRule>();
                 try
                 {
                     string path = StingToolsApp.FindDataFile("STING_MATERIAL_PROD_OVERRIDES.csv");
@@ -104,34 +95,9 @@ namespace StingTools.Core
                         StingLog.Info("MaterialProdOverrideRegistry: no CSV found — material-aware PROD disabled.");
                         return;
                     }
-                    var lines = File.ReadAllLines(path);
-                    if (lines.Length < 2) return;
-                    var header = StingToolsApp.ParseCsvLine(lines[0]);
-                    int iCat   = Array.FindIndex(header, h => string.Equals(h, "Category",        StringComparison.OrdinalIgnoreCase));
-                    int iPat   = Array.FindIndex(header, h => string.Equals(h, "MaterialPattern", StringComparison.OrdinalIgnoreCase));
-                    int iSuf   = Array.FindIndex(header, h => string.Equals(h, "Suffix",          StringComparison.OrdinalIgnoreCase));
-                    if (iCat < 0 || iPat < 0 || iSuf < 0)
-                    { StingLog.Warn($"MaterialProdOverrideRegistry: bad header in {path}"); return; }
-                    for (int li = 1; li < lines.Length; li++)
-                    {
-                        var f = StingToolsApp.ParseCsvLine(lines[li]);
-                        if (f == null || f.Length <= iSuf) continue;
-                        string cat = (f[iCat] ?? "").Trim();
-                        string pat = (f[iPat] ?? "").Trim();
-                        string suf = (f[iSuf] ?? "").Trim();
-                        if (string.IsNullOrEmpty(pat) || string.IsNullOrEmpty(suf)) continue;
-                        try
-                        {
-                            _rules.Add(new Rule
-                            {
-                                Category = string.IsNullOrEmpty(cat) ? "*" : cat,
-                                MaterialPattern = new System.Text.RegularExpressions.Regex(pat,
-                                    System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled),
-                                Suffix = suf,
-                            });
-                        }
-                        catch (Exception ex) { StingLog.Warn($"MaterialProdOverride bad regex '{pat}': {ex.Message}"); }
-                    }
+                    var warnings = new List<string>();
+                    _rules = MaterialProdOverrideRules.Parse(File.ReadAllLines(path), warnings);
+                    foreach (string w in warnings) StingLog.Warn($"MaterialProdOverride {w}");
                     StingLog.Info($"MaterialProdOverrideRegistry: loaded {_rules.Count} rule(s) from {path}");
                 }
                 catch (Exception ex) { StingLog.Warn($"MaterialProdOverride load: {ex.Message}"); }

--- a/StingTools/Core/MaterialProdOverrideRules.cs
+++ b/StingTools/Core/MaterialProdOverrideRules.cs
@@ -1,0 +1,118 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialProdOverrideRules.cs — the Revit-free half of the material-driven
+//  PROD suffix: parse the rule table, and answer a suffix for a MATERIAL NAME.
+//
+//  Split out of MaterialProdOverrideRegistry (which needs an Element to read
+//  the material name off) for one reason: the rules are UNANCHORED REGEXES,
+//  and an unanchored regex over short chemistry abbreviations misfires in
+//  exactly the way PatternMatch.Contains was written to stop.
+//
+//      "Sheeps Wool Insulation"    matched  (?i)eps      -> INS-EPS
+//      "Acoustic Spiral Liner"     matched  (?i)pir      -> INS-PIR
+//      "Respirator Filter Housing" matched  (?i)pir      -> INS-PIR
+//      "Prefabricated Ductwork"    matched  (?i)fabric   -> FAB
+//
+//  Sheep's wool is the one that matters: a REAL insulation handed a DIFFERENT
+//  insulation's code. Nothing errors, and the tag reads as a confident fact.
+//
+//  The fix is in the DATA, not here — \b anchors, curated per alternative,
+//  because only the author knows whether a stem is deliberate. `galv` must
+//  keep matching "galvanised" and `cement` must keep matching "cementitious",
+//  while `eps` must stop matching "sheeps". No mechanism can infer that split,
+//  so this class exists to make the data ASSERTABLE instead of guessing at it.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace StingTools.Core
+{
+    /// <summary>One parsed row of STING_MATERIAL_PROD_OVERRIDES.csv.</summary>
+    public sealed class MaterialProdRule
+    {
+        /// <summary>Revit category name, or "*" for every category.</summary>
+        public string Category = "*";
+
+        /// <summary>The compiled MaterialPattern cell.</summary>
+        public Regex Pattern;
+
+        /// <summary>The raw cell, kept verbatim for diagnostics and for the data gate.</summary>
+        public string PatternText = "";
+
+        /// <summary>Appended to the base PROD with a "-" separator.</summary>
+        public string Suffix = "";
+    }
+
+    public static class MaterialProdOverrideRules
+    {
+        /// <summary>
+        /// Parse the CSV lines (header included) into rules, in file order —
+        /// which IS the precedence order, first match wins.
+        ///
+        /// A row with a malformed regex is skipped and named in
+        /// <paramref name="warnings"/> rather than aborting the load: one bad
+        /// cell must not disable material-aware PROD for the whole project.
+        /// </summary>
+        public static List<MaterialProdRule> Parse(IEnumerable<string> lines, List<string> warnings = null)
+        {
+            var rules = new List<MaterialProdRule>();
+            if (lines == null) return rules;
+
+            bool first = true;
+            foreach (string raw in lines)
+            {
+                string line = (raw ?? "").Trim();
+                if (first) { first = false; continue; }          // header
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+
+                // Category,MaterialPattern,Suffix — the pattern may itself contain
+                // no commas by construction (alternation uses '|'), so a plain
+                // 3-way split is faithful and keeps this Revit-free.
+                var cols = line.Split(new[] { ',' }, 3);
+                if (cols.Length < 3) continue;
+
+                string cat = cols[0].Trim();
+                string pat = cols[1].Trim();
+                string suf = cols[2].Trim();
+                if (pat.Length == 0 || suf.Length == 0) continue;
+
+                try
+                {
+                    rules.Add(new MaterialProdRule
+                    {
+                        Category = cat.Length == 0 ? "*" : cat,
+                        Pattern = new Regex(pat, RegexOptions.IgnoreCase | RegexOptions.Compiled),
+                        PatternText = pat,
+                        Suffix = suf,
+                    });
+                }
+                catch (Exception ex)
+                {
+                    warnings?.Add($"bad regex '{pat}': {ex.Message}");
+                }
+            }
+            return rules;
+        }
+
+        /// <summary>
+        /// First rule whose category applies and whose pattern matches the
+        /// material name, or null. Null means "no suffix" — the base PROD stands.
+        /// </summary>
+        public static string ResolveSuffix(
+            IReadOnlyList<MaterialProdRule> rules, string materialName, string categoryName)
+        {
+            if (rules == null || string.IsNullOrWhiteSpace(materialName)) return null;
+
+            for (int i = 0; i < rules.Count; i++)
+            {
+                var r = rules[i];
+                if (r?.Pattern == null) continue;
+                if (!string.IsNullOrEmpty(r.Category) && r.Category != "*" &&
+                    !string.Equals(r.Category, categoryName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (r.Pattern.IsMatch(materialName)) return r.Suffix;
+            }
+            return null;
+        }
+    }
+}

--- a/StingTools/Core/ProdPatternMatcher.cs
+++ b/StingTools/Core/ProdPatternMatcher.cs
@@ -31,7 +31,9 @@ namespace StingTools.Core
     public static class ProdPatternMatcher
     {
         // One parsed alternative: either a bare substring (Sub) or a compiled glob (Rx).
-        private sealed class Alt { public string Sub; public Regex Rx; }
+        // Weight is the alternative's LITERAL length — the pattern with the wildcards
+        // stripped — and is what makes "most specific wins" computable. See Strength.
+        private sealed class Alt { public string Sub; public Regex Rx; public int Weight; }
 
         // Keyed by the raw (upper-cased) pattern string; thread-safe + persists for the
         // session. Cleared via Reset() when the rule sets are reloaded.
@@ -55,6 +57,42 @@ namespace StingTools.Core
             return false;
         }
 
+        /// <summary>
+        /// How SPECIFICALLY a pattern matches: the literal length of the longest
+        /// matching alternative, or -1 when nothing matches. Zero is a legal
+        /// strength (a pattern that is nothing but wildcards).
+        ///
+        /// <para>This exists because STING_PROD_CODES.csv reads like a dictionary of
+        /// independent rules and behaves like an ordered chain. Ten shipped rows were
+        /// written by authors who expected the specific rule to win and it did not:
+        /// <c>*Boiler Feed*</c> sat below <c>*Boiler*</c>, <c>*Fire Damper*</c> below
+        /// <c>*Damper*</c>, <c>*Fume Hood*</c> below <c>*Hood*</c>, <c>*Mop Sink*</c>
+        /// below <c>*Sink*</c>. Three rows could never fire at all. Nothing errored —
+        /// a boiler feed pump simply tagged as a boiler.</para>
+        ///
+        /// <para>Reordering the file would have fixed those ten and left the eleventh
+        /// author to make the same mistake, so the ranking moved here instead. Length
+        /// of the LITERAL is the measure: <c>*Fire Damper*</c> (12) beats
+        /// <c>*Damper*</c> (6) because it says more about the thing it matched.</para>
+        /// </summary>
+        public static int Strength(string nameUpper, string patternUpper)
+        {
+            if (string.IsNullOrEmpty(nameUpper) || string.IsNullOrEmpty(patternUpper))
+                return -1;
+
+            int best = -1;
+            Alt[] alts = _cache.GetOrAdd(patternUpper, Parse);
+            for (int i = 0; i < alts.Length; i++)
+            {
+                Alt a = alts[i];
+                bool hit = a.Sub != null
+                    ? nameUpper.Contains(a.Sub)
+                    : (a.Rx != null && a.Rx.IsMatch(nameUpper));
+                if (hit && a.Weight > best) best = a.Weight;
+            }
+            return best;
+        }
+
         /// <summary>Drop the compiled-pattern cache (call on rule-set reload).</summary>
         public static void Reset() => _cache.Clear();
 
@@ -66,16 +104,22 @@ namespace StingTools.Core
                 string alt = altRaw.Trim();
                 if (alt.Length == 0) continue;
 
+                int weight = LiteralLength(alt);
+
                 if (alt.IndexOfAny(GlobChars) < 0)
                 {
-                    list.Add(new Alt { Sub = alt }); // bare substring — fast path
+                    list.Add(new Alt { Sub = alt, Weight = weight }); // bare substring — fast path
                     continue;
                 }
 
                 try
                 {
                     string rx = GlobToRegex(alt);
-                    list.Add(new Alt { Rx = new Regex(rx, RegexOptions.Compiled | RegexOptions.CultureInvariant) });
+                    list.Add(new Alt
+                    {
+                        Rx = new Regex(rx, RegexOptions.Compiled | RegexOptions.CultureInvariant),
+                        Weight = weight,
+                    });
                 }
                 catch { /* malformed glob — skip this alternative */ }
             }
@@ -83,6 +127,28 @@ namespace StingTools.Core
         }
 
         private static readonly char[] GlobChars = { '*', '?', '[' };
+
+        /// <summary>
+        /// The alternative's literal length: every character that is not a wildcard.
+        /// A character class counts as ONE character, because it stands for one —
+        /// <c>DN20-PN1[06]</c> says as much about a match as <c>DN20-PN106</c> does.
+        /// </summary>
+        private static int LiteralLength(string alt)
+        {
+            int n = 0;
+            for (int i = 0; i < alt.Length; i++)
+            {
+                char c = alt[i];
+                if (c == '*') continue;
+                if (c == '[')
+                {
+                    int close = alt.IndexOf(']', i + 1);
+                    if (close >= 0) { n++; i = close; continue; }
+                }
+                n++;   // '?' included: it still occupies a position
+            }
+            return n;
+        }
 
         /// <summary>
         /// Translate a glob (<c>*</c> = any run, <c>?</c> = any one char,

--- a/StingTools/Core/ProdResolver.cs
+++ b/StingTools/Core/ProdResolver.cs
@@ -59,14 +59,12 @@ namespace StingTools.Core
             if (!string.IsNullOrEmpty(familyName))
             {
                 // 1. Project overlay wins.
-                if (projRulesForCategory != null)
-                    foreach (var (pattern, prodCode) in projRulesForCategory)
-                        if (ProdPatternMatcher.Matches(combinedName, pattern)) { source = Sources.Project; return prodCode; }
+                string proj = Strongest(projRulesForCategory, combinedName);
+                if (proj != null) { source = Sources.Project; return proj; }
 
                 // 2. Corporate baseline.
-                if (corpRulesForCategory != null)
-                    foreach (var (pattern, prodCode) in corpRulesForCategory)
-                        if (ProdPatternMatcher.Matches(combinedName, pattern)) { source = Sources.Corporate; return prodCode; }
+                string corp = Strongest(corpRulesForCategory, combinedName);
+                if (corp != null) { source = Sources.Corporate; return corp; }
 
                 // 3. Lightning Protection System (BS EN 62305) — CROSS-category;
                 //    family-name (not category) discriminates the sub-element kind.
@@ -90,6 +88,38 @@ namespace StingTools.Core
             }
             source = Sources.Gen;
             return "GEN";
+        }
+
+        /// <summary>
+        /// The PROD code of the MOST SPECIFIC rule that matches, or null when none does.
+        ///
+        /// <para>Within one tier the rules are peers, not a chain: the author of
+        /// <c>*Fire Damper*</c> and the author of <c>*Damper*</c> were describing two
+        /// different products, and which of them sits higher in the CSV is an accident
+        /// of when each was added. Ten shipped rows lost that accident — see
+        /// <see cref="ProdPatternMatcher.Strength"/> for the list.</para>
+        ///
+        /// <para>Ties keep FILE ORDER, so two rules of equal specificity resolve exactly
+        /// as they always did, and the project overlay's documented "prepended wins"
+        /// behaviour is unchanged.</para>
+        /// </summary>
+        private static string Strongest(
+            IReadOnlyList<(string Pattern, string ProdCode)> rules, string combinedName)
+        {
+            if (rules == null) return null;
+
+            string best = null;
+            int bestStrength = int.MinValue;
+
+            for (int i = 0; i < rules.Count; i++)
+            {
+                int s = ProdPatternMatcher.Strength(combinedName, rules[i].Pattern);
+                if (s < 0) continue;                 // no match
+                if (s <= bestStrength) continue;     // strictly greater, so ties keep file order
+                bestStrength = s;
+                best = rules[i].ProdCode;
+            }
+            return best;
         }
 
         /// <summary>Returns the LPS PROD code for an upper-cased family+type name,

--- a/StingTools/Data/STING_MATERIAL_PROD_OVERRIDES.csv
+++ b/StingTools/Data/STING_MATERIAL_PROD_OVERRIDES.csv
@@ -3,28 +3,48 @@ Category,MaterialPattern,Suffix
 # First match wins. Category = "*" applies to every category.
 # MaterialPattern is regex, case-insensitive.
 # Suffix is appended to the base PROD with a "-" separator.
-*,(?i)concrete|cement|grout|mortar,CON
-*,(?i)steel|metal|stainless|galv|UB |UC |^IPE|^HE[ABMR]?,STL
-*,(?i)timber|wood|hardwood|softwood|plywood|MDF|chipboard|OSB,TIM
-*,(?i)brick|masonry|block,MAS
-*,(?i)glass|glazing|laminate.*glass|toughened,GLZ
-*,(?i)plaster|gypsum|drywall,GYP
-*,(?i)copper,CU
-*,(?i)brass,BRZ
-*,(?i)aluminium|aluminum,ALU
-*,(?i)pvc|vinyl|hdpe|abs|polypropylene|polyethylene,PLA
-*,(?i)mineral wool|rockwool|stone wool|glass wool,INS-MW
-*,(?i)pir|polyurethane,INS-PIR
-*,(?i)eps|expanded polystyrene,INS-EPS
-*,(?i)xps|extruded polystyrene,INS-XPS
-*,(?i)cellulose,INS-CEL
-*,(?i)bitumen|asphalt,BIT
-*,(?i)stone|granite|marble|limestone|sandstone,STN
-*,(?i)tile|ceramic|porcelain,TIL
-*,(?i)carpet,CPT
-*,(?i)rubber|EPDM|neoprene,RBR
-*,(?i)fabric|textile|curtain.*material,FAB
-*,(?i)paint|coating,PNT
-*,(?i)resin|epoxy,RSN
-*,(?i)lead,PB
-*,(?i)zinc,ZN
+#
+# ANCHOR EVERY ALTERNATIVE. These patterns are unanchored regexes run over a
+# free-text material name, so a bare stem matches INSIDE longer words:
+#     eps    matched  "SheEPS Wool Insulation"    -> INS-EPS
+#     pir    matched  "Acoustic SPIRal Liner"     -> INS-PIR
+#     pir    matched  "ResPIRator Filter Housing" -> INS-PIR
+#     fabric matched  "PreFABRICated Ductwork"    -> FAB
+# Sheep's wool is the one that shows the shape of it: a real insulation given
+# a different insulation's code, silently, in a tag nobody re-reads.
+#
+# Leading \b on everything. Trailing \b ONLY where no legitimate longer word
+# exists — because several stems are DELIBERATE prefixes and must stay open:
+#     \bgalv    -> galvanised        \bcement  -> cementitious
+#     \bsteel   -> steelwork         \bplaster -> plasterboard
+#     \bblock   -> blockwork         \bstone   -> stonework
+# Only the author knows which is which, which is why this is curated data and
+# not an inferred rule. ProdCodeDataTests asserts both halves: the four names
+# above must NOT match, and the six stems above must STILL match.
+*,(?i)\bconcrete|\bcement|\bgrout|\bmortar,CON
+*,(?i)\bsteel|\bmetal|\bstainless|\bgalv|\bUB |\bUC |^IPE\b|^HE[ABMR]?\b,STL
+*,(?i)\btimber|\bwood|\bhardwood|\bsoftwood|\bplywood|\bMDF\b|\bchipboard|\bOSB\b,TIM
+*,(?i)\bbrick|\bmasonry|\bblock,MAS
+*,(?i)\bglass|\bglazing|\blaminate.*glass|\btoughened,GLZ
+*,(?i)\bplaster|\bgypsum|\bdrywall,GYP
+*,(?i)\bcopper,CU
+*,(?i)\bbrass,BRZ
+*,(?i)\baluminium|\baluminum,ALU
+# pvc keeps a TRAILING-only anchor so uPVC / cPVC / PVCu still resolve; no
+# English word contains "pvc", so the leading edge needs no guard.
+*,(?i)pvc\b|\bvinyl|\bhdpe\b|\babs\b|\bpolypropylene|\bpolyethylene,PLA
+*,(?i)\bmineral wool|\brockwool|\bstone wool|\bglass wool,INS-MW
+*,(?i)\bpir\b|\bpolyurethane,INS-PIR
+*,(?i)\beps\b|\bexpanded polystyrene,INS-EPS
+*,(?i)\bxps\b|\bextruded polystyrene,INS-XPS
+*,(?i)\bcellulose,INS-CEL
+*,(?i)\bbitumen|\basphalt,BIT
+*,(?i)\bstone|\bgranite|\bmarble|\blimestone|\bsandstone,STN
+*,(?i)\btile|\bceramic|\bporcelain,TIL
+*,(?i)\bcarpet,CPT
+*,(?i)\brubber|\bEPDM\b|\bneoprene,RBR
+*,(?i)\bfabrics?\b|\btextile|\bcurtain.*material,FAB
+*,(?i)\bpaint|\bcoating,PNT
+*,(?i)\bresin|\bepoxy,RSN
+*,(?i)\blead\b,PB
+*,(?i)\bzinc,ZN

--- a/StingTools/Data/STING_PROD_CODES.csv
+++ b/StingTools/Data/STING_PROD_CODES.csv
@@ -18,7 +18,7 @@ SRB,Mechanical Equipment,*Sorption*,Sorption / Desiccant Unit,M,HVAC,CIBSE Guide
 HEX,Mechanical Equipment,*Heat Exchanger*|*Plate*,Plate Heat Exchanger,M,HWS,CIBSE Guide B
 CAL,Mechanical Equipment,*Calorifier*,Calorifier / Hot Water Storage Vessel,M,HWS,BS EN 12897
 EXP,Mechanical Equipment,*Expansion*,Expansion Vessel,M,HWS,BS EN 13831
-CIR,Mechanical Equipment,*Circulating*|*Pump*,Circulation Pump,M,HWS,BS EN 16297
+CIR,Mechanical Equipment,*Circulating*|*Circulation Pump*,Circulation Pump,M,HWS,BS EN 16297
 BFP,Mechanical Equipment,*Boiler Feed*,Boiler Feed Pump,M,HWS,CIBSE Guide B
 PMP,Mechanical Equipment,*Pump*,General Pump,M,HWS,BS EN 16297
 DMP,Ducts,*Damper*|*Motorised*,Motorised Volume Control Damper,M,HVAC,BS EN 1751
@@ -121,9 +121,9 @@ MGA,Specialty Equipment,*Air*|*Medical Air*|*MAP*,Medical Air Outlet — Bedhead
 MGV,Specialty Equipment,*Vacuum*|*MGPS Vac*,Medical Vacuum Outlet — Bedhead,P,MGS,HTM 02-01
 MGE,Specialty Equipment,*EVAC*,Anaesthetic Gas Scavenging (EVAC) Outlet,P,MGS,HTM 02-01
 MNF,Specialty Equipment,*Manifold*|*Medical Manifold*,Medical Gas Manifold / Cylinder Manifold,P,MGS,HTM 02-01
-VIE,Specialty Equipment,*VIE*|*Vacuum Insulated*,Vacuum Insulated Evaporator (VIE),P,MGS,HTM 02-01
-ZVB,Specialty Equipment,*Zone Valve*|*MGS Valve*,Medical Gas Zone Valve Box,P,MGS,HTM 02-01
-AAP,Specialty Equipment,*Area Alarm*|*MGS Alarm*,Medical Gas Area Alarm Panel,P,MGS,HTM 02-01
+VIE,Specialty Equipment,*VIE*|*Vacuum Insulated*,Vacuum Insulated Evaporator (VIE),MG,MGS,HTM 02-01
+ZVB,Specialty Equipment,*Zone Valve*|*MGS Valve*,Medical Gas Zone Valve Box,MG,MGS,HTM 02-01
+AAP,Specialty Equipment,*Area Alarm*|*MGS Alarm*,Medical Gas Area Alarm Panel,MG,MGS,HTM 02-01
 MSP,Mechanical Equipment,*Medical Suction*,Medical Suction / Vacuum Pump Set,P,MGS,HTM 02-01
 MCP,Mechanical Equipment,*Medical Compressor*,Medical Air Compressor Set,P,MGS,HTM 02-01
 BHD,Specialty Equipment,*Bedhead*|*Trunking*,Bedhead Trunking / Service Panel,E,NCL,HTM 08-03


### PR DESCRIPTION
Product-code automation had well-tested **logic** and untested **data**. `ProdResolver` has 15 tests; the two CSVs it reads had none. Three defects were sitting in them, and every one resolved to a confident wrong code rather than to an error.

## 1. Ten rules were shadowed; three could never fire at all

```
BFP *Boiler Feed*            eaten by  BCH *Boiler*
MVP *Vacuum Pump Plant*      eaten by  CIR *Circulating*|*Pump*
FSD *Fire Damper*            eaten by  DMP *Damper*
MOP *Mop Sink*               eaten by  SKT *Sink*
TRV *Thermostatic Radiator*  eaten by  TSV *Thermostatic*
FHD *Fume Hood*              eaten by  HED *Hood*
```
12 dead alternatives across 10 rules. A boiler feed pump tagged as a boiler.

Ten different authors each wrote a specific rule expecting it to win. That is not ten data mistakes — **the file reads like a dictionary of independent rules and behaves like an ordered chain.** So the fix is in the matcher: reordering 188 rows would have freed these ten and left the eleventh author to make the same mistake.

Within a tier the most specific matching rule now wins, measured by the literal length of the matched alternative. **Ties keep file order**, so nothing that used to resolve one way starts resolving the other for want of a tie-break, and **the tier chain is untouched** — a vaguer project rule still beats a sharper corporate one.

One data fix was still needed: `CIR` kept a bare `*Pump*` doing `PMP`'s job, and ranking cannot separate a tie.

## 2. A stem matched inside a longer word

The material-override patterns are unanchored regexes over a free-text material name:

```
"SheEPS Wool Insulation"     -> INS-EPS
"Acoustic SPIRal Liner"      -> INS-PIR
"ResPIRator Filter Housing"  -> INS-PIR
"PreFABRICated Ductwork"     -> FAB
```

Sheep's wool shows the shape: **a real insulation handed a different insulation's code.** Same class as the roof claiming a Van Gogh in #863.

Fixed in the data, because no mechanism can infer intent — `\bgalv` must keep matching "galvanised" and `\bcement` "cementitious", while `\beps\b` must stop matching "sheeps". `pvc` keeps a trailing-only anchor so uPVC/cPVC still resolve.

## 3. One PROD code declared two disciplines

`VIE` / `ZVB` / `AAP` each said `P` in one row and `MG` in another, so a tag's discipline depended on which category somebody modelled the thing in. All six rows are `SYSTEM=MGS` / HTM 02-01; `MG` is the discipline the healthcare pack added for exactly that.

Only columns 0–2 are read today, so this is currently inert — asserted anyway, because an inert disagreement is a live one the day someone wires the `DISCIPLINE` column.

## The gate

Every shipped rule is now fed the literal it was authored for and must be the row that answers. Two things are **named rather than decided quietly**, and each fails the day it is settled so the note cannot rot:

- **"Lead-Free Solder" still takes `-PB`.** Not a boundary problem — the word *is* "lead". A `(?!-free)` special case invites tin-free and chrome-free after it.
- **BHD and BHT are two codes for one product** (bedhead trunking) under two disciplines. Retiring one is a healthcare-catalogue call.

`MaterialProdOverrideRules` is split out of the Revit-bound registry so the shipped table is assertable outside Revit.

## Verification

Tests **362 → 392**. Build **0 errors / 0 warnings**. Boq suite unaffected (1,225 passing). **Six mutations verified failing.**

One mutation initially **passed** and is worth recording: M4 over-anchored `galv`, and the test survived because `"Galvanised Steel Sheet"` also contains "Steel" — so it proved the *row* resolved, never that the *prefix* did the work. The data point is now a name with no other stem in it.

Not verified in Revit: this changes tagging resolution for the 12 alternatives above, all of them moving from a generic code to the specific one their author asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)