### PR TITLE
feat(baseline): a house standard, and the two tools that get a model to it

### DIFF
--- a/StingTools.Tags.Tests/BaselineCatalogueTests.cs
+++ b/StingTools.Tags.Tests/BaselineCatalogueTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// The house standard, checked against the plugin that has to read it.
+    ///
+    /// <para><b>A standard the tool cannot read is the failure this catalogue exists to
+    /// prevent.</b> Its whole purpose is to replace type names like
+    /// <c>Exterior_CreamWhite_230</c> and <c>Generic - 225mm</c> — real names from
+    /// delivered models, neither of which can ever be measured — with names that resolve.
+    /// If the catalogue itself contained one, it would be prescribing the disease.</para>
+    ///
+    /// <para>Writing it, this gate caught three: <c>RC Steps - Terrazzo</c> (no Floors
+    /// rule for steps), <c>Stone Coated Tile Roof</c> (the tile rule read "Roof Tile" but
+    /// not "Tile Roof") and <c>Plastered Soffit</c> (a rendered soffit is not
+    /// plasterboard). All three were gaps in the RULES, not mistakes in the names — which
+    /// is the useful direction for a cross-check to fail in.</para>
+    /// </summary>
+    public class BaselineCatalogueTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_PROD_CODES.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data");
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private sealed class Catalogue
+        {
+            [JsonProperty("materials")] public List<BaselineMaterial> Materials;
+            [JsonProperty("wallTypes")] public List<BaselineHostType> WallTypes;
+            [JsonProperty("floorTypes")] public List<BaselineHostType> FloorTypes;
+            [JsonProperty("roofTypes")] public List<BaselineHostType> RoofTypes;
+            [JsonProperty("ceilingTypes")] public List<BaselineHostType> CeilingTypes;
+        }
+
+        private static Catalogue Load()
+        {
+            var c = JsonConvert.DeserializeObject<Catalogue>(
+                File.ReadAllText(Path.Combine(DataDir(), "STING_PROJECT_BASELINE.json")));
+            Assert.True(c?.Materials != null && c.Materials.Count > 20,
+                "STING_PROJECT_BASELINE.json did not parse into a catalogue");
+            return c;
+        }
+
+        private static List<(string Pattern, string ProdCode)> Rules(string category)
+        {
+            var outList = new List<(string, string)>();
+            foreach (string raw in File.ReadAllLines(Path.Combine(DataDir(), "STING_PROD_CODES.csv")).Skip(1))
+            {
+                string line = (raw ?? "").Trim();
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+                var c = line.Split(',');
+                if (c.Length < 3) continue;
+                if (!string.Equals(c[1].Trim(), category, StringComparison.OrdinalIgnoreCase)) continue;
+                outList.Add((c[2].Trim().ToUpperInvariant(), c[0].Trim()));
+            }
+            return outList;
+        }
+
+        public static IEnumerable<object[]> HostTypeGroups()
+        {
+            var c = Load();
+            foreach (var t in c.WallTypes) yield return new object[] { "Walls", t.Name };
+            foreach (var t in c.FloorTypes) yield return new object[] { "Floors", t.Name };
+            foreach (var t in c.RoofTypes) yield return new object[] { "Roofs", t.Name };
+            foreach (var t in c.CeilingTypes) yield return new object[] { "Ceilings", t.Name };
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Every name in the standard resolves
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [MemberData(nameof(HostTypeGroups))]
+        public void Every_Catalogue_Type_Resolves_To_A_Specific_Prod_Code(string category, string typeName)
+        {
+            // The family name is the catch-all one Revit gives every element of this
+            // kind, so the TYPE name is doing all the work — same as in a real model.
+            string family = category == "Walls" ? "Basic Wall"
+                          : category == "Roofs" ? "Basic Roof"
+                          : category == "Floors" ? "Floor" : "Compound Ceiling";
+
+            ProdResolver.Resolve(family, typeName, category, null, Rules(category), null, out string source);
+
+            Assert.True(ProdResolver.IsSpecific(source),
+                $"The house standard prescribes '{typeName}', and the plugin resolves it to the "
+                + $"{category} category default. A standard that names a type the tool cannot read "
+                + "is prescribing the problem it exists to fix — add the rule, or rename the type.");
+        }
+
+        [Fact]
+        public void Every_Catalogue_Material_Is_Classifiable_Or_Deliberately_Not()
+        {
+            // A material with no suffix is not automatically wrong — Terrazzo had none
+            // until a rule was added for it — but a catalogue where MOST materials fail
+            // to classify would mean the naming shape and the override table disagree.
+            var rules = MaterialProdOverrideRules.Parse(
+                File.ReadAllLines(Path.Combine(DataDir(), "STING_MATERIAL_PROD_OVERRIDES.csv")));
+
+            var unclassified = Load().Materials
+                .Where(m => MaterialProdOverrideRules.ResolveSuffix(rules, m.Name, "Walls") == null)
+                .Select(m => m.Name).ToList();
+
+            Assert.True(unclassified.Count == 0,
+                "Catalogue materials the override table cannot classify. Either the name does not "
+                + "lead with its material family (rule M1), or the table is missing that family:\n  "
+                + string.Join("\n  ", unclassified));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Internal integrity
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Every_Layer_Names_A_Material_The_Catalogue_Declares()
+        {
+            // The minter creates materials first, then types that reference them by name.
+            // A layer naming a material the list omits produces a type with a missing
+            // material — which is precisely the "no material decided" state that made
+            // 631 m2 of roof unmeasurable on a delivered model.
+            var c = Load();
+            var declared = new HashSet<string>(c.Materials.Select(m => m.Name), StringComparer.OrdinalIgnoreCase);
+
+            var orphans = new[] { c.WallTypes, c.FloorTypes, c.RoofTypes, c.CeilingTypes }
+                .SelectMany(g => g)
+                .SelectMany(t => (t.Layers ?? new List<BaselineLayer>()).Select(l => new { t.Name, l.Material }))
+                .Where(x => !string.IsNullOrWhiteSpace(x.Material) && !declared.Contains(x.Material))
+                .Select(x => $"{x.Name} -> '{x.Material}'")
+                .Distinct().ToList();
+
+            Assert.True(orphans.Count == 0,
+                "Layers naming a material the catalogue does not declare:\n  " + string.Join("\n  ", orphans));
+        }
+
+        [Fact]
+        public void Every_Structural_Type_Flags_Its_Core()
+        {
+            // Rule T1. Without a Structure layer the element is named after its thickest
+            // layer of any function, which is how 11 rendered masonry walls came to read
+            // as gypsum. A catalogue that shipped an unflagged core would teach the defect.
+            var c = Load();
+            var unflagged = new[] { c.WallTypes, c.FloorTypes, c.RoofTypes }
+                .SelectMany(g => g)
+                .Where(t => (t.Layers?.Count ?? 0) > 1)
+                .Where(t => !t.Layers.Any(l => string.Equals(l.Function, "Structure", StringComparison.OrdinalIgnoreCase)))
+                .Select(t => t.Name).ToList();
+
+            Assert.True(unflagged.Count == 0,
+                "Multi-layer types with no layer flagged Structure — the core must say it is the core:\n  "
+                + string.Join("\n  ", unflagged));
+        }
+
+        [Fact]
+        public void The_Catalogue_Covers_The_Builds_A_Real_Model_Used()
+        {
+            // Anchored to what two delivered models actually contained, so the standard
+            // cannot shrink to a set that is easy to satisfy and useless in practice.
+            var c = Load();
+            var all = new[] { c.WallTypes, c.FloorTypes, c.RoofTypes, c.CeilingTypes }
+                .SelectMany(g => g).Select(t => t.Name).ToList();
+
+            foreach (string must in new[]
+            {
+                "Blockwork 200",       // the Uganda default wall
+                "Clay Brick",          // 48 elements on one model
+                "Stud Partition",      // the 97mm partition
+                "Ground Slab",         // was entirely absent from the starter set
+                "Hollow Pot",          // the East African economy span
+                "Corrugated Sheet",    // IT4, the default roof
+                "RC Flat Roof",
+            })
+                Assert.True(all.Any(n => n.IndexOf(must, StringComparison.OrdinalIgnoreCase) >= 0),
+                    $"The catalogue no longer covers '{must}', which a delivered model used.");
+        }
+
+        [Fact]
+        public void Tiled_Finishes_Survive_As_LAYERS()
+        {
+            // The reason the baseline exists: an export found 10 wall/floor types with ONE
+            // finish layer between them, so no tiling could be measured at all. At least
+            // one floor and one wall must carry a tile layer, or the catalogue has
+            // regressed to the state it was written to fix.
+            var c = Load();
+            Assert.Contains(c.FloorTypes, t => t.HasTiledFinish);
+            Assert.Contains(c.WallTypes, t => t.HasTiledFinish);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/ProdCodeDataTests.cs
+++ b/StingTools.Tags.Tests/ProdCodeDataTests.cs
@@ -363,6 +363,15 @@ namespace StingTools.Tags.Tests
         [InlineData("Floors", "Floor", "50 Screed", "FSC")]
         [InlineData("Floors", "Floor", "Concrete Slab 200", "SLB")]   // pre-existing, unmoved
         [InlineData("Ceilings", "Compound Ceiling", "Suspended Ceiling 600x600", "CSU")]
+        // Reclassified while writing the house standard, which needed a Floors rule
+        // for steps. "stepsr 7" was on the CANNOT-RESOLVE list as a typo naming
+        // nothing — but it does name steps, badly, and *Steps* reads it. Moving it
+        // here rather than loosening the negative test around it: the name became
+        // resolvable because a real rule was added, not because a gate was relaxed.
+        [InlineData("Floors", "Floor", "stepsr 7", "FSP")]
+        [InlineData("Floors", "Floor", "RC Steps - Terrazzo", "FSP")]
+        [InlineData("Roofs", "Basic Roof", "Stone Coated Tile Roof", "RTL")]
+        [InlineData("Ceilings", "Compound Ceiling", "Plastered Soffit", "CPL")]
         // Openings, circulation, MEP linear services — the categories where the
         // sub-distinction changes what you BUY, which is the BOQ's criterion.
         [InlineData("Doors", "Door", "Flush Door 900x2100", "DRT")]
@@ -407,7 +416,6 @@ namespace StingTools.Tags.Tests
         [InlineData("Walls", "Basic Wall", "Exterior_CreamWhite_230 2")]
         [InlineData("Walls", "Basic Wall", "Exterior_BrownWhite_230")]
         [InlineData("Roofs", "Basic Roof", "Generic - 225mm")]
-        [InlineData("Floors", "Floor", "stepsr 7")]
         [InlineData("Floors", "Floor", "IntFloor_tile_150")]
         public void A_Type_Name_That_Says_Nothing_Stays_Generic(string category, string family, string type)
         {

--- a/StingTools.Tags.Tests/StandardisePlannerTests.cs
+++ b/StingTools.Tags.Tests/StandardisePlannerTests.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// The two bulk operations the house standard needs, and the refusals that make
+    /// them safe to run on a delivered model.
+    ///
+    /// <para>Both share one discipline: <b>they read what the model says, and stop where
+    /// it says nothing.</b> A renamer that guessed would replace a name a reader can see
+    /// is empty — "Generic - 225mm" — with one they cannot: "RC Slab 225" on a timber
+    /// deck. A classifier that guessed would launder that guess into <c>MaterialClass</c>,
+    /// the one controlled field the carbon and cost engines trust.</para>
+    /// </summary>
+    public class StandardisePlannerTests
+    {
+        private static MaterialLayer L(int i, string mat, double mm, bool structure = false)
+            => new MaterialLayer { Index = i, MaterialName = mat, ThicknessMm = mm, IsStructure = structure };
+
+        private static TypeRenameInput In(string cat, string name, params MaterialLayer[] ls)
+            => new TypeRenameInput { Category = cat, CurrentName = name, Layers = ls.ToList(), InstanceCount = 5 };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Renaming: the model supplies the words
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Wall_That_Could_Not_Be_Named_Gets_A_Name()
+        {
+            // Verbatim: 6 elements, a name carrying a colour and a thickness. Its
+            // MATERIALS were right all along — which is the whole premise.
+            var p = TypeRenamePlanner.Plan(In("Walls", "Exterior_CreamWhite_230 2",
+                L(0, "Plaster - Cement Render 1:4", 12),
+                L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true),
+                L(2, "Plaster - Cement Render 1:4", 12)));
+
+            Assert.Equal("STING WL - Blockwork 200 - Plastered", p.ProposedName);
+        }
+
+        [Fact]
+        public void The_Size_Comes_From_The_CORE_Not_The_Old_Name()
+        {
+            // "230" in the old name is the nominal wall; the block is 200. The proposal
+            // must describe the thing, not repeat the number it was called.
+            var p = TypeRenamePlanner.Plan(In("Walls", "Exterior_BrownWhite_230",
+                L(0, "Plaster - Cement Render 1:4", 12),
+                L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true)));
+
+            Assert.Contains("Blockwork 200", p.ProposedName);
+            Assert.DoesNotContain("230", p.ProposedName);
+        }
+
+        [Fact]
+        public void A_Tiled_Floor_Names_Its_Finish()
+        {
+            var p = TypeRenamePlanner.Plan(In("Floors", "stepsr 7",
+                L(0, "Tile - Ceramic Floor 300x300", 10),
+                L(1, "Screed - Cement Sand 1:3", 40),
+                L(2, "Concrete C25", 150, structure: true)));
+
+            Assert.Equal("STING FL - RC 150 - Ceramic Tiled", p.ProposedName);
+        }
+
+        [Fact]
+        public void The_CORE_Wins_Over_A_Thicker_Non_Structural_Layer()
+        {
+            // Same rule as the PROD suffix reads. One definition, not two.
+            var p = TypeRenamePlanner.Plan(In("Walls", "whatever",
+                L(0, "Insulation - Mineral Wool", 200),
+                L(1, "Timber - Softwood Cypress", 90, structure: true)));
+
+            Assert.Contains("Timber 90", p.ProposedName);
+        }
+
+        // ── the refusals ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void A_Type_Whose_Materials_Say_Nothing_Gets_NO_Proposal()
+        {
+            // The roof at the centre of this whole run: 11 elements, material
+            // "Default Roof", nothing to read. Naming it would be inventing.
+            var p = TypeRenamePlanner.Plan(In("Roofs", "Generic - 225mm",
+                L(0, "Default Roof", 225, structure: true)));
+
+            Assert.Null(p.ProposedName);
+            Assert.Contains("names no substance", p.Reason);
+            Assert.Contains("rename the MATERIAL first", p.Reason);
+        }
+
+        [Fact]
+        public void A_Type_With_No_Materials_At_All_Gets_NO_Proposal()
+        {
+            var p = TypeRenamePlanner.Plan(In("Roofs", "Generic - 225mm", L(0, "", 225, structure: true)));
+            Assert.Null(p.ProposedName);
+            Assert.Contains("nothing to read", p.Reason);
+        }
+
+        [Fact]
+        public void A_Conforming_Type_Is_Reported_But_Not_Renamed()
+        {
+            // Running twice must not churn. The second run proposes the same name and
+            // recognises the type already has it.
+            var input = In("Walls", "STING WL - Blockwork 200 - Plastered",
+                L(0, "Plaster - Cement Render 1:4", 12),
+                L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true));
+
+            var p = TypeRenamePlanner.Plan(input);
+            Assert.True(p.IsProposal);
+            Assert.True(p.AlreadyConforms);
+        }
+
+        [Fact]
+        public void The_Summary_Says_The_Refusals_Are_Not_Failures()
+        {
+            var ps = TypeRenamePlanner.PlanAll(new[]
+            {
+                In("Walls", "a", L(0, "Masonry - Clay Brick 295x150x130", 295, structure: true)),
+                In("Roofs", "b", L(0, "Default Roof", 225, structure: true)),
+            });
+            string s = TypeRenamePlanner.Summary(ps);
+            Assert.Contains("1 can be renamed", s);
+            Assert.Contains("1 cannot be named", s);
+            Assert.Contains("not failures of this tool", s);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Material Class: fill the blank, never the chosen
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData("Concrete C25", "Concrete")]
+        [InlineData("Masonry - Hollow Concrete Block 200mm", "Masonry")]
+        [InlineData("Masonry - Clay Brick 295x150x130", "Masonry")]
+        [InlineData("Steel - Reinforcement Bar Y", "Metal")]
+        [InlineData("Steel - Galvanised Sheet G28", "Metal")]
+        [InlineData("Roofing - Stone Coated Tile", "Metal")]
+        [InlineData("Timber - Hardwood Mvule", "Wood")]
+        [InlineData("Tile - Porcelain Floor 600x600", "Ceramic")]
+        [InlineData("Plaster - Cement Render 1:4", "Gypsum")]
+        [InlineData("Bitumen - DPM 1000 Gauge", "Membrane")]
+        [InlineData("Insulation - Mineral Wool", "Insulation")]
+        [InlineData("Glass - Toughened 10mm", "Glass")]
+        [InlineData("PVC - uPVC Section", "Plastic")]
+        [InlineData("Hardcore - Stone Fill", "Stone")]
+        [InlineData("Paint - Weatherguard Exterior", "Paint")]
+        public void A_Named_Material_Is_Classified(string name, string expected)
+        {
+            Assert.Equal(expected, MaterialClassPlanner.Plan(name, "").ProposedClass);
+        }
+
+        [Fact]
+        public void Stone_Coated_Steel_Tile_Is_METAL_Not_Stone()
+        {
+            // The ordering that makes the table work: the most specific needle first, or
+            // "Stone Coated" reads as Stone and a steel roof tile is priced as masonry.
+            Assert.Equal("Metal", MaterialClassPlanner.Plan("Roofing - Stone Coated Tile", "").ProposedClass);
+            Assert.Equal("Stone", MaterialClassPlanner.Plan("Hardcore - Stone Fill", "").ProposedClass);
+        }
+
+        [Theory]
+        [InlineData("Default Roof")]
+        [InlineData("Material 12")]
+        [InlineData("Finish - As Specified")]
+        [InlineData("Exterior_CreamWhite_230")]
+        public void A_Material_That_Names_No_Substance_Is_Left_BLANK(string name)
+        {
+            var p = MaterialClassPlanner.Plan(name, "");
+            Assert.Null(p.ProposedClass);
+            Assert.Contains("left blank rather than guessed", p.Reason);
+        }
+
+        [Theory]
+        [InlineData("Concrete")]
+        [InlineData("Wood")]
+        public void An_EXISTING_Class_Is_Never_Overwritten(string existing)
+        {
+            // Somebody chose it. A bulk tool that replaces a human's classification is
+            // worse than one that does nothing.
+            var p = MaterialClassPlanner.Plan("Steel - Structural S275", existing);
+            Assert.Null(p.ProposedClass);
+            Assert.Contains("already classified", p.Reason);
+        }
+
+        [Fact]
+        public void Unassigned_Counts_As_Blank()
+        {
+            // Revit's own placeholder, not a decision.
+            Assert.Equal("Metal", MaterialClassPlanner.Plan("Steel - Structural S275", "Unassigned").ProposedClass);
+        }
+
+        [Fact]
+        public void Every_Proposed_Class_Is_One_Revit_Actually_Uses()
+        {
+            // Inventing a class would fragment the very field this exists to make
+            // dependable — the carbon and cost engines group on it.
+            var known = new HashSet<string>(MaterialClassPlanner.RevitClasses);
+            var names = new[]
+            {
+                "Concrete C25", "Masonry - Clay Brick", "Steel - Rebar", "Timber - Mvule",
+                "Tile - Ceramic", "Plaster - Render", "Bitumen - Felt", "Insulation - EPS Board",
+                "Glass - Float", "PVC - uPVC", "Hardcore - Stone", "Paint - Emulsion",
+                "Sand - Building Sand", "Carpet - Wool",
+            };
+            foreach (string n in names)
+            {
+                string c = MaterialClassPlanner.Plan(n, "").ProposedClass;
+                if (c != null) Assert.Contains(c, known);
+            }
+        }
+
+        [Fact]
+        public void The_Summary_Points_At_The_Materials_Worth_Renaming()
+        {
+            var ps = MaterialClassPlanner.PlanAll(new[]
+            {
+                ("Concrete C25", ""), ("Steel - Structural S275", "Metal"), ("Default Roof", ""),
+            });
+            string s = MaterialClassPlanner.Summary(ps);
+            Assert.Contains("1 already classified and untouched", s);
+            Assert.Contains("1 will be set", s);
+            Assert.Contains("1 left blank", s);
+            Assert.Contains("a blank Class is visible, and a guessed one is not", s);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -73,6 +73,10 @@
     <Compile Include="..\StingTools\Core\ScopeBoxLoc.cs" Link="Core\ScopeBoxLoc.cs" />
     <Compile Include="..\StingTools\Core\ProdPatternMatcher.cs" Link="Core\ProdPatternMatcher.cs" />
     <Compile Include="..\StingTools\Core\ProdResolver.cs" Link="Core\ProdResolver.cs" />
+    <!-- The house-standard catalogue POCOs, so the shipped baseline is checked
+         against the rules that must read it. -->
+    <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Core\Baseline\ProjectBaselineModel.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\FinishTextClassifier.cs" Link="Core\MaterialSchedule\FinishTextClassifier.cs" />
     <!-- The shared "not a thing" mechanism + the PROD policy that loads it. Kept
          Revit-free so the shipped exclusion list is asserted against the real
          model counts that exposed the 0.8%-vs-3.1% denominator. -->
@@ -85,6 +89,10 @@
     <!-- Which layer of a compound element NAMES it. Revit-free so the choice is
          testable: every defect here has been a wrong choice, not a failed read. -->
     <Compile Include="..\StingTools\Core\PrimaryMaterialSelector.cs" Link="Core\PrimaryMaterialSelector.cs" />
+    <!-- The two bulk standardisation planners. Revit-free so the REFUSALS - the
+         half that makes them safe on a delivered model - are provable. -->
+    <Compile Include="..\StingTools\Core\Baseline\TypeRenamePlanner.cs" Link="Core\Baseline\TypeRenamePlanner.cs" />
+    <Compile Include="..\StingTools\Core\Materials\MaterialClassPlanner.cs" Link="Core\Materials\MaterialClassPlanner.cs" />
     <!-- IM-15: config-driven revision scheme. Kept Revit-free so the P→C default and the
          per-appointment override are provable without a Revit host. -->
     <Compile Include="..\StingTools\Docs\Templates\RevisionScheme.cs" Link="Docs\Templates\RevisionScheme.cs" />

--- a/StingTools/Commands/Baseline/StandardiseCommands.cs
+++ b/StingTools/Commands/Baseline/StandardiseCommands.cs
@@ -1,0 +1,300 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  StandardiseCommands.cs — the two bulk operations the house standard needs.
+//
+//    Baseline_RenameTypes   propose house-standard names for existing host
+//                           types, from the model's OWN materials
+//    Materials_SetClass     fill Revit's Material Class where it is blank
+//
+//  Both are two-step by design: the audit form writes a CSV and changes
+//  nothing; the apply form asks first and reports what it did. A rename
+//  changes what schedules, filters and view templates key on, and a Class is
+//  read by the carbon and cost engines — neither is a thing to do silently.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using StingTools.Core.Materials;
+
+namespace StingTools.Commands.Baseline
+{
+    internal static class Standardise
+    {
+        internal static string Csv(string s)
+        {
+            s = s ?? "";
+            return s.IndexOfAny(new[] { ',', '"', '\n' }) >= 0 ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+        }
+
+        internal static string Write(Document doc, string stem, IEnumerable<string> rows)
+        {
+            try
+            {
+                string dir = StingPaths.Meta(doc, "_BIM_COORD");
+                Directory.CreateDirectory(dir);
+                string path = Path.Combine(dir, $"{stem}_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+                File.WriteAllLines(path, rows, Encoding.UTF8);
+                return path;
+            }
+            catch (Exception ex) { StingLog.Warn($"{stem} CSV: {ex.Message}"); return null; }
+        }
+
+        /// <summary>Every layered host type in the document, with its layers flattened
+        /// and its instance count — the planner's input.</summary>
+        internal static List<TypeRenameInput> ReadHostTypes(Document doc)
+        {
+            var counts = new Dictionary<long, int>();
+            foreach (Element el in new FilteredElementCollector(doc).WhereElementIsNotElementType()
+                                      .OfClass(typeof(HostObject)))
+            {
+                var tid = el.GetTypeId();
+                if (tid == null || tid.Value <= 0) continue;
+                counts.TryGetValue(tid.Value, out int n);
+                counts[tid.Value] = n + 1;
+            }
+
+            var outList = new List<TypeRenameInput>();
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(HostObjAttributes))
+                                 .Cast<HostObjAttributes>())
+            {
+                string cat = t.Category?.Name;
+                if (string.IsNullOrEmpty(cat)) continue;
+
+                CompoundStructure cs = null;
+                try { cs = t.GetCompoundStructure(); }
+                catch (Exception ex) { StingLog.WarnRateLimited("Std.CS", $"GetCompoundStructure {t.Id}: {ex.Message}"); }
+                if (cs == null) continue;
+
+                var layers = new List<MaterialLayer>();
+                var cls = cs.GetLayers();
+                for (int i = 0; i < cls.Count; i++)
+                {
+                    var cl = cls[i];
+                    string name = null;
+                    if (cl.MaterialId != null && cl.MaterialId.Value > 0)
+                        name = doc.GetElement(cl.MaterialId)?.Name;
+                    if (string.IsNullOrWhiteSpace(name)) continue;
+                    layers.Add(new MaterialLayer
+                    {
+                        Index = i,
+                        MaterialName = name,
+                        ThicknessMm = cl.Width * 304.8,
+                        IsStructure = cl.Function == MaterialFunctionAssignment.Structure,
+                    });
+                }
+
+                counts.TryGetValue(t.Id.Value, out int used);
+                outList.Add(new TypeRenameInput
+                {
+                    Category = cat, CurrentName = t.Name, Layers = layers, InstanceCount = used,
+                });
+            }
+            return outList;
+        }
+    }
+
+    /// <summary>
+    /// Baseline_RenameTypes — propose house-standard names for the host types this
+    /// model already has, reading the substance off each type's own core material.
+    /// Writes a CSV and, on confirmation, applies the renames.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class RenameTypesToStandardCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+                Document doc = ctx.Doc;
+
+                var plans = TypeRenamePlanner.PlanAll(Standardise.ReadHostTypes(doc));
+                if (plans.Count == 0)
+                {
+                    TaskDialog.Show("Rename Types", "No layered host types found in this model.");
+                    return Result.Succeeded;
+                }
+
+                var rows = new List<string> { "Category,CurrentName,ProposedName,Instances,Outcome,Reason" };
+                foreach (var p in plans.OrderBy(x => x.Category).ThenBy(x => x.CurrentName))
+                    rows.Add(string.Join(",", Standardise.Csv(p.Category), Standardise.Csv(p.CurrentName),
+                        Standardise.Csv(p.ProposedName ?? ""), p.InstanceCount,
+                        p.AlreadyConforms ? "conforms" : p.IsProposal ? "rename" : "cannot name",
+                        Standardise.Csv(p.Reason)));
+                string path = Standardise.Write(doc, "type_rename_plan", rows);
+
+                var todo = plans.Where(p => p.IsProposal && !p.AlreadyConforms).ToList();
+                var sb = new StringBuilder();
+                sb.AppendLine(TypeRenamePlanner.Summary(plans));
+                sb.AppendLine();
+                foreach (var p in todo.OrderByDescending(p => p.InstanceCount).Take(12))
+                    sb.AppendLine($"  {p.InstanceCount,4} x  {p.CurrentName}  →  {p.ProposedName}");
+                if (todo.Count > 12) sb.AppendLine($"  … and {todo.Count - 12} more, in the CSV");
+                if (path != null) { sb.AppendLine(); sb.AppendLine("Plan: " + path); }
+
+                if (todo.Count == 0)
+                {
+                    TaskDialog.Show("Rename Types", sb.ToString());
+                    return Result.Succeeded;
+                }
+
+                sb.AppendLine();
+                sb.AppendLine("A rename changes what schedules, filters and view templates key on. "
+                            + "Apply these now?");
+                var td = new TaskDialog("Rename Types to House Standard")
+                {
+                    MainInstruction = $"{todo.Count} type(s) can be renamed",
+                    MainContent = sb.ToString(),
+                    CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton = TaskDialogResult.No,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+
+                int done = 0; var failed = new List<string>();
+                using (var t = new Transaction(doc, "STING Rename Types to Standard"))
+                {
+                    t.Start();
+                    // Name by name, so one clash does not lose the rest.
+                    foreach (var p in todo)
+                    {
+                        var type = new FilteredElementCollector(doc).OfClass(typeof(HostObjAttributes))
+                            .FirstOrDefault(e => string.Equals(e.Name, p.CurrentName, StringComparison.Ordinal)
+                                              && string.Equals(e.Category?.Name, p.Category, StringComparison.OrdinalIgnoreCase));
+                        if (type == null) { failed.Add($"{p.CurrentName} — no longer present"); continue; }
+                        try { type.Name = p.ProposedName; done++; }
+                        catch (Exception ex) { failed.Add($"{p.CurrentName} — {ex.Message}"); }
+                    }
+                    t.Commit();
+                }
+
+                var res = new StringBuilder($"Renamed {done} of {todo.Count} type(s).");
+                if (failed.Count > 0)
+                {
+                    res.AppendLine().AppendLine();
+                    res.AppendLine("Not renamed — most often a name already in use:");
+                    foreach (string f in failed.Take(10)) res.AppendLine("  " + f);
+                }
+                TaskDialog.Show("Rename Types", res.ToString());
+                StingLog.Info($"Baseline_RenameTypes: {done}/{todo.Count} renamed, {failed.Count} failed -> {path}");
+                return Result.Succeeded;
+            }
+            catch (OperationCanceledException) { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("Baseline_RenameTypes", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Materials_SetClass — fill Revit's Material Class where it is blank, from the
+    /// material's own name. Never overwrites a class somebody already chose, and never
+    /// guesses one for a name that says nothing.
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class SetMaterialClassCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+                Document doc = ctx.Doc;
+
+                var mats = new FilteredElementCollector(doc).OfClass(typeof(Material))
+                              .Cast<Material>().OrderBy(m => m.Name).ToList();
+                if (mats.Count == 0)
+                {
+                    TaskDialog.Show("Material Class", "This model has no materials.");
+                    return Result.Succeeded;
+                }
+
+                var plans = mats.Select(m => new
+                {
+                    Mat = m,
+                    Plan = MaterialClassPlanner.Plan(m.Name, SafeClass(m)),
+                }).ToList();
+
+                var rows = new List<string> { "Material,ExistingClass,ProposedClass,Reason" };
+                foreach (var x in plans)
+                    rows.Add(string.Join(",", Standardise.Csv(x.Plan.MaterialName),
+                        Standardise.Csv(x.Plan.ExistingClass), Standardise.Csv(x.Plan.ProposedClass ?? ""),
+                        Standardise.Csv(x.Plan.Reason)));
+                string path = Standardise.Write(doc, "material_class_plan", rows);
+
+                var todo = plans.Where(x => x.Plan.WillWrite).ToList();
+                var sb = new StringBuilder();
+                sb.AppendLine(MaterialClassPlanner.Summary(plans.Select(x => x.Plan).ToList()));
+                sb.AppendLine();
+                sb.AppendLine("Class is read by the embodied-carbon and BOQ cost engines. A material "
+                            + "with none is answered by nothing at all.");
+                foreach (var x in todo.Take(12))
+                    sb.AppendLine($"  {x.Plan.MaterialName}  →  {x.Plan.ProposedClass}");
+                if (todo.Count > 12) sb.AppendLine($"  … and {todo.Count - 12} more, in the CSV");
+                if (path != null) { sb.AppendLine(); sb.AppendLine("Plan: " + path); }
+
+                if (todo.Count == 0)
+                {
+                    TaskDialog.Show("Material Class", sb.ToString());
+                    return Result.Succeeded;
+                }
+
+                var td = new TaskDialog("Set Material Class")
+                {
+                    MainInstruction = $"{todo.Count} material(s) will be classified",
+                    MainContent = sb.ToString() + Environment.NewLine + "Apply?",
+                    CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton = TaskDialogResult.No,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+
+                int done = 0; var failed = new List<string>();
+                using (var t = new Transaction(doc, "STING Set Material Class"))
+                {
+                    t.Start();
+                    foreach (var x in todo)
+                    {
+                        try { x.Mat.MaterialClass = x.Plan.ProposedClass; done++; }
+                        catch (Exception ex) { failed.Add($"{x.Plan.MaterialName} — {ex.Message}"); }
+                    }
+                    t.Commit();
+                }
+
+                var res = new StringBuilder($"Classified {done} of {todo.Count} material(s).");
+                if (failed.Count > 0)
+                {
+                    res.AppendLine().AppendLine("Not set:");
+                    foreach (string f in failed.Take(10)) res.AppendLine("  " + f);
+                }
+                TaskDialog.Show("Material Class", res.ToString());
+                StingLog.Info($"Materials_SetClass: {done}/{todo.Count} set, {failed.Count} failed -> {path}");
+                return Result.Succeeded;
+            }
+            catch (OperationCanceledException) { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("Materials_SetClass", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        private static string SafeClass(Material m)
+        {
+            try { return m?.MaterialClass ?? ""; }
+            catch (Exception ex) { StingLog.WarnRateLimited("Std.MatCls", $"MaterialClass: {ex.Message}"); return ""; }
+        }
+    }
+}

--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -1,0 +1,182 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeRenamePlanner.cs — propose house-standard names for the types a model
+//  already has, and refuse to guess.
+//
+//  The house standard tells you what to CALL things. It does nothing for the
+//  model already delivered, whose types are called "Exterior_CreamWhite_230",
+//  "Generic - 225mm" and "stepsr 7" — names that carry a colour, a thickness
+//  and a typo, and that no rule can ever measure.
+//
+//  Renaming those by hand is the work this closes. But a rename is destructive
+//  in a way a tag is not: it changes what a schedule, a filter and a view
+//  template all key on. So this PLANS, and the caller applies.
+//
+//  THE RULE THAT MAKES IT SAFE: a proposal is only made when the model itself
+//  supplies the words. The substance comes from the type's own thickest
+//  STRUCTURAL LAYER MATERIAL — chosen by whoever built the model, not inferred
+//  from a name — and the size from that layer's thickness. Where there is no
+//  structural layer to read, this proposes NOTHING and says so. A renamer that
+//  guessed would replace a bad name with a confident wrong one, which is worse:
+//  a reader can see that "Generic - 225mm" says nothing, and cannot see that
+//  "RC Slab 225" is a lie about a timber deck.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace StingTools.Core.Baseline
+{
+    /// <summary>What the planner was able to read off one type.</summary>
+    public sealed class TypeRenameInput
+    {
+        /// <summary>Revit category display name — Walls / Floors / Roofs / Ceilings.</summary>
+        public string Category = "";
+        public string CurrentName = "";
+        /// <summary>Layers as the compound structure gives them, exterior to interior.</summary>
+        public List<MaterialLayer> Layers = new List<MaterialLayer>();
+        /// <summary>How many elements use this type. Renaming an unused type is noise.</summary>
+        public int InstanceCount;
+    }
+
+    public sealed class TypeRenameProposal
+    {
+        public string Category = "";
+        public string CurrentName = "";
+        /// <summary>Null when the model does not say enough to name the type.</summary>
+        public string ProposedName;
+        /// <summary>Why — shown to the reader either way.</summary>
+        public string Reason = "";
+        public int InstanceCount;
+
+        public bool IsProposal => !string.IsNullOrEmpty(ProposedName);
+        /// <summary>True when the current name already matches what would be proposed.</summary>
+        public bool AlreadyConforms =>
+            IsProposal && string.Equals(CurrentName?.Trim(), ProposedName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static class TypeRenamePlanner
+    {
+        private static readonly Dictionary<string, string> UseCode =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Walls"] = "WL", ["Floors"] = "FL", ["Roofs"] = "RF", ["Ceilings"] = "CL",
+            };
+
+        /// <summary>
+        /// Words that name a substance, longest first so "Hollow Concrete Block" beats
+        /// "Concrete". Keyed on the MATERIAL name, which is the deliberate half of the
+        /// model — nobody renames a material to make a schedule work.
+        /// </summary>
+        private static readonly (string Needle, string Word)[] Substance =
+        {
+            ("hollow concrete block", "Blockwork"), ("solid concrete block", "Blockwork"),
+            ("concrete block", "Blockwork"), ("blockwork", "Blockwork"),
+            ("clay brick", "Clay Brick"), ("brick", "Clay Brick"),
+            ("screen block", "Screen Block"),
+            ("concrete", "RC"),
+            ("reinforcement", "RC"),
+            ("timber", "Timber"), ("softwood", "Timber"), ("hardwood", "Timber"),
+            ("plywood", "Plywood"),
+            ("galvanised sheet", "Corrugated Sheet"), ("galvanized sheet", "Corrugated Sheet"),
+            ("clay tile", "Clay Tile Roof"), ("stone coated", "Stone Coated Tile Roof"),
+            ("steel", "Steel"),
+            ("gypsum", "Plasterboard"), ("plasterboard", "Plasterboard"),
+            ("stone", "Stone"),
+        };
+
+        /// <summary>Finish words, read off the FINISH layers the same way.</summary>
+        private static readonly (string Needle, string Word)[] Finish =
+        {
+            ("porcelain", "Porcelain Tiled"), ("ceramic", "Ceramic Tiled"), ("tile", "Tiled"),
+            ("terrazzo", "Terrazzo"),
+            ("plaster", "Plastered"), ("render", "Plastered"),
+            ("gypsum", "Boarded"), ("plasterboard", "Boarded"),
+            ("felt", "Felt"), ("bitumen", "Felt"),
+            ("paint", "Painted"), ("screed", "Screed Only"),
+        };
+
+        /// <summary>
+        /// Propose one name, or explain why not.
+        ///
+        /// <para>Shape: <c>STING {use} - {substance} {size} - {finish}</c>, which is the
+        /// order the rules read and the order a browser sorts usefully.</para>
+        /// </summary>
+        public static TypeRenameProposal Plan(TypeRenameInput input)
+        {
+            var p = new TypeRenameProposal
+            {
+                Category = input?.Category ?? "",
+                CurrentName = input?.CurrentName ?? "",
+                InstanceCount = input?.InstanceCount ?? 0,
+            };
+
+            if (input == null || !UseCode.TryGetValue(p.Category, out string use))
+            { p.Reason = "not a layered host category"; return p; }
+
+            var layers = (input.Layers ?? new List<MaterialLayer>())
+                .Where(l => l != null && !string.IsNullOrWhiteSpace(l.MaterialName)).ToList();
+            if (layers.Count == 0)
+            { p.Reason = "no layer names a material — nothing to read"; return p; }
+
+            // The core, by the same rule the PROD suffix uses: thickest structural layer,
+            // else thickest of any function. One definition, not two.
+            var core = layers.Where(l => l.IsStructure && l.ThicknessMm > 0)
+                             .OrderByDescending(l => l.ThicknessMm).ThenBy(l => l.Index).FirstOrDefault()
+                    ?? layers.OrderByDescending(l => l.ThicknessMm).ThenBy(l => l.Index).FirstOrDefault();
+
+            string substance = Match(core.MaterialName, Substance);
+            if (substance == null)
+            {
+                p.Reason = $"the core material '{core.MaterialName}' names no substance this "
+                         + "recognises — rename the MATERIAL first (rule M1), then re-run";
+                return p;
+            }
+
+            // Size from the core's own thickness, so it describes the thing rather than
+            // repeating whatever number the old name happened to carry.
+            string size = core.ThicknessMm >= 1
+                ? " " + Math.Round(core.ThicknessMm).ToString("0", CultureInfo.InvariantCulture)
+                : "";
+
+            // Finish from the finish layers, not from the core.
+            string finish = layers.Where(l => !ReferenceEquals(l, core))
+                                  .Select(l => Match(l.MaterialName, Finish))
+                                  .FirstOrDefault(f => f != null);
+
+            p.ProposedName = $"STING {use} - {substance}{size}"
+                           + (finish != null ? $" - {finish}" : "");
+            p.Reason = finish != null
+                ? $"core '{core.MaterialName}' + finish layer"
+                : $"core '{core.MaterialName}'; no finish layer to read";
+            return p;
+        }
+
+        public static List<TypeRenameProposal> PlanAll(IEnumerable<TypeRenameInput> inputs)
+            => (inputs ?? Enumerable.Empty<TypeRenameInput>()).Select(Plan).ToList();
+
+        /// <summary>
+        /// One line per outcome, so a reader sees the shape of the run before opening
+        /// the CSV — and so "nothing proposed" is never mistaken for "nothing wrong".
+        /// </summary>
+        public static string Summary(IReadOnlyCollection<TypeRenameProposal> ps)
+        {
+            if (ps == null || ps.Count == 0) return "No layered host types found.";
+            int conform = ps.Count(x => x.AlreadyConforms);
+            int propose = ps.Count(x => x.IsProposal && !x.AlreadyConforms);
+            int cannot = ps.Count(x => !x.IsProposal);
+            return $"{ps.Count} type(s): {conform} already conform, {propose} can be renamed, "
+                 + $"{cannot} cannot be named from the model. The {cannot} are not failures of this "
+                 + "tool — their materials do not say what they are, and a rename that guessed would "
+                 + "replace a name a reader can see is empty with one they cannot.";
+        }
+
+        private static string Match(string text, (string Needle, string Word)[] table)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return null;
+            foreach (var (needle, word) in table)
+                if (text.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0) return word;
+            return null;
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialClassPlanner.cs
+++ b/StingTools/Core/Materials/MaterialClassPlanner.cs
@@ -1,0 +1,154 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialClassPlanner.cs — fill Revit's Material CLASS from the material's
+//  own name, for the materials that have none.
+//
+//  WHY. Three parts of StingTools ask "what is this material?". Embodied carbon
+//  and BOQ cost read Material.MaterialClass — a controlled field. The material
+//  schedule and the PROD suffix pattern-match the NAME, which is free text.
+//  Until the last two read Class as well, a model with Class left blank has its
+//  carbon and cost answered by nothing at all.
+//
+//  Setting it by hand across 43 materials is the work this closes.
+//
+//  TWO RULES KEEP IT HONEST:
+//    1. An EXISTING Class is never overwritten. Somebody chose it, and a bulk
+//       tool that silently replaces a human's classification is worse than one
+//       that does nothing.
+//    2. A name that says nothing gets NOTHING. "Default Roof", "Material 12"
+//       and "Finish - As Specified" are real material names from delivered
+//       models; assigning them a plausible Class would launder a guess into a
+//       controlled field, which is precisely the confidence this codebase keeps
+//       having to unpick.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StingTools.Core.Materials
+{
+    public sealed class MaterialClassProposal
+    {
+        public string MaterialName = "";
+        public string ExistingClass = "";
+        /// <summary>Null when the name says nothing, or a class is already set.</summary>
+        public string ProposedClass;
+        public string Reason = "";
+
+        public bool WillWrite => !string.IsNullOrEmpty(ProposedClass);
+    }
+
+    public static class MaterialClassPlanner
+    {
+        /// <summary>
+        /// Revit's own Class vocabulary. These are the strings Revit ships and that its
+        /// material browser groups by — inventing new ones would fragment the very field
+        /// this exists to make dependable.
+        /// </summary>
+        public static readonly string[] RevitClasses =
+        {
+            "Concrete", "Masonry", "Metal", "Wood", "Glass", "Plastic", "Gypsum",
+            "Ceramic", "Stone", "Paint", "Insulation", "Membrane", "Liquid", "Gas",
+            "Textile", "Earth", "Generic",
+        };
+
+        // Longest, most specific needle first: "stone coated" must not read as Stone.
+        private static readonly (string Needle, string Class)[] Map =
+        {
+            ("stone coated", "Metal"), ("galvanised", "Metal"), ("galvanized", "Metal"),
+            ("reinforcement", "Metal"), ("rebar", "Metal"), ("steel", "Metal"),
+            ("aluminium", "Metal"), ("aluminum", "Metal"), ("copper", "Metal"),
+            ("brass", "Metal"), ("zinc", "Metal"), ("lead", "Metal"),
+
+            // Masonry BEFORE concrete, or "Hollow Concrete Block" reads as Concrete and a
+            // block wall is classified as in-situ. A concrete block is masonry; the word
+            // "concrete" in its name describes what the block is made of, not what the
+            // element is. Caught by a test, which is the only way an ordering bug of this
+            // kind ever shows up.
+            ("clay brick", "Masonry"), ("brick", "Masonry"),
+            ("concrete block", "Masonry"), ("screen block", "Masonry"),
+            ("block", "Masonry"), ("masonry", "Masonry"),
+
+            ("concrete", "Concrete"), ("screed", "Concrete"), ("mortar", "Concrete"),
+            ("grout", "Concrete"), ("terrazzo", "Concrete"),
+
+            ("plaster", "Gypsum"), ("render", "Gypsum"), ("gypsum", "Gypsum"),
+            ("plasterboard", "Gypsum"), ("drywall", "Gypsum"),
+
+            ("porcelain", "Ceramic"), ("ceramic", "Ceramic"), ("tile", "Ceramic"),
+
+            ("timber", "Wood"), ("hardwood", "Wood"), ("softwood", "Wood"),
+            ("plywood", "Wood"), ("mvule", "Wood"), ("cypress", "Wood"),
+
+            ("glass", "Glass"), ("glazing", "Glass"),
+
+            ("upvc", "Plastic"), ("pvc", "Plastic"), ("hdpe", "Plastic"),
+            ("polyethylene", "Plastic"), ("polypropylene", "Plastic"), ("vinyl", "Plastic"),
+
+            ("mineral wool", "Insulation"), ("rockwool", "Insulation"),
+            ("insulation", "Insulation"), ("polystyrene", "Insulation"),
+            ("polyurethane", "Insulation"),
+
+            ("bitumen", "Membrane"), ("dpm", "Membrane"), ("felt", "Membrane"),
+            ("membrane", "Membrane"),
+
+            ("granite", "Stone"), ("marble", "Stone"), ("limestone", "Stone"),
+            ("sandstone", "Stone"), ("hardcore", "Stone"), ("aggregate", "Stone"),
+            ("stone", "Stone"),
+
+            ("paint", "Paint"), ("emulsion", "Paint"), ("enamel", "Paint"),
+            ("coating", "Paint"), ("weatherguard", "Paint"),
+
+            ("carpet", "Textile"), ("fabric", "Textile"),
+
+            ("sand", "Earth"), ("murram", "Earth"), ("soil", "Earth"),
+        };
+
+        /// <param name="existingClass">What Revit already holds. Non-empty means leave it.</param>
+        public static MaterialClassProposal Plan(string materialName, string existingClass)
+        {
+            var p = new MaterialClassProposal
+            {
+                MaterialName = materialName ?? "",
+                ExistingClass = existingClass ?? "",
+            };
+
+            if (!string.IsNullOrWhiteSpace(existingClass)
+                && !string.Equals(existingClass.Trim(), "Unassigned", StringComparison.OrdinalIgnoreCase))
+            {
+                p.Reason = "already classified — not overwritten";
+                return p;
+            }
+
+            if (string.IsNullOrWhiteSpace(materialName))
+            { p.Reason = "unnamed"; return p; }
+
+            foreach (var (needle, cls) in Map)
+                if (materialName.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    p.ProposedClass = cls;
+                    p.Reason = $"name contains '{needle}'";
+                    return p;
+                }
+
+            p.Reason = "the name names no substance — left blank rather than guessed";
+            return p;
+        }
+
+        public static List<MaterialClassProposal> PlanAll(
+            IEnumerable<(string Name, string ExistingClass)> materials)
+            => (materials ?? Enumerable.Empty<(string, string)>())
+               .Select(m => Plan(m.Name, m.ExistingClass)).ToList();
+
+        public static string Summary(IReadOnlyCollection<MaterialClassProposal> ps)
+        {
+            if (ps == null || ps.Count == 0) return "No materials found.";
+            int write = ps.Count(x => x.WillWrite);
+            int had = ps.Count(x => !string.IsNullOrWhiteSpace(x.ExistingClass)
+                                 && !string.Equals(x.ExistingClass.Trim(), "Unassigned", StringComparison.OrdinalIgnoreCase));
+            int blank = ps.Count - write - had;
+            return $"{ps.Count} material(s): {had} already classified and untouched, {write} will be set, "
+                 + $"{blank} left blank because the name names no substance. Those {blank} are the ones to "
+                 + "rename — a blank Class is visible, and a guessed one is not.";
+        }
+    }
+}

--- a/StingTools/Data/STING_MATERIAL_PROD_OVERRIDES.csv
+++ b/StingTools/Data/STING_MATERIAL_PROD_OVERRIDES.csv
@@ -41,6 +41,7 @@ Category,MaterialPattern,Suffix
 *,(?i)\bbitumen|\basphalt,BIT
 *,(?i)\bstone|\bgranite|\bmarble|\blimestone|\bsandstone,STN
 *,(?i)\btile|\bceramic|\bporcelain,TIL
+*,(?i)\bterrazzo,TRZ
 *,(?i)\bcarpet,CPT
 *,(?i)\brubber|\bEPDM\b|\bneoprene,RBR
 *,(?i)\bfabrics?\b|\btextile|\bcurtain.*material,FAB

--- a/StingTools/Data/STING_PROD_CODES.csv
+++ b/StingTools/Data/STING_PROD_CODES.csv
@@ -134,16 +134,18 @@ WCP,Walls,*Coping*,Wall Coping,A,ARC,BS 5642-2
 WBD,Walls,*Boundary Wall*|*Compound Wall*|*Perimeter Wall*|*Fence Wall*,Boundary / Compound Wall,A,ARC,none
 RWL,Walls,*Retaining*,Retaining Wall,S,STR,BS EN 1997-1
 RSH,Roofs,*Sheet*|*Corrugated*|*Profiled Metal*|*IT4*|*IT5*,Profiled Sheet Roof Covering,A,ARC,BS EN 508-1
-RTL,Roofs,*Roof Tile*|*Tiled Roof*|*Clay Tile*|*Concrete Tile*|*Shingle*,Tiled / Shingled Roof Covering,A,ARC,BS 5534
+RTL,Roofs,*Roof Tile*|*Tile Roof*|*Tiled Roof*|*Clay Tile*|*Concrete Tile*|*Stone Coated*|*Shingle*,Tiled / Shingled Roof Covering,A,ARC,BS 5534
 RCS,Roofs,*Concrete Roof*|*RC Roof*|*Roof Slab*,Reinforced Concrete Roof Slab,S,STR,BS EN 1992-1-1
 RFL,Roofs,*Flat Roof*|*Built-Up Felt*|*Single Ply*|*Roof Membrane*,Flat Roof Membrane System,A,ARC,BS 8217
 RSG,Roofs,*Sloped Glazing*|*Rooflight*|*Skylight*,Rooflight / Sloped Glazing,A,ARC,BS 5516-2
 FGS,Floors,*Ground Slab*|*Ground Bearing*|*Slab on Grade*|*Oversite*,Ground-Bearing Floor Slab,S,STR,BS 8204-1
 FRB,Floors,*Ribbed Slab*|*Hollow Pot*|*Hollowpot*|*Waffle*|*Coffered*,Ribbed / Hollow-Pot Suspended Slab,S,STR,BS EN 1992-1-1
+FSP,Floors,*Steps*|*Step Slab*|*Stair Landing Slab*,Cast-in-Place Steps / Landing,S,STR,BS EN 1992-1-1
 FSC,Floors,*Screed*,Floor Screed,A,ARC,BS 8204-1
 FTM,Floors,*Timber Floor*|*Floor Joist*,Timber Suspended Floor,S,STR,BS EN 1995-1-1
 CSU,Ceilings,*Suspended Ceiling*|*Grid Ceiling*|*Lay-in*|*MF Ceiling*,Suspended Ceiling System,A,ARC,BS EN 13964
 CPB,Ceilings,*Plasterboard Ceiling*|*Gypsum Ceiling*|*Skim Ceiling*,Plasterboard Ceiling,A,ARC,BS 8212
+CPL,Ceilings,*Plastered Soffit*|*Rendered Soffit*|*Plaster Ceiling*,Plastered Soffit,A,ARC,BS EN 13914-1
 # ── Openings: DOORS + WINDOWS ───────────────────────────────────────────────
 # Leaf material and operation are what a door schedule and a BOQ price on.
 DRT,Doors,*Timber Door*|*Flush Door*|*Panel Door*|*Solid Core*|*Hollow Core*,Timber Leaf Door,A,ARC,BS EN 14351-2

--- a/StingTools/Data/STING_PROJECT_BASELINE.json
+++ b/StingTools/Data/STING_PROJECT_BASELINE.json
@@ -1,167 +1,870 @@
 {
-  "schemaVersion": "1.0",
-  "note": "STING model-authoring baseline. Corporate default; project override at <project>/_BIM_COORD/project_baseline.json, which wins by name. Material NAMES are load-bearing: the compound take-off infers brick vs block vs RC from them, and the finish classifier recognises tiling from them. Renaming a material here without checking those two is how a schedule goes quiet. Levels are deliberately EMPTY - level names and elevations are project decisions, so put them in the project override rather than auditing every model against someone else's storey heights.",
-
-  "materials": [
-    { "name": "Concrete C25", "purpose": "General structural concrete - slabs, columns, foundations", "colour": "150,150,150" },
-    { "name": "Concrete C30", "purpose": "Higher-grade structural concrete - RC walls, transfer elements", "colour": "140,140,140" },
-    { "name": "Blinding Concrete C15", "purpose": "Unreinforced blinding under foundations", "colour": "170,170,170" },
-    { "name": "Burnt Clay Brick", "purpose": "Brick masonry - the take-off reads 'brick' from this name", "colour": "150,80,60" },
-    { "name": "Hollow Concrete Block 200mm", "purpose": "Block masonry - the take-off falls to block when the name is not brick", "colour": "160,160,150" },
-    { "name": "Cement Plaster", "purpose": "Render / plaster coat; the painted area is derived from it", "colour": "200,195,185" },
-    { "name": "Cement Screed", "purpose": "Floor screed under a tiled or applied finish", "colour": "190,185,175" },
-    { "name": "Ceramic Tile", "purpose": "Floor and wall tiling - recognised as tiling by the finish classifier", "colour": "220,215,205" },
-    { "name": "Porcelain Tile", "purpose": "Large-format tiling; carries a higher adhesive coverage", "colour": "225,222,215" },
-    { "name": "Terrazzo Tile", "purpose": "Terrazzo flooring", "colour": "205,200,190" },
-    { "name": "Reinforcement Steel", "purpose": "Rebar - reported in kg from the concrete volume", "colour": "90,90,95" },
-    { "name": "Timber Formwork", "purpose": "Sawn formwork, measured by contact area", "colour": "180,150,110" },
-    { "name": "Gypsum Wall Board", "purpose": "Plasterboard linings and suspended ceilings", "colour": "230,228,222" },
-    { "name": "Emulsion Paint - Interior", "purpose": "Interior decoration to plastered faces", "colour": "245,245,240" },
-    { "name": "Weather-guard Paint - Exterior", "purpose": "Exterior decoration to plastered faces", "colour": "240,238,230" },
-    { "name": "Corrugated Iron Sheet", "purpose": "Sheet roof covering - the supplier rule converts it per sheet", "colour": "120,125,130" },
-    { "name": "Clay Roof Tile", "purpose": "Tiled roof covering", "colour": "160,90,70" }
+  "_comment": [
+    "STING HOUSE STANDARD - the host types and materials a model is authored with.",
+    "",
+    "Every name here is chosen so the plugin can READ it. Type names resolve to a",
+    "specific PROD code through STING_PROD_CODES.csv; material names resolve to a",
+    "material suffix through STING_MATERIAL_PROD_OVERRIDES.csv. A standard the tool",
+    "cannot read is the failure this whole catalogue exists to prevent, and",
+    "BaselineCatalogueTests fails the build if any entry stops resolving.",
+    "",
+    "NAMING SHAPE: <use> - <substance + size> - <finish>",
+    "  use        WL / FL / RF / CL, so a browser sorts by element kind",
+    "  substance  what the schedule measures - Blockwork 200, RC Slab 150",
+    "  finish     what the take-off decomposes - Plastered Both Faces, Ceramic Tiled",
+    "A size alone is not a product name. 'Generic - 225mm' and 'Exterior_CreamWhite_230'",
+    "are real type names from delivered models and neither can ever be measured.",
+    "",
+    "LAYERS, NOT PAINT: every finish is a LAYER with its own material, and the core",
+    "carries the Structure function. An element-level material overrides all of it.",
+    "",
+    "Project override: <project>/_data/coord/project_baseline.json, same shape."
   ],
-
+  "materials": [
+    {
+      "name": "Concrete C15 Blinding",
+      "purpose": "Blinding under foundations and ground slabs",
+      "colour": "170,170,170"
+    },
+    {
+      "name": "Concrete C20",
+      "purpose": "Non-structural fill, kerbs, mass concrete",
+      "colour": "160,160,160"
+    },
+    {
+      "name": "Concrete C25",
+      "purpose": "General structural concrete - slabs, columns, foundations",
+      "colour": "150,150,150"
+    },
+    {
+      "name": "Concrete C30",
+      "purpose": "Suspended slabs and beams where C25 is insufficient",
+      "colour": "140,140,140"
+    },
+    {
+      "name": "Masonry - Hollow Concrete Block 100mm",
+      "purpose": "Internal non-load-bearing partition block",
+      "colour": "196,186,170"
+    },
+    {
+      "name": "Masonry - Hollow Concrete Block 150mm",
+      "purpose": "Internal load-bearing block",
+      "colour": "192,182,166"
+    },
+    {
+      "name": "Masonry - Hollow Concrete Block 200mm",
+      "purpose": "External and load-bearing block, the Uganda default",
+      "colour": "188,178,162"
+    },
+    {
+      "name": "Masonry - Solid Concrete Block 150mm",
+      "purpose": "Retaining and below-DPC masonry",
+      "colour": "180,170,155"
+    },
+    {
+      "name": "Masonry - Clay Brick 295x150x130",
+      "purpose": "Facing and fair-faced clay brickwork",
+      "colour": "150,88,64"
+    },
+    {
+      "name": "Masonry - Screen Block 200x200",
+      "purpose": "Breeze / screen block to curtain and ventilation panels",
+      "colour": "198,190,178"
+    },
+    {
+      "name": "Mortar - Cement Sand 1:4",
+      "purpose": "Bedding mortar to blockwork and brickwork",
+      "colour": "175,172,165"
+    },
+    {
+      "name": "Plaster - Cement Render 1:4",
+      "purpose": "Two-coat cement plaster to masonry, internal and external",
+      "colour": "205,202,195"
+    },
+    {
+      "name": "Screed - Cement Sand 1:3",
+      "purpose": "Floor screed under tiling and to falls",
+      "colour": "198,195,188"
+    },
+    {
+      "name": "Grout - Tile Joint",
+      "purpose": "Tile joint grout",
+      "colour": "215,213,208"
+    },
+    {
+      "name": "Steel - Reinforcement Bar Y",
+      "purpose": "High-yield reinforcement to BS 4449",
+      "colour": "110,110,118"
+    },
+    {
+      "name": "Steel - Fabric Mesh A142",
+      "purpose": "Mesh reinforcement to ground slabs",
+      "colour": "115,115,122"
+    },
+    {
+      "name": "Steel - Structural S275",
+      "purpose": "Structural sections, plates and connections",
+      "colour": "100,100,110"
+    },
+    {
+      "name": "Steel - Galvanised Sheet G28",
+      "purpose": "Roof sheeting, gutters and flashings",
+      "colour": "168,172,178"
+    },
+    {
+      "name": "Steel - Mild Steel Section",
+      "purpose": "Railings, balustrades, gates and grilles",
+      "colour": "105,105,112"
+    },
+    {
+      "name": "Timber - Hardwood Mvule",
+      "purpose": "Joinery, doors, fascia and external timber",
+      "colour": "128,92,54"
+    },
+    {
+      "name": "Timber - Softwood Cypress",
+      "purpose": "Roof trusses, purlins and carcassing",
+      "colour": "176,140,96"
+    },
+    {
+      "name": "Timber - Plywood 18mm",
+      "purpose": "Formwork, soffits and sheathing",
+      "colour": "190,162,120"
+    },
+    {
+      "name": "Tile - Ceramic Floor 300x300",
+      "purpose": "Standard ceramic floor tiling",
+      "colour": "216,210,200"
+    },
+    {
+      "name": "Tile - Porcelain Floor 600x600",
+      "purpose": "Large-format porcelain floor tiling",
+      "colour": "222,218,212"
+    },
+    {
+      "name": "Tile - Ceramic Wall 250x400",
+      "purpose": "Wall tiling to wet areas",
+      "colour": "228,226,222"
+    },
+    {
+      "name": "Terrazzo - Cast In Situ",
+      "purpose": "In-situ terrazzo floor and skirting",
+      "colour": "205,200,190"
+    },
+    {
+      "name": "Paint - Emulsion Interior",
+      "purpose": "Internal emulsion to plaster and board",
+      "colour": "238,236,230"
+    },
+    {
+      "name": "Paint - Weatherguard Exterior",
+      "purpose": "External weatherproof coating to render",
+      "colour": "232,228,220"
+    },
+    {
+      "name": "Paint - Gloss Enamel",
+      "purpose": "Gloss to joinery and metalwork",
+      "colour": "236,234,228"
+    },
+    {
+      "name": "Gypsum - Wall Board 12.5mm",
+      "purpose": "Plasterboard to stud partitions",
+      "colour": "230,228,222"
+    },
+    {
+      "name": "Gypsum - Ceiling Board 9mm",
+      "purpose": "Plasterboard to suspended ceilings",
+      "colour": "232,230,225"
+    },
+    {
+      "name": "Roofing - Clay Tile",
+      "purpose": "Clay roof tiling",
+      "colour": "158,92,66"
+    },
+    {
+      "name": "Roofing - Stone Coated Tile",
+      "purpose": "Stone-coated steel roof tile",
+      "colour": "120,112,100"
+    },
+    {
+      "name": "Bitumen - Felt Membrane",
+      "purpose": "Built-up felt to flat roofs",
+      "colour": "70,68,66"
+    },
+    {
+      "name": "Bitumen - DPM 1000 Gauge",
+      "purpose": "Damp-proof membrane under ground slabs",
+      "colour": "60,58,58"
+    },
+    {
+      "name": "Insulation - Mineral Wool",
+      "purpose": "Thermal and acoustic quilt",
+      "colour": "222,214,186"
+    },
+    {
+      "name": "Insulation - EPS Board",
+      "purpose": "Expanded polystyrene board",
+      "colour": "238,236,228"
+    },
+    {
+      "name": "Glass - Float Clear 6mm",
+      "purpose": "Standard glazing",
+      "colour": "196,214,220"
+    },
+    {
+      "name": "Glass - Toughened 10mm",
+      "purpose": "Balustrades, doors and low-level glazing",
+      "colour": "190,210,218"
+    },
+    {
+      "name": "Aluminium - Powder Coated",
+      "purpose": "Window and door frames, louvres",
+      "colour": "170,174,178"
+    },
+    {
+      "name": "PVC - uPVC Section",
+      "purpose": "uPVC windows, gutters and rainwater goods",
+      "colour": "225,225,222"
+    },
+    {
+      "name": "Hardcore - Stone Fill",
+      "purpose": "Compacted hardcore bed under ground slabs",
+      "colour": "142,138,130"
+    },
+    {
+      "name": "Aggregate - Crushed Stone 20mm",
+      "purpose": "Coarse aggregate",
+      "colour": "150,146,138"
+    }
+  ],
   "wallTypes": [
     {
-      "name": "STING Blockwork 200 - Plastered Both Faces",
-      "purpose": "Standard internal / external block wall, plastered and painted both sides",
+      "name": "STING WL - Blockwork 200 - Plastered Both Faces",
+      "purpose": "External and load-bearing default. Both plaster faces are LAYERS, which is what makes rendering measurable",
       "layers": [
-        { "function": "Finish1", "material": "Cement Plaster", "thicknessMm": 12 },
-        { "function": "Structure", "material": "Hollow Concrete Block 200mm", "thicknessMm": 200 },
-        { "function": "Finish2", "material": "Cement Plaster", "thicknessMm": 12 }
+        {
+          "function": "Finish1",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        },
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 200mm",
+          "thicknessMm": 200
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
       ]
     },
     {
-      "name": "STING Blockwork 200 - Tiled Wet Area",
-      "purpose": "Bathroom / kitchen wall: plastered outside, tiled inside. The tiled face is measured as tiling and is NOT painted",
+      "name": "STING WL - Blockwork 150 - Plastered Both Faces",
+      "purpose": "Internal load-bearing wall",
       "layers": [
-        { "function": "Finish1", "material": "Cement Plaster", "thicknessMm": 12 },
-        { "function": "Structure", "material": "Hollow Concrete Block 200mm", "thicknessMm": 200 },
-        { "function": "Finish2", "material": "Ceramic Tile", "thicknessMm": 8 }
+        {
+          "function": "Finish1",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        },
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 150mm",
+          "thicknessMm": 150
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
       ]
     },
     {
-      "name": "STING Brickwork 230 - Plastered Both Faces",
-      "purpose": "Burnt clay brick wall - the take-off reads 'brick' and counts bricks, not blocks",
+      "name": "STING WL - Blockwork 100 - Plastered Both Faces",
+      "purpose": "Internal non-load-bearing partition",
       "layers": [
-        { "function": "Finish1", "material": "Cement Plaster", "thicknessMm": 12 },
-        { "function": "Structure", "material": "Burnt Clay Brick", "thicknessMm": 230 },
-        { "function": "Finish2", "material": "Cement Plaster", "thicknessMm": 12 }
+        {
+          "function": "Finish1",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        },
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 100mm",
+          "thicknessMm": 100
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
       ]
     },
     {
-      "name": "STING RC Wall 200",
-      "purpose": "Reinforced concrete wall - decomposes to concrete, rebar and formwork to both faces",
+      "name": "STING WL - Blockwork 200 - Fair Face External",
+      "purpose": "External block wall left fair-faced outside, plastered inside",
       "layers": [
-        { "function": "Structure", "material": "Concrete C30", "thicknessMm": 200 }
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 200mm",
+          "thicknessMm": 200
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
+      ]
+    },
+    {
+      "name": "STING WL - Clay Brick 295 - Fair Faced",
+      "purpose": "Fair-faced clay brickwork, no render either side",
+      "layers": [
+        {
+          "function": "Structure",
+          "material": "Masonry - Clay Brick 295x150x130",
+          "thicknessMm": 295
+        }
+      ]
+    },
+    {
+      "name": "STING WL - Clay Brick 150 - Plastered Internal",
+      "purpose": "Half-brick skin, rendered internally",
+      "layers": [
+        {
+          "function": "Structure",
+          "material": "Masonry - Clay Brick 295x150x130",
+          "thicknessMm": 150
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
+      ]
+    },
+    {
+      "name": "STING WL - RC Wall 200 - Plastered Both Faces",
+      "purpose": "Reinforced concrete wall. The EXPLICIT concrete material is what lets it decompose to concrete, rebar and formwork",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 200
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
+      ]
+    },
+    {
+      "name": "STING WL - RC Retaining Wall 250",
+      "purpose": "Below-ground retaining wall, tanked externally",
+      "layers": [
+        {
+          "function": "Membrane",
+          "material": "Bitumen - DPM 1000 Gauge",
+          "thicknessMm": 1
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 250
+        }
+      ]
+    },
+    {
+      "name": "STING WL - Stud Partition 100 - Boarded Both Faces",
+      "purpose": "Metal or timber stud partition with plasterboard both faces",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Gypsum - Wall Board 12.5mm",
+          "thicknessMm": 12.5
+        },
+        {
+          "function": "Structure",
+          "material": "Timber - Softwood Cypress",
+          "thicknessMm": 75
+        },
+        {
+          "function": "Finish2",
+          "material": "Gypsum - Wall Board 12.5mm",
+          "thicknessMm": 12.5
+        }
+      ]
+    },
+    {
+      "name": "STING WL - Blockwork 200 - Tiled One Face",
+      "purpose": "Wet-area wall. The tile LAYER is what makes wall tiling measurable",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Tile - Ceramic Wall 250x400",
+          "thicknessMm": 8
+        },
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 200mm",
+          "thicknessMm": 200
+        },
+        {
+          "function": "Finish2",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
+      ]
+    },
+    {
+      "name": "STING WL - Boundary Wall 200 - Fair Faced",
+      "purpose": "Compound / boundary wall with coping",
+      "layers": [
+        {
+          "function": "Structure",
+          "material": "Masonry - Hollow Concrete Block 200mm",
+          "thicknessMm": 200
+        }
       ]
     }
   ],
-
   "floorTypes": [
     {
-      "name": "STING RC Slab 150 - Ceramic Tiled",
+      "name": "STING FL - RC Slab 150 - Ceramic Tiled",
       "purpose": "Suspended slab with a tiled finish. The tile LAYER is what makes floor tiling measurable",
       "layers": [
-        { "function": "Finish1", "material": "Ceramic Tile", "thicknessMm": 10 },
-        { "function": "Substrate", "material": "Cement Screed", "thicknessMm": 40 },
-        { "function": "Structure", "material": "Concrete C25", "thicknessMm": 150 }
+        {
+          "function": "Finish1",
+          "material": "Tile - Ceramic Floor 300x300",
+          "thicknessMm": 10
+        },
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 40
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        }
       ]
     },
     {
-      "name": "STING RC Slab 200 - Porcelain Tiled",
-      "purpose": "Heavier slab with large-format porcelain; adhesive coverage is higher than ceramic",
+      "name": "STING FL - RC Slab 200 - Porcelain Tiled",
+      "purpose": "Heavier suspended slab, large-format porcelain",
       "layers": [
-        { "function": "Finish1", "material": "Porcelain Tile", "thicknessMm": 10 },
-        { "function": "Substrate", "material": "Cement Screed", "thicknessMm": 40 },
-        { "function": "Structure", "material": "Concrete C25", "thicknessMm": 200 }
+        {
+          "function": "Finish1",
+          "material": "Tile - Porcelain Floor 600x600",
+          "thicknessMm": 12
+        },
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 40
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 200
+        }
       ]
     },
     {
-      "name": "STING RC Slab 150 - Screed Only",
-      "purpose": "Slab left screeded, finish applied later or scheduled on the room",
+      "name": "STING FL - RC Slab 150 - Terrazzo",
+      "purpose": "Suspended slab with in-situ terrazzo",
       "layers": [
-        { "function": "Substrate", "material": "Cement Screed", "thicknessMm": 40 },
-        { "function": "Structure", "material": "Concrete C25", "thicknessMm": 150 }
+        {
+          "function": "Finish1",
+          "material": "Terrazzo - Cast In Situ",
+          "thicknessMm": 20
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        }
       ]
     },
     {
-      "name": "STING Ground Slab 150 on Blinding",
-      "purpose": "Ground-bearing slab; the blinding is unreinforced by definition",
+      "name": "STING FL - RC Slab 150 - Screed Only",
+      "purpose": "Suspended slab left screeded, finish by others",
       "layers": [
-        { "function": "Structure", "material": "Concrete C25", "thicknessMm": 150 },
-        { "function": "Substrate", "material": "Blinding Concrete C15", "thicknessMm": 50 }
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 50
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        }
+      ]
+    },
+    {
+      "name": "STING FL - Ground Slab 150 - Ceramic Tiled",
+      "purpose": "Ground-bearing slab on DPM and hardcore. Hardcore and DPM are LAYERS so both are measurable",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Tile - Ceramic Floor 300x300",
+          "thicknessMm": 10
+        },
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 40
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        },
+        {
+          "function": "Membrane",
+          "material": "Bitumen - DPM 1000 Gauge",
+          "thicknessMm": 1
+        },
+        {
+          "function": "Substrate",
+          "material": "Hardcore - Stone Fill",
+          "thicknessMm": 200
+        }
+      ]
+    },
+    {
+      "name": "STING FL - Ground Slab 150 - Screed Only",
+      "purpose": "Ground-bearing slab, finish by others",
+      "layers": [
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 50
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        },
+        {
+          "function": "Membrane",
+          "material": "Bitumen - DPM 1000 Gauge",
+          "thicknessMm": 1
+        },
+        {
+          "function": "Substrate",
+          "material": "Hardcore - Stone Fill",
+          "thicknessMm": 200
+        }
+      ]
+    },
+    {
+      "name": "STING FL - Hollow Pot Slab 250 - Ceramic Tiled",
+      "purpose": "Ribbed / hollow-pot suspended slab, the East African economy span",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Tile - Ceramic Floor 300x300",
+          "thicknessMm": 10
+        },
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 40
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 250
+        }
+      ]
+    },
+    {
+      "name": "STING FL - RC Steps - Terrazzo",
+      "purpose": "Cast-in-place steps and landings",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Terrazzo - Cast In Situ",
+          "thicknessMm": 20
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 150
+        }
       ]
     }
   ],
