### PR TITLE
feat(iso): type names follow BS EN ISO 22014, and the Type field is the PROD code

### DIFF
--- a/StingTools.Boq.Tests/ProjectBaselineTests.cs
+++ b/StingTools.Boq.Tests/ProjectBaselineTests.cs
@@ -247,8 +247,12 @@ namespace StingTools.Boq.Tests
             // CompoundTakeoffBuilder.BuildWall decides by material name:
             // contains "brick" -> bricks, else blocks.
             var b = Shipped();
-            var brickWall = b.WallTypes.First(t => t.Name.IndexOf("Brick", StringComparison.OrdinalIgnoreCase) >= 0);
-            var blockWall = b.WallTypes.First(t => t.Name.IndexOf("Blockwork", StringComparison.OrdinalIgnoreCase) >= 0);
+            // Selected on the ISO 22014 TYPE FIELD, not on an English word. The house
+            // standard deliberately moved "Brick" and "Blockwork" out of the name and into
+            // the PROD code, so a test keyed on the word was keyed on the one part of the
+            // name the standard does not promise to keep.
+            var brickWall = b.WallTypes.First(t => t.Name.IndexOf("_WBK_", StringComparison.OrdinalIgnoreCase) >= 0);
+            var blockWall = b.WallTypes.First(t => t.Name.IndexOf("_WBL_", StringComparison.OrdinalIgnoreCase) >= 0);
 
             Assert.Contains(brickWall.Layers, l => l.Material.ToLowerInvariant().Contains("brick"));
             Assert.DoesNotContain(blockWall.Layers, l => l.Material.ToLowerInvariant().Contains("brick"));
@@ -260,7 +264,9 @@ namespace StingTools.Boq.Tests
             // A roof only decomposes when its material EXPLICITLY reads as
             // concrete — an unnamed roof is treated as unknown, never as
             // concrete, so 137 m3 is not invented.
-            var roof = Shipped().RoofTypes.First(t => t.Name.IndexOf("Flat Roof", StringComparison.OrdinalIgnoreCase) >= 0);
+            // RFL is the flat-roof-membrane code; "Flat Roof" now lives in the PROD code
+            // rather than in the type name.
+            var roof = Shipped().RoofTypes.First(t => t.Name.IndexOf("_RFL_", StringComparison.OrdinalIgnoreCase) >= 0);
 
             Assert.Contains(roof.Layers, l => l.Material.ToLowerInvariant().Contains("concrete"));
         }

--- a/StingTools.Tags.Tests/BaselineCatalogueTests.cs
+++ b/StingTools.Tags.Tests/BaselineCatalogueTests.cs
@@ -68,6 +68,17 @@ namespace StingTools.Tags.Tests
             return outList;
         }
 
+        private static IEnumerable<string> AllCodes()
+        {
+            foreach (string raw in File.ReadAllLines(Path.Combine(DataDir(), "STING_PROD_CODES.csv")).Skip(1))
+            {
+                string line = (raw ?? "").Trim();
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+                var c = line.Split(new[] { ',' });
+                if (c.Length >= 3 && c[0].Trim().Length > 0) yield return c[0].Trim();
+            }
+        }
+
         public static IEnumerable<object[]> HostTypeGroups()
         {
             var c = Load();
@@ -91,12 +102,20 @@ namespace StingTools.Tags.Tests
                           : category == "Roofs" ? "Basic Roof"
                           : category == "Floors" ? "Floor" : "Compound Ceiling";
 
-            ProdResolver.Resolve(family, typeName, category, null, Rules(category), null, out string source);
+            var codes = new HashSet<string>(AllCodes(), StringComparer.OrdinalIgnoreCase);
+            ProdResolver.Resolve(family, typeName, category, null, Rules(category), null,
+                                 out string source, codes);
 
             Assert.True(ProdResolver.IsSpecific(source),
                 $"The house standard prescribes '{typeName}', and the plugin resolves it to the "
                 + $"{category} category default. A standard that names a type the tool cannot read "
                 + "is prescribing the problem it exists to fix — add the rule, or rename the type.");
+
+            // And specifically via the DECLARED tier. The ISO 22014 Type field IS the PROD
+            // code, so nothing should be inferred from a conforming name — a catalogue
+            // entry resolving by PATTERN would mean that field is decorative, and the two
+            // vocabularies this shape exists to merge would still be running in parallel.
+            Assert.Equal(ProdResolver.Sources.Declared, source);
         }
 
         [Fact]
@@ -172,13 +191,15 @@ namespace StingTools.Tags.Tests
 
             foreach (string must in new[]
             {
-                "Blockwork 200",       // the Uganda default wall
-                "Clay Brick",          // 48 elements on one model
-                "Stud Partition",      // the 97mm partition
-                "Ground Slab",         // was entirely absent from the starter set
-                "Hollow Pot",          // the East African economy span
-                "Corrugated Sheet",    // IT4, the default roof
-                "RC Flat Roof",
+                // Keyed on the ISO 22014 SUBTYPE field, which is where the human-readable
+                // build survives once the Type field became the PROD code.
+                "_WBL_Hollow200",      // the Uganda default wall
+                "_WBK_Clay295",        // clay brick, 48 elements on one model
+                "_WPT_Stud100",        // the 97mm partition
+                "_FGS_Ground150",      // ground slab, absent from the starter set
+                "_FRB_HollowPot250",   // the East African economy span
+                "_RSH_IT4",            // corrugated sheet, the default roof
+                "_RFL_RC225",          // RC flat roof
             })
                 Assert.True(all.Any(n => n.IndexOf(must, StringComparison.OrdinalIgnoreCase) >= 0),
                     $"The catalogue no longer covers '{must}', which a delivered model used.");

