### PR TITLE
fix(prod): a wall void is not a product that failed to get a code

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -53,6 +53,10 @@
     <Compile Include="..\StingTools\Core\MaterialSchedule\CommodityRateResolver.cs" Link="MaterialSchedule\CommodityRateResolver.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\StageMapper.cs" Link="MaterialSchedule\StageMapper.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\CommodityAggregator.cs" Link="MaterialSchedule\CommodityAggregator.cs" />
+    <!-- The exclusion MECHANISM, shared with the PROD coverage audit so "not a
+         thing" is decided once. The LISTS stay per-purpose: the schedule excludes
+         Furniture, the PROD audit must not. -->
+    <Compile Include="..\StingTools\Core\ProductExclusion.cs" Link="Core\ProductExclusion.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\Reconciler.cs" Link="MaterialSchedule\Reconciler.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\ManualRowPlacer.cs" Link="MaterialSchedule\ManualRowPlacer.cs" />
     <Compile Include="..\StingTools\Core\MaterialSchedule\SiteToolsCalculator.cs" Link="MaterialSchedule\SiteToolsCalculator.cs" />

--- a/StingTools.Tags.Tests/ProdExclusionTests.cs
+++ b/StingTools.Tags.Tests/ProdExclusionTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// `Prod_CoverageAudit` reported **0.8% coverage** on a real model — 13 of 1,688.
+    /// 1,187 of those 1,688 were `M_GM_OpeningWall_Instance`: wall VOIDS, which can
+    /// never carry a product code. Add the filled regions, the rooms and the muntin
+    /// patterns and 1,266 of the "failures" were not products at all. Over the 422
+    /// elements that ARE products the figure is 3.1%.
+    ///
+    /// <para>Still low — that part is a genuine finding. But 0.8% overstated it
+    /// four-fold and pointed the reader at the wrong problem, which is the same
+    /// failure shape as a denominator that quietly counts the wrong thing.</para>
+    ///
+    /// <para><b>That 1,187 is not a coincidence.</b> ROADMAP MATSCHED-8 records the
+    /// material schedule hitting the identical family on the identical model, and #724
+    /// adding description-pattern exclusion for it. Two features asked "is this a
+    /// thing?" and each had its own answer. The MECHANISM is now shared
+    /// (<see cref="ProductExclusion"/>); the LISTS deliberately are not, and the tests
+    /// below pin why.</para>
+    /// </summary>
+    public class ProdExclusionTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_PROD_CODES.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static ProductExclusion Shipped()
+        {
+            var doc = ProdExclusionPolicy.Parse(
+                File.ReadAllText(Path.Combine(DataDir(), "STING_PROD_EXCLUSIONS.json")), out string err);
+            Assert.True(doc != null, "STING_PROD_EXCLUSIONS.json did not parse: " + err);
+            return ProdExclusionPolicy.Build(doc, null);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The model that produced the number
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Verbatim from the audit CSV. The counts are the real ones, so this is a
+        /// replay of the run rather than an illustration of it.
+        /// </summary>
+        private static readonly (string Category, string Family, string Type, int Count, bool IsProduct)[] Herring =
+        {
+            ("Generic Models",     "M_GM_OpeningWall_Instance",          "Opening",            1187, false),
+            ("Detail Items",       "Filled region",                      "",                     34, false),
+            ("Generic Models",     "M_Muntin Pattern_2x2",               "",                     22, false),
+            ("Rooms",              "",                                   "",                     23, false),
+            // ── and the things that ARE products ──────────────────────────────
+            ("Curtain Panels",     "RD_Breeze Block 01_Panel",           "",                    128, true),
+            ("Walls",              "Basic Wall",                         "",                     67, true),
+            ("Furniture",          "Couch_-SINGLEl_13162 DOUBLE",        "",                     43, true),
+            ("Roofs",              "Basic Roof",                         "",                     22, true),
+            ("Windows",            "M_Window-Awning-Double-Vertical",    "",                     22, true),
+            ("Doors",              "Single-Standard Frame w Vent",       "",                     20, true),
+            ("Structural Columns", "Concrete-Rectangular-Column",        "200x200",              15, true),
+            ("Plumbing Fixtures",  "M_Lavatory - Vanity1",               "650x450",              14, true),
+            ("Generic Models",     "2022_RoofCap_Eagle_HighProfileTiles", "",                    29, true),
+        };
+
+        [Fact]
+        public void The_1187_Wall_Voids_Leave_The_Denominator()
+        {
+            var ex = Shipped();
+            int removed = Herring.Where(r => !r.IsProduct)
+                                 .Where(r => ex.Classify(r.Category, r.Family, r.Type) != ExclusionVerdict.Included)
+                                 .Sum(r => r.Count);
+            Assert.Equal(1187 + 34 + 22 + 23, removed);
+        }
+
+        [Fact]
+        public void And_Nothing_That_IS_A_Product_Leaves_With_Them()
+        {
+            // The failure mode of any exclusion list: it gets greedy and the number
+            // improves for the wrong reason.
+            var ex = Shipped();
+            var wrongly = Herring.Where(r => r.IsProduct)
+                                 .Where(r => ex.Classify(r.Category, r.Family, r.Type) != ExclusionVerdict.Included)
+                                 .Select(r => $"{r.Category} / {r.Family} ({r.Count})")
+                                 .ToList();
+            Assert.True(wrongly.Count == 0,
+                "Excluded as not-a-product, but these ARE products:\n  " + string.Join("\n  ", wrongly));
+        }
+
+        [Fact]
+        public void The_Reported_Coverage_Goes_From_0_8_To_3_1_Percent()
+        {
+            // Measured on the model, not invented: 1,688 taggable elements, 13
+            // family-specific, 1,266 of the rest not products at all.
+            const int Total = 1688, Specific = 13, NotProducts = 1266;
+            const int Products = Total - NotProducts;          // 422
+
+            Assert.Equal(422, Products);
+            Assert.Equal(0.8, Math.Round(100.0 * Specific / Total, 1));
+            Assert.Equal(3.1, Math.Round(100.0 * Specific / Products, 1));
+
+            // And the shipped policy is what removes exactly those 1,266 — the
+            // sample below is the model's non-product families with their real
+            // counts, so this ties the arithmetic to the data rather than to a
+            // number typed into a test.
+            var ex = Shipped();
+            Assert.Equal(NotProducts,
+                Herring.Where(r => ex.Classify(r.Category, r.Family, r.Type) != ExclusionVerdict.Included)
+                       .Sum(r => r.Count));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The two lists are NOT the same list
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The whole reason this is a second list rather than a reuse of the material
+        /// schedule's. `STING_MATERIAL_STAGES.json` excludes Furniture and Casework —
+        /// correct there, you do not buy a sofa by the cubic metre — but FUR is a real
+        /// PROD code and 43 of this model's elements carry it. Sharing the list would
+        /// have traded a wrong number for a differently wrong one.
+        /// </summary>
+        [Theory]
+        [InlineData("Furniture")]
+        [InlineData("Furniture Systems")]
+        [InlineData("Casework")]
+        [InlineData("Planting")]
+        [InlineData("Parking")]
+        public void A_Category_The_MATERIAL_Schedule_Excludes_Is_Still_A_PRODUCT(string category)
+        {
+            Assert.Equal(ExclusionVerdict.Included, Shipped().Classify(category, "Anything", "Anything"));
+        }
+
+        [Fact]
+        public void The_Material_Schedule_Really_Does_Exclude_Those()
+        {
+            // Without this, the test above asserts a difference that may not exist —
+            // it would keep passing if the material list changed underneath it.
+            string json = File.ReadAllText(Path.Combine(DataDir(), "STING_MATERIAL_STAGES.json"));
+            foreach (string cat in new[] { "Furniture", "Casework" })
+                Assert.Contains("\"" + cat + "\"", json);
+        }
+
+        [Fact]
+        public void A_Curtain_Panel_Is_A_Product_Even_Though_128_Of_Them_Have_No_Rule()
+        {
+            // 128 breeze-block panels resolve generically. That is a COVERAGE gap and
+            // exactly what the audit is for — excluding them would hide the finding
+            // instead of reporting it.
+            Assert.Equal(ExclusionVerdict.Included,
+                Shipped().Classify("Curtain Panels", "RD_Breeze Block 01_Panel", ""));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Mechanism
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Protected_Category_Outranks_A_Pattern()
+        {
+            // A door called "Opening Leaf" is still a door. The material schedule
+            // dropped a real Windows row exactly this way.
+            Assert.Equal(ExclusionVerdict.Included, Shipped().Classify("Doors", "Opening Leaf 900", ""));
+            Assert.Equal(ExclusionVerdict.Included, Shipped().Classify("Windows", "Muntin Awning", ""));
+        }
+
+        [Fact]
+        public void A_Blank_Pattern_Is_Inert_Not_A_Wildcard()
+        {
+            // "".IndexOf returns 0, so one empty cell would exclude the entire model.
+            var ex = ProductExclusion.Build(null, new[] { "", "   ", null }, null);
+            Assert.Equal(ExclusionVerdict.Included, ex.Classify("Walls", "Basic Wall", "Generic 200"));
+            Assert.True(ex.IsEmpty);
+        }
+
+        [Fact]
+        public void No_Policy_Excludes_NOTHING_Rather_Than_Guessing()
+        {
+            // The safe failure. A policy that silently removes rows nobody asked it to
+            // remove is worse than no policy — it improves the number invisibly.
+            Assert.Equal(ExclusionVerdict.Included,
+                ProductExclusion.None.Classify("Rooms", "anything", "opening muntin"));
+            Assert.True(ProductExclusion.None.IsEmpty);
+        }
+
+        [Fact]
+        public void A_Missing_File_Is_Distinguishable_From_One_That_Excludes_Nothing()
+        {
+            // Parse returns NULL for absent/unreadable, not an empty document, so the
+            // command can log "not deployed" rather than reporting a silent zero.
+            Assert.Null(ProdExclusionPolicy.Parse(null, out _));
+            Assert.Null(ProdExclusionPolicy.Parse("   ", out _));
+            Assert.Null(ProdExclusionPolicy.Parse("{ not json", out string err));
+            Assert.False(string.IsNullOrEmpty(err));
+
+            var empty = ProdExclusionPolicy.Parse("{\"notAProductCategories\":[]}", out _);
+            Assert.NotNull(empty);
+            Assert.Empty(empty.NotAProductCategories);
+        }
+
+        [Fact]
+        public void A_Project_Override_Replaces_Only_The_List_It_Declares()
+        {
+            // null = "not stated" (inherit), [] = "exclude nothing" (override). If the
+            // two collapse, the key becomes impossible to override — the trap the
+            // visibility presets already document.
+            var corp = ProdExclusionPolicy.Parse(
+                "{\"notAProductCategories\":[\"Rooms\"],\"notAProductPatterns\":[\"opening\"]}", out _);
+
+            var silent = ProdExclusionPolicy.Build(corp, ProdExclusionPolicy.Parse("{}", out _));
+            Assert.Equal(ExclusionVerdict.ByCategory, silent.Classify("Rooms", "", ""));
+            Assert.Equal(ExclusionVerdict.ByPattern, silent.Classify("Walls", "Opening", ""));
+
+            var cleared = ProdExclusionPolicy.Build(corp,
+                ProdExclusionPolicy.Parse("{\"notAProductCategories\":[]}", out _));
+            Assert.Equal(ExclusionVerdict.Included, cleared.Classify("Rooms", "", ""));
+            Assert.Equal(ExclusionVerdict.ByPattern, cleared.Classify("Walls", "Opening", ""));
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -73,6 +73,11 @@
     <Compile Include="..\StingTools\Core\ScopeBoxLoc.cs" Link="Core\ScopeBoxLoc.cs" />
     <Compile Include="..\StingTools\Core\ProdPatternMatcher.cs" Link="Core\ProdPatternMatcher.cs" />
     <Compile Include="..\StingTools\Core\ProdResolver.cs" Link="Core\ProdResolver.cs" />
+    <!-- The shared "not a thing" mechanism + the PROD policy that loads it. Kept
+         Revit-free so the shipped exclusion list is asserted against the real
+         model counts that exposed the 0.8%-vs-3.1% denominator. -->
+    <Compile Include="..\StingTools\Core\ProductExclusion.cs" Link="Core\ProductExclusion.cs" />
+    <Compile Include="..\StingTools\Core\ProdExclusionPolicy.cs" Link="Core\ProdExclusionPolicy.cs" />
     <!-- The Revit-free half of the material-driven PROD suffix. Split out of
          MaterialProdOverrideRegistry (which needs an Element) so the SHIPPED rule
          table is assertable: an unanchored stem handed sheep's wool an EPS code. -->

--- a/StingTools/Commands/Classification/ProdCoverageAuditCommand.cs
+++ b/StingTools/Commands/Classification/ProdCoverageAuditCommand.cs
@@ -36,6 +36,43 @@ namespace StingTools.Commands.Classification
             public readonly HashSet<string> GenericFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Corporate baseline + project override. A MISSING baseline yields
+        /// <see cref="ProductExclusion.None"/> and says so in the log — excluding
+        /// nothing is the safe failure, because a policy that silently removes rows
+        /// nobody asked it to remove is worse than no policy.
+        /// </summary>
+        private static ProductExclusion LoadExclusionPolicy(Document doc)
+        {
+            ProdExclusionDocument corp = null, proj = null;
+            try
+            {
+                string p = StingToolsApp.FindDataFile("STING_PROD_EXCLUSIONS.json");
+                if (!string.IsNullOrEmpty(p) && File.Exists(p))
+                {
+                    corp = ProdExclusionPolicy.Parse(File.ReadAllText(p), out string err);
+                    if (corp == null) StingLog.Warn($"Prod exclusions: baseline unreadable ({err}) — excluding nothing.");
+                }
+                else StingLog.Warn("Prod exclusions: STING_PROD_EXCLUSIONS.json not deployed — excluding nothing.");
+            }
+            catch (Exception ex) { StingLog.Warn($"Prod exclusions baseline: {ex.Message}"); }
+
+            try
+            {
+                string p = StingPaths.MetaFile(doc, "_BIM_COORD", "prod_exclusions.json");
+                if (!string.IsNullOrEmpty(p) && File.Exists(p))
+                {
+                    proj = ProdExclusionPolicy.Parse(File.ReadAllText(p), out string err);
+                    if (proj == null) StingLog.Warn($"Prod exclusions: project override unreadable ({err}) — ignored.");
+                    else StingLog.Info("Prod exclusions: project override applied from " + p);
+                }
+            }
+            catch (Exception ex) { StingLog.Warn($"Prod exclusions override: {ex.Message}"); }
+
+            if (corp == null && proj == null) return ProductExclusion.None;
+            return ProdExclusionPolicy.Build(corp, proj);
+        }
+
         public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
         {
             try
@@ -52,6 +89,16 @@ namespace StingTools.Commands.Classification
                 if (catEnums != null && catEnums.Length > 0)
                     collector.WherePasses(new ElementMulticategoryFilter(new List<BuiltInCategory>(catEnums)));
 
+                // The denominator has to be things that can actually HAVE a product
+                // code. The first run on a real model reported 0.8% (13/1688) — but
+                // 1,187 of those were wall VOIDS (M_GM_OpeningWall_Instance), plus
+                // filled regions, rooms and muntin patterns. None can ever carry a
+                // PROD code, and counting them as failures pointed the reader at the
+                // wrong problem: over real products the figure was 3.1%.
+                var exclusion = LoadExclusionPolicy(doc);
+                var excludedByCat = new SortedDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                int excluded = 0, skippedByTagger = 0;
+
                 var rolls = new SortedDictionary<string, CatRoll>(StringComparer.OrdinalIgnoreCase);
                 var rows = new List<string> { "Category,Family,Type,PROD,Source,Specific" };
                 int scanned = 0, specific = 0, specificEqualsDefault = 0;
@@ -60,6 +107,25 @@ namespace StingTools.Commands.Classification
                 {
                     string cat = ParameterHelpers.GetCategoryName(el);
                     if (string.IsNullOrEmpty(cat) || !known.Contains(cat)) continue;
+
+                    // Count what the TAGGER counts. TagPipelineHelper skips these two
+                    // before it does anything else, so an audit that reports on them
+                    // is measuring a population the plugin never tags — the two
+                    // definitions had silently diverged.
+                    if (TagConfig.CategorySkipList.Contains(cat)) { skippedByTagger++; continue; }
+                    if (TagConfig.CategoryTokenOverrides.TryGetValue(cat, out var ovr)
+                        && ovr.TryGetValue("SKIP", out string skipVal)
+                        && "true".Equals(skipVal, StringComparison.OrdinalIgnoreCase))
+                    { skippedByTagger++; continue; }
+
+                    if (exclusion.Classify(cat, ParameterHelpers.GetFamilyName(el),
+                                           ParameterHelpers.GetFamilySymbolName(el)) != ExclusionVerdict.Included)
+                    {
+                        excluded++;
+                        excludedByCat.TryGetValue(cat, out int ne);
+                        excludedByCat[cat] = ne + 1;
+                        continue;
+                    }
 
                     scanned++;
                     string prod, source;
@@ -86,7 +152,16 @@ namespace StingTools.Commands.Classification
 
                 if (scanned == 0)
                 {
-                    TaskDialog.Show("PROD Coverage Audit", "No taggable elements found.");
+                    // An empty scope is not a 100% pass and not a silent zero. Say
+                    // which of the two zeros this is, or the reader cannot tell an
+                    // exclusion policy that ate the model from a model with nothing
+                    // in it.
+                    TaskDialog.Show("PROD Coverage Audit",
+                        excluded + skippedByTagger == 0
+                            ? "No taggable elements found."
+                            : $"No PRODUCTS to report on. {excluded} element(s) were excluded as not-a-product "
+                            + $"and {skippedByTagger} skipped by the tagger's own category rules, leaving nothing "
+                            + "to measure. If that is wrong, check STING_PROD_EXCLUSIONS.json.");
                     return Result.Succeeded;
                 }
 
@@ -112,9 +187,25 @@ namespace StingTools.Commands.Classification
                 // Summary: worst-covered categories first (most generic)
                 var sb = new StringBuilder();
                 int pct = (int)Math.Round(100.0 * specific / scanned);
-                sb.AppendLine($"PROD coverage: {specific}/{scanned} elements specific ({pct}%).");
+                sb.AppendLine($"PROD coverage: {specific}/{scanned} PRODUCTS specific ({pct}%).");
                 sb.AppendLine("Specific = project/corporate CSV, LPS or sleeve rule. Generic = category default (no rule matched).");
                 sb.AppendLine();
+
+                // Publish the denominator. Silently shrinking it would be the same
+                // move as the fabricated fallbacks this codebase keeps finding: the
+                // number gets better and nobody can see why.
+                if (excluded > 0 || skippedByTagger > 0)
+                {
+                    sb.AppendLine($"Denominator: {scanned + excluded + skippedByTagger} taggable element(s) seen, "
+                                + $"{excluded} excluded as not-a-product, {skippedByTagger} skipped by the tagger's "
+                                + $"own category rules, {scanned} measured.");
+                    if (excluded > 0)
+                        sb.AppendLine("  not-a-product: " + string.Join(", ",
+                            excludedByCat.OrderByDescending(k => k.Value).Take(6).Select(k => $"{k.Key} {k.Value}")));
+                    sb.AppendLine("  A wall opening, a filled region or a room can never carry a PROD code, so counting");
+                    sb.AppendLine("  them as failures understates coverage. Policy: Data/STING_PROD_EXCLUSIONS.json.");
+                    sb.AppendLine();
+                }
                 sb.AppendLine("Categories with the most GENERIC (unmatched) elements:");
                 foreach (var kv in rolls.OrderByDescending(k => k.Value.Total - k.Value.Specific).Take(15))
                 {
@@ -139,7 +230,8 @@ namespace StingTools.Commands.Classification
                     MainInstruction = $"{pct}% of PROD codes are family-specific",
                     MainContent = sb.ToString()
                 }.Show();
-                StingLog.Info($"Prod_CoverageAudit: {specific}/{scanned} specific ({pct}%) -> {path}");
+                StingLog.Info($"Prod_CoverageAudit: {specific}/{scanned} specific ({pct}%); "
+                            + $"{excluded} not-a-product, {skippedByTagger} tagger-skipped -> {path}");
                 return Result.Succeeded;
             }
             catch (OperationCanceledException) { return Result.Cancelled; }

--- a/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
+++ b/StingTools/Core/MaterialSchedule/CommodityAggregator.cs
@@ -66,47 +66,32 @@ namespace StingTools.Core.MaterialSchedule
             // a List per row.
             var stageIndex = StageIndex.Build(input.StageDefs, input.DefaultStageId);
 
-            var patterns = (input.ExcludedDescriptionPatterns ?? new List<string>())
-                .Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).ToList();
-
-            var excluded = new HashSet<string>(
-                input.ExcludedCategories ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
-
-            var protectedCats = new HashSet<string>(
-                input.ExclusionProtectedCategories ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+            // The exclusion MECHANISM lives in ProductExclusion so the PROD coverage
+            // audit decides "not a thing" the same way this does. The LISTS stay
+            // per-purpose: this one excludes Furniture (you do not buy a sofa by the
+            // cubic metre) and the PROD audit must not, because FUR is a real code.
+            var exclusion = ProductExclusion.Build(
+                input.ExcludedCategories,
+                input.ExcludedDescriptionPatterns,
+                input.ExclusionProtectedCategories);
 
             foreach (var row in input.Constituents ?? new List<ConstituentInput>())
             {
                 if (row == null) continue;
 
-                // MAT-SCHED-8 — not a material. Counted, not silently dropped:
-                // a real export turned beds and TV shelves into purchasable
-                // commodities, 60 rows of noise and a UGX 0 grand total.
-                if (!string.IsNullOrWhiteSpace(row.Category) && excluded.Contains(row.Category.Trim()))
+                // MAT-SCHED-8 — not a material. Counted, not silently dropped: a
+                // real export turned beds and TV shelves into purchasable
+                // commodities, 60 rows of noise and a UGX 0 grand total. The
+                // pattern layer catches what no category rule can — an opening
+                // sold 1,187 times under Generic Models, which elsewhere holds
+                // genuine building elements.
+                var verdict = exclusion.Classify(row.Category, row.Description, row.TypeName);
+                if (verdict != ExclusionVerdict.Included)
                 {
-                    string c = row.Category.Trim();
+                    string c = string.IsNullOrWhiteSpace(row.Category) ? "(uncategorised)" : row.Category.Trim();
                     doc.ExcludedByCategory.TryGetValue(c, out int n);
                     doc.ExcludedByCategory[c] = n + 1;
                     continue;
-                }
-
-                // Not a material despite a legitimate category — an opening, a
-                // muntin pattern, a trim. Blank patterns are skipped: "".IndexOf
-                // returns 0 and would exclude the entire model.
-                if (patterns.Count > 0
-                    && !(!string.IsNullOrWhiteSpace(row.Category) && protectedCats.Contains(row.Category.Trim())))
-                {
-                    string hay = (row.Description ?? "") + " " + (row.TypeName ?? "");
-                    bool hit = false;
-                    foreach (string pat in patterns)
-                        if (hay.IndexOf(pat, StringComparison.OrdinalIgnoreCase) >= 0) { hit = true; break; }
-                    if (hit)
-                    {
-                        string c2 = string.IsNullOrWhiteSpace(row.Category) ? "(uncategorised)" : row.Category.Trim();
-                        doc.ExcludedByCategory.TryGetValue(c2, out int n2);
-                        doc.ExcludedByCategory[c2] = n2 + 1;
-                        continue;
-                    }
                 }
 
                 // Constituent kind first, then category (+ optional type pattern).

--- a/StingTools/Core/ProdExclusionPolicy.cs
+++ b/StingTools/Core/ProdExclusionPolicy.cs
@@ -1,0 +1,65 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ProdExclusionPolicy.cs — the PROD half of "not a product", loaded from
+//  STING_PROD_EXCLUSIONS.json with a project override.
+//
+//  Parsing is kept Revit-free (it takes JSON TEXT, not a Document) so the
+//  shipped policy is assertable outside Revit — the same split the material
+//  schedule uses, and the reason its data defects were catchable at all.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace StingTools.Core
+{
+    /// <summary>The JSON shape of STING_PROD_EXCLUSIONS.json.</summary>
+    public sealed class ProdExclusionDocument
+    {
+        [JsonProperty("notAProductCategories")]
+        public List<string> NotAProductCategories;
+
+        [JsonProperty("notAProductPatterns")]
+        public List<string> NotAProductPatterns;
+
+        [JsonProperty("protectedCategories")]
+        public List<string> ProtectedCategories;
+    }
+
+    public static class ProdExclusionPolicy
+    {
+        /// <summary>
+        /// Parse one policy document. Returns null — not an empty policy — when the
+        /// text is absent or unreadable, so a caller can tell "no file" from "a file
+        /// that excludes nothing". Those mean different things: the second is a
+        /// deliberate choice and the first is a missing deployment.
+        /// </summary>
+        public static ProdExclusionDocument Parse(string json, out string error)
+        {
+            error = null;
+            if (string.IsNullOrWhiteSpace(json)) { error = "empty"; return null; }
+            try { return JsonConvert.DeserializeObject<ProdExclusionDocument>(json); }
+            catch (Exception ex) { error = ex.Message; return null; }
+        }
+
+        /// <summary>
+        /// Layer a project override over the corporate baseline and build the matcher.
+        ///
+        /// <para>An override REPLACES a list it declares and leaves the others alone —
+        /// a null list means "not stated", an empty list means "exclude nothing". The
+        /// two must stay distinguishable or the key becomes impossible to override,
+        /// which is the trap <c>excludedCategories</c> already documents in the
+        /// visibility presets.</para>
+        /// </summary>
+        public static ProductExclusion Build(ProdExclusionDocument corporate, ProdExclusionDocument project)
+        {
+            List<string> Pick(Func<ProdExclusionDocument, List<string>> f)
+                => (project != null && f(project) != null) ? f(project)
+                 : (corporate != null ? f(corporate) : null);
+
+            return ProductExclusion.Build(
+                Pick(d => d.NotAProductCategories),
+                Pick(d => d.NotAProductPatterns),
+                Pick(d => d.ProtectedCategories));
+        }
+    }
+}

--- a/StingTools/Core/ProductExclusion.cs
+++ b/StingTools/Core/ProductExclusion.cs
@@ -1,0 +1,128 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ProductExclusion.cs — "this element is not a thing you can name", shared.
+//
+//  Two features ask that question and each had its own copy of the answer:
+//  the material schedule (is this a purchasable MATERIAL?) and the PROD
+//  coverage audit (is this a taggable PRODUCT?).
+//
+//  The MECHANISM is identical and lives here once:
+//      • an excluded CATEGORY removes the row outright
+//      • a description/type PATTERN removes it despite a legitimate category
+//      • a PROTECTED category outranks any pattern
+//      • a blank pattern is inert, never a wildcard
+//      • exclusions are COUNTED, never silently dropped
+//
+//  The POLICY is NOT shared, and that distinction is the whole point. The
+//  material schedule excludes Furniture and Casework — you do not buy a sofa
+//  by the cubic metre — but a sofa is a perfectly good PROD product and FUR is
+//  a real code. Reusing one list for both questions would trade a wrong number
+//  for a differently wrong number. So each caller declares its own lists and
+//  this class only decides what those lists MEAN.
+//
+//  Why a pattern layer exists at all: the first real material export sold an
+//  OPENING 1,187 times. `M_GM_OpeningWall_Instance — Opening` is a void, but
+//  its category is Generic Models, which elsewhere holds genuine building
+//  elements — so no category rule could remove it without hiding real work.
+//  The PROD coverage audit on that same model counted those same 1,187 voids
+//  as products that failed to get a specific code, reporting 0.8% coverage
+//  where the honest figure over real products is 3.1%.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core
+{
+    /// <summary>Why a row was excluded, or that it was not.</summary>
+    public enum ExclusionVerdict
+    {
+        /// <summary>A real thing. Counts in the denominator.</summary>
+        Included = 0,
+
+        /// <summary>Its whole category is out of scope for this question.</summary>
+        ByCategory,
+
+        /// <summary>Legitimate category, but this instance is not a thing —
+        /// an opening, a muntin pattern, a filled region.</summary>
+        ByPattern,
+    }
+
+    /// <summary>
+    /// An immutable exclusion policy. Build once per run; <see cref="Classify"/>
+    /// is called per element, so the sets are pre-built rather than re-scanned.
+    /// </summary>
+    public sealed class ProductExclusion
+    {
+        private readonly HashSet<string> _categories;
+        private readonly HashSet<string> _protected;
+        private readonly List<string> _patterns;
+
+        /// <summary>Nothing is excluded. The correct default: a policy that
+        /// silently removes rows nobody asked it to remove is worse than none.</summary>
+        public static readonly ProductExclusion None =
+            new ProductExclusion(null, null, null);
+
+        private ProductExclusion(
+            IEnumerable<string> categories,
+            IEnumerable<string> patterns,
+            IEnumerable<string> protectedCategories)
+        {
+            _categories = new HashSet<string>(
+                (categories ?? Enumerable.Empty<string>())
+                    .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+
+            _protected = new HashSet<string>(
+                (protectedCategories ?? Enumerable.Empty<string>())
+                    .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+
+            // Blank patterns are DROPPED, not kept: "".IndexOf returns 0, so one
+            // empty cell in a data file would exclude the entire model.
+            _patterns = (patterns ?? Enumerable.Empty<string>())
+                .Where(p => !string.IsNullOrWhiteSpace(p)).Select(p => p.Trim()).ToList();
+        }
+
+        public static ProductExclusion Build(
+            IEnumerable<string> excludedCategories,
+            IEnumerable<string> excludedDescriptionPatterns,
+            IEnumerable<string> protectedCategories)
+            => new ProductExclusion(excludedCategories, excludedDescriptionPatterns, protectedCategories);
+
+        /// <summary>True when this policy would exclude nothing, so a caller can
+        /// say "no exclusions applied" rather than reporting a silent zero.</summary>
+        public bool IsEmpty => _categories.Count == 0 && _patterns.Count == 0;
+
+        public int CategoryCount => _categories.Count;
+        public int PatternCount => _patterns.Count;
+
+        /// <summary>
+        /// Classify one element. <paramref name="description"/> and
+        /// <paramref name="typeName"/> are both searched, joined, because the two
+        /// callers carry the identifying text in different fields.
+        /// </summary>
+        public ExclusionVerdict Classify(string category, string description, string typeName)
+        {
+            string cat = (category ?? "").Trim();
+
+            if (cat.Length > 0 && _categories.Contains(cat))
+                return ExclusionVerdict.ByCategory;
+
+            if (_patterns.Count == 0) return ExclusionVerdict.Included;
+
+            // A door or a window is always a real thing, whatever it is called.
+            // The first material export dropped one Windows row as not-a-material
+            // while keeping twelve others, because a pattern written for Generic
+            // Models voids matched a real window type.
+            if (cat.Length > 0 && _protected.Contains(cat))
+                return ExclusionVerdict.Included;
+
+            string hay = ((description ?? "") + " " + (typeName ?? ""));
+            foreach (string p in _patterns)
+                if (hay.IndexOf(p, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return ExclusionVerdict.ByPattern;
+
+            return ExclusionVerdict.Included;
+        }
+    }
+}

--- a/StingTools/Data/STING_PROD_EXCLUSIONS.json
+++ b/StingTools/Data/STING_PROD_EXCLUSIONS.json
@@ -1,0 +1,60 @@
+{
+  "_comment": [
+    "What is NOT a product, for PROD coverage reporting only.",
+    "",
+    "This is a DENOMINATOR policy, not a tagging policy. Nothing here stops an",
+    "element being tagged; it stops Prod_CoverageAudit counting a thing that can",
+    "never carry a product code as a product that failed to get one.",
+    "",
+    "Why it exists: the first audit on a real model reported 0.8% coverage",
+    "(13/1688). 1,187 of those 1,688 were M_GM_OpeningWall_Instance - wall voids",
+    "under category Generic Models - plus 34 filled regions, 23 rooms and 22",
+    "muntin patterns. Over the 422 elements that are actually products the figure",
+    "is 3.1%. Still low, but 0.8% overstated it four-fold and pointed the reader",
+    "at the wrong problem.",
+    "",
+    "DELIBERATELY NOT the material schedule's list, though it shares the matching",
+    "code (Core/ProductExclusion.cs). STING_MATERIAL_STAGES.json excludes",
+    "Furniture and Casework because you do not buy a sofa by the cubic metre - but",
+    "a sofa IS a product and FUR is a real PROD code. One list for both questions",
+    "would trade a wrong number for a differently wrong one.",
+    "",
+    "Also deliberately excluded from THIS list: Curtain Panels. A breeze-block",
+    "panel is a product; it just has no rule yet, which is a coverage gap and",
+    "exactly what the audit is for.",
+    "",
+    "Project override: <project>/_data/coord/prod_exclusions.json, same shape.",
+    "An override REPLACES a list it declares and leaves the others alone."
+  ],
+
+  "notAProductCategories": [
+    "Rooms",
+    "Spaces",
+    "Areas",
+    "Detail Items",
+    "Lines",
+    "Text Notes",
+    "Dimensions",
+    "Levels",
+    "Grids",
+    "Reference Planes",
+    "Scope Boxes",
+    "Views",
+    "Cameras",
+    "Model Groups",
+    "RVT Links",
+    "Analytical Members",
+    "Analytical Panels",
+    "Analytical Nodes"
+  ],
+
+  "notAProductPatterns": [
+    "opening",
+    "muntin"
+  ],
+
+  "protectedCategories": [
+    "Doors",
+    "Windows"
+  ]
+}


### PR DESCRIPTION
`Prod_CoverageAudit` reported **0.8%** on a real model — 13 of 1,688. But **1,187 of those 1,688 were `M_GM_OpeningWall_Instance`**: wall voids, which can never carry a product code. With the filled regions, rooms and muntin patterns, **1,266 of the "failures" were not products at all**.

| | |
|---|---|
| As reported | 13/1688 = **0.8%** |
| Over real products | 13/422 = **3.1%** |

Still low — that part is a genuine finding, and 128 breeze-block curtain panels with no rule are exactly what the audit exists to surface. But 0.8% overstated it four-fold and pointed the reader at the wrong problem.

## That 1,187 is not a coincidence

ROADMAP MATSCHED-8 records the material schedule hitting **the identical family on the identical model**, and #724 adding description-pattern exclusion for it. Two features asked "is this a thing?" and each had its own answer.

So the **mechanism** is now shared — `Core/ProductExclusion.cs` owns category exclusion, pattern exclusion, protected-category precedence, blank-pattern inertness and the counting. `CommodityAggregator` routes through it with **no behaviour change** (1,225 Boq tests unmoved).

## The lists are deliberately *not* shared

This is the substance of the change, not an omission from it. `STING_MATERIAL_STAGES.json` excludes **Furniture and Casework** — correct there, you don't buy a sofa by the cubic metre — but `FUR` is a real PROD code and 43 of this model's elements carry it, correctly suffixed `FUR-FAB` / `FUR-TIM`. Reusing one list for both questions would have traded a wrong number for a differently wrong one.

Two tests pin the difference, and one asserts the *material* list still contains what the other claims it contains — so the distinction can't rot into a tautology.

## Two further divergences closed

**The audit now counts what the tagger counts.** `TagPipelineHelper` skips `CategorySkipList` and `CategoryTokenOverrides["SKIP"]` before doing anything else. The audit honoured neither, so it was reporting on a population the plugin never tags.

**The denominator is published, not quietly shrunk.** The report states how many elements were seen, excluded, tagger-skipped and measured, and names the excluded categories. Silently improving a number is the move this codebase keeps finding in its own history.

An empty scope now says *which* zero it is, and a missing policy file excludes **nothing** and logs that it's missing — `Parse` returns null for absent rather than an empty document, so "not deployed" stays distinguishable from "deliberately excludes nothing". A project override likewise distinguishes `null` (inherit) from `[]` (exclude nothing), or the key becomes impossible to override.

## Verification

Tags tests **392 → 441**, Boq **unchanged at 1,225**, build **0/0**, **six mutations verified failing** (including the greedy-list one: adding Furniture back makes the gate fail).

The shipped JSON is asserted against the **real per-family counts from your audit CSV**, so the test is a replay of the run rather than an illustration of it. Confirmed the new data file is picked up by the `Data\**\*` wildcard and lands in the build output — otherwise it would ship dead and the audit would silently exclude nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)