-
   "roofTypes": [
     {
-      "name": "STING RC Flat Roof 225",
-      "purpose": "Concrete flat roof. The EXPLICIT concrete material is what lets it decompose to concrete, rebar and formwork - an unnamed roof material is treated as unknown, never as concrete",
+      "name": "STING RF - RC Flat Roof 225 - Felt",
+      "purpose": "Concrete flat roof with built-up felt. The EXPLICIT concrete material is what lets it decompose to concrete, rebar and formwork",
       "layers": [
-        { "function": "Structure", "material": "Concrete C25", "thicknessMm": 225 }
+        {
+          "function": "Finish1",
+          "material": "Bitumen - Felt Membrane",
+          "thicknessMm": 4
+        },
+        {
+          "function": "Substrate",
+          "material": "Screed - Cement Sand 1:3",
+          "thicknessMm": 50
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 225
+        }
       ]
     },
     {
-      "name": "STING Sheet Roof - Corrugated IT4 G28",
-      "purpose": "Sheet covering. The type NAME carries the supplier rule's patterns (sheet / corrugat / it4 / g28) so it converts to a sheet count",
+      "name": "STING RF - Corrugated Sheet Roof - IT4 on Timber",
+      "purpose": "Galvanised IT4 sheeting on softwood purlins, the Uganda default",
       "layers": [
-        { "function": "Finish1", "material": "Corrugated Iron Sheet", "thicknessMm": 1 }
+        {
+          "function": "Finish1",
+          "material": "Steel - Galvanised Sheet G28",
+          "thicknessMm": 0.5
+        },
+        {
+          "function": "Structure",
+          "material": "Timber - Softwood Cypress",
+          "thicknessMm": 50
+        }
       ]
     },
     {
-      "name": "STING Tiled Roof - Clay Tile",
-      "purpose": "Tiled covering; the name carries the roof-tile rule's patterns",
+      "name": "STING RF - Clay Tile Roof - on Timber",
+      "purpose": "Clay roof tiling on battens and softwood",
       "layers": [
-        { "function": "Finish1", "material": "Clay Roof Tile", "thicknessMm": 20 }
+        {
+          "function": "Finish1",
+          "material": "Roofing - Clay Tile",
+          "thicknessMm": 15
+        },
+        {
+          "function": "Structure",
+          "material": "Timber - Softwood Cypress",
+          "thicknessMm": 50
+        }
+      ]
+    },
+    {
+      "name": "STING RF - Stone Coated Tile Roof - on Timber",
+      "purpose": "Stone-coated steel tile on softwood",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Roofing - Stone Coated Tile",
+          "thicknessMm": 5
+        },
+        {
+          "function": "Structure",
+          "material": "Timber - Softwood Cypress",
+          "thicknessMm": 50
+        }
+      ]
+    },
+    {
+      "name": "STING RF - RC Roof Slab 200 - Insulated Felt",
+      "purpose": "Warm flat roof with insulation between deck and membrane",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Bitumen - Felt Membrane",
+          "thicknessMm": 4
+        },
+        {
+          "function": "Insulation",
+          "material": "Insulation - EPS Board",
+          "thicknessMm": 50
+        },
+        {
+          "function": "Structure",
+          "material": "Concrete C25",
+          "thicknessMm": 200
+        }
       ]
     }
   ],
