### PR TITLE
fix(prod): the audit hid the only field that tells one wall from another

### DIFF
--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -195,6 +195,85 @@ namespace StingTools.Tags.Tests
         }
 
         // ══════════════════════════════════════════════════════════════════════
+        //  1b. A system-category rule must need the TYPE name
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>Families that are not loadable — every element in these categories
+        /// shares the family name, so it discriminates nothing.</summary>
+        private static readonly (string Category, string Family)[] SystemFamilies =
+        {
+            ("Walls", "Basic Wall"), ("Walls", "Curtain Wall"), ("Walls", "Stacked Wall"),
+            ("Roofs", "Basic Roof"), ("Roofs", "Sloped Glazing"),
+            ("Floors", "Floor"),
+            ("Ceilings", "Compound Ceiling"), ("Ceilings", "Basic Ceiling"),
+            ("Ducts", "Rectangular Duct"), ("Ducts", "Round Duct"), ("Ducts", "Oval Duct"),
+            ("Pipes", "Pipe Types"),
+            ("Structural Foundations", "Wall Foundation"), ("Structural Foundations", "Foundation Slab"),
+        };
+
+        /// <summary>
+        /// All 11 shipped rules on a system category resolve on the TYPE name, and none
+        /// on the family name alone.
+        ///
+        /// <para>This is what makes the audit's advice true. `Prod_GenerateRules`
+        /// deliberately SKIPS system families — a project overlay row keyed on
+        /// "Basic Wall" would match every wall in the model, a category default wearing
+        /// a family rule's clothes — so the only route to a specific PROD code for a
+        /// wall is a rule keyed on its type. If someone adds a bare family rule here it
+        /// will not error; it will quietly give every wall in every project one code.</para>
+        ///
+        /// <para>The resolver matches against <c>"{family} {type}"</c>, so a wall with no
+        /// type name resolved against <c>"Basic Wall "</c> — which is what this feeds.</para>
+        /// </summary>
+        [Fact]
+        public void No_Shipped_Rule_On_A_System_Category_Matches_The_Bare_Family_Name()
+        {
+            var rows = ProdRows();
+            var offenders = new List<string>();
+
+            foreach (var (cat, fam) in SystemFamilies)
+                foreach (var row in rows.Where(r => string.Equals(r.Category, cat, StringComparison.OrdinalIgnoreCase)))
+                    if (ProdPatternMatcher.Matches((fam + " ").ToUpperInvariant(), row.Pattern))
+                        offenders.Add($"{row} matches the bare family name '{fam}'");
+
+            Assert.True(offenders.Count == 0,
+                "A PROD rule on a system category that matches the FAMILY name alone gives EVERY element "
+                + "in that category the same code — the family name is shared by all of them. Put the "
+                + "material, size or service test in the pattern so it needs the TYPE name:\n  "
+                + string.Join("\n  ", offenders));
+        }
+
+        [Fact]
+        public void The_System_Family_Guard_Actually_Fires()
+        {
+            // The row it exists to catch, fed to the same matcher.
+            Assert.True(ProdPatternMatcher.Matches("BASIC WALL ", "*BASIC WALL*"));
+        }
+
+        [Fact]
+        public void And_Those_Rules_Still_Resolve_Once_A_Type_Name_Arrives()
+        {
+            // The guard above must not be satisfiable by shipping rules that match
+            // NOTHING. This is the payoff half: a floor typed "Concrete Slab 200"
+            // resolves to SLB, which is only reachable because the resolver reads
+            // GetElementTypeName rather than GetFamilySymbolName (KUT-11).
+            var rows = ProdRows();
+            Assert.Equal("SLB", ProdResolver.Resolve(
+                "Floor", "Concrete Slab 200", "Floors",
+                null, ForCategory(rows, "Floors"), null, out string src));
+            Assert.Equal(ProdResolver.Sources.Corporate, src);
+
+            // ...and the same floor with NO type name cannot resolve, which is exactly
+            // the state the audit used to REPORT (blank Type column) while the resolver
+            // was seeing the type all along.
+            ProdResolver.Resolve("Floor", "", "Floors",
+                null, ForCategory(rows, "Floors"),
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Floors"] = "FLR" },
+                out string blindSrc);
+            Assert.False(ProdResolver.IsSpecific(blindSrc));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
         //  2. One code, one discipline
         // ══════════════════════════════════════════════════════════════════════
 

--- a/StingTools/Commands/Classification/ProdCoverageAuditCommand.cs
+++ b/StingTools/Commands/Classification/ProdCoverageAuditCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -102,6 +102,7 @@ namespace StingTools.Commands.Classification
                 var rolls = new SortedDictionary<string, CatRoll>(StringComparer.OrdinalIgnoreCase);
                 var rows = new List<string> { "Category,Family,Type,PROD,Source,Specific" };
                 int scanned = 0, specific = 0, specificEqualsDefault = 0;
+                int genericLoadable = 0, genericSystem = 0;
 
                 foreach (Element el in collector)
                 {
@@ -119,7 +120,7 @@ namespace StingTools.Commands.Classification
                     { skippedByTagger++; continue; }
 
                     if (exclusion.Classify(cat, ParameterHelpers.GetFamilyName(el),
-                                           ParameterHelpers.GetFamilySymbolName(el)) != ExclusionVerdict.Included)
+                                           ParameterHelpers.GetElementTypeName(el)) != ExclusionVerdict.Included)
                     {
                         excluded++;
                         excludedByCat.TryGetValue(cat, out int ne);
@@ -144,8 +145,31 @@ namespace StingTools.Commands.Classification
                     r.BySource[source] = r.BySource.TryGetValue(source, out int n) ? n + 1 : 1;
 
                     string fam = ParameterHelpers.GetFamilyName(el) ?? "";
-                    string typ = ParameterHelpers.GetFamilySymbolName(el) ?? "";
+                    // GetElementTypeName, NOT GetFamilySymbolName. The latter answers ""
+                    // for anything that is not a FamilyInstance, so every wall, roof and
+                    // floor reported a BLANK type — while the resolver this is REPORTING
+                    // ON matched against "Generic - 200mm" all along (KUT-11 moved it to
+                    // GetElementTypeName; the audit was never moved with it).
+                    //
+                    // It is the field that matters most here. Prod_GenerateRules skips
+                    // system families on purpose — a rule keyed on "Basic Wall" matches
+                    // every wall in the model — so the ONLY route to a specific PROD code
+                    // for a wall is a hand-written rule keyed on its TYPE name, and the
+                    // audit was hiding exactly that.
+                    string typ = ParameterHelpers.GetElementTypeName(el) ?? "";
                     if (!isSpecific && !string.IsNullOrEmpty(fam)) r.GenericFamilies.Add(fam);
+
+                    // Split the gap by what can actually CLOSE it. Prod_GenerateRules
+                    // seeds only LOADABLE families; a system element (wall, roof, floor)
+                    // needs a hand-written rule keyed on its type name, because a rule
+                    // keyed on "Basic Wall" would match every wall in the model. Telling
+                    // a reader to run the seeder for those sends them somewhere that will
+                    // silently skip their 98 elements.
+                    if (!isSpecific)
+                    {
+                        if (string.IsNullOrEmpty(ParameterHelpers.GetLoadableFamilyName(el))) genericSystem++;
+                        else genericLoadable++;
+                    }
 
                     rows.Add(string.Join(",", Csv(cat), Csv(fam), Csv(typ), Csv(prod), Csv(source), isSpecific ? "Y" : "N"));
                 }
