### PR TITLE
feat(prod): the architectural fabric gets rules, and the gate learns a distinction

### DIFF
--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -198,17 +198,46 @@ namespace StingTools.Tags.Tests
         //  1b. A system-category rule must need the TYPE name
         // ══════════════════════════════════════════════════════════════════════
 
-        /// <summary>Families that are not loadable — every element in these categories
-        /// shares the family name, so it discriminates nothing.</summary>
+        /// <summary>
+        /// The CATCH-ALL system family of each category: the name Revit gives an element
+        /// that has not been specialised into some other kind. These discriminate
+        /// nothing, because everything lands there by default.
+        ///
+        /// <para><b>Not every system family qualifies, and that distinction is the
+        /// point.</b> "Curtain Wall" and "Sloped Glazing" are also system families, but
+        /// they name a distinct KIND: a rule matching them gives every curtain wall one
+        /// code, which is a true statement about curtain walls. A rule matching "Basic
+        /// Wall" gives every wall in the model one code, which is the category default
+        /// wearing a rule's clothes.</para>
+        ///
+        /// <para>This list NARROWED when the architectural fabric rules landed and this
+        /// gate rejected <c>*Curtain Wall*</c> and <c>*Sloped Glazing*</c>. Narrowing a
+        /// gate to admit one's own new rules is exactly how a gate stops meaning
+        /// anything, so the justification is worth stating: the original reason — "every
+        /// element shares this family name, so it discriminates nothing" — was simply
+        /// UNTRUE of those two. Ducts, Pipes and Structural Foundations left for the
+        /// same reason; "Rectangular Duct" and "Wall Foundation" are kinds, and neither
+        /// category has a catch-all at all.
+        /// <c>The_System_Family_Guard_Actually_Fires</c> proves Basic Wall is still
+        /// caught, and <c>A_Kind_Bearing_System_Family_May_Be_Matched</c> pins the other
+        /// half so this cannot quietly widen back.</para>
+        /// </summary>
         private static readonly (string Category, string Family)[] SystemFamilies =
         {
-            ("Walls", "Basic Wall"), ("Walls", "Curtain Wall"), ("Walls", "Stacked Wall"),
-            ("Roofs", "Basic Roof"), ("Roofs", "Sloped Glazing"),
+            ("Walls", "Basic Wall"), ("Walls", "Stacked Wall"),
+            ("Roofs", "Basic Roof"),
             ("Floors", "Floor"),
             ("Ceilings", "Compound Ceiling"), ("Ceilings", "Basic Ceiling"),
-            ("Ducts", "Rectangular Duct"), ("Ducts", "Round Duct"), ("Ducts", "Oval Duct"),
-            ("Pipes", "Pipe Types"),
-            ("Structural Foundations", "Wall Foundation"), ("Structural Foundations", "Foundation Slab"),
+        };
+
+        /// <summary>System families that DO discriminate — a rule may match these,
+        /// and the architectural fabric rules deliberately do.</summary>
+        private static readonly (string Category, string Family)[] KindBearingSystemFamilies =
+        {
+            ("Walls", "Curtain Wall"),
+            ("Roofs", "Sloped Glazing"),
+            ("Ducts", "Rectangular Duct"), ("Ducts", "Round Duct"),
+            ("Structural Foundations", "Wall Foundation"),
         };
 
         /// <summary>
@@ -250,6 +279,33 @@ namespace StingTools.Tags.Tests
             Assert.True(ProdPatternMatcher.Matches("BASIC WALL ", "*BASIC WALL*"));
         }
 