-
   "ceilingTypes": [
     {
-      "name": "STING Suspended Gypsum Ceiling",
+      "name": "STING CL - Suspended Gypsum Ceiling",
       "purpose": "Plasterboard ceiling on a concealed grid",
       "layers": [
-        { "function": "Finish1", "material": "Gypsum Wall Board", "thicknessMm": 12.5 }
+        {
+          "function": "Finish1",
+          "material": "Gypsum - Ceiling Board 9mm",
+          "thicknessMm": 9
+        }
+      ]
+    },
+    {
+      "name": "STING CL - Plasterboard Ceiling on Timber",
+      "purpose": "Board fixed direct to softwood brandering",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Gypsum - Ceiling Board 9mm",
+          "thicknessMm": 9
+        },
+        {
+          "function": "Structure",
+          "material": "Timber - Softwood Cypress",
+          "thicknessMm": 50
+        }
+      ]
+    },
+    {
+      "name": "STING CL - Plastered Soffit",
+      "purpose": "Rendered soffit direct to the slab, no void",
+      "layers": [
+        {
+          "function": "Finish1",
+          "material": "Plaster - Cement Render 1:4",
+          "thicknessMm": 12
+        }
       ]
     }
   ],
-
   "levels": [],
-
   "familyExpectations": [
     {
       "category": "Structural Columns",
-      "namePatterns": [ "Concrete", "RC", "STING" ],
+      "namePatterns": [
+        "Concrete",
+        "RC",
+        "STING"
+      ],
       "minimumTypes": 1,
       "guidance": "Load a concrete column family and name its types so the material reads as concrete - the take-off decides column decomposition from the material, not the family name."
     },
     {
-      "category": "Structural Foundations",
-      "namePatterns": [ "Pad", "Strip", "Raft", "Concrete", "STING" ],
+      "category": "Structural Framing",
+      "namePatterns": [
+        "Concrete",
+        "RC",
+        "Steel",
+        "STING"
+      ],
       "minimumTypes": 1,
-      "guidance": "Load a foundation family. Pads and strips shutter on their SIDES only because they bear on the ground; blinding carries no rebar."
+      "guidance": "Beam types must name their material. A beam called 300x600 decomposes to nothing."
     },
     {
-      "category": "Structural Framing",
-      "namePatterns": [ "Concrete", "RC", "Beam", "STING" ],
+      "category": "Structural Foundations",
+      "namePatterns": [
+        "Pad",
+        "Strip",
+        "Raft",
+        "Concrete",
+        "STING"
+      ],
       "minimumTypes": 1,
-      "guidance": "Load a concrete beam family; steel framing is left on the composite line rather than decomposed."
+      "guidance": "Name the foundation KIND - Pad, Strip, Raft - so the PROD rules can tell them apart. A size alone resolves to the category default."
     },
     {
       "category": "Doors",
-      "namePatterns": [],
-      "minimumTypes": 1,
-      "guidance": "Doors are bought and belong in the schedule. They need a RATE keyed by type name in _BIM_COORD/commodity_rates.csv - the export names the exact key for every unpriced one."
+      "namePatterns": [
+        "Flush",
+        "Timber",
+        "Steel",
+        "Glazed",
+        "Fire",
+        "Sliding",
+        "FD30",
+        "FD60"
+      ],
+      "minimumTypes": 2,
+      "guidance": "Door types must name the leaf material or the fire rating. '900 x 2100' is a size, and a size is not a product - 20 doors on a delivered model resolved to nothing for exactly this reason."
     },
     {
       "category": "Windows",
-      "namePatterns": [],
+      "namePatterns": [
+        "Aluminium",
+        "uPVC",
+        "Timber",
+        "Steel",
+        "Casement",
+        "Awning",
+        "Sliding",
+        "Fixed"
+      ],
+      "minimumTypes": 2,
+      "guidance": "Window types must name the frame material or the operation. Both are what a window schedule prices."
+    },
+    {
+      "category": "Curtain Panels",
+      "namePatterns": [
+        "Glazed",
+        "Solid",
+        "Louvre",
+        "Screen Block",
+        "Breeze"
+      ],
       "minimumTypes": 1,
-      "guidance": "As doors: present in the schedule, priced by type name in the project rate card."
+      "guidance": "A curtain panel that names its infill resolves; one called by a supplier code does not."
+    },
+    {
+      "category": "Stairs",
+      "namePatterns": [
+        "RC",
+        "Concrete",
+        "Precast",
+        "Steel",
+        "Timber"
+      ],
+      "minimumTypes": 1,
+      "guidance": "Name the stair construction. The finish belongs in the type name after the construction, not instead of it."
+    },
+    {
+      "category": "Railings",
+      "namePatterns": [
+        "Mild Steel",
+        "MS",
+        "Stainless",
+        "Glass",
+        "Timber"
+      ],
+      "minimumTypes": 1,
+      "guidance": "Railing types are priced by material and height - both belong in the name."
+    },
+    {
+      "category": "Pipes",
+      "namePatterns": [
+        "uPVC",
+        "PVC",
+        "PPR",
+        "Copper",
+        "GI",
+        "Galvanised",
+        "HDPE"
+      ],
+      "minimumTypes": 1,
+      "guidance": "For a linear service the MATERIAL is the product. A pipe type that does not name its material cannot be priced."
+    },
+    {
+      "category": "Plumbing Fixtures",
+      "namePatterns": [
+        "WC",
+        "Basin",
+        "Lavatory",
+        "Sink",
+        "Shower",
+        "Urinal",
+        "Bath"
+      ],
+      "minimumTypes": 3,
+      "guidance": "Sanitaryware resolves well already - these are the fixture words the corporate rules match."
     }
   ]
 }

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -794,6 +794,8 @@ namespace StingTools.UI
                     // would create and writes nothing until that is confirmed.
                     case "Baseline_Audit": RunCommand<Commands.Baseline.BaselineAuditCommand>(app); break;
                     case "Baseline_Apply": RunCommand<Commands.Baseline.BaselineApplyCommand>(app); break;