--- a/StingTools.Tags.Tests/IsoTypeNameTests.cs
+++ b/StingTools.Tags.Tests/IsoTypeNameTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using StingTools.Core;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// BS EN ISO 22014:2024 — which superseded BS 8541-1 in May 2024 — names a library
+    /// object in three underscore-separated fields: <c>Source_Type_Subtype</c>.
+    ///
+    /// <code>
+    ///     PLNS_WBL_Hollow200-PlasteredBothFaces
+    ///     ^^^^ ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ///     |    |   Subtype — hyphens between components
+    ///     |    Type — the ISO 19650 PROD code
+    ///     Source — originator
+    /// </code>
+    ///
+    /// <para><b>Why the Type field is the PROD code.</b> Before this, a conforming name
+    /// carried the WORD "Blockwork" while the resolver derived the CODE "WBL" from it by
+    /// pattern. Two vocabularies for one fact, free to disagree the moment either was
+    /// edited — the exact defect class this codebase has spent a long session removing.
+    /// Naming the code directly means the resolver READS it.</para>
+    ///
+    /// <para>ISO 19650 is NOT what governs a type name — it governs information
+    /// containers. Saying otherwise is a common and wrong shorthand.</para>
+    /// </summary>
+    public class IsoTypeNameTests
+    {
+        private static readonly HashSet<string> Codes =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "WBL", "WBK", "SLB", "RSH", "DR", "WIN", "PMP" };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Reading a name that states its code
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData("PLNS_WBL_Hollow200-PlasteredBothFaces", "WBL")]
+        [InlineData("PLNS_SLB_RC150-CeramicTiled", "SLB")]
+        [InlineData("PLNS_RSH_IT4-OnTimberPurlins", "RSH")]
+        [InlineData("ABC_WBK_Clay295", "WBK")]
+        public void The_Type_Field_Is_Read_As_The_Product_Code(string name, string expected)
+        {
+            Assert.Equal(expected, ProdNameCode.Extract(name, Codes));
+        }
+
+        [Fact]
+        public void Only_The_SECOND_Field_Counts()
+        {
+            // The safety property. "DR" is a real code, and a subtype component that
+            // happens to spell one must not hijack the name.
+            Assert.Equal("WBL", ProdNameCode.Extract("PLNS_WBL_DR-Set", Codes));
+        }
+
+        [Fact]
+        public void An_Unknown_Token_Is_Not_A_Code()
+        {
+            // Without this, any underscore-delimited word becomes a classification and a
+            // naming convention turns into a guessing game.
+            Assert.Null(ProdNameCode.Extract("PLNS_ZZZ_Whatever", Codes));
+            Assert.Null(ProdNameCode.Extract("Exterior_CreamWhite_230", Codes));
+        }
+
+        [Theory]
+        [InlineData("PLNS")]                    // one field
+        [InlineData("Generic - 225mm")]         // the real delivered name
+        [InlineData("")]
+        [InlineData(null)]
+        public void A_Name_With_No_Type_Field_Declares_Nothing(string name)
+        {
+            Assert.Null(ProdNameCode.Extract(name, Codes));
+        }
+
+        [Fact]
+        public void With_No_Known_Codes_Nothing_Is_Declared()
+        {
+            // A caller that has not loaded the rule set must get inference, not a
+            // free-for-all where every second field becomes a code.
+            Assert.Null(ProdNameCode.Extract("PLNS_WBL_Hollow200", null));
+            Assert.Null(ProdNameCode.Extract("PLNS_WBL_Hollow200", new HashSet<string>()));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Composing one
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Fields_Take_Underscores_And_Components_Take_Hyphens()
+        {
+            // The separator rule is the whole of the format. Mixing them makes the name
+            // unparseable, which would make the Type field decorative again.
+            Assert.Equal("PLNS_WBL_Hollow200-Plastered",
+                ProdNameCode.Compose("PLNS", "WBL", "Hollow200", "Plastered"));
+        }
+
+        [Fact]
+        public void A_Subtype_Is_Optional()
+        {
+            Assert.Equal("PLNS_WBL", ProdNameCode.Compose("PLNS", "WBL"));
+            Assert.Equal("PLNS_WBL", ProdNameCode.Compose("PLNS", "WBL", null, "  "));
+        }
+
+        [Fact]
+        public void Spaces_And_Stray_Separators_Are_Stripped()
+        {
+            // ISO 22014 permits neither. A space would break the field split, and a
+            // stray underscore inside a component would invent a fourth field.
+            Assert.Equal("PLNS_WBL_Hollow200-CeramicTiled",
+                ProdNameCode.Compose(" PLNS ", "WBL", "Hollow 200", "Ceramic_Tiled"));
+        }
+
+        [Fact]
+        public void A_Missing_Originator_Falls_Back_To_PLNS()
+        {
+            Assert.Equal("PLNS_WBL_Hollow200", ProdNameCode.Compose("", "WBL", "Hollow200"));
+        }
+
+        [Fact]
+        public void No_Code_Means_No_Name()
+        {
+            // Composing a name with an empty Type field would produce PLNS__Hollow200,
+            // which parses to nothing and looks deliberate.
+            Assert.Null(ProdNameCode.Compose("PLNS", "", "Hollow200"));
+        }
+
+        [Fact]
+        public void What_Compose_Writes_Extract_Reads()
+        {
+            // The round trip. If these two ever disagree, a conforming name stops
+            // resolving and silently falls back to pattern inference.
+            foreach (string code in new[] { "WBL", "SLB", "RSH" })
+            {
+                string name = ProdNameCode.Compose("PLNS", code, "Core200", "Finished");
+                Assert.Equal(code, ProdNameCode.Extract(name, Codes));
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The resolver tier
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static readonly List<(string, string)> WallRules =
+            new List<(string, string)> { ("*BLOCKWORK*", "WBL"), ("*BRICK*", "WBK") };
+
+        [Fact]
+        public void A_Declared_Code_Beats_Pattern_Inference()
+        {
+            // The name says WBK. A pattern would say WBL from the word "Blockwork" in the
+            // subtype. The statement wins — that is the point of stating it.
+            string got = ProdResolver.Resolve("Basic Wall", "PLNS_WBK_BlockworkLook", "Walls",
+                null, WallRules, null, out string src, Codes);
+
+            Assert.Equal("WBK", got);
+            Assert.Equal(ProdResolver.Sources.Declared, src);
+            Assert.True(ProdResolver.IsSpecific(src));
+        }
+
+        [Fact]
+        public void A_PROJECT_Overlay_Still_Beats_A_Declared_Code()
+        {
+            // The tier order is deliberate: a project overlay is an explicit instruction
+            // for THIS job and outranks even a stated code, exactly as it outranks
+            // corporate rules.
+            string got = ProdResolver.Resolve("Basic Wall", "PLNS_WBL_Hollow200", "Walls",
+                new List<(string, string)> { ("*HOLLOW200*", "PRJ") }, WallRules, null,
+                out string src, Codes);
+
+            Assert.Equal("PRJ", got);
+            Assert.Equal(ProdResolver.Sources.Project, src);
+        }
+
+        [Fact]
+        public void A_NON_Conforming_Name_Still_Resolves_By_Pattern()
+        {
+            // The rescue path is unchanged. Every delivered model is full of names like
+            // this, and the standard does not retire the rules that carry them.
+            string got = ProdResolver.Resolve("Basic Wall", "230 Blockwork Rendered", "Walls",
+                null, WallRules, null, out string src, Codes);
+
+            Assert.Equal("WBL", got);
+            Assert.Equal(ProdResolver.Sources.Corporate, src);
+        }
+
+        [Fact]
+        public void A_Coded_Name_Resolves_Even_With_No_Family_Name()
+        {
+            // A wall's family name is "Basic Wall" for every wall ever made, and the
+            // empty-family guard exists because a family name usually discriminates
+            // nothing. A name carrying its own answer does not need that guard.
+            string got = ProdResolver.Resolve("", "PLNS_SLB_RC150", "Floors",
+                null, null, new Dictionary<string, string> { ["Floors"] = "FL" },
+                out string src, Codes);
+
+            Assert.Equal("SLB", got);
+            Assert.Equal(ProdResolver.Sources.Declared, src);
+        }
+
+        [Fact]
+        public void Callers_That_Pass_No_Codes_Behave_Exactly_As_Before()
+        {
+            // knownCodes defaults to null, so the ~10 existing call sites are untouched
+            // and the tier is opt-in rather than a change under everyone's feet.
+            string got = ProdResolver.Resolve("Basic Wall", "PLNS_WBK_BlockworkLook", "Walls",
+                null, WallRules, null, out string src);
+
+            Assert.Equal("WBL", got);                       // inferred, not declared
+            Assert.Equal(ProdResolver.Sources.Corporate, src);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StandardisePlannerTests.cs
+++ b/StingTools.Tags.Tests/StandardisePlannerTests.cs
@@ -39,7 +39,10 @@ namespace StingTools.Tags.Tests
                 L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true),
                 L(2, "Plaster - Cement Render 1:4", 12)));
 
-            Assert.Equal("STING WL - Blockwork 200 - Plastered", p.ProposedName);
+            // BS EN ISO 22014: Source_Type_Subtype. The Type field is the PROD code, so a
+            // conforming name and the element's ISO 19650 tag cannot fork.
+            Assert.Equal("PLNS_WBL_Blockwork200-Plastered", p.ProposedName);
+            Assert.Equal("WBL", p.ProdCode);
         }
 
         [Fact]
