### PR TITLE
fix(prod): a catch-all should not name a specific product

### DIFF
--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -274,6 +274,50 @@ namespace StingTools.Tags.Tests
         }
 
         // ══════════════════════════════════════════════════════════════════════
+        //  1c. A generic default must not wear a specific product's name
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The category default is the LAST RESORT — "no rule matched". So it must not
+        /// be a code that a family-specific rule also issues, or the generic and the
+        /// specific become indistinguishable in the output.
+        ///
+        /// <para>Two shipped defaults did exactly that: Electrical Equipment defaulted
+        /// to <c>DB</c> (distribution board) and Mechanical Equipment to <c>AHU</c> (air
+        /// handling unit), while every other default names its CATEGORY — Doors→DR,
+        /// Walls→WL, Furniture→FUR, Plumbing Equipment→PEQ. A Bosch built-in appliance
+        /// therefore read as a distribution board, confidently, in a tag nobody
+        /// re-reads. They are now EEQ and MEQ, following the file's own PEQ precedent,
+        /// and the DB / AHU rules still fire for real boards and real AHUs.</para>
+        ///
+        /// <para>The map itself lives on the Revit-bound TagConfig, so what is asserted
+        /// here is the half that can be: the two generic codes are issued by NO rule,
+        /// and the two they replaced ARE — which is what made them wrong.</para>
+        /// </summary>
+        [Theory]
+        [InlineData("EEQ")]
+        [InlineData("MEQ")]
+        public void A_Generic_Category_Default_Is_Issued_By_No_Specific_Rule(string generic)
+        {
+            var owners = ProdRows().Where(r => r.Code == generic).Select(r => r.ToString()).ToList();
+            Assert.True(owners.Count == 0,
+                $"'{generic}' is a CATEGORY DEFAULT — the code for 'no rule matched'. A specific "
+                + "rule issuing it too makes the two indistinguishable: " + string.Join("; ", owners));
+        }
+
+        [Theory]
+        [InlineData("DB", "Electrical Equipment")]
+        [InlineData("AHU", "Mechanical Equipment")]
+        public void And_The_Codes_They_Replaced_Really_Were_Specific_Products(string code, string category)
+        {
+            // Without this the test above asserts a distinction that may not exist. These
+            // two are named by real rules, which is precisely why using them as the
+            // catch-all was a confident wrong answer rather than a vague one.
+            Assert.Contains(ProdRows(),
+                r => r.Code == code && string.Equals(r.Category, category, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
         //  2. One code, one discipline
         // ══════════════════════════════════════════════════════════════════════
 

--- a/StingTools.Tags.Tests/ProdExclusionTests.cs
+++ b/StingTools.Tags.Tests/ProdExclusionTests.cs
@@ -162,6 +162,52 @@ namespace StingTools.Tags.Tests
         //  Mechanism
         // ══════════════════════════════════════════════════════════════════════
 
+        // ══════════════════════════════════════════════════════════════════════
+        //  Exact family names: deliberate identity beats an accident guard
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Named_Family_Is_Excluded_EVEN_In_A_Protected_Category()
+        {
+            // Window-Square Opening is Revit's stock wall-void family. It sits in
+            // Windows, which is protected, so the "opening" PATTERN cannot reach it —
+            // correctly, because that guard exists to stop a fuzzy match eating a real
+            // window. An EXACT name is a different act and is allowed through.
+            Assert.Equal(ExclusionVerdict.ByFamily,
+                Shipped().Classify("Windows", "Window-Square Opening", "1000"));
+        }
+
+        [Fact]
+        public void The_Pattern_Still_Cannot_Reach_Into_A_Protected_Category()
+        {
+            // The guard this overrides must still be doing its job for everything else,
+            // or the override has quietly disabled it.
+            Assert.Equal(ExclusionVerdict.Included,
+                Shipped().Classify("Windows", "M_Window-Awning-Double-Vertical", "Opening 600"));
+        }
+
+        [Fact]
+        public void An_Exact_Name_Is_EXACT_Not_A_Substring()
+        {
+            // The whole reason this is safe. A family merely CONTAINING the listed name
+            // is a different family and stays a product.
+            var ex = ProductExclusion.Build(null, null, null, new[] { "Window-Square Opening" });
+            Assert.Equal(ExclusionVerdict.ByFamily, ex.Classify("Windows", "window-square opening", ""));
+            Assert.Equal(ExclusionVerdict.Included, ex.Classify("Windows", "Window-Square Opening Frame", ""));
+            Assert.Equal(ExclusionVerdict.Included, ex.Classify("Windows", "Steel Window-Square Opening", ""));
+        }
+
+        [Fact]
+        public void Toposolid_Is_Topography_Not_A_Product()
+        {
+            // Four of them carried NO family and NO type, so nothing could ever key a
+            // rule on them. The material schedule has excluded Toposolid and Topography
+            // all along; PROD now agrees.
+            Assert.Equal(ExclusionVerdict.ByCategory, Shipped().Classify("Toposolid", "Toposolid", "Generic - 1000mm"));
+            Assert.Equal(ExclusionVerdict.ByCategory, Shipped().Classify("Toposolid", "", ""));
+            Assert.Equal(ExclusionVerdict.ByCategory, Shipped().Classify("Topography", "", ""));
+        }
+
         [Fact]
         public void A_Protected_Category_Outranks_A_Pattern()
         {

--- a/StingTools/Core/ProdExclusionPolicy.cs
+++ b/StingTools/Core/ProdExclusionPolicy.cs
@@ -23,6 +23,12 @@ namespace StingTools.Core
 
         [JsonProperty("protectedCategories")]
         public List<string> ProtectedCategories;
+
+        /// <summary>Exact family names that are never products. Exact, so it cannot
+        /// misfire the way a substring can — and therefore allowed to override
+        /// <see cref="ProtectedCategories"/>.</summary>
+        [JsonProperty("notAProductFamilies")]
+        public List<string> NotAProductFamilies;
     }
 
     public static class ProdExclusionPolicy
@@ -59,7 +65,8 @@ namespace StingTools.Core
             return ProductExclusion.Build(
                 Pick(d => d.NotAProductCategories),
                 Pick(d => d.NotAProductPatterns),
-                Pick(d => d.ProtectedCategories));
+                Pick(d => d.ProtectedCategories),
+                Pick(d => d.NotAProductFamilies));
         }
     }
 }