+                    case "Baseline_RenameTypes": RunCommand<Commands.Baseline.RenameTypesToStandardCommand>(app); break;
+                    case "Materials_SetClass":   RunCommand<Commands.Baseline.SetMaterialClassCommand>(app); break;
                     // Read-only: writes a catalogue pack JSON, never the model.
                     case "Baseline_HarvestTypes": RunCommand<Commands.Baseline.BaselineHarvestTypesCommand>(app); break;
 

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="StingTools.UI.StingDockPanel"
+<Page x:Class="StingTools.UI.StingDockPanel"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Title="STING Tools"
@@ -1961,6 +1961,12 @@
                                         HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
                                 <Button Style="{StaticResource OrangeBtn}" Content="Apply baseline (asks first)" Tag="Baseline_Apply" Click="Cmd_Click"
                                         ToolTip="Shows the full list of what it would create, then writes only after you confirm. Creates ONLY what is missing — an existing type is never edited, even when its build-up differs from the baseline. A material schedule can only measure finishes the model actually describes; this is what gives it something to read."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
+                                <Button Style="{StaticResource OrangeBtn}" Content="Rename types to standard (asks first)" Tag="Baseline_RenameTypes" Click="Cmd_Click"
+                                        ToolTip="Proposes house-standard names for the host types this model already has, reading the substance off each type's own CORE MATERIAL rather than guessing from its name. Writes the full plan to CSV and renames only after you confirm. A type whose materials do not say what it is gets NO proposal — a rename that guessed would replace a name you can see is empty with one you cannot."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
+                                <Button Style="{StaticResource OrangeBtn}" Content="Set material Class (asks first)" Tag="Materials_SetClass" Click="Cmd_Click"
+                                        ToolTip="Fills Revit's Material Class from the material name where it is blank. Class is the controlled field the embodied-carbon and BOQ cost engines read, so a material with none is answered by nothing at all. Never overwrites a class somebody chose, and never invents one for a name that says nothing."
                                         HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
                             </StackPanel>
                         </Border>