@@ -51,7 +54,7 @@ namespace StingTools.Tags.Tests
                 L(0, "Plaster - Cement Render 1:4", 12),
                 L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true)));
 
-            Assert.Contains("Blockwork 200", p.ProposedName);
+            Assert.Contains("Blockwork200", p.ProposedName);
             Assert.DoesNotContain("230", p.ProposedName);
         }
 
@@ -63,7 +66,7 @@ namespace StingTools.Tags.Tests
                 L(1, "Screed - Cement Sand 1:3", 40),
                 L(2, "Concrete C25", 150, structure: true)));
 
-            Assert.Equal("STING FL - RC 150 - Ceramic Tiled", p.ProposedName);
+            Assert.Equal("PLNS_SLB_RC150-CeramicTiled", p.ProposedName);
         }
 
         [Fact]
@@ -74,7 +77,7 @@ namespace StingTools.Tags.Tests
                 L(0, "Insulation - Mineral Wool", 200),
                 L(1, "Timber - Softwood Cypress", 90, structure: true)));
 
-            Assert.Contains("Timber 90", p.ProposedName);
+            Assert.Contains("Timber90", p.ProposedName);
         }
 
         // ── the refusals ──────────────────────────────────────────────────────
@@ -105,7 +108,7 @@ namespace StingTools.Tags.Tests
         {
             // Running twice must not churn. The second run proposes the same name and
             // recognises the type already has it.
-            var input = In("Walls", "STING WL - Blockwork 200 - Plastered",
+            var input = In("Walls", "PLNS_WBL_Blockwork200-Plastered",
                 L(0, "Plaster - Cement Render 1:4", 12),
                 L(1, "Masonry - Hollow Concrete Block 200mm", 200, structure: true));
 

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -73,6 +73,8 @@
     <Compile Include="..\StingTools\Core\ScopeBoxLoc.cs" Link="Core\ScopeBoxLoc.cs" />
     <Compile Include="..\StingTools\Core\ProdPatternMatcher.cs" Link="Core\ProdPatternMatcher.cs" />
     <Compile Include="..\StingTools\Core\ProdResolver.cs" Link="Core\ProdResolver.cs" />
+    <!-- BS EN ISO 22014 name parsing. Revit-free so the "declared" tier is provable. -->
+    <Compile Include="..\StingTools\Core\ProdNameCode.cs" Link="Core\ProdNameCode.cs" />
     <!-- The house-standard catalogue POCOs, so the shipped baseline is checked
          against the rules that must read it. -->
     <Compile Include="..\StingTools\Core\Baseline\ProjectBaselineModel.cs" Link="Core\Baseline\ProjectBaselineModel.cs" />

--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -33,6 +33,8 @@ namespace StingTools.Core.Baseline
         /// <summary>Revit category display name — Walls / Floors / Roofs / Ceilings.</summary>
         public string Category = "";
         public string CurrentName = "";
+        /// <summary>ISO 22014 Source field, from PRJ_ORG_ORIGINATOR_CODE_TXT. Defaults PLNS.</summary>
+        public string Originator = "PLNS";
         /// <summary>Layers as the compound structure gives them, exterior to interior.</summary>
         public List<MaterialLayer> Layers = new List<MaterialLayer>();
         /// <summary>How many elements use this type. Renaming an unused type is noise.</summary>
@@ -43,8 +45,12 @@ namespace StingTools.Core.Baseline
     {
         public string Category = "";
         public string CurrentName = "";
+        /// <summary>ISO 22014 Source field.</summary>
+        public string Originator = "PLNS";
         /// <summary>Null when the model does not say enough to name the type.</summary>
         public string ProposedName;
+        /// <summary>The PROD code the proposed name declares in its Type field.</summary>
+        public string ProdCode;
         /// <summary>Why — shown to the reader either way.</summary>
         public string Reason = "";
         public int InstanceCount;
@@ -57,10 +63,36 @@ namespace StingTools.Core.Baseline
 
     public static class TypeRenamePlanner
     {
-        private static readonly Dictionary<string, string> UseCode =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        /// <summary>
+        /// Category → the PROD code each substance resolves to there.
+        ///
+        /// <para>The ISO 22014 <b>Type</b> field IS the PROD code, so a conforming type
+        /// name and the element's ISO 19650 tag cannot fork. Before this, a name carried
+        /// the word "Blockwork" while the resolver derived "WBL" from it — two
+        /// vocabularies for one fact, free to disagree the moment either was edited.</para>
+        /// </summary>
+        private static readonly Dictionary<string, Dictionary<string, string>> CodeFor =
+            new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["Walls"] = "WL", ["Floors"] = "FL", ["Roofs"] = "RF", ["Ceilings"] = "CL",
+                ["Walls"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Blockwork"] = "WBL", ["Clay Brick"] = "WBK", ["Screen Block"] = "SBP",
+                    ["RC"] = "WRC", ["Timber"] = "WPT", ["Plasterboard"] = "WPT",
+                    ["Steel"] = "WPT", ["Stone"] = "WSN",
+                },
+                ["Floors"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["RC"] = "SLB", ["Timber"] = "FTM", ["Plywood"] = "FTM",
+                },
+                ["Roofs"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["RC"] = "RCS", ["Corrugated Sheet"] = "RSH", ["Clay Tile Roof"] = "RTL",
+                    ["Stone Coated Tile Roof"] = "RTL", ["Timber"] = "RSH",
+                },
+                ["Ceilings"] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Plasterboard"] = "CPB", ["Timber"] = "CPB",
+                },
             };
 
         /// <summary>
@@ -109,9 +141,10 @@ namespace StingTools.Core.Baseline
                 Category = input?.Category ?? "",
                 CurrentName = input?.CurrentName ?? "",
                 InstanceCount = input?.InstanceCount ?? 0,
+                Originator = string.IsNullOrWhiteSpace(input?.Originator) ? "PLNS" : input.Originator,
             };
 
-            if (input == null || !UseCode.TryGetValue(p.Category, out string use))
+            if (input == null || !CodeFor.TryGetValue(p.Category, out var codes))
             { p.Reason = "not a layered host category"; return p; }
 
             var layers = (input.Layers ?? new List<MaterialLayer>())
@@ -126,7 +159,7 @@ namespace StingTools.Core.Baseline
                     ?? layers.OrderByDescending(l => l.ThicknessMm).ThenBy(l => l.Index).FirstOrDefault();
 
             string substance = Match(core.MaterialName, Substance);
-            if (substance == null)
+            if (substance == null || !codes.TryGetValue(substance, out string prod))
             {
                 p.Reason = $"the core material '{core.MaterialName}' names no substance this "
                          + "recognises — rename the MATERIAL first (rule M1), then re-run";
@@ -136,7 +169,7 @@ namespace StingTools.Core.Baseline
             // Size from the core's own thickness, so it describes the thing rather than
             // repeating whatever number the old name happened to carry.
             string size = core.ThicknessMm >= 1
-                ? " " + Math.Round(core.ThicknessMm).ToString("0", CultureInfo.InvariantCulture)
+                ? Math.Round(core.ThicknessMm).ToString("0", CultureInfo.InvariantCulture)
                 : "";
 
             // Finish from the finish layers, not from the core.
@@ -144,11 +177,13 @@ namespace StingTools.Core.Baseline
                                   .Select(l => Match(l.MaterialName, Finish))
                                   .FirstOrDefault(f => f != null);
 
-            p.ProposedName = $"STING {use} - {substance}{size}"
-                           + (finish != null ? $" - {finish}" : "");
+            // BS EN ISO 22014: Source_Type_Subtype. Underscore between fields, hyphen
+            // between components inside a field, no spaces anywhere.
+            p.ProdCode = prod;
+            p.ProposedName = ProdNameCode.Compose(p.Originator, prod, substance + size, finish);
             p.Reason = finish != null
-                ? $"core '{core.MaterialName}' + finish layer"
-                : $"core '{core.MaterialName}'; no finish layer to read";
+                ? $"core '{core.MaterialName}' + finish layer → {prod}"
+                : $"core '{core.MaterialName}' → {prod}; no finish layer to read";
             return p;
         }
 

--- a/StingTools/Core/ProdNameCode.cs
+++ b/StingTools/Core/ProdNameCode.cs
@@ -1,0 +1,101 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ProdNameCode.cs — a type name that STATES its product code, read rather
+//  than re-inferred.
+//
+//  BS EN ISO 22014:2024 (superseding BS 8541-1) names a library object in
+//  three underscore-separated fields — Source_Type_Subtype — with no spaces
+//  and components hyphenated inside a field. The middle field is the object's
+//  TYPE, and for STING that is the PROD code the plugin already mints:
+//
+//      PLNS_WBL_Hollow200-Plastered
+//      ^^^^ ^^^ ^^^^^^^^^^^^^^^^^^^
+//      |    |   subtype: what distinguishes this one
+//      |    the ISO 19650 PROD code
+//      originator, from PRJ_ORG_ORIGINATOR_CODE_TXT
+//
+//  WHY THIS TIER EXISTS. Before it, a type name had to CONTAIN a substance
+//  word — "Blockwork", "Clay Brick" — for the pattern rules to infer a code
+//  from it. That works, and rescues the badly-named types a delivered model is
+//  full of. But it means a conforming model carries TWO vocabularies for one
+//  fact: the word "Blockwork" in the name and the code WBL the resolver
+//  derives from it, free to disagree the moment either is edited.
+//
+//  One fact, one place. When the name states the code, believe it; the pattern
+//  rules stay exactly as they are for every name that does not.
+//
+//  THE SAFETY PROPERTY: only a token that IS a known PROD code counts, and only
+//  in the second field. "PLNS_WBL_DR-Set" reads WBL, not DR — a subtype word
+//  that happens to collide with some code cannot hijack the name.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core
+{
+    public static class ProdNameCode
+    {
+        /// <summary>
+        /// The PROD code a type name declares, or null when it declares none.
+        ///
+        /// <param name="typeName">The Revit type name.</param>
+        /// <param name="knownCodes">Every code the loaded rule set can issue. A token
+        /// is only a code if it is one of these — otherwise any underscore-delimited
+        /// word would become one, which is how a naming convention turns into a
+        /// guessing game.</param>
+        /// </summary>
+        public static string Extract(string typeName, ICollection<string> knownCodes)
+        {
+            if (string.IsNullOrWhiteSpace(typeName) || knownCodes == null || knownCodes.Count == 0)
+                return null;
+
+            // Fields are underscore-separated; components inside a field are hyphenated,
+            // so a hyphen must not split. ISO 22014 puts the Type in the second field.
+            var fields = typeName.Split('_');
+            if (fields.Length < 2) return null;
+
+            string candidate = fields[1].Trim();
+            if (candidate.Length == 0) return null;
+
+            foreach (string code in knownCodes)
+                if (string.Equals(code, candidate, StringComparison.OrdinalIgnoreCase))
+                    return code;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Compose an ISO 22014 name. Subtype components arrive as separate words and
+        /// are joined with hyphens, because the underscore is reserved for the field
+        /// boundary — mixing the two is what makes a coded name unparseable.
+        /// </summary>
+        public static string Compose(string originator, string prodCode, params string[] subtypeParts)
+        {
+            string org = Clean(originator);
+            string code = Clean(prodCode);
+            if (org.Length == 0) org = "PLNS";
+            if (code.Length == 0) return null;
+
+            var parts = new List<string>();
+            foreach (string p in subtypeParts ?? new string[0])
+            {
+                string c = Clean(p);
+                if (c.Length > 0) parts.Add(c);
+            }
+
+            return parts.Count > 0
+                ? $"{org}_{code}_{string.Join("-", parts)}"
+                : $"{org}_{code}";
+        }
+
+        /// <summary>Strip what ISO 22014 does not allow: spaces, and the two separators
+        /// when they appear inside a component. PascalCase survives untouched.</summary>
+        private static string Clean(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return "";
+            var sb = new System.Text.StringBuilder(s.Length);
+            foreach (char c in s.Trim())
+                if (!char.IsWhiteSpace(c) && c != '_' && c != '-') sb.Append(c);
+            return sb.ToString();
+        }
+    }
+}

--- a/StingTools/Core/ProdResolver.cs
+++ b/StingTools/Core/ProdResolver.cs
@@ -20,6 +20,11 @@ namespace StingTools.Core
         public static class Sources
         {
             public const string Project = "project";
+
+            /// <summary>The TYPE NAME stated the code itself, in ISO 22014 form
+            /// (<c>PLNS_WBL_Hollow200-Plastered</c>). Nothing was inferred.</summary>
+            public const string Declared = "declared";
+
             public const string Corporate = "corporate";
             public const string Lps = "lps";
             public const string Sleeve = "sleeve";
@@ -35,7 +40,8 @@ namespace StingTools.Core
         /// Prod_CoverageAudit (coverage %).
         /// </summary>
         public static bool IsSpecific(string source)
-            => source == Sources.Project || source == Sources.Corporate
+            => source == Sources.Project || source == Sources.Declared
+            || source == Sources.Corporate
             || source == Sources.Lps || source == Sources.Sleeve;
 
         /// <param name="familyName">Element family name (may be null/empty).</param>
@@ -52,15 +58,28 @@ namespace StingTools.Core
             IReadOnlyList<(string Pattern, string ProdCode)> projRulesForCategory,
             IReadOnlyList<(string Pattern, string ProdCode)> corpRulesForCategory,
             IReadOnlyDictionary<string, string> prodMap,
-            out string source)
+            out string source,
+            ICollection<string> knownCodes = null)
         {
             string combinedName = $"{familyName} {typeName}".ToUpperInvariant();
+
+            // 0. The TYPE NAME states its own code, ISO 22014 style. This sits ABOVE
+            //    the corporate patterns and BELOW the project overlay: a stated code
+            //    beats an inference, an explicit project instruction beats both.
+            //
+            //    Deliberately OUTSIDE the non-empty-family guard below. A wall's family
+            //    name is "Basic Wall" for every wall ever made, so gating a name that
+            //    already carries its answer on that check would be testing the one thing
+            //    the name has made irrelevant.
+            string declared = ProdNameCode.Extract(typeName, knownCodes);
 
             if (!string.IsNullOrEmpty(familyName))
             {
                 // 1. Project overlay wins.
                 string proj = Strongest(projRulesForCategory, combinedName);
                 if (proj != null) { source = Sources.Project; return proj; }
+
+                if (declared != null) { source = Sources.Declared; return declared; }
 
                 // 2. Corporate baseline.
                 string corp = Strongest(corpRulesForCategory, combinedName);
@@ -78,6 +97,9 @@ namespace StingTools.Core
                     return "SLV";
                 }
             }
+
+            // A coded name answers even with no family name at all.
+            if (declared != null) { source = Sources.Declared; return declared; }
 
             // 5. Category default — last resort (generic, not family-specific).
             if (prodMap != null && categoryName != null &&

--- a/StingTools/Data/STING_PROJECT_BASELINE.json
+++ b/StingTools/Data/STING_PROJECT_BASELINE.json
@@ -2,18 +2,30 @@
   "_comment": [
     "STING HOUSE STANDARD - the host types and materials a model is authored with.",
     "",
-    "Every name here is chosen so the plugin can READ it. Type names resolve to a",
-    "specific PROD code through STING_PROD_CODES.csv; material names resolve to a",
-    "material suffix through STING_MATERIAL_PROD_OVERRIDES.csv. A standard the tool",
-    "cannot read is the failure this whole catalogue exists to prevent, and",
-    "BaselineCatalogueTests fails the build if any entry stops resolving.",
+    "TYPE NAMES FOLLOW BS EN ISO 22014:2024 (which superseded BS 8541-1 in May 2024):",
     "",
-    "NAMING SHAPE: <use> - <substance + size> - <finish>",
-    "  use        WL / FL / RF / CL, so a browser sorts by element kind",
-    "  substance  what the schedule measures - Blockwork 200, RC Slab 150",
-    "  finish     what the take-off decomposes - Plastered Both Faces, Ceramic Tiled",
-    "A size alone is not a product name. 'Generic - 225mm' and 'Exterior_CreamWhite_230'",
-    "are real type names from delivered models and neither can ever be measured.",
+    "    PLNS_WBL_Hollow200-PlasteredBothFaces",
+    "    ^^^^ ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+    "    |    |   Subtype - what distinguishes this one from its siblings",
+    "    |    Type - the ISO 19650 PROD code the plugin already mints",
+    "    Source - originator, from PRJ_ORG_ORIGINATOR_CODE_TXT",
+    "",
+    "Underscore between FIELDS, hyphen between COMPONENTS inside a field, no spaces,",
+    "PascalCase within a component. Three fields, in that order.",
+    "",
+    "WHY THE TYPE FIELD IS THE PROD CODE. The plugin already mints an ISO 19650 asset",
+    "tag whose PROD segment classifies the product. A type name carrying the WORD",
+    "'Blockwork' beside a tag carrying the CODE 'WBL' is two vocabularies for one fact,",
+    "free to disagree the moment either is edited. Naming the code directly means the",
+    "resolver READS it rather than inferring it - source tier 'declared', above the",
+    "corporate patterns and below a project overlay.",
+    "",
+    "The pattern rules are unchanged and still carry every model that does NOT conform.",
+    "They are the rescue path, not the standard.",
+    "",
+    "MATERIAL names keep their readable shape - <Family> - <Qualifier> - <Grade> - because",
+    "Revit materials are not library objects and ISO 22014 does not govern them. Their",
+    "controlled field is Material.Class, which Materials_SetClass fills.",
     "",
     "LAYERS, NOT PAINT: every finish is a LAYER with its own material, and the core",
     "carries the Structure function. An element-level material overrides all of it.",
@@ -239,7 +251,7 @@
   ],
   "wallTypes": [
     {
-      "name": "STING WL - Blockwork 200 - Plastered Both Faces",
+      "name": "PLNS_WBL_Hollow200-PlasteredBothFaces",
       "purpose": "External and load-bearing default. Both plaster faces are LAYERS, which is what makes rendering measurable",
       "layers": [
         {
@@ -260,7 +272,7 @@
       ]
     },
     {
-      "name": "STING WL - Blockwork 150 - Plastered Both Faces",
+      "name": "PLNS_WBL_Hollow150-PlasteredBothFaces",
       "purpose": "Internal load-bearing wall",
       "layers": [
         {
@@ -281,7 +293,7 @@
       ]
     },
     {
-      "name": "STING WL - Blockwork 100 - Plastered Both Faces",
+      "name": "PLNS_WBL_Hollow100-PlasteredBothFaces",
       "purpose": "Internal non-load-bearing partition",
       "layers": [
         {
@@ -302,7 +314,7 @@
       ]
     },
     {
-      "name": "STING WL - Blockwork 200 - Fair Face External",
+      "name": "PLNS_WBL_Hollow200-FairFaceExternal",
       "purpose": "External block wall left fair-faced outside, plastered inside",
       "layers": [
         {
@@ -318,7 +330,7 @@
       ]
     },
     {
-      "name": "STING WL - Clay Brick 295 - Fair Faced",
+      "name": "PLNS_WBK_Clay295-FairFaced",
       "purpose": "Fair-faced clay brickwork, no render either side",
       "layers": [
         {
@@ -329,7 +341,7 @@
       ]
     },
     {
-      "name": "STING WL - Clay Brick 150 - Plastered Internal",
+      "name": "PLNS_WBK_Clay150-PlasteredInternal",
       "purpose": "Half-brick skin, rendered internally",
       "layers": [
         {
@@ -345,7 +357,7 @@
       ]
     },
     {
-      "name": "STING WL - RC Wall 200 - Plastered Both Faces",
+      "name": "PLNS_WRC_Wall200-PlasteredBothFaces",
       "purpose": "Reinforced concrete wall. The EXPLICIT concrete material is what lets it decompose to concrete, rebar and formwork",
       "layers": [
         {
@@ -366,7 +378,7 @@
       ]
     },
     {
-      "name": "STING WL - RC Retaining Wall 250",
+      "name": "PLNS_RWL_Retaining250-Tanked",
       "purpose": "Below-ground retaining wall, tanked externally",
       "layers": [
         {
@@ -382,7 +394,7 @@
       ]
     },
     {
-      "name": "STING WL - Stud Partition 100 - Boarded Both Faces",
+      "name": "PLNS_WPT_Stud100-BoardedBothFaces",
       "purpose": "Metal or timber stud partition with plasterboard both faces",
       "layers": [
         {
@@ -403,7 +415,7 @@
       ]
     },
     {
-      "name": "STING WL - Blockwork 200 - Tiled One Face",
+      "name": "PLNS_WBL_Hollow200-TiledOneFace",
       "purpose": "Wet-area wall. The tile LAYER is what makes wall tiling measurable",
       "layers": [
         {
@@ -424,7 +436,7 @@
       ]
     },
     {
-      "name": "STING WL - Boundary Wall 200 - Fair Faced",
+      "name": "PLNS_WBD_Boundary200-FairFaced",
       "purpose": "Compound / boundary wall with coping",
       "layers": [
         {
@@ -437,7 +449,7 @@
   ],
   "floorTypes": [
     {
-      "name": "STING FL - RC Slab 150 - Ceramic Tiled",
+      "name": "PLNS_SLB_RC150-CeramicTiled",
       "purpose": "Suspended slab with a tiled finish. The tile LAYER is what makes floor tiling measurable",
       "layers": [
         {
@@ -458,7 +470,7 @@
       ]
     },
     {
-      "name": "STING FL - RC Slab 200 - Porcelain Tiled",
+      "name": "PLNS_SLB_RC200-PorcelainTiled",
       "purpose": "Heavier suspended slab, large-format porcelain",
       "layers": [
         {
@@ -479,7 +491,7 @@
       ]
     },
     {
-      "name": "STING FL - RC Slab 150 - Terrazzo",
+      "name": "PLNS_SLB_RC150-Terrazzo",
       "purpose": "Suspended slab with in-situ terrazzo",
       "layers": [
         {
@@ -495,7 +507,7 @@
       ]
     },
     {
-      "name": "STING FL - RC Slab 150 - Screed Only",
+      "name": "PLNS_SLB_RC150-ScreedOnly",
       "purpose": "Suspended slab left screeded, finish by others",
       "layers": [
         {
@@ -511,7 +523,7 @@
       ]
     },
     {
-      "name": "STING FL - Ground Slab 150 - Ceramic Tiled",
+      "name": "PLNS_FGS_Ground150-CeramicTiled",
       "purpose": "Ground-bearing slab on DPM and hardcore. Hardcore and DPM are LAYERS so both are measurable",
       "layers": [
         {
@@ -542,7 +554,7 @@
       ]
     },
     {
-      "name": "STING FL - Ground Slab 150 - Screed Only",
+      "name": "PLNS_FGS_Ground150-ScreedOnly",
       "purpose": "Ground-bearing slab, finish by others",
       "layers": [
         {
@@ -568,7 +580,7 @@
       ]
     },
     {
-      "name": "STING FL - Hollow Pot Slab 250 - Ceramic Tiled",
+      "name": "PLNS_FRB_HollowPot250-CeramicTiled",
       "purpose": "Ribbed / hollow-pot suspended slab, the East African economy span",
       "layers": [
         {
@@ -589,7 +601,7 @@
       ]
     },
     {
-      "name": "STING FL - RC Steps - Terrazzo",
+      "name": "PLNS_FSP_RC150-Terrazzo",
       "purpose": "Cast-in-place steps and landings",
       "layers": [
         {
@@ -607,7 +619,7 @@
   ],
   "roofTypes": [
     {
-      "name": "STING RF - RC Flat Roof 225 - Felt",
+      "name": "PLNS_RFL_RC225-BuiltUpFelt",
       "purpose": "Concrete flat roof with built-up felt. The EXPLICIT concrete material is what lets it decompose to concrete, rebar and formwork",
       "layers": [
         {
@@ -628,7 +640,7 @@
       ]
     },
     {
-      "name": "STING RF - Corrugated Sheet Roof - IT4 on Timber",
+      "name": "PLNS_RSH_IT4-OnTimberPurlins",
       "purpose": "Galvanised IT4 sheeting on softwood purlins, the Uganda default",
       "layers": [
         {
@@ -644,7 +656,7 @@
       ]
     },
     {
-      "name": "STING RF - Clay Tile Roof - on Timber",
+      "name": "PLNS_RTL_ClayTile-OnTimberBattens",
       "purpose": "Clay roof tiling on battens and softwood",
       "layers": [
         {
@@ -660,7 +672,7 @@
       ]
     },
     {
-      "name": "STING RF - Stone Coated Tile Roof - on Timber",
+      "name": "PLNS_RTL_StoneCoated-OnTimberBattens",
       "purpose": "Stone-coated steel tile on softwood",
       "layers": [
         {
@@ -676,7 +688,7 @@
       ]
     },
     {
-      "name": "STING RF - RC Roof Slab 200 - Insulated Felt",
+      "name": "PLNS_RCS_RC200-InsulatedFelt",
       "purpose": "Warm flat roof with insulation between deck and membrane",
       "layers": [
         {
@@ -699,7 +711,7 @@
   ],
   "ceilingTypes": [
     {
-      "name": "STING CL - Suspended Gypsum Ceiling",
+      "name": "PLNS_CSU_Gypsum9-ConcealedGrid",
       "purpose": "Plasterboard ceiling on a concealed grid",
       "layers": [
         {
@@ -710,7 +722,7 @@
       ]
     },
     {
-      "name": "STING CL - Plasterboard Ceiling on Timber",
+      "name": "PLNS_CPB_Gypsum9-OnTimberBrandering",
       "purpose": "Board fixed direct to softwood brandering",
       "layers": [
         {
@@ -726,7 +738,7 @@
       ]
     },
     {
-      "name": "STING CL - Plastered Soffit",
+      "name": "PLNS_CPL_CementRender12-DirectToSlab",
       "purpose": "Rendered soffit direct to the slab, no void",
       "layers": [
         {


### PR DESCRIPTION
**ISO 19650 does not govern type names** — it governs information containers, and saying otherwise is a common shorthand that's simply wrong. What governs a library object's name is [**BS EN ISO 22014:2024**](https://www.iso.org/standard/84473.html), which superseded BS 8541-1 in May 2024: three underscore-separated fields, `Source_Type_Subtype`, hyphens between components inside a field, no spaces.

```
PLNS_WBL_Hollow200-PlasteredBothFaces
^^^^ ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
|    |   Subtype
|    Type — the ISO 19650 PROD code the plugin already mints
Source — PRJ_ORG_ORIGINATOR_CODE_TXT
```

## The shape I shipped yesterday was wrong, in a way worth naming

`STING WL - Blockwork 200 - Plastered` carried the **word** "Blockwork" while the resolver derived the **code** "WBL" from it by pattern. Two vocabularies for one fact, free to disagree the moment either is edited — the exact defect class this session has spent its length removing, reproduced inside the fix for it.

So the Type field **is** the code, and a new resolver tier **reads** it instead of inferring: source `declared`, above the corporate patterns and below a project overlay. A stated code beats an inference; an explicit project instruction beats both.

**The safety property:** only a token that *is* a known PROD code counts, and only in the second field. `PLNS_WBL_DR-Set` reads `WBL`, not `DR` — a subtype component that happens to spell a code can't hijack the name. With no known codes supplied the tier is inert, so the ~10 existing call sites are untouched and this is opt-in.

**The pattern rules are unchanged** and still carry every model that doesn't conform. They're the rescue path, not the standard.

All 27 catalogue types renamed, and the gate now requires them to resolve via the **declared** tier specifically — an entry resolving by *pattern* would mean the Type field is decorative and the two vocabularies are still running in parallel.

## A real migration cost, found by two existing tests

The ISO shape moves English words **out** of type names, so anything selecting on those words breaks. Two Boq tests picked their fixture by `"Blockwork"` and `"Flat Roof"`; both now select on the Type field, which is the part the standard promises to keep.

**In a live model the same applies to view filters and schedule filters** that match type-name substrings. Renaming types will break them — which is why the rename command asks first and writes a plan.

## What keeps its old shape

Materials stay `<Family> - <Qualifier> - <Grade>`. Revit materials are not library objects and ISO 22014 doesn't govern them; their controlled field is `Material.Class`, which `Materials_SetClass` fills.

## Verification

Tags **582 → 604**, Boq **1,249**, build **0/0**, **six mutations verified failing** — including one moving the declared tier below the corporate patterns, one moving it above the project overlay, and one letting any field carry the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)