### PR TITLE
fix(prod): a wall is what holds it up, not what it is painted with

### DIFF
--- a/StingTools.Tags.Tests/PrimaryMaterialSelectorTests.cs
+++ b/StingTools.Tags.Tests/PrimaryMaterialSelectorTests.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// A wall is what holds it up, not what it is painted with.
+    ///
+    /// <para>Found on a real model. Every rendered exterior wall came back as
+    /// gypsum:</para>
+    /// <code>
+    ///   48 x  CLAY BRICK VILLAGE LARGE (295x150x130MM)  ->  WL-MAS   correct
+    ///   11 x  Exterior_CreamWhite_230 2                 ->  WL-GYP   wrong
+    ///    5 x  Exterior_BrownWhite_230                   ->  WL-GYP   wrong
+    /// </code>
+    ///
+    /// <para>The override table could not be at fault — <c>\bbrick|\bmasonry|\bblock</c>
+    /// sits ABOVE <c>\bplaster|\bgypsum</c> in the file, so first-match-wins would
+    /// have answered MAS had it seen the brick. It never saw the brick: the reader
+    /// took <c>GetMaterialIds(false)</c> and returned the first non-zero id, which on
+    /// a compound wall is whichever layer sorts first.</para>
+    ///
+    /// <para>The roofs showed the same shape from the other side: <c>Generic - 225mm</c>
+    /// took no suffix while <c>Generic - 225mm 2</c> took <c>-BIT</c>. Two roofs of the
+    /// same nominal build, told apart by layer order.</para>
+    /// </summary>
+    public class PrimaryMaterialSelectorTests
+    {
+        private static MaterialLayer L(int i, string mat, double mm, bool structure = false)
+            => new MaterialLayer { Index = i, MaterialName = mat, ThicknessMm = mm, IsStructure = structure };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The wall that produced the finding
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>A 230 mm rendered masonry wall, layered exterior-to-interior the
+        /// way Revit lists it — render first, which is exactly how gypsum won.</summary>
+        private static List<MaterialLayer> RenderedMasonryWall230() => new List<MaterialLayer>
+        {
+            L(0, "Plaster - Cream White",              12.5),
+            L(1, "Masonry - Brick, Clay Village Large", 205, structure: true),
+            L(2, "Plaster - Interior",                  12.5),
+        };
+
+        [Fact]
+        public void The_230_Wall_Is_Masonry_Not_The_Render()
+        {
+            Assert.Equal("Masonry - Brick, Clay Village Large",
+                         PrimaryMaterialSelector.Select(RenderedMasonryWall230()));
+        }
+
+        [Fact]
+        public void First_Layer_Wins_Was_The_Bug_And_Is_Not_The_Rule()
+        {
+            // State the defect rather than describe it: the OLD behaviour, spelled
+            // out, must not be what the selector produces.
+            var layers = RenderedMasonryWall230();
+            string oldAnswer = layers.First(l => !string.IsNullOrWhiteSpace(l.MaterialName)).MaterialName;
+
+            Assert.Equal("Plaster - Cream White", oldAnswer);        // what it used to say
+            Assert.NotEqual(oldAnswer, PrimaryMaterialSelector.Select(layers));
+        }
+
+        /// <summary>The single-layer wall that was ALREADY right must stay right —
+        /// a fix that moves the 48 correct ones is not a fix.</summary>
+        [Fact]
+        public void A_Single_Layer_Masonry_Wall_Is_Unmoved()
+        {
+            Assert.Equal("Masonry - Brick",
+                PrimaryMaterialSelector.Select(new[] { L(0, "Masonry - Brick", 295, structure: true) }));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The rule
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_THICKEST_Structural_Layer_Wins_Not_Merely_A_Structural_One()
+        {
+            // A cavity wall: two structural leaves, and the outer one is thinner.
+            Assert.Equal("Blockwork 140", PrimaryMaterialSelector.Select(new[]
+            {
+                L(0, "Brick Facing 102", 102, structure: true),
+                L(1, "Air",                50),
+                L(2, "Blockwork 140",     140, structure: true),
+            }));
+        }
+
+        [Fact]
+        public void A_Thick_NON_Structural_Layer_Does_Not_Beat_A_Thinner_Structural_One()
+        {
+            // The insulation is thicker than the frame. The wall is still a timber
+            // wall — this is why pass 1 is structure-only rather than plain thickest.
+            Assert.Equal("Timber Stud", PrimaryMaterialSelector.Select(new[]
+            {
+                L(0, "Mineral Wool", 200),
+                L(1, "Timber Stud",   90, structure: true),
+            }));
+        }
+
+        [Fact]
+        public void With_No_Structural_Layer_The_Thickest_Wins()
+        {
+            // The roofs: Generic - 225mm carries no declared structure at all.
+            Assert.Equal("Concrete Deck", PrimaryMaterialSelector.Select(new[]
+            {
+                L(0, "Bitumen Membrane",   3),
+                L(1, "Concrete Deck",    200),
+                L(2, "Plaster Soffit",    12),
+            }));
+        }
+
+        [Fact]
+        public void A_Zero_Thickness_Membrane_Never_Names_The_Element()
+        {
+            // Exactly how -BIT came to name a roof: a membrane listed first.
+            Assert.Equal("Concrete Deck", PrimaryMaterialSelector.Select(new[]
+            {
+                L(0, "Bitumen Membrane", 0),
+                L(1, "Concrete Deck",  200),
+            }));
+        }
+
+        [Fact]
+        public void A_Zero_Width_STRUCTURAL_Layer_Does_Not_Beat_The_Real_Core()
+        {
+            // This is what makes the `ThicknessMm > 0` in the structural pass do work.
+            // A barrier flagged Structure has no thickness to lose on, so without the
+            // filter it wins pass 1 outright and the deck never gets considered.
+            //
+            // Written after a mutation showed the ORIGINAL zero-thickness filter (on
+            // the non-structural pass) changed nothing at all — it was dead code, and
+            // the test that "covered" it passed either way.
+            Assert.Equal("Concrete Deck", PrimaryMaterialSelector.Select(new[]
+            {
+                L(0, "Vapour Barrier",   0, structure: true),
+                L(1, "Concrete Deck",  200),
+            }));
+        }
+
+        [Fact]
+        public void But_A_Membrane_Answers_When_It_Is_All_There_Is()
+        {
+            // Returning null here would send the caller to the fallback, which would
+            // pick the same layer anyway — with an extra Revit read and no reason.
+            Assert.Equal("Bitumen Membrane",
+                PrimaryMaterialSelector.Select(new[] { L(0, "Bitumen Membrane", 0) }));
+        }
+
+        [Fact]
+        public void Equal_Thickness_Breaks_On_ORDER_So_The_Answer_Is_Stable()
+        {
+            // Without a tie-break the answer depends on the order a collector
+            // happened to return, which is how this whole defect started.
+            var layers = new[]
+            {
+                L(0, "Blockwork A", 100, structure: true),
+                L(1, "Blockwork B", 100, structure: true),
+            };
+            Assert.Equal("Blockwork A", PrimaryMaterialSelector.Select(layers));
+            Assert.Equal("Blockwork A", PrimaryMaterialSelector.Select(layers.Reverse().ToArray()));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  What it refuses to answer
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void No_Material_Means_NULL_So_The_Caller_Falls_Back(int count)
+        {
+            var layers = Enumerable.Range(0, count).Select(i => L(i, null, 100)).ToArray();
+            Assert.Null(PrimaryMaterialSelector.Select(layers));
+        }
+
+        [Fact]
+        public void Null_And_Empty_Are_Null_Not_An_Exception()
+        {
+            Assert.Null(PrimaryMaterialSelector.Select(null));
+            Assert.Null(PrimaryMaterialSelector.Select(new MaterialLayer[0]));
+            Assert.Null(PrimaryMaterialSelector.Select(new MaterialLayer[] { null }));
+            Assert.Null(PrimaryMaterialSelector.Select(new[] { L(0, "   ", 100) }));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  End to end, through the SHIPPED override table
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The selector is only worth having if the suffix it produces is different.
+        /// This runs the chosen material through the real rules to show WL-GYP
+        /// becoming WL-MAS — the whole point, asserted rather than asserted about.
+        /// </summary>
+        [Fact]
+        public void The_Rendered_Wall_Now_Takes_MAS_Where_It_Took_GYP()
+        {
+            var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_PROD_CODES.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data");
+
+            var rules = MaterialProdOverrideRules.Parse(File.ReadAllLines(
+                Path.Combine(dir.FullName, "StingTools", "Data", "STING_MATERIAL_PROD_OVERRIDES.csv")));
+
+            var layers = RenderedMasonryWall230();
+
+            string oldMat = layers.First().MaterialName;                 // first-layer-wins
+            string newMat = PrimaryMaterialSelector.Select(layers);      // core-wins
+
+            Assert.Equal("GYP", MaterialProdOverrideRules.ResolveSuffix(rules, oldMat, "Walls"));
+            Assert.Equal("MAS", MaterialProdOverrideRules.ResolveSuffix(rules, newMat, "Walls"));
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -82,6 +82,9 @@
          MaterialProdOverrideRegistry (which needs an Element) so the SHIPPED rule
          table is assertable: an unanchored stem handed sheep's wool an EPS code. -->
     <Compile Include="..\StingTools\Core\MaterialProdOverrideRules.cs" Link="Core\MaterialProdOverrideRules.cs" />
+    <!-- Which layer of a compound element NAMES it. Revit-free so the choice is
+         testable: every defect here has been a wrong choice, not a failed read. -->
+    <Compile Include="..\StingTools\Core\PrimaryMaterialSelector.cs" Link="Core\PrimaryMaterialSelector.cs" />
     <!-- IM-15: config-driven revision scheme. Kept Revit-free so the P→C default and the
          per-appointment override are provable without a Revit host. -->
     <Compile Include="..\StingTools\Docs\Templates\RevisionScheme.cs" Link="Docs\Templates\RevisionScheme.cs" />

--- a/StingTools/Core/MaterialProdOverrideRegistry.cs
+++ b/StingTools/Core/MaterialProdOverrideRegistry.cs
@@ -60,6 +60,8 @@ namespace StingTools.Core
         {
             try
             {
+                // 1. An EXPLICIT material on the instance or type wins outright —
+                //    somebody said what this is, and no inference beats that.
                 Parameter p = el.LookupParameter("Material") ?? el.get_Parameter(BuiltInParameter.MATERIAL_ID_PARAM);
                 if (p != null && p.StorageType == StorageType.ElementId)
                 {
@@ -67,6 +69,14 @@ namespace StingTools.Core
                     if (mid != null && mid.Value > 0)
                         return el.Document?.GetElement(mid)?.Name;
                 }
+
+                // 2. A COMPOUND element is named by its core, not its skin. Without
+                //    this, a 230 mm rendered masonry wall reported gypsum, because
+                //    GetMaterialIds returns the finish layer first.
+                string layered = ReadCompoundPrimaryMaterial(el);
+                if (!string.IsNullOrEmpty(layered)) return layered;
+
+                // 3. Last resort: first material the element admits to.
                 var mats = el.GetMaterialIds(false);
                 if (mats != null)
                 {
@@ -79,6 +89,56 @@ namespace StingTools.Core
             }
             catch (Exception ex) { StingLog.Warn($"ReadPrimaryMaterialName {el?.Id}: {ex.Message}"); }
             return null;
+        }
+
+        /// <summary>
+        /// Flatten the element type's <c>CompoundStructure</c> into layers and ask
+        /// <see cref="PrimaryMaterialSelector"/> which one names the element.
+        ///
+        /// <para>Returns null for anything that is not a layered host (a
+        /// FamilyInstance, a type with no compound structure), so the caller falls
+        /// through to its existing behaviour unchanged.</para>
+        /// </summary>
+        private static string ReadCompoundPrimaryMaterial(Element el)
+        {
+            try
+            {
+                var doc = el?.Document;
+                if (doc == null) return null;
+                if (!(doc.GetElement(el.GetTypeId()) is HostObjAttributes host)) return null;
+
+                CompoundStructure cs = host.GetCompoundStructure();
+                if (cs == null) return null;
+
+                var layers = new List<MaterialLayer>();
+                var csLayers = cs.GetLayers();
+                for (int i = 0; i < csLayers.Count; i++)
+                {
+                    var cl = csLayers[i];
+                    string name = null;
+                    if (cl.MaterialId != null && cl.MaterialId.Value > 0)
+                        name = doc.GetElement(cl.MaterialId)?.Name;
+                    if (string.IsNullOrWhiteSpace(name)) continue;
+
+                    layers.Add(new MaterialLayer
+                    {
+                        Index = i,
+                        MaterialName = name,
+                        // Width is in FEET. Millimetres only because the selector
+                        // compares thicknesses to each other — any consistent unit
+                        // would do, and mm is what every other STING layer reader uses.
+                        ThicknessMm = cl.Width * 304.8,
+                        IsStructure = cl.Function == MaterialFunctionAssignment.Structure,
+                    });
+                }
+
+                return PrimaryMaterialSelector.Select(layers);
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"ReadCompoundPrimaryMaterial {el?.Id}: {ex.Message}");
+                return null;
+            }
         }
 
         private static void EnsureLoaded()

--- a/StingTools/Core/PrimaryMaterialSelector.cs
+++ b/StingTools/Core/PrimaryMaterialSelector.cs
@@ -1,0 +1,112 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  PrimaryMaterialSelector.cs — which layer of a compound element IS the
+//  element, for the purpose of naming what it is made of.
+//
+//  Found on a real model. Every 230 mm exterior wall came out as WL-GYP:
+//
+//      48 x  CLAY BRICK VILLAGE LARGE (295x150x130MM)  ->  WL-MAS   correct
+//      11 x  Exterior_CreamWhite_230 2                 ->  WL-GYP   wrong
+//       5 x  Exterior_BrownWhite_230                   ->  WL-GYP   wrong
+//
+//  A 230 mm exterior wall is masonry with a plaster render, and the override
+//  table cannot be at fault: `\bbrick|\bmasonry|\bblock` sits ABOVE
+//  `\bplaster|\bgypsum` in the file, so first-match-wins would have said MAS
+//  had it seen the brick. It never saw the brick. The reader took
+//  GetMaterialIds(false) and returned the FIRST NON-ZERO id, which on a
+//  compound wall is whichever layer happens to come first — the finish skin.
+//
+//  The same shape showed on the roofs: `Generic - 225mm` took no suffix while
+//  `Generic - 225mm 2` took -BIT. Two roofs of the same nominal build, told
+//  apart by which layer sorted first.
+//
+//  THIS IS PHASE 254's LESSON ONE LAYER ALONG. That phase found no layer
+//  reader accepted STRUCTURE, so a shingle carried on a structure layer was
+//  invisible to the take-off. The take-off learned it; the PROD suffix did
+//  not. A wall's product is its core, not its paint.
+//
+//  Revit-free on purpose: the Revit half reads CompoundStructure and hands the
+//  layers here, so the CHOICE is testable without a Document. Every defect
+//  this area has produced has been a wrong choice, not a failed read.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core
+{
+    /// <summary>One layer of a compound element, flattened out of Revit's
+    /// <c>CompoundStructureLayer</c> so the selection rule can be tested.</summary>
+    public sealed class MaterialLayer
+    {
+        /// <summary>Position in the compound structure, exterior-to-interior. The
+        /// tie-break, so the answer is stable rather than dependent on sort order.</summary>
+        public int Index;
+
+        /// <summary>Layer material name, or null/empty when the layer has none.</summary>
+        public string MaterialName;
+
+        /// <summary>Layer thickness in millimetres. Membranes are 0.</summary>
+        public double ThicknessMm;
+
+        /// <summary>True when Revit's layer function is Structure.</summary>
+        public bool IsStructure;
+    }
+
+    public static class PrimaryMaterialSelector
+    {
+        /// <summary>
+        /// The material that names the element.
+        ///
+        /// <list type="number">
+        /// <item>The THICKEST STRUCTURE layer. A wall is what holds it up.</item>
+        /// <item>Failing that, the thickest layer of any function — a build-up with
+        /// no declared structure is still mostly one thing.</item>
+        /// <item>Ties break on the lowest index, so the answer never depends on the
+        /// order a collector happened to return.</item>
+        /// </list>
+        ///
+        /// <para>Zero-thickness layers (membranes, vapour barriers) lose on thickness
+        /// like anything else — being listed first is exactly how a bitumen membrane
+        /// came to name a roof, and ranking by thickness is what stops it. They can
+        /// still answer when they are all there is, which is correct: the caller's
+        /// fallback would pick the same layer with an extra Revit read.</para>
+        ///
+        /// <para>Returns null when no layer carries a material — the caller then
+        /// falls back, rather than this inventing a name.</para>
+        /// </summary>
+        public static string Select(IReadOnlyList<MaterialLayer> layers)
+        {
+            if (layers == null || layers.Count == 0) return null;
+
+            // Pass 1: structural layers of real thickness. The `> 0` is load-bearing:
+            // a zero-width layer flagged Structure (a barrier, a modelled-in reinforcement
+            // plane) would otherwise beat the actual core on the index tie-break.
+            MaterialLayer best = Best(layers, l => l.IsStructure && l.ThicknessMm > 0);
+
+            // Pass 2: anything. Thickest wins, so membranes lose without needing a rule
+            // of their own — a `ThicknessMm > 0` filter here would be DEAD CODE, since a
+            // zero-thickness layer can only win when every layer is zero, which this same
+            // pass already handles on the tie-break. (Found by mutating it: removing the
+            // filter changed nothing, which is the definition of a line that is not there.)
+            if (best == null) best = Best(layers, l => true);
+
+            return best?.MaterialName;
+        }
+
+        private static MaterialLayer Best(IReadOnlyList<MaterialLayer> layers, Func<MaterialLayer, bool> ok)
+        {
+            MaterialLayer best = null;
+            for (int i = 0; i < layers.Count; i++)
+            {
+                var l = layers[i];
+                if (l == null || string.IsNullOrWhiteSpace(l.MaterialName)) continue;
+                if (!ok(l)) continue;
+
+                if (best == null
+                    || l.ThicknessMm > best.ThicknessMm
+                    || (l.ThicknessMm == best.ThicknessMm && l.Index < best.Index))
+                    best = l;
+            }
+            return best;
+        }
+    }
+}


### PR DESCRIPTION
Found in the coverage CSV from a real model. Every rendered exterior wall came back as **gypsum**:

```
48 x  CLAY BRICK VILLAGE LARGE (295x150x130MM)  ->  WL-MAS   correct
11 x  Exterior_CreamWhite_230 2                 ->  WL-GYP   wrong
 5 x  Exterior_BrownWhite_230                   ->  WL-GYP   wrong
```

A 230 mm exterior wall is masonry with a plaster render. **The override table cannot be at fault** — `\bbrick|\bmasonry|\bblock` sits *above* `\bplaster|\bgypsum` in the file, so first-match-wins would have answered MAS had it seen the brick.

It never saw the brick. `ReadPrimaryMaterialName` took `GetMaterialIds(false)` and returned the **first non-zero id**, which on a compound wall is whichever layer sorts first — the finish skin.

The roofs showed it from the other side: `Generic - 225mm` took no suffix while `Generic - 225mm 2` took `-BIT`. Two roofs of the same nominal build, told apart by layer order.

**This is Phase 254's lesson one layer along.** That phase found no layer reader accepted `STRUCTURE`, so a shingle carried on a structure layer was invisible to the take-off. The take-off learned it; the PROD suffix did not.

## The fix

The type's `CompoundStructure` is now read and the layer that *names* the element is chosen: the **thickest structural layer**, else the thickest of any function, ties breaking on layer order so the answer never depends on what a collector happened to return.

An explicit instance/type `Material` parameter still wins outright — somebody said what it is — and anything without a compound structure falls through to the old path untouched.

The choice is Revit-free (`PrimaryMaterialSelector` takes flattened layers), so it's testable without a Document. Every defect this area has produced has been a wrong *choice*, not a failed read.

## Verification

Tags tests **444 → 458**, Boq **unchanged at 1,225**, build **0/0**, **five mutations verified failing**.

**Three mutations proved nothing first, and one found a real defect in this commit.** The zero-thickness filter on the non-structural pass changed *nothing* when removed: `Best` already ranks by thickness, so a zero-thickness layer can only win when every layer is zero — which the same pass handles on the tie-break. **Two of the three passes were the same pass**, and the test that "covered" it passed either way. The dead pass is gone, the surviving filter moved to where it does work (a zero-width layer flagged `Structure` would otherwise win pass 1 outright), and there's now a test for that with a mutation that fails without it.

The other two proved nothing for duller reasons: one anchor dropped an `if`'s closing paren so the mutant wouldn't compile, and one picked a change this wall can't distinguish — the brick is *both* the structural layer and the thickest, so only literal first-layer-wins produces GYP. Mutating to exactly that fails the end-to-end test, which is what it was always guarding.

**Not verified in Revit** — the compound-structure read can't be exercised from a terminal. The next coverage CSV is the proof: `Exterior_CreamWhite_230` should read `WL-MAS`, and the 48 `CLAY BRICK` rows must not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)