### PR DESCRIPTION
Closes the two gaps named in the modelling review, and expands the starter catalogue into an actual house standard.

## The catalogue: 17 materials / 12 types → **43 / 27**

Written for East African practice: hollow block 100/150/200, clay brick, screen block, RC and retaining walls, stud partitions, ground-bearing and hollow-pot slabs, IT4 corrugated sheet, clay and stone-coated tile, RC flat roof, suspended and boarded ceilings. Ten **family expectations** name the words a door, window, stair, railing or pipe type must carry to be measurable at all.

### Every name is cross-checked against the plugin that reads it

A standard naming a type the tool resolves generically would prescribe the disease it exists to cure — `Generic - 225mm` is a real delivered type name and can never be measured. `BaselineCatalogueTests` resolves all 27 type names through the **real** resolver and all 43 materials through the **real** override table.

Writing it, that gate caught three gaps — **in the rules, not the names**:

```
RC Steps - Terrazzo      no Floors rule for steps         -> FSP added
Stone Coated Tile Roof   the rule read "Roof Tile" only   -> RTL widened
Plastered Soffit         a rendered soffit is not board   -> CPL added
```

plus terrazzo, which had no material suffix at all → `TRZ`.

`stepsr 7` **moved from the cannot-resolve list to the resolves list**, recorded as a reclassification rather than done quietly: the name became resolvable because a real rule was added, not because a gate was loosened around it.