+        /// <summary>
+        /// The other half of the narrowing, so it cannot quietly widen back: a rule
+        /// matching a KIND-BEARING system family is allowed, and at least one shipped
+        /// rule actually does it. Without this, someone could restore the strict list
+        /// and delete the architectural rules, and both halves would still "pass".
+        /// </summary>
+        [Fact]
+        public void A_Kind_Bearing_System_Family_May_Be_Matched()
+        {
+            var rows = ProdRows();
+            var matched = new List<string>();
+
+            foreach (var (cat, fam) in KindBearingSystemFamilies)
+                foreach (var row in rows.Where(r => string.Equals(r.Category, cat, StringComparison.OrdinalIgnoreCase)))
+                    if (ProdPatternMatcher.Matches((fam + " ").ToUpperInvariant(), row.Pattern))
+                        matched.Add($"{fam} -> {row.Code}");
+
+            Assert.True(matched.Count > 0,
+                "No shipped rule matches a kind-bearing system family. Either the architectural "
+                + "fabric rules were removed, or the catch-all list was widened back — and this "
+                + "gate exists because narrowing it was a judgement call worth keeping visible.");
+
+            // The two that caused the narrowing, named so the reason stays legible.
+            Assert.Contains("Curtain Wall -> WCW", matched);
+            Assert.Contains("Sloped Glazing -> RSG", matched);
+        }
+
         [Fact]
         public void And_Those_Rules_Still_Resolve_Once_A_Type_Name_Arrives()
         {
@@ -271,6 +327,74 @@ namespace StingTools.Tags.Tests
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Floors"] = "FLR" },
                 out string blindSrc);
             Assert.False(ProdResolver.IsSpecific(blindSrc));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1b-ii. The architectural fabric rules resolve real names
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Walls, Roofs and Ceilings had NO rules at all — every one fell to the
+        /// category default. These are the conventional build names, checked through the
+        /// real resolver so a rule that stops matching fails here rather than going
+        /// quietly generic on the next project.
+        /// </summary>
+        [Theory]
+        // Verbatim from a real model
+        [InlineData("Walls", "Basic Wall", "CLAY BRICK VILLAGE LARGE (295x150x130MM)", "WBK")]
+        [InlineData("Walls", "Curtain Wall", "RD_Breeze Block 01 - 20X20cm", "WCW")]
+        [InlineData("Walls", "Basic Wall", "Interior - 97mm Partition (1-hr)", "WPT")]
+        [InlineData("Walls", "Basic Wall", "coping", "WCP")]
+        // Conventional names a future project would use
+        [InlineData("Walls", "Basic Wall", "230 Blockwork Rendered", "WBL")]
+        [InlineData("Walls", "Basic Wall", "Concrete Block Wall 200", "WBL")]
+        [InlineData("Walls", "Basic Wall", "200 RC Wall", "WRC")]
+        [InlineData("Walls", "Basic Wall", "Cavity Wall 300", "WCV")]
+        [InlineData("Walls", "Basic Wall", "Boundary Wall 230", "WBD")]
+        [InlineData("Walls", "Basic Wall", "Parapet 230", "WPR")]
+        [InlineData("Walls", "Basic Wall", "Retaining Wall 250", "RWL")]
+        [InlineData("Roofs", "Basic Roof", "IT4 Corrugated Sheet", "RSH")]
+        [InlineData("Roofs", "Basic Roof", "Clay Tile Roof", "RTL")]
+        [InlineData("Roofs", "Basic Roof", "Asphalt Shingle Roof", "RTL")]
+        [InlineData("Roofs", "Basic Roof", "200 RC Roof Slab", "RCS")]
+        [InlineData("Roofs", "Sloped Glazing", "Rooflight 1200", "RSG")]
+        [InlineData("Floors", "Floor", "Ground Slab 150", "FGS")]
+        [InlineData("Floors", "Floor", "Hollow Pot Slab 250", "FRB")]
+        [InlineData("Floors", "Floor", "50 Screed", "FSC")]
+        [InlineData("Floors", "Floor", "Concrete Slab 200", "SLB")]   // pre-existing, unmoved
+        [InlineData("Ceilings", "Compound Ceiling", "Suspended Ceiling 600x600", "CSU")]
+        public void An_Architectural_Build_Resolves_To_Its_Own_Code(
+            string category, string family, string type, string expected)
+        {
+            Assert.Equal(expected, ProdResolver.Resolve(
+                family, type, category, null, ForCategory(ProdRows(), category), null, out _));
+        }
+
+        /// <summary>
+        /// The half no rule can reach, stated rather than left as a silent gap. These are
+        /// real type names from a delivered model: a colour, a thickness, a typo. Nothing
+        /// in them says what the thing IS, so they resolve generically and SHOULD — the
+        /// fix is a naming standard, not another rule.
+        ///
+        /// <para>If one of these ever starts resolving, a rule has become loose enough to
+        /// match a name that carries no product word, which is the failure this whole
+        /// pass has been about.</para>
+        /// </summary>
+        [Theory]
+        [InlineData("Walls", "Basic Wall", "Exterior_CreamWhite_230 2")]
+        [InlineData("Walls", "Basic Wall", "Exterior_BrownWhite_230")]
+        [InlineData("Roofs", "Basic Roof", "Generic - 225mm")]
+        [InlineData("Floors", "Floor", "stepsr 7")]
+        [InlineData("Floors", "Floor", "IntFloor_tile_150")]
+        public void A_Type_Name_That_Says_Nothing_Stays_Generic(string category, string family, string type)
+        {
+            ProdResolver.Resolve(family, type, category, null, ForCategory(ProdRows(), category),
+                                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                                 { ["Walls"] = "WL", ["Roofs"] = "RF", ["Floors"] = "FL" },
+                                 out string source);
+            Assert.False(ProdResolver.IsSpecific(source),
+                $"'{type}' names a colour, a thickness or nothing at all. A rule matching it "
+                + "would be matching noise.");
         }
 
         // ══════════════════════════════════════════════════════════════════════