@@ -217,8 +241,15 @@ namespace StingTools.Commands.Classification
                     sb.AppendLine($"  {kv.Key}: {gen}/{r.Total} generic  → add prod_codes.csv rows for: {fams}");
                 }
                 sb.AppendLine();
-                sb.AppendLine("Fix: run Prod_GenerateRules, then add/curate FAMILY_PATTERN rows for the families above,");
-                sb.AppendLine("and re-run Tag & Combine (Skip mode) to fill the now-specific PROD codes.");
+                sb.AppendLine($"Of the {scanned - specific} generic element(s): {genericLoadable} are LOADABLE families and");
+                sb.AppendLine("  Prod_GenerateRules will seed a rule for each; " + genericSystem + " are SYSTEM elements");
+                sb.AppendLine("  (walls, roofs, floors) which it deliberately SKIPS — a rule keyed on \"Basic Wall\"");
+                sb.AppendLine("  would match every wall in the model. Those need a rule keyed on the TYPE name");
+                sb.AppendLine("  instead; the Type column of the CSV below is that name.");
+                sb.AppendLine();
+                sb.AppendLine("Fix: run Prod_GenerateRules for the loadable ones, hand-write FAMILY_PATTERN rows");
+                sb.AppendLine("for the system ones (the pattern matches FAMILY + TYPE), then re-run Tag & Combine");
+                sb.AppendLine("(Skip mode) to fill the now-specific PROD codes.");
                 sb.AppendLine();
                 sb.AppendLine("Note: \"specific %\" counts every project/corporate/LPS/sleeve match (a generous");
                 sb.AppendLine($"measure) and does not credit material-suffix differentiation; of those, {specificEqualsDefault}");


### PR DESCRIPTION
Acting on the 3.1% finding from #869 turned up a reporting defect underneath it.

## The blank column

`Prod_CoverageAudit` reported a **blank Type for every wall, roof and floor**:

```
67   Walls   Basic Wall     | (blank)
22   Roofs   Basic Roof     | (blank)
 9   Floors  Floor          | (blank)
```

It read `GetFamilySymbolName`, which answers `""` for anything that is not a `FamilyInstance`. The resolver it is reporting on has matched against `GetElementTypeName` (`"Generic - 200mm"`) since KUT-11 (#847) — the audit was never moved with it.

**So this is a reporting defect, not a resolution one.** Resolution was correct all along.

## Why it mattered more than it looks

`Prod_GenerateRules` **deliberately skips system families** — a project overlay row keyed on `Basic Wall` would match every wall in the model, a category default wearing a family rule's clothes. So the only route to a specific PROD code for a wall is a rule keyed on its **type** name.

The audit was hiding exactly that field. Which means "run `Prod_GenerateRules`" — the advice in the audit's own summary, and the advice I gave — was wrong for **98 of this model's 409 generic products**.

The report now splits the gap by what can actually close it: how many generic elements are **loadable** (the seeder handles them) versus **system** (hand-written type-keyed rules), instead of sending the reader somewhere that will silently skip their walls.

## The gate

**All 11 shipped rules on a system category resolve on the type name and none on the family name alone** — asserted by feeding each the bare family name the resolver would see (`"Basic Wall "`) and requiring no match. A bare family rule wouldn't error; it would quietly give every wall in every project one code.

Two companions keep that honest: one proves the guard fires, and one proves the 11 **still resolve once a type name does arrive** — so the guard can't be satisfied by shipping rules that match nothing.

Also aligned: the exclusion classifier now sees the type name too, so it judges "is this a thing" against the same string the resolver matched.

## Verification

Tags tests **441 → 444**, build **0/0**, **two mutations verified failing** (a bare `*Basic Wall*` rule inserted into the shipped CSV; the Floors rules detached from their category).

**Not verified in Revit** — the Type column is a Revit read and can't be exercised from a terminal. The next coverage CSV is the proof: walls should show `Generic - 200mm` where they showed blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)