--- a/StingTools/Core/ProductExclusion.cs
+++ b/StingTools/Core/ProductExclusion.cs
@@ -45,6 +45,10 @@ namespace StingTools.Core
         /// <summary>Legitimate category, but this instance is not a thing —
         /// an opening, a muntin pattern, a filled region.</summary>
         ByPattern,
+
+        /// <summary>Named outright, by exact family name. Unlike a pattern this
+        /// cannot misfire, so it overrides a protected category.</summary>
+        ByFamily,
     }
 
     /// <summary>
@@ -56,17 +60,24 @@ namespace StingTools.Core
         private readonly HashSet<string> _categories;
         private readonly HashSet<string> _protected;
         private readonly List<string> _patterns;
+        private readonly HashSet<string> _families;
 
         /// <summary>Nothing is excluded. The correct default: a policy that
         /// silently removes rows nobody asked it to remove is worse than none.</summary>
         public static readonly ProductExclusion None =
-            new ProductExclusion(null, null, null);
+            new ProductExclusion(null, null, null, null);
 
         private ProductExclusion(
             IEnumerable<string> categories,
             IEnumerable<string> patterns,
-            IEnumerable<string> protectedCategories)
+            IEnumerable<string> protectedCategories,
+            IEnumerable<string> families)
         {
+            _families = new HashSet<string>(
+                (families ?? Enumerable.Empty<string>())
+                    .Where(f => !string.IsNullOrWhiteSpace(f)).Select(f => f.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+
             _categories = new HashSet<string>(
                 (categories ?? Enumerable.Empty<string>())
                     .Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()),
@@ -86,12 +97,14 @@ namespace StingTools.Core
         public static ProductExclusion Build(
             IEnumerable<string> excludedCategories,
             IEnumerable<string> excludedDescriptionPatterns,
-            IEnumerable<string> protectedCategories)
-            => new ProductExclusion(excludedCategories, excludedDescriptionPatterns, protectedCategories);
+            IEnumerable<string> protectedCategories,
+            IEnumerable<string> excludedFamilies = null)
+            => new ProductExclusion(excludedCategories, excludedDescriptionPatterns,
+                                    protectedCategories, excludedFamilies);
 
         /// <summary>True when this policy would exclude nothing, so a caller can
         /// say "no exclusions applied" rather than reporting a silent zero.</summary>
-        public bool IsEmpty => _categories.Count == 0 && _patterns.Count == 0;
+        public bool IsEmpty => _categories.Count == 0 && _patterns.Count == 0 && _families.Count == 0;
 
         public int CategoryCount => _categories.Count;
         public int PatternCount => _patterns.Count;
@@ -107,6 +120,19 @@ namespace StingTools.Core
 
             if (cat.Length > 0 && _categories.Contains(cat))
                 return ExclusionVerdict.ByCategory;
+
+            // An EXACT family name, checked before the protected-category guard and
+            // able to override it.
+            //
+            // The guard exists because a fuzzy substring written for one thing matched
+            // another — a pattern for Generic Models voids ate a real window type. An
+            // exact name cannot do that: "Window-Square Opening" is Revit's stock
+            // wall-void family, named in full by somebody who looked at it, and there is
+            // no other family it could accidentally be. Deliberate identity outranks a
+            // guard built to catch accidents; a substring never does.
+            if (_families.Count > 0 && !string.IsNullOrWhiteSpace(description)
+                && _families.Contains(description.Trim()))
+                return ExclusionVerdict.ByFamily;
 
             if (_patterns.Count == 0) return ExclusionVerdict.Included;
 

--- a/StingTools/Core/TagConfig.Defaults.cs
+++ b/StingTools/Core/TagConfig.Defaults.cs
@@ -491,7 +491,7 @@ namespace StingTools.Core
                 { "Air Terminals", "GRL" }, { "Duct Accessories", "DAC" },
                 { "Duct Fittings", "DFT" }, { "Ducts", "DU" },
                 { "Duct Insulation", "DIN" }, { "Duct Lining", "DLN" },
-                { "Flex Ducts", "FDU" }, { "Mechanical Equipment", "AHU" },
+                { "Flex Ducts", "FDU" }, { "Mechanical Equipment", "MEQ" },
                 { "Mechanical Control Devices", "MCD" }, { "Mechanical Equipment Sets", "MES" },
                 { "Pipes", "PP" }, { "Pipe Fittings", "PFT" },
                 { "Pipe Accessories", "PAC" }, { "Pipe Insulation", "PIN" },
@@ -502,7 +502,7 @@ namespace StingTools.Core
                 { "Sprinklers", "SPR" }, { "Fire Alarm Devices", "FAD" },
                 { "Fire Protection", "FPR" },
                 // MEP — Electrical
-                { "Electrical Equipment", "DB" }, { "Electrical Fixtures", "SKT" },
+                { "Electrical Equipment", "EEQ" }, { "Electrical Fixtures", "SKT" },
                 { "Electrical Connectors", "ECN" },
                 { "Lighting Fixtures", "LUM" }, { "Lighting Devices", "LDV" },
                 { "Conduits", "CDT" }, { "Conduit Fittings", "CFT" },

--- a/StingTools/Data/STING_PROD_EXCLUSIONS.json
+++ b/StingTools/Data/STING_PROD_EXCLUSIONS.json
@@ -30,6 +30,8 @@
   "notAProductCategories": [
     "Rooms",
     "Spaces",
+    "Toposolid",
+    "Topography",
     "Areas",
     "Detail Items",
     "Lines",
@@ -56,5 +58,23 @@
   "protectedCategories": [
     "Doors",
     "Windows"
+  ],
+
+  "_families_comment": [
+    "EXACT family names that are never products. Exact, so unlike a pattern it",
+    "cannot misfire — and therefore allowed to override protectedCategories.",
+    "",
+    "Window-Square Opening is Revit's stock wall-void family: it sits in the",
+    "Windows category, which is protected, so the 'opening' PATTERN cannot touch",
+    "it and should not be able to. Naming the family in full is a different act —",
+    "somebody looked at it and said what it is.",
+    "",
+    "Keep this list to families that ship with Revit or a shared library. A family",
+    "that exists in one project (a supplier's entourage car, say) belongs in that",
+    "project's _data/coord/prod_exclusions.json, not here."
+  ],
+
+  "notAProductFamilies": [
+    "Window-Square Opening"
   ]
 }


### PR DESCRIPTION
The four leftovers from the coverage review. The first turned out to be the largest thing found in this whole pass.

## 1. A Bosch appliance read as a distribution board

Not a rule misfiring — the **category default**. Two of ~100 defaults name a specific product where every other names its category:

```
Electrical Equipment -> DB    (distribution board)
Mechanical Equipment -> AHU   (air handling unit)

Doors -> DR   Walls -> WL   Furniture -> FUR   Plumbing Equipment -> PEQ
```

The default is the **last resort** — it means "no rule matched". Spelling it as a real product makes *"this genuinely is a distribution board"* and *"we had no idea"* the same string. Now `EEQ` / `MEQ`, following the file's own `PEQ` precedent. The `DB` and `AHU` **rules are untouched**, so real boards and AHUs resolve exactly as before.

Adding appliance rules wouldn't have fixed it: `Bosch_FSR_HGS3023UC` is a model number with no product word in it, so no generic pattern can reach it. It now reads `EEQ` — honest — and a project rule is the route to better.

## 2. A Toposolid is topography

Five of them, **four carrying no family and no type**, so nothing could ever key a rule on them. The material schedule has excluded `Toposolid` and `Topography` all along; PROD now agrees.

## 3. An exact family name can override a protected category

`Window-Square Opening` is Revit's stock wall-void family. It sits in `Windows`, which is protected, so the `opening` **pattern** can't reach it — correctly, because that guard exists precisely because a fuzzy pattern once ate a real window type.

So the new list is **exact, not substring**, and that's the whole reason it's allowed through: a full name is a deliberate statement about one family and cannot accidentally match another. `Window-Square Opening Frame` stays a product, and a test pins that.

## 4. The car is *not* fixed here, deliberately

`A_Revit_Suv_3d_car` is entourage modelled in `Site`, and Site holds real products (paving, kerbs), so the category can't go. Every safe pattern for a vehicle is fitted to that one family name — `car` alone matches **carpet, carport, cargo**, which is the #863 defect wearing a different hat.

The mechanism to exclude it now exists; the entry belongs in that project's `_data/coord/prod_exclusions.json`:

```json
{ "notAProductFamilies": ["A_Revit_Suv_3d_car"] }
```

Better still, the car belongs in the `Entourage` category.

## Verification

Tags **458 → 466**, Boq **1,225 → 1,238**, build **0/0**, **six mutations verified failing** — including one that moves the family check *below* the protected-category guard, and one that relaxes exact-match to a substring.

**Not verified in Revit.** Expected on the next coverage CSV: **422 → 414** measured (5 Toposolid + 3 Window-Square Opening leave), 13/414 = 3.1%, the two Bosch rows read `EEQ-GLZ`, and **nothing else moves**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)