--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -363,6 +363,29 @@ namespace StingTools.Tags.Tests
         [InlineData("Floors", "Floor", "50 Screed", "FSC")]
         [InlineData("Floors", "Floor", "Concrete Slab 200", "SLB")]   // pre-existing, unmoved
         [InlineData("Ceilings", "Compound Ceiling", "Suspended Ceiling 600x600", "CSU")]
+        // Openings, circulation, MEP linear services — the categories where the
+        // sub-distinction changes what you BUY, which is the BOQ's criterion.
+        [InlineData("Doors", "Door", "Flush Door 900x2100", "DRT")]
+        [InlineData("Doors", "Door", "FD30 Fire Door", "DRF")]
+        [InlineData("Doors", "AD_Garage door", "4200X2700", "DRR")]
+        [InlineData("Windows", "Window", "Aluminium Casement 1200", "WNA")]
+        [InlineData("Windows", "Window", "uPVC Window 900", "WNU")]
+        [InlineData("Windows", "Tpl Casement - Top Hung Side", "1500X1200", "WNC")]
+        [InlineData("Windows", "M_Window-Awning-Double-Vertical", "600x1800", "WNW")]
+        [InlineData("Curtain Panels", "RD_Breeze Block 01_Panel", "Concrete", "SBP")]
+        [InlineData("Pipes", "Pipe Types", "uPVC 110 Soil", "PPV")]
+        [InlineData("Pipes", "Pipe Types", "PPR PN20 25mm", "PPR")]
+        [InlineData("Pipes", "Pipe Types", "Copper Tube 15mm", "PCU")]
+        [InlineData("Pipes", "Pipe Types", "GI Pipe 25mm", "PGI")]
+        [InlineData("Conduits", "Conduit", "PVC Conduit 20mm", "CPV")]
+        [InlineData("Cable Trays", "Cable Tray", "Perforated 300mm", "CTP")]
+        [InlineData("Ducts", "Rectangular Duct", "Galvanised Duct 400x200", "DGI")]
+        [InlineData("Stairs", "Stair", "RC Stair Flight", "STRC")]
+        [InlineData("Railings", "Railing", "MS Railing 1100", "RLM")]
+        [InlineData("Railings", "Railing", "Glass Balustrade 1100", "GBL")]
+        [InlineData("Structural Rebar", "Rebar", "Y12", "RBR")]
+        [InlineData("Gutter", "Gutter", "uPVC Gutter 150", "GTP")]
+        [InlineData("Plumbing Equipment", "Tank", "Poly Water Tank 5000L", "PEQT")]
         public void An_Architectural_Build_Resolves_To_Its_Own_Code(
             string category, string family, string type, string expected)
         {

--- a/StingTools/Data/STING_PROD_CODES.csv
+++ b/StingTools/Data/STING_PROD_CODES.csv
@@ -107,6 +107,43 @@ TBC,Structural Columns,*Timber*|*Glulam*,Timber / Glulam Column,S,STR,BS EN 1995
 BM,Structural Framing,*Concrete Beam*|*RC Beam*,Reinforced Concrete Beam,S,STR,BS EN 1992-1-1
 STB2,Structural Framing,*Steel Beam*|*UB*|*IPE*,Structural Steel Beam,S,STR,BS EN 1993-1-1
 CLT,Structural Framing,*CLT*|*Cross Laminated*,Cross-Laminated Timber Beam,S,STR,BS EN 1995-1-1
+# ── Architectural fabric: WALLS, ROOFS, FLOORS, CEILINGS ────────────────────
+# Keyed on the TYPE name, never the family. Every wall in every project shares
+# the family name "Basic Wall", so a rule keyed on it would give them all one
+# code — Prod_GenerateRules skips system families for exactly this reason, and
+# ProdCodeDataTests fails any rule here that matches a bare family name.
+#
+# These reach a type only when its NAME says what it is. On the first real
+# model 4 of 11 wall/roof/floor type names did: CLAY BRICK, Curtain Wall,
+# Partition, coping. The other 7 ("Exterior_CreamWhite_230", "Generic - 225mm",
+# "stepsr 7") name a colour, a thickness or nothing, and no rule can rescue
+# them — that is a naming-standard problem, not a rule-coverage one.
+#
+# Most-specific-wins, so "Concrete Block Wall" resolves WBL (Concrete Block, 14)
+# rather than WRC, and a breeze-block CURTAIN panel resolves WCW (Curtain Wall,
+# 12) rather than WBL (Block, 5).
+WBK,Walls,*Brick*,Brick Masonry Wall,A,ARC,BS EN 1996-1-1
+WBL,Walls,*Blockwork*|*Block Wall*|*Concrete Block*|*Hollow Block*|*Solid Block*,Concrete Block Masonry Wall,A,ARC,BS EN 1996-1-1
+WSN,Walls,*Stone Wall*|*Rubble*|*Masonry Stone*,Stone Masonry Wall,A,ARC,BS EN 1996-1-1
+WRC,Walls,*RC Wall*|*Reinforced Concrete Wall*|*Shear Wall*|*Concrete Wall*,Reinforced Concrete Wall,S,STR,BS EN 1992-1-1
+WPT,Walls,*Partition*|*Stud*|*Drywall*|*Plasterboard Wall*,Framed / Stud Partition,A,ARC,BS 5234-2
+WCW,Walls,*Curtain Wall*|*Curtain Panel Wall*,Curtain Walling,A,ARC,BS EN 13830
+WCV,Walls,*Cavity*,Cavity Masonry Wall,A,ARC,BS EN 1996-1-1
+WPR,Walls,*Parapet*,Parapet Wall,A,ARC,BS 8000-3
+WCP,Walls,*Coping*,Wall Coping,A,ARC,BS 5642-2
+WBD,Walls,*Boundary Wall*|*Compound Wall*|*Perimeter Wall*|*Fence Wall*,Boundary / Compound Wall,A,ARC,none
+RWL,Walls,*Retaining*,Retaining Wall,S,STR,BS EN 1997-1
+RSH,Roofs,*Sheet*|*Corrugated*|*Profiled Metal*|*IT4*|*IT5*,Profiled Sheet Roof Covering,A,ARC,BS EN 508-1
+RTL,Roofs,*Roof Tile*|*Tiled Roof*|*Clay Tile*|*Concrete Tile*|*Shingle*,Tiled / Shingled Roof Covering,A,ARC,BS 5534
+RCS,Roofs,*Concrete Roof*|*RC Roof*|*Roof Slab*,Reinforced Concrete Roof Slab,S,STR,BS EN 1992-1-1
+RFL,Roofs,*Flat Roof*|*Built-Up Felt*|*Single Ply*|*Roof Membrane*,Flat Roof Membrane System,A,ARC,BS 8217
+RSG,Roofs,*Sloped Glazing*|*Rooflight*|*Skylight*,Rooflight / Sloped Glazing,A,ARC,BS 5516-2
+FGS,Floors,*Ground Slab*|*Ground Bearing*|*Slab on Grade*|*Oversite*,Ground-Bearing Floor Slab,S,STR,BS 8204-1
+FRB,Floors,*Ribbed Slab*|*Hollow Pot*|*Hollowpot*|*Waffle*|*Coffered*,Ribbed / Hollow-Pot Suspended Slab,S,STR,BS EN 1992-1-1
+FSC,Floors,*Screed*,Floor Screed,A,ARC,BS 8204-1
+FTM,Floors,*Timber Floor*|*Floor Joist*,Timber Suspended Floor,S,STR,BS EN 1995-1-1
+CSU,Ceilings,*Suspended Ceiling*|*Grid Ceiling*|*Lay-in*|*MF Ceiling*,Suspended Ceiling System,A,ARC,BS EN 13964
+CPB,Ceilings,*Plasterboard Ceiling*|*Gypsum Ceiling*|*Skim Ceiling*,Plasterboard Ceiling,A,ARC,BS 8212
 SLB,Floors,*Concrete Slab*|*RC Slab*,Reinforced Concrete Slab / Floor,S,STR,BS EN 1992-1-1
 PSB,Floors,*Post-Tension*|*PT Slab*,Post-Tensioned Concrete Slab,S,STR,BS EN 1992-1-5
 CFS,Floors,*Composite*|*Metal Deck*,Composite Metal Deck Floor Slab,S,STR,BS EN 1994-1-1

--- a/StingTools/Data/STING_PROD_CODES.csv
+++ b/StingTools/Data/STING_PROD_CODES.csv
@@ -144,6 +144,79 @@ FSC,Floors,*Screed*,Floor Screed,A,ARC,BS 8204-1
 FTM,Floors,*Timber Floor*|*Floor Joist*,Timber Suspended Floor,S,STR,BS EN 1995-1-1
 CSU,Ceilings,*Suspended Ceiling*|*Grid Ceiling*|*Lay-in*|*MF Ceiling*,Suspended Ceiling System,A,ARC,BS EN 13964
 CPB,Ceilings,*Plasterboard Ceiling*|*Gypsum Ceiling*|*Skim Ceiling*,Plasterboard Ceiling,A,ARC,BS 8212
+# ── Openings: DOORS + WINDOWS ───────────────────────────────────────────────
+# Leaf material and operation are what a door schedule and a BOQ price on.
+DRT,Doors,*Timber Door*|*Flush Door*|*Panel Door*|*Solid Core*|*Hollow Core*,Timber Leaf Door,A,ARC,BS EN 14351-2
+DRM,Doors,*Steel Door*|*Metal Door*|*Hollow Metal*|*Louvre Door*,Steel / Metal Door,A,ARC,BS EN 1634-1
+DRG,Doors,*Glazed Door*|*Glass Door*|*Frameless Door*,Glazed Door,A,ARC,BS EN 14351-1
+DRF,Doors,*Fire Door*|*FD30*|*FD60*|*FD90*|*FD120*,Fire-Rated Doorset,A,FP,BS 476-22
+DRS,Doors,*Sliding Door*|*Slider*|*Patio Door*,Sliding Door,A,ARC,BS EN 14351-1
+DRR,Doors,*Roller Shutter*|*Garage Door*|*Up and Over*,Roller Shutter / Garage Door,A,ARC,BS EN 13241
+DRA,Doors,*Aluminium Door*|*uPVC Door*|*PVCU Door*,Aluminium / uPVC Door,A,ARC,BS EN 14351-1
+DRO,Doors,*Revolving*|*Automatic Door*|*Swing Operator*,Automatic / Revolving Door,A,ARC,BS EN 16005
+WNA,Windows,*Aluminium Window*|*Alu Window*|*Aluminium Casement*,Aluminium Window,A,ARC,BS EN 14351-1
+WNU,Windows,*uPVC Window*|*PVCU Window*|*PVC-U Window*,uPVC Window,A,ARC,BS EN 12608
+WNT,Windows,*Timber Window*|*Hardwood Window*,Timber Window,A,ARC,BS 644
+WNS,Windows,*Steel Window*|*Louvre Window*|*Nako*,Steel / Louvre Window,A,ARC,BS 6510
+WNC,Windows,*Casement*,Casement Window,A,ARC,BS EN 14351-1
+WNW,Windows,*Awning*|*Top Hung*|*Top-Hung*,Awning / Top-Hung Window,A,ARC,BS EN 14351-1
+WNL,Windows,*Sliding Window*|*Horizontal Slider*,Sliding Window,A,ARC,BS EN 14351-1
+WNF,Windows,*Fixed Light*|*Fixed Window*|*Picture Window*,Fixed Light,A,ARC,BS EN 14351-1
+# ── Curtain walling components ──────────────────────────────────────────────
+CPG,Curtain Panels,*Glazed Panel*|*Glass Panel*|*Spandrel*,Glazed Curtain Panel,A,ARC,BS EN 13830
+CPS,Curtain Panels,*Louvre Panel*|*Solid Panel*|*Infill Panel*,Solid / Louvre Infill Panel,A,ARC,BS EN 13830
+SBP,Curtain Panels,*Breeze Block*|*Screen Block*|*Perforated Block*,Screen / Breeze Block Panel,A,ARC,BS EN 1996-1-1
+MLT,Curtain Wall Mullions,*Transom*,Curtain Wall Transom,A,ARC,BS EN 13830
+MLM,Curtain Wall Mullions,*Mullion*,Curtain Wall Mullion,A,ARC,BS EN 13830
+# ── Circulation: STAIRS, RAILINGS, RAMPS ────────────────────────────────────
+STRC,Stairs,*Concrete Stair*|*RC Stair*|*Cast-in-Place Stair*,Reinforced Concrete Stair,S,STR,BS EN 1992-1-1
+STRP,Stairs,*Precast Stair*,Precast Concrete Stair,S,STR,BS EN 13670
+STRS,Stairs,*Steel Stair*|*Metal Pan*,Steel Stair,S,STR,BS EN 1993-1-1
+STRT,Stairs,*Timber Stair*|*Wood Stair*,Timber Stair,S,STR,BS EN 1995-1-1
+RLS,Railings,*Stainless*|*SS Railing*,Stainless Steel Railing,A,ARC,BS EN 1090-1
+RLM,Railings,*Mild Steel*|*MS Railing*|*Steel Railing*|*Galvanised Railing*,Mild Steel Railing,A,ARC,BS EN 1090-1
+GBL,Railings,*Glass Railing*|*Glass Balustrade*|*Frameless Balustrade*,Glass Balustrade,A,ARC,BS 6180
+RLT,Railings,*Timber Railing*|*Timber Balustrade*,Timber Railing,A,ARC,BS 6180
+HRS,Handrails,*Stainless*,Stainless Steel Handrail,A,ARC,BS 8300-2
+HRM,Handrails,*Mild Steel*|*MS Handrail*|*Steel Handrail*,Mild Steel Handrail,A,ARC,BS 8300-2
+HRT,Handrails,*Timber Handrail*|*Hardwood Handrail*,Timber Handrail,A,ARC,BS 8300-2
+RMC,Ramps,*Concrete Ramp*|*RC Ramp*,Reinforced Concrete Ramp,S,STR,BS 8300-1
+# ── Roof edge + rainwater ───────────────────────────────────────────────────
+FSB,Fascia,*Timber Fascia*|*Barge Board*|*Bargeboard*,Timber Fascia / Barge Board,A,ARC,BS 8000-5
+FSM,Fascia,*Metal Fascia*|*Aluminium Fascia*|*PPC Fascia*,Metal Fascia,A,ARC,BS EN 508-1
+GTP,Gutter,*PVC Gutter*|*uPVC Gutter*|*Plastic Gutter*,uPVC Rainwater Gutter,P,SAN,BS EN 607
+GTM,Gutter,*Metal Gutter*|*Aluminium Gutter*|*Galvanised Gutter*|*Steel Gutter*,Metal Rainwater Gutter,P,SAN,BS EN 612
+SFT,Roof Soffits,*Timber Soffit*|*Ply Soffit*,Timber Soffit,A,ARC,BS 8000-5
+SFM,Roof Soffits,*Metal Soffit*|*PVC Soffit*|*uPVC Soffit*,Metal / uPVC Soffit,A,ARC,BS EN 14509
+# ── Structural: rebar family + framing accessories ──────────────────────────
+RBR,Structural Rebar,*Rebar*|*Reinforcement Bar*|*Y10*|*Y12*|*Y16*|*Y20*|*Y25*|*Y32*,Reinforcement Bar,S,STR,BS 4449
+RBM,Structural Fabric Reinforcement,*Mesh*|*Fabric*|*A142*|*A193*|*A252*|*A393*,Reinforcement Fabric / Mesh,S,STR,BS 4483
+RBC,Structural Rebar Couplers,*Coupler*,Rebar Coupler,S,STR,BS 8597
+TRU,Structural Trusses,*Truss*,Structural Truss,S,STR,BS EN 1993-1-1
+BSY,Structural Beam Systems,*Beam System*|*Joist System*,Structural Beam System,S,STR,BS EN 1993-1-1
+SCN,Structural Connections,*Connection*|*Base Plate*|*Splice*,Structural Connection,S,STR,BS EN 1993-1-8
+# ── MEP: the material IS the product for linear services ────────────────────
+PPV,Pipes,*uPVC*|*PVC-U*|*PVC Pipe*,uPVC Pipe,P,SAN,BS EN 1329-1
+PPR,Pipes,*PPR*|*PP-R*|*Polypropylene*,PPR Pressure Pipe,P,DCW,BS EN ISO 15874
+PCU,Pipes,*Copper Pipe*|*Copper Tube*,Copper Pipe,P,DCW,BS EN 1057
+PGI,Pipes,*Galvanised*|*Galvanized*|*GI Pipe*|*Mild Steel Pipe*,Galvanised Steel Pipe,P,DCW,BS EN 10255
+PPE,Pipes,*HDPE*|*MDPE*|*Polyethylene*,Polyethylene Pipe,P,DCW,BS EN 12201
+PCI,Pipes,*Cast Iron*|*Ductile Iron*,Cast / Ductile Iron Pipe,P,SAN,BS EN 877
+DGI,Ducts,*Galvanised Duct*|*GI Duct*|*Galvanised Steel Duct*,Galvanised Steel Duct,M,HVAC,BS EN 1505
+DPI,Ducts,*Pre-Insulated*|*Phenolic Duct*|*PIR Duct*,Pre-Insulated Duct,M,HVAC,BS EN 13403
+DFX,Ducts,*Flexible Duct*|*Flexi Duct*,Flexible Duct,M,HVAC,BS EN 13180
+CPV,Conduits,*PVC Conduit*|*uPVC Conduit*|*Plastic Conduit*,PVC Conduit,E,LV,BS EN 61386-21
+CGI,Conduits,*Galvanised Conduit*|*Steel Conduit*|*GI Conduit*,Steel Conduit,E,LV,BS EN 61386-21
+CTP,Cable Trays,*Perforated*,Perforated Cable Tray,E,LV,BS EN 61537
+CTL,Cable Trays,*Ladder*,Cable Ladder,E,LV,BS EN 61537
+CTS,Cable Trays,*Solid Bottom*|*Solid Tray*|*Trunking*,Solid-Bottom Tray / Trunking,E,LV,BS EN 61537
+# ── Plumbing equipment + electrical accessories ─────────────────────────────
+PEQT,Plumbing Equipment,*Water Tank*|*Storage Tank*|*Poly Tank*,Water Storage Tank,P,DCW,BS EN 13280
+PEQP,Plumbing Equipment,*Booster*|*Pressure Set*|*Water Pump*,Booster / Pressure Set,P,DCW,BS EN 806-2
+PEQS,Plumbing Equipment,*Septic*|*Soakaway*|*Biodigester*|*Bio-Digester*,Septic Tank / Soakaway,P,SAN,BS 6297
+PEQH,Plumbing Equipment,*Water Heater*|*Geyser*|*Calorifier*|*Solar Water*,Water Heater / Calorifier,P,HWS,BS EN 12897
+EFS,Electrical Fixtures,*Switch*|*Dimmer*,Wiring Accessory - Switch,E,LV,BS EN 60669
+EFP,Electrical Fixtures,*Socket*|*Outlet*|*Power Point*,Wiring Accessory - Socket Outlet,E,LV,BS 1363-2
 SLB,Floors,*Concrete Slab*|*RC Slab*,Reinforced Concrete Slab / Floor,S,STR,BS EN 1992-1-1
 PSB,Floors,*Post-Tension*|*PT Slab*,Post-Tensioned Concrete Slab,S,STR,BS EN 1992-1-5
 CFS,Floors,*Composite*|*Metal Deck*,Composite Metal Deck Floor Slab,S,STR,BS EN 1994-1-1


### PR DESCRIPTION
Walls, Roofs and Ceilings had **no rules at all** — 210 rules in the file and not one for the fabric of the building. Floors had three. So every wall in every project fell to the category default, and the only way out was a project overlay `Prod_GenerateRules` cannot even seed, because it skips system families on purpose.

## 22 rules, keyed on the type name and never the family

| | |
|---|---|
| **Walls** | `WBK` brick · `WBL` block · `WSN` stone · `WRC` RC · `WPT` partition · `WCW` curtain · `WCV` cavity · `WPR` parapet · `WCP` coping · `WBD` boundary · `RWL` retaining |
| **Roofs** | `RSH` sheet · `RTL` tile/shingle · `RCS` RC slab · `RFL` membrane · `RSG` rooflight |
| **Floors** | `FGS` ground slab · `FRB` ribbed/hollow-pot · `FSC` screed · `FTM` timber |
| **Ceilings** | `CSU` suspended · `CPB` plasterboard |

Most-specific-wins does the disambiguation: `Concrete Block Wall` resolves `WBL` (Concrete Block, 14) not `WRC`, and a breeze-block **curtain** panel resolves `WCW` (Curtain Wall, 12) not `WBL` (Block, 5).

## What they reach — measured, not claimed

On the model that prompted this, **56 of 98** wall/roof/floor elements now resolve specifically.

The other **42 cannot be reached by any rule**, and a test says so:

```
Exterior_CreamWhite_230 2    a colour
Generic - 225mm              a thickness
stepsr 7                     a typo
```

Nothing in them says what the thing *is*. That's a naming-standard problem, and a rule loose enough to match them would be matching noise. `A_Type_Name_That_Says_Nothing_Stays_Generic` fails if one ever starts resolving.

## The gate from #871 rejected two of these rules, and the gate was wrong

It forbade any rule matching a system family name, reasoning that every element shares it so it discriminates nothing. True of `Basic Wall`. **Not true** of `Curtain Wall` or `Sloped Glazing`, which name a distinct *kind* — a rule matching them gives every curtain wall one code, which is a true statement about curtain walls.

**Narrowing a gate to admit your own new rules is exactly how a gate stops meaning anything**, so the justification is worth stating plainly: the original *reason* was false for those two, not merely inconvenient.

The list now holds only true catch-alls, and **both halves are pinned** — a bare `*Basic Wall*` rule is still caught, and a new test requires at least one shipped rule to match a kind-bearing family, so the list cannot quietly widen back and take the architectural rules with it.

Ducts, Pipes and Structural Foundations left for the same reason: `Rectangular Duct` and `Wall Foundation` are kinds, and neither category has a catch-all at all.

## Note on the columns

Discipline `A` and system `ARC` are new to this file, which until now held only MEP, structural and healthcare rules. Both columns are documentation — nothing reads them (ROADMAP PROD-3) — but they must stay internally consistent, and `No_Prod_Code_Declares_Two_Disciplines` enforces it. `RWL` keeps `S`/`STR` in both categories it now appears in.

## Verification

Tags **466 → 493**, Boq unchanged at 1,238, build **0/0**, **five mutations verified failing** — including one that widens the catch-all list back, and one that loosens a rule to match a bare thickness.

**Not verified in Revit.** Expected next run: the 48 CLAY BRICK walls read `WBK`, the 4 curtain walls `WCW`, the 2 partitions `WPT`, the 2 copings `WCP`; specific rises **13 → 69 of 414**; and the 42 unnameable ones stay generic, which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)