## Two new commands, both two-step, both refusing to guess

**`Baseline_RenameTypes`** proposes house-standard names for the types a model already has. The substance comes from the type's own **thickest structural layer material** — chosen by whoever built the model — and the size from that layer's thickness:

```
Exterior_CreamWhite_230 2   ->  STING WL - Blockwork 200 - Plastered
```

The `230` isn't carried over, because the block is 200. Where no material names a substance it proposes **nothing** and says to rename the material first. A renamer that guessed would replace a name a reader can *see* is empty with one they cannot — `RC Slab 225` on a timber deck.

**`Materials_SetClass`** fills Revit's Material Class where it's blank. Class is the controlled field the carbon and cost engines already read, while the material schedule and PROD suffix pattern-match the free-text name — so a model with Class blank has its carbon and cost answered by nothing. An existing class is never overwritten, and a name that says nothing is left blank rather than laundered into a controlled field.

Both write a CSV plan, then ask. A rename changes what schedules, filters and view templates key on.

## A test caught a real ordering bug

`"Masonry - Hollow Concrete Block 200mm"` classified as **Concrete**, because `concrete` sat above the masonry needles. A concrete block is masonry — the word describes what the block is made of, not what the element is. Masonry now sorts first.

## Verification

Tags **549 → 582**, Boq **1,238 → 1,243**, build **0/0**, **seven mutations verified failing** — including one that makes the renamer guess, one that overwrites a human's class, and one that strips a Structure flag out of the catalogue.

**Not verified in Revit.** Neither command has been run against a model; the planners are Revit-free and tested, the Revit halves that read compound structures and write names are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)