### PR TITLE
Rename gate: refuse a rename that would overwrite a product code already resolving

### DIFF
--- a/StingTools.Tags.Tests/Fixtures/host_types_20260908.csv
+++ b/StingTools.Tags.Tests/Fixtures/host_types_20260908.csv
@@ -1,0 +1,7 @@
+Category,Family,CurrentName,ExistingProd,ExistingSource,CoreMaterial,CoreThicknessMm,FinishMaterial,RecordedProposal,MustPropose
+Floors,Floor,stepsr 7,FSP,corporate,"Concrete, Cast In Situ(1)",450,Floor Tile 300x300,PLNS_SLB_RC450-Tiled,no
+Walls,Basic Wall,coping,WCP,corporate,CONCRETE CAST IN SITU 50MM,250,,PLNS_WRC_RC250,no
+Walls,Basic Wall,CLAY BRICK VILLAGE LARGE (295×150×130MM),WBK,corporate,CLAY BRICK VILLAGE LARGE (295×150×130MM),150,,PLNS_WBK_ClayBrick150,yes
+Walls,Basic Wall,Exterior_CreamWhite_230 2,WL,category,"Brick, Common(1)",205,Plaster - Cement Render 1:4,PLNS_WBK_ClayBrick205-Plastered,yes
+Walls,Basic Wall,Exterior_BrownWhite_230,WL,category,"Brick, Common(1)",205,Plaster - Cement Render 1:4,PLNS_WBK_ClayBrick205-Plastered,yes
+Floors,Floor,IntFloor_tile_150,FL,category,"Concrete, Cast In Situ(1)",500,Tile - Ceramic Floor,PLNS_SLB_RC500-CeramicTiled,yes

--- a/StingTools.Tags.Tests/TypeRenameCodeGateTests.cs
+++ b/StingTools.Tags.Tests/TypeRenameCodeGateTests.cs
@@ -1,0 +1,480 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeRenameCodeGateTests.cs — a rename must not write a WORSE product code
+//  into the one field the resolver trusts above every rule.
+//
+//  WHY. `ProdResolver` puts a code DECLARED in the type name above the corporate
+//  pattern rules, deliberately: a name that states its answer beats an inference.
+//  `TypeRenamePlanner` composes exactly such a name. So a rename is not a
+//  cosmetic act — it OVERWRITES the classification, permanently and silently.
+//
+//  Two rows from a real run on 2026-09-08 prove the failure. Both resolve
+//  CORRECTLY today, from a corporate rule, and the rename plan from the same
+//  session proposed to change them:
+//
+//      Floors,Floor,stepsr 7,FSP-CON,corporate,Y   → PLNS_SLB_RC450-Tiled   FSP → SLB
+//      Walls,Basic Wall,coping,WCP-CON,corporate,Y → PLNS_WRC_RC250         WCP → WRC
+//
+//  `CodeFor` has no steps entry for Floors and no coping entry for Walls, so the
+//  planner reached for the nearest thing it knew. **It cannot have those entries**:
+//  `CodeFor` is keyed on the SUBSTANCE read off the core material, and "steps" and
+//  "coping" are what an element IS FOR, not what it is made of — a concrete step
+//  and a concrete slab have the same core material and must not have the same
+//  code. Adding words to the table cannot fix this class of defect, which is why
+//  the fix is a refusal.
+//
+//  THE RULE, and the line it draws:
+//
+//      A rename is refused when the proposed name would declare a DIFFERENT code
+//      from one the type already resolves to SPECIFICALLY — from a project or
+//      corporate rule, an LPS or sleeve special case, or a code already declared
+//      in its name.
+//
+//      It is NOT refused when the current code is the CATEGORY DEFAULT (WL, FL,
+//      RF, CLG). That is the absence of an answer, and replacing it is the entire
+//      purpose of the command.
+//
+//  That distinction is load-bearing, and the fixture pins both sides of it:
+//  `CLAY BRICK VILLAGE LARGE` resolves WBK from a corporate rule and the proposal
+//  declares WBK, so it stands; `Exterior_CreamWhite_230 2` resolves WL from the
+//  category default and the proposal declares WBK, so it stands too. A gate that
+//  refused every code change would refuse both — and with them nearly every
+//  rename the command exists to make.
+//
+//  The fixture is the two real CSVs from that session, joined: the coverage audit
+//  (what each type resolves to, and how) and the rename plan (what was proposed,
+//  and off which core material). The core material and thickness reproduce each
+//  recorded proposal exactly, which the test asserts before it asserts anything
+//  else — a reconstruction that did not reproduce the run would make every
+//  verdict below meaningless.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class TypeRenameCodeGateTests
+    {
+        // ══════════════════════════════════════════════════════════════════════
+        //  The resolver, wired exactly as the plugin wires it
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_PROD_CODES.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static string FixtureDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(
+                       dir.FullName, "StingTools.Tags.Tests", "Fixtures", "host_types_20260908.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate the host-type fixture from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures");
+        }
+
+        private static Dictionary<string, List<(string Pattern, string ProdCode)>> _corp;
+        private static HashSet<string> _codes;
+
+        private static void LoadRules()
+        {
+            if (_corp != null) return;
+            var corp = new Dictionary<string, List<(string, string)>>(StringComparer.OrdinalIgnoreCase);
+            var codes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string raw in File.ReadAllLines(Path.Combine(DataDir(), "STING_PROD_CODES.csv")).Skip(1))
+            {
+                string line = (raw ?? "").Trim();
+                if (line.Length == 0 || line.StartsWith("#")) continue;
+                var c = line.Split(',');
+                if (c.Length < 3) continue;
+                string code = c[0].Trim(), cat = c[1].Trim(), pat = c[2].Trim().ToUpperInvariant();
+                if (code.Length == 0) continue;
+                codes.Add(code);
+                if (cat.Length == 0 || pat.Length == 0) continue;
+                if (!corp.TryGetValue(cat, out var list)) corp[cat] = list = new List<(string, string)>();
+                list.Add((pat, code));
+            }
+            Assert.True(codes.Count > 100, "STING_PROD_CODES.csv looks empty: " + codes.Count);
+            _codes = codes;
+            _corp = corp;
+        }
+
+        /// <summary>
+        /// The category defaults, copied from <c>TagConfig.DefaultProdMap</c> for the four
+        /// layered host categories. These are the codes that mean "nobody has classified
+        /// this", and telling them apart from a real answer is the whole gate.
+        /// </summary>
+        private static readonly Dictionary<string, string> CategoryDefault =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Walls"] = "WL", ["Floors"] = "FL", ["Roofs"] = "RF", ["Ceilings"] = "CLG",
+            };
+
+        private static ExistingProdCode Resolve(TypeRenameInput input)
+        {
+            LoadRules();
+            _corp.TryGetValue(input.Category ?? "", out var corpForCat);
+            string code = ProdResolver.Resolve(
+                input.FamilyName, input.CurrentName, input.Category,
+                null, corpForCat, CategoryDefault, out string source, _codes);
+            return new ExistingProdCode
+            {
+                Code = code,
+                Source = source,
+                IsSpecific = ProdResolver.IsSpecific(source),
+            };
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The fixture
+        // ══════════════════════════════════════════════════════════════════════
+
+        private sealed class Row
+        {
+            public string Category, Family, CurrentName, ExistingProd, ExistingSource,
+                          CoreMaterial, FinishMaterial, RecordedProposal;
+            public double CoreThicknessMm;
+            public bool MustPropose;
+
+            public TypeRenameInput ToInput()
+            {
+                var layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer
+                    {
+                        Index = 0, MaterialName = CoreMaterial,
+                        ThicknessMm = CoreThicknessMm, IsStructure = true,
+                    },
+                };
+                if (!string.IsNullOrWhiteSpace(FinishMaterial))
+                    layers.Add(new MaterialLayer
+                    {
+                        Index = 1, MaterialName = FinishMaterial, ThicknessMm = 12, IsStructure = false,
+                    });
+                return new TypeRenameInput
+                {
+                    Category = Category, FamilyName = Family, CurrentName = CurrentName,
+                    Layers = layers, InstanceCount = 5,
+                };
+            }
+
+            public override string ToString() => $"{Category}/{CurrentName}";
+        }
+
+        private static List<Row> Fixture()
+        {
+            var rows = new List<Row>();
+            foreach (string line in File.ReadAllLines(
+                         Path.Combine(FixtureDir(), "host_types_20260908.csv"), Encoding.UTF8).Skip(1))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var f = SplitCsv(line);
+                Assert.True(f.Count == 10, "Malformed fixture line: " + line);
+                rows.Add(new Row
+                {
+                    Category = f[0], Family = f[1], CurrentName = f[2],
+                    ExistingProd = f[3], ExistingSource = f[4],
+                    CoreMaterial = f[5],
+                    CoreThicknessMm = double.Parse(f[6], System.Globalization.CultureInfo.InvariantCulture),
+                    FinishMaterial = f[7], RecordedProposal = f[8],
+                    MustPropose = f[9].Trim().Equals("yes", StringComparison.OrdinalIgnoreCase),
+                });
+            }
+            Assert.Equal(6, rows.Count);
+            return rows;
+        }
+
+        private static List<string> SplitCsv(string line)
+        {
+            var fields = new List<string>();
+            var cur = new StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < line.Length; i++)
+            {
+                char c = line[i];
+                if (quoted)
+                {
+                    if (c != '"') { cur.Append(c); continue; }
+                    if (i + 1 < line.Length && line[i + 1] == '"') { cur.Append('"'); i++; continue; }
+                    quoted = false;
+                }
+                else if (c == '"' && cur.Length == 0) quoted = true;
+                else if (c == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(c);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  0. The harness agrees with the Revit run it is standing in for
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Test_Resolver_Reproduces_What_The_Model_Actually_Resolved()
+        {
+            // The fixture's ExistingProd and ExistingSource columns are copied out of
+            // prod_coverage_20260908_221546.csv — a real Revit run. If this test's own
+            // wiring of ProdResolver disagreed with it, every verdict below would be
+            // measuring the harness rather than the planner.
+            var wrong = new List<string>();
+            foreach (var r in Fixture())
+            {
+                var got = Resolve(r.ToInput());
+                if (!string.Equals(got.Code, r.ExistingProd, StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(got.Source, r.ExistingSource, StringComparison.OrdinalIgnoreCase))
+                    wrong.Add($"{r}: run said {r.ExistingProd}/{r.ExistingSource}, "
+                            + $"this harness says {got.Code}/{got.Source}");
+            }
+            Assert.True(wrong.Count == 0, string.Join("\n", wrong));
+        }
+
+        [Fact]
+        public void The_Reconstructed_Layers_Reproduce_The_Names_The_Run_Proposed()
+        {
+            // The fixture carries a core material and a thickness, not the whole compound
+            // structure. They must compose the SAME name the 2026-09-08 run produced, or
+            // the refusals below are being proved against a different type.
+            var wrong = new List<string>();
+            foreach (var r in Fixture())
+            {
+                var p = TypeRenamePlanner.Plan(r.ToInput());   // no resolver: the raw proposal
+                if (!string.Equals(p.ProposedName, r.RecordedProposal, StringComparison.Ordinal))
+                    wrong.Add($"{r}: run proposed '{r.RecordedProposal}', reconstruction gives "
+                            + $"'{p.ProposedName ?? "(refused: " + p.Reason + ")"}'");
+            }
+            Assert.True(wrong.Count == 0, string.Join("\n", wrong));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The gate
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void No_Rename_Replaces_A_Code_That_Already_Resolves_Specifically()
+        {
+            var misses = new List<string>();
+            foreach (var r in Fixture())
+            {
+                var p = TypeRenamePlanner.Plan(r.ToInput(), Resolve);
+                var existing = Resolve(r.ToInput());
+
+                if (r.MustPropose)
+                {
+                    if (!p.IsProposal)
+                        misses.Add($"{r}: REFUSED but must stand — it resolves {existing.Code} "
+                                 + $"from {existing.Source}. Reason given: {p.Reason}");
+                    continue;
+                }
+
+                if (p.IsProposal)
+                    misses.Add($"{r}: proposes '{p.ProposedName}' declaring {p.DeclaredCode}, "
+                             + $"but the type already resolves {existing.Code} from {existing.Source} "
+                             + "— the rename would overwrite a correct code with a worse one.");
+            }
+            Assert.True(misses.Count == 0,
+                $"{misses.Count} of 6 fixture rows disagree:\n  " + string.Join("\n  ", misses));
+        }
+
+        [Fact]
+        public void The_Refusal_Says_Which_Code_Would_Have_Been_Lost()
+        {
+            // A refusal a reviewer cannot act on is a refusal they will override.
+            var steps = Fixture().First(r => r.CurrentName == "stepsr 7");
+            var p = TypeRenamePlanner.Plan(steps.ToInput(), Resolve);
+
+            Assert.Null(p.ProposedName);
+            Assert.Contains("FSP", p.Reason);
+            Assert.Contains("SLB", p.Reason);
+            Assert.Equal("SLB", p.DeclaredCode);
+            Assert.Equal("FSP", p.Existing?.Code);
+        }
+
+        [Fact]
+        public void A_Category_Default_Is_Not_An_Answer_And_Can_Be_Replaced()
+        {
+            // WL / FL / RF / CLG mean "nobody has classified this". Replacing one is the
+            // whole point of the command, and a gate that stopped it would leave the tool
+            // able to rename only the types that least need it.
+            var wall = Fixture().First(r => r.CurrentName == "Exterior_CreamWhite_230 2");
+            var p = TypeRenamePlanner.Plan(wall.ToInput(), Resolve);
+
+            Assert.Equal("PLNS_WBK_ClayBrick205-Plastered", p.ProposedName);
+            Assert.Equal("WL", p.Existing?.Code);
+            Assert.Equal("category", p.Existing?.Source);
+            Assert.False(p.Existing.IsSpecific);
+        }
+
+        [Fact]
+        public void The_Same_Code_Restated_Is_Not_A_Change()
+        {
+            // The row that keeps the gate from being "refuse every code change": a
+            // corporate rule already says WBK and the proposed name declares WBK, so
+            // nothing moves and the rename is pure improvement to the NAME.
+            var brick = Fixture().First(r => r.CurrentName.StartsWith("CLAY BRICK VILLAGE LARGE"));
+            var p = TypeRenamePlanner.Plan(brick.ToInput(), Resolve);
+
+            Assert.Equal("WBK", p.Existing?.Code);
+            Assert.True(p.Existing.IsSpecific);
+            Assert.Equal("WBK", p.DeclaredCode);
+            Assert.Equal("PLNS_WBK_ClayBrick150", p.ProposedName);
+        }
+
+        [Fact]
+        public void A_Rename_That_Changes_Nothing_Is_Not_Refused_For_Changing_Something()
+        {
+            // A project overlay can map a type to a different code from the one its own
+            // name declares. The planner then composes the name the type ALREADY has, and
+            // a gate that looked only at the codes would report "would change the product
+            // code" about a rename that changes no characters at all — and the type would
+            // drop out of "already conforms" into "cannot be named".
+            var input = new TypeRenameInput
+            {
+                Category = "Walls",
+                FamilyName = "Basic Wall",
+                CurrentName = "PLNS_WBL_Blockwork200-Plastered",
+                InstanceCount = 4,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Plaster - Cement Render 1:4", ThicknessMm = 12 },
+                    new MaterialLayer { Index = 1, MaterialName = "Masonry - Hollow Concrete Block 200mm",
+                                        ThicknessMm = 200, IsStructure = true },
+                },
+            };
+
+            var p = TypeRenamePlanner.Plan(input,
+                _ => new ExistingProdCode { Code = "WPT", Source = "project", IsSpecific = true });
+
+            Assert.True(p.AlreadyConforms);
+            Assert.False(p.RefusedToProtectCode);
+        }
+
+        [Fact]
+        public void The_Summary_Separates_Cannot_Name_From_Held_Back()
+        {
+            // "cannot be named from the model" and "would have changed a correct code" are
+            // different problems with different fixes, and a reader who sees one count for
+            // both will read the refusals as the tool failing.
+            var ps = TypeRenamePlanner.PlanAll(
+                Fixture().Select(r => r.ToInput()).ToList(), Resolve);
+
+            string s = TypeRenamePlanner.Summary(ps);
+            Assert.Contains("4 can be renamed", s);
+            Assert.Contains("0 cannot be named", s);
+            Assert.Contains("A further 2 were held back", s);
+            Assert.Contains("DIFFERENT product code", s);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. The same invariant over the shipped catalogue
+        // ══════════════════════════════════════════════════════════════════════
+
+        private sealed class Cat
+        {
+            [JsonProperty("wallTypes")] public List<BaselineHostType> WallTypes;
+            [JsonProperty("floorTypes")] public List<BaselineHostType> FloorTypes;
+            [JsonProperty("roofTypes")] public List<BaselineHostType> RoofTypes;
+            [JsonProperty("ceilingTypes")] public List<BaselineHostType> CeilingTypes;
+        }
+
+        private static IEnumerable<(string Category, string Family, BaselineHostType Type)> Catalogue()
+        {
+            var c = JsonConvert.DeserializeObject<Cat>(
+                File.ReadAllText(Path.Combine(DataDir(), "STING_PROJECT_BASELINE.json")));
+            foreach (var t in c.WallTypes) yield return ("Walls", "Basic Wall", t);
+            foreach (var t in c.FloorTypes) yield return ("Floors", "Floor", t);
+            foreach (var t in c.RoofTypes) yield return ("Roofs", "Basic Roof", t);
+            foreach (var t in c.CeilingTypes) yield return ("Ceilings", "Compound Ceiling", t);
+        }
+
+        private static TypeRenameInput FromCatalogue(string category, string family, BaselineHostType t)
+            => new TypeRenameInput
+            {
+                Category = category,
+                FamilyName = family,
+                CurrentName = t.Name,
+                InstanceCount = 5,
+                Layers = (t.Layers ?? new List<BaselineLayer>()).Select((l, i) => new MaterialLayer
+                {
+                    Index = i,
+                    MaterialName = l.Material,
+                    ThicknessMm = l.ThicknessMm,
+                    IsStructure = string.Equals(l.Function, "Structure", StringComparison.OrdinalIgnoreCase),
+                }).ToList(),
+            };
+
+        [Fact]
+        public void No_Catalogue_Type_Would_Have_Its_Own_Code_Renamed_Away()
+        {
+            // Every type in the house catalogue already declares its code in its name, so
+            // ProdResolver reads it from the "declared" tier — the most specific there is.
+            // Re-planning one must therefore either produce the SAME code or refuse. A
+            // catalogue type whose own planner disagrees with its own name is a
+            // contradiction in the shipped data, not a rename question.
+            var misses = new List<string>();
+            int checkedCount = 0;
+            foreach (var (category, family, t) in Catalogue())
+            {
+                var input = FromCatalogue(category, family, t);
+                var existing = Resolve(input);
+                var p = TypeRenamePlanner.Plan(input, Resolve);
+                checkedCount++;
+
+                if (!p.IsProposal) continue;              // refused — always safe
+                if (string.Equals(p.DeclaredCode, existing.Code, StringComparison.OrdinalIgnoreCase)) continue;
+
+                misses.Add($"{category}/{t.Name}: resolves {existing.Code} ({existing.Source}) "
+                         + $"but the plan would declare {p.DeclaredCode} via '{p.ProposedName}'");
+            }
+            Assert.True(checkedCount >= 20, "catalogue looks empty: " + checkedCount + " types");
+            Assert.True(misses.Count == 0,
+                $"{misses.Count} of {checkedCount} catalogue types would be downgraded:\n  "
+                + string.Join("\n  ", misses));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. Concrete Masonry Units are masonry
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData("Concrete Masonry Units", 300, "WBL")]
+        [InlineData("Concrete Masonry Unit", 200, "WBL")]
+        [InlineData("CMU", 190, "WBL")]
+        [InlineData("Masonry - Hollow Concrete Block 200mm", 200, "WBL")]
+        [InlineData("Concrete, Cast-in-Place gray", 250, "WRC")]
+        public void A_Concrete_Masonry_Unit_Is_Blockwork_Not_Reinforced_Concrete(
+            string coreMaterial, double mm, string expectedCode)
+        {
+            // "Generic - 300mm Masonry", "Generic - 200mm Masonry", "Generic - 150mm
+            // Masonry" and "M_Exterior - Brick on CMU" all carry the core material
+            // "Concrete Masonry Units" and all four were proposed as PLNS_WRC_* —
+            // reinforced concrete — because the substance table saw the word "concrete"
+            // and had no longer needle above it. A block wall is masonry; the concrete
+            // in its name is what the block is made of, not what the wall is. The last
+            // row is the control: real cast in-situ concrete must still read RC.
+            var p = TypeRenamePlanner.Plan(new TypeRenameInput
+            {
+                Category = "Walls",
+                FamilyName = "Basic Wall",
+                CurrentName = "Generic - " + mm + "mm Masonry",
+                InstanceCount = 3,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = coreMaterial, ThicknessMm = mm, IsStructure = true },
+                },
+            });
+            Assert.Equal(expectedCode, p.DeclaredCode);
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/StandardiseCommands.cs
+++ b/StingTools/Commands/Baseline/StandardiseCommands.cs
@@ -90,9 +90,18 @@ namespace StingTools.Commands.Baseline
                 }
 
                 counts.TryGetValue(t.Id.Value, out int used);
+
+                // FamilyName is half of what the PROD rules match against ("Basic Wall
+                // Exterior_CreamWhite_230"), so without it the planner cannot ask what the
+                // type resolves to today and the code gate cannot fire.
+                string fam = null;
+                try { fam = t.FamilyName; }
+                catch (Exception ex) { StingLog.WarnRateLimited("Std.Fam", $"FamilyName {t.Id}: {ex.Message}"); }
+
                 outList.Add(new TypeRenameInput
                 {
-                    Category = cat, CurrentName = t.Name, Layers = layers, InstanceCount = used,
+                    Category = cat, FamilyName = fam ?? "", CurrentName = t.Name,
+                    Layers = layers, InstanceCount = used,
                 });
             }
             return outList;
@@ -116,18 +125,36 @@ namespace StingTools.Commands.Baseline
                 if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
                 Document doc = ctx.Doc;
 
-                var plans = TypeRenamePlanner.PlanAll(Standardise.ReadHostTypes(doc));
+                // The resolver is passed IN, so TypeRenamePlanner stays Revit-free and the
+                // rename asks the same question ProdResolver answers for every tag.
+                var plans = TypeRenamePlanner.PlanAll(
+                    Standardise.ReadHostTypes(doc),
+                    i =>
+                    {
+                        string code = TagConfig.ResolveProdForNames(
+                            doc, i.FamilyName, i.CurrentName, i.Category, out string src);
+                        return new ExistingProdCode
+                        {
+                            Code = code, Source = src, IsSpecific = ProdResolver.IsSpecific(src),
+                        };
+                    });
                 if (plans.Count == 0)
                 {
                     TaskDialog.Show("Rename Types", "No layered host types found in this model.");
                     return Result.Succeeded;
                 }
 
-                var rows = new List<string> { "Category,CurrentName,ProposedName,Instances,Outcome,Reason" };
+                var rows = new List<string>
+                { "Category,CurrentName,ProposedName,Instances,Outcome,ExistingCode,ExistingSource,DeclaredCode,Reason" };
                 foreach (var p in plans.OrderBy(x => x.Category).ThenBy(x => x.CurrentName))
                     rows.Add(string.Join(",", Standardise.Csv(p.Category), Standardise.Csv(p.CurrentName),
                         Standardise.Csv(p.ProposedName ?? ""), p.InstanceCount,
-                        p.AlreadyConforms ? "conforms" : p.IsProposal ? "rename" : "cannot name",
+                        p.AlreadyConforms ? "conforms"
+                            : p.IsProposal ? "rename"
+                            : p.RefusedToProtectCode ? "refused - would change the product code"
+                            : "cannot name",
+                        Standardise.Csv(p.Existing?.Code ?? ""), Standardise.Csv(p.Existing?.Source ?? ""),
+                        Standardise.Csv(p.DeclaredCode ?? ""),
                         Standardise.Csv(p.Reason)));
                 string path = Standardise.Write(doc, "type_rename_plan", rows);
 

--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -32,6 +32,10 @@ namespace StingTools.Core.Baseline
     {
         /// <summary>Revit category display name — Walls / Floors / Roofs / Ceilings.</summary>
         public string Category = "";
+        /// <summary>Revit family name — "Basic Wall", "Floor", "Basic Roof". Half of what
+        /// the PROD rules match against, so the planner cannot ask what a type resolves to
+        /// today without it.</summary>
+        public string FamilyName = "";
         public string CurrentName = "";
         /// <summary>ISO 22014 Source field, from PRJ_ORG_ORIGINATOR_CODE_TXT. Defaults PLNS.</summary>
         public string Originator = "PLNS";
@@ -39,6 +43,22 @@ namespace StingTools.Core.Baseline
         public List<MaterialLayer> Layers = new List<MaterialLayer>();
         /// <summary>How many elements use this type. Renaming an unused type is noise.</summary>
         public int InstanceCount;
+    }
+
+    /// <summary>
+    /// What a type resolves to TODAY, handed in by the caller so the planner stays
+    /// Revit-free. <paramref name="IsSpecific"/> is the important half: a code that came
+    /// from a family-aware rule is an ANSWER, and a category default is the absence of
+    /// one. Replacing the first is a downgrade; replacing the second is the point.
+    /// </summary>
+    public sealed class ExistingProdCode
+    {
+        /// <summary>Base PROD code, without the material suffix — "FSP", not "FSP-CON".</summary>
+        public string Code = "";
+        /// <summary>project | declared | corporate | lps | sleeve | category | gen.</summary>
+        public string Source = "";
+        /// <summary>True for a family-aware rule; false for the category default.</summary>
+        public bool IsSpecific;
     }
 
     public sealed class TypeRenameProposal
@@ -51,9 +71,19 @@ namespace StingTools.Core.Baseline
         public string ProposedName;
         /// <summary>The PROD code the proposed name declares in its Type field.</summary>
         public string ProdCode;
+        /// <summary>The code the proposed name WOULD declare — set even when the proposal
+        /// is refused, so the CSV can show what was rejected and why.</summary>
+        public string DeclaredCode;
+        /// <summary>What the type resolves to today, or null when the caller did not say.</summary>
+        public ExistingProdCode Existing;
         /// <summary>Why — shown to the reader either way.</summary>
         public string Reason = "";
         public int InstanceCount;
+
+        /// <summary>True when a name COULD have been composed and was withheld because it
+        /// would have declared a different product code from the one the type already
+        /// resolves to. A different thing from "the model does not say enough".</summary>
+        public bool RefusedToProtectCode;
 
         public bool IsProposal => !string.IsNullOrEmpty(ProposedName);
         /// <summary>True when the current name already matches what would be proposed.</summary>
@@ -70,6 +100,33 @@ namespace StingTools.Core.Baseline
         /// name and the element's ISO 19650 tag cannot fork. Before this, a name carried
         /// the word "Blockwork" while the resolver derived "WBL" from it — two
         /// vocabularies for one fact, free to disagree the moment either was edited.</para>
+        ///
+        /// <para><b>This table is narrower than STING_PROD_CODES.csv, and cannot stop
+        /// being.</b> Reconciled 2026-09-08 against the rule file and the house
+        /// catalogue: eight codes the rules use on these four categories are unreachable
+        /// from here, and every one of them is keyed on what the element is FOR, not what
+        /// it is made of —</para>
+        ///
+        /// <code>
+        ///   WCP  *Coping*                             RWL  *Retaining*
+        ///   WBD  *Boundary Wall*|*Compound Wall*      FGS  *Ground Slab*|*Slab on Grade*
+        ///   FSP  *Steps*|*Stair Landing Slab*         FRB  *Hollow Pot*|*Waffle*|*Ribbed Slab*
+        ///   RFL  *Flat Roof*|*Built-Up Felt*          CSU  *Suspended Ceiling*|*Grid Ceiling*
+        /// </code>
+        ///
+        /// <para>A concrete step and a concrete slab have the SAME core material. So does
+        /// a retaining wall and a shear wall, a ground-bearing slab and a suspended one.
+        /// No substance word can separate them, because the distinction is not a
+        /// substance — which is why the fix for the FSP → SLB and WCP → WRC downgrades
+        /// found on a delivered model is the refusal in <see cref="Plan"/>, not more rows
+        /// here. Adding a row that guessed would put a confident wrong code in the one
+        /// field the resolver trusts above all others.</para>
+        ///
+        /// <para>Two of the eight are arguably reachable and are deliberately left out
+        /// for want of evidence: <b>FRB</b> could be read from a core material named
+        /// "Hollow Pot", and <b>RTL</b> from the TILE in a roof's finish layer rather than
+        /// the timber in its core. Both need a corpus of real material names to add
+        /// safely, and this had one only for materials, not for host build-ups.</para>
         /// </summary>
         private static readonly Dictionary<string, Dictionary<string, string>> CodeFor =
             new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase)
@@ -104,6 +161,14 @@ namespace StingTools.Core.Baseline
         {
             ("hollow concrete block", "Blockwork"), ("solid concrete block", "Blockwork"),
             ("concrete block", "Blockwork"), ("blockwork", "Blockwork"),
+            // "Concrete Masonry Units" is the Revit library's name for a block, and it
+            // contains the word "concrete". Without these three above the RC row, four
+            // block walls on a delivered model — Generic - 150/200/300mm Masonry and
+            // M_Exterior - Brick on CMU — were proposed as PLNS_WRC_*: reinforced
+            // concrete. The concrete in the name is what the BLOCK is made of, not what
+            // the WALL is; same ordering rule as the class table next door.
+            ("concrete masonry unit", "Blockwork"), ("masonry unit", "Blockwork"),
+            ("cmu", "Blockwork"),
             ("clay brick", "Clay Brick"), ("brick", "Clay Brick"),
             ("screen block", "Screen Block"),
             ("concrete", "RC"),
@@ -134,7 +199,14 @@ namespace StingTools.Core.Baseline
         /// <para>Shape: <c>STING {use} - {substance} {size} - {finish}</c>, which is the
         /// order the rules read and the order a browser sorts usefully.</para>
         /// </summary>
-        public static TypeRenameProposal Plan(TypeRenameInput input)
+        /// <param name="resolveExisting">
+        /// What this type resolves to TODAY. Optional so every existing caller and test
+        /// still compiles, but the command passes it, and without it the code-downgrade
+        /// refusal below cannot fire — a planner that is not told what the answer is
+        /// cannot notice it is about to replace one.
+        /// </param>
+        public static TypeRenameProposal Plan(
+            TypeRenameInput input, Func<TypeRenameInput, ExistingProdCode> resolveExisting = null)
         {
             var p = new TypeRenameProposal
             {
@@ -180,15 +252,60 @@ namespace StingTools.Core.Baseline
             // BS EN ISO 22014: Source_Type_Subtype. Underscore between fields, hyphen
             // between components inside a field, no spaces anywhere.
             p.ProdCode = prod;
-            p.ProposedName = ProdNameCode.Compose(p.Originator, prod, substance + size, finish);
+            p.DeclaredCode = prod;
+            try { p.Existing = resolveExisting?.Invoke(input); }
+            catch (Exception) { p.Existing = null; }   // an unavailable resolver is not a proposal
+
+            string composed = ProdNameCode.Compose(p.Originator, prod, substance + size, finish);
+
+            // ── The code gate. ───────────────────────────────────────────────────
+            // ProdResolver puts a code DECLARED in a type name above the corporate
+            // pattern rules, so composing a name does not merely rename the type — it
+            // OVERWRITES its classification, and nothing downstream will ever query the
+            // rule again. Where the type already resolves to a code from a real rule,
+            // and this proposal would declare a different one, the rename is refused.
+            //
+            // A CATEGORY DEFAULT is not such a code. WL / FL / RF / CLG mean nobody has
+            // classified the thing, and replacing one is the entire purpose of this
+            // command; gating on those would leave it able to rename only the types that
+            // least need it.
+            //
+            // Measured on a delivered model (2026-09-08): "stepsr 7" resolves FSP from
+            // *Steps*, and "coping" resolves WCP from *Coping*. Both would have become
+            // SLB and WRC. Ten of the twenty-seven types in the shipped house catalogue
+            // are in the same shape — see the CodeFor note above.
+            bool nameUnchanged = string.Equals(composed, p.CurrentName?.Trim(),
+                                               StringComparison.OrdinalIgnoreCase);
+            if (!nameUnchanged
+                && p.Existing != null && p.Existing.IsSpecific
+                && !string.IsNullOrWhiteSpace(p.Existing.Code)
+                && !string.Equals(p.Existing.Code, prod, StringComparison.OrdinalIgnoreCase))
+            {
+                p.RefusedToProtectCode = true;
+                p.Reason = $"would change the product code {p.Existing.Code} → {prod}. "
+                         + $"'{p.CurrentName}' already resolves to {p.Existing.Code} from the "
+                         + $"{p.Existing.Source} rules, and a code declared in a type NAME outranks "
+                         + $"every rule — so renaming it '{composed}' would replace a correct answer "
+                         + "with a worse one. The core material cannot say what an element is FOR, "
+                         + "which is what that code records.";
+                return p;
+            }
+
+            p.ProposedName = composed;
             p.Reason = finish != null
                 ? $"core '{core.MaterialName}' + finish layer → {prod}"
                 : $"core '{core.MaterialName}' → {prod}; no finish layer to read";
+            if (p.Existing != null && !p.Existing.IsSpecific
+                && !string.Equals(p.Existing.Code, prod, StringComparison.OrdinalIgnoreCase))
+                p.Reason += $"; upgrades the product code {p.Existing.Code} ({p.Existing.Source}) → {prod}";
             return p;
         }
 
-        public static List<TypeRenameProposal> PlanAll(IEnumerable<TypeRenameInput> inputs)
-            => (inputs ?? Enumerable.Empty<TypeRenameInput>()).Select(Plan).ToList();
+        public static List<TypeRenameProposal> PlanAll(
+            IEnumerable<TypeRenameInput> inputs,
+            Func<TypeRenameInput, ExistingProdCode> resolveExisting = null)
+            => (inputs ?? Enumerable.Empty<TypeRenameInput>())
+               .Select(i => Plan(i, resolveExisting)).ToList();
 
         /// <summary>
         /// One line per outcome, so a reader sees the shape of the run before opening
@@ -199,11 +316,18 @@ namespace StingTools.Core.Baseline
             if (ps == null || ps.Count == 0) return "No layered host types found.";
             int conform = ps.Count(x => x.AlreadyConforms);
             int propose = ps.Count(x => x.IsProposal && !x.AlreadyConforms);
-            int cannot = ps.Count(x => !x.IsProposal);
-            return $"{ps.Count} type(s): {conform} already conform, {propose} can be renamed, "
-                 + $"{cannot} cannot be named from the model. The {cannot} are not failures of this "
-                 + "tool — their materials do not say what they are, and a rename that guessed would "
-                 + "replace a name a reader can see is empty with one they cannot.";
+            int guarded = ps.Count(x => x.RefusedToProtectCode);
+            int cannot = ps.Count(x => !x.IsProposal) - guarded;
+            string s = $"{ps.Count} type(s): {conform} already conform, {propose} can be renamed, "
+                     + $"{cannot} cannot be named from the model. The {cannot} are not failures of this "
+                     + "tool — their materials do not say what they are, and a rename that guessed would "
+                     + "replace a name a reader can see is empty with one they cannot.";
+            if (guarded > 0)
+                s += $" A further {guarded} were held back because the new name would have declared a "
+                   + "DIFFERENT product code from the one the type already resolves to — those are "
+                   + "listed in the CSV with both codes, and the answer is usually to fix the name by "
+                   + "hand rather than to let a rename overwrite a correct classification.";
+            return s;
         }
 
         private static string Match(string text, (string Needle, string Word)[] table)

--- a/StingTools/Core/TagConfig.cs
+++ b/StingTools/Core/TagConfig.cs
@@ -2117,6 +2117,36 @@ namespace StingTools.Core
         }
 
         /// <summary>
+        /// What a TYPE would resolve to, from names alone and with no element in hand.
+        ///
+        /// <para>The rename planner has to ask this before anything is placed, and it must
+        /// get the same answer the element path gives — same rule lists, same precedence,
+        /// same source tier. So it goes through the same <see cref="ProdResolver.Resolve"/>
+        /// call rather than a second copy of the chain: a rename that consults a private
+        /// re-implementation of the resolver would be protecting a code nothing else
+        /// computes.</para>
+        ///
+        /// <para>Returns the BASE code. The material suffix (<c>-CON</c>, <c>-MAS</c>) is
+        /// added by <see cref="GetFamilyAwareProdCode(Element, string)"/> from an element's
+        /// materials and has no meaning for a type.</para>
+        /// </summary>
+        public static string ResolveProdForNames(
+            Document doc, string familyName, string typeName, string categoryName, out string source)
+        {
+            EnsureProdRulesLoaded();
+            List<(string Pattern, string ProdCode)> projForCat = null;
+            List<(string Pattern, string ProdCode)> corpForCat = null;
+            if (!string.IsNullOrEmpty(familyName))
+            {
+                var projRules = GetProjectProdRules(doc);
+                projRules?.TryGetValue(categoryName ?? "", out projForCat);
+                _csvProdRules?.TryGetValue(categoryName ?? "", out corpForCat);
+            }
+            return ProdResolver.Resolve(familyName, typeName, categoryName,
+                                        projForCat, corpForCat, ProdMap, out source);
+        }
+
+        /// <summary>
         /// Check if a tag string has the expected number of non-empty tokens.
         /// A tag is only "complete" when it has exactly expectedTokens segments
         /// and none of them are empty strings.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,95 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 257 — a rename stops overwriting a product code that was already right)
+
+`ProdResolver` puts a code DECLARED in a type name **above** the corporate
+pattern rules, deliberately: a name that states its answer beats an inference.
+`TypeRenamePlanner` composes exactly such a name. So `Baseline_RenameTypes` was
+never only a rename — it overwrites the classification, permanently, and nothing
+downstream queries the rule again.
+
+**Two rows from a real run on 2026-09-08 prove it.** Both resolve correctly
+today, from a corporate rule, and the rename plan from the same session proposed
+to change them:
+
+    Floors,Floor,stepsr 7,FSP-CON,corporate,Y    ->  PLNS_SLB_RC450-Tiled   FSP -> SLB
+    Walls,Basic Wall,coping,WCP-CON,corporate,Y  ->  PLNS_WRC_RC250         WCP -> WRC
+
+**`CodeFor` cannot be widened to cover them, and that is the finding.** It is
+keyed on the SUBSTANCE read off the core material, and `*Steps*` and `*Coping*`
+describe what an element is FOR. A concrete step and a concrete slab have the
+same core material; so do a retaining wall and a shear wall, a ground-bearing
+slab and a suspended one. Reconciled against `STING_PROD_CODES.csv`, **eight
+codes the rules use on these four categories are unreachable from a substance
+word** — WCP, RWL, WBD, FGS, FSP, FRB, RFL, CSU — and the reconciliation is now
+in the file as a comment naming each one, per the brief's "either give it a word
+or record why it cannot".
+
+**So the fix is a refusal, not a bigger table.** `TypeRenameProposal` gains
+`DeclaredCode` and `Existing` (code + source + whether it is specific), the
+resolution is passed in as a delegate so the planner stays Revit-free, and a
+proposal is withheld when it would declare a different code from one the type
+already resolves to **specifically**.
+
+**The line that took the most care: a CATEGORY DEFAULT is not an answer.** WL /
+FL / RF / CLG mean nobody has classified the thing, and replacing one is the
+entire purpose of the command. A gate that refused *every* code change — which
+is how the defect was first written up — would refuse `Exterior_CreamWhite_230 2`
+(WL, category) and `IntFloor_tile_150` (FL, category), and with them nearly every
+rename worth making, leaving the tool able to rename only the types that least
+need it. Both sides are pinned: `CLAY BRICK VILLAGE LARGE` resolves WBK from a
+corporate rule and the proposal declares WBK, so it stands.
+
+**The gate found ten more, in the shipped house catalogue.** `No_Catalogue_Type_
+Would_Have_Its_Own_Code_Renamed_Away` walks `STING_PROJECT_BASELINE.json` and
+found **10 of 27** types whose own planner disagrees with their own name —
+`PLNS_FSP_RC150-Terrazzo` would have been renamed to `PLNS_SLB_RC150-Terrazzo`,
+`PLNS_RWL_Retaining250-Tanked` to `PLNS_WRC_RC250-Felt`, and eight more. All ten
+are now refused.
+
+**One data fix, separately evidenced.** Four wall types on the same model
+— `Generic - 150/200/300mm Masonry` and `M_Exterior - Brick on CMU` — carry the
+core material *Concrete Masonry Units* and were all proposed as `PLNS_WRC_*`,
+reinforced concrete, because the substance table saw the word "concrete" and had
+no longer needle above it. `concrete masonry unit`, `masonry unit` and `cmu` now
+sit above `concrete`, the same ordering rule the class table next door already
+used. Cast in-situ concrete still reads RC — pinned as the control row.
+
+**Two claims in the brief did not survive contact with the data, and are not
+implemented.** `Exterior_CreamWhite_230 2 -> PLNS_WBK_ClayBrick205-Plastered` was
+described as "clay brick proposed for a 230 render wall": the model's own core
+material for that type is **`Brick, Common(1)`**, so the proposal is the planner
+doing exactly what it promises. And `IntFloor_tile_150 -> PLNS_SLB_RC500` was
+described as "a 500 mm core on a type named 150": the size comes from the core
+LAYER, which is 500 — the planner's header already says it will not repeat
+whatever number the old name happened to carry, and the name is what is wrong.
+Both rows now pass the gate as legitimate upgrades from a category default.
+
+**RED then GREEN.** Against the planner with the new fields but no refusal:
+`No_Rename_Replaces_A_Code_That_Already_Resolves_Specifically` failed on **2 of
+6** fixture rows (`stepsr 7`, `coping` — exactly the two the brief named);
+`No_Catalogue_Type_Would_Have_Its_Own_Code_Renamed_Away` failed on **10 of 27**;
+`A_Concrete_Masonry_Unit_Is_Blockwork_Not_Reinforced_Concrete` failed **4 of 5**
+cases; whole file **7 failed / 5 passed of 12**. After: 0, 0, 0, and 14 of 14.
+Tags 732 passed, Boq 1249 passed, plugin builds 0 warnings / 0 errors.
+
+The fixture is the two real CSVs joined — the coverage audit (what each type
+resolves to, and how) and the rename plan (what was proposed, off which core
+material). Two tests run before any verdict: one asserts the test's own resolver
+reproduces what the Revit run recorded, the other that the reconstructed layers
+compose the same names the run proposed. Without those, every refusal below them
+would be proved against a different type.
+
+**Not verified in Revit.** `Baseline_RenameTypes` was not run in a Revit session
+and `deploy.bat` was not run. `HostObjAttributes.FamilyName` is read for the
+first time here and is unexercised; `TagConfig.ResolveProdForNames` is new and
+its project-overlay branch has never run against a real
+`_BIM_COORD/prod_codes.csv`. **`Baseline_RenameTypes` is still not safe to
+apply** on the strength of this alone — the gate stops the downgrade it was
+built for, and the remaining question, whether every proposed name is *right*,
+is a separate one.
+
 #### Completed (Phase 255 — the specific rule wins, and a stem matches a word)
 
 Asked to review product-code automation for consistency. The **logic** turned


### PR DESCRIPTION
## What this is

W3 from `HANDOVER_MATERIAL_CLASS_REPAIR.md`. Branched from `origin/main`, not stacked on #890.

`ProdResolver` puts a code **declared in a type name above the corporate pattern rules**, deliberately: a name that states its answer beats an inference. `TypeRenamePlanner` composes exactly such a name. So `Baseline_RenameTypes` was never only a rename — it **overwrites the classification**, permanently, and nothing downstream queries the rule again.

## The proof, from a real run

Two rows from 2026-09-08. Both resolve **correctly today**, from a corporate rule, and the rename plan from the same session proposed to change them:

```
Floors,Floor,stepsr 7,FSP-CON,corporate,Y    ->  PLNS_SLB_RC450-Tiled    FSP -> SLB
Walls,Basic Wall,coping,WCP-CON,corporate,Y  ->  PLNS_WRC_RC250          WCP -> WRC
```

## `CodeFor` cannot be widened to cover them — that is the finding

`CodeFor` is keyed on the **substance** read off the core material. `*Steps*` and `*Coping*` describe what an element is **for**. A concrete step and a concrete slab have the same core material; so do a retaining wall and a shear wall, a ground-bearing slab and a suspended one.

Reconciled against `STING_PROD_CODES.csv` — **eight codes the rules use on these four categories are unreachable from a substance word**, and each is now named in a comment in the file:

```
WCP  *Coping*                          RWL  *Retaining*
WBD  *Boundary Wall*|*Compound Wall*   FGS  *Ground Slab*|*Slab on Grade*
FSP  *Steps*|*Stair Landing Slab*      FRB  *Hollow Pot*|*Waffle*|*Ribbed Slab*
RFL  *Flat Roof*|*Built-Up Felt*       CSU  *Suspended Ceiling*|*Grid Ceiling*
```

Two of the eight are arguably reachable and deliberately left out for want of evidence: **FRB** from a core material named "Hollow Pot", **RTL** from the tile in a roof's *finish* layer rather than the timber in its core. Both need a corpus of real host build-ups, which this had only for materials.

**So the fix is a refusal, not a bigger table.** Adding a row that guessed would put a confident wrong code in the one field the resolver trusts above all others.

## The line that took the most care

> **A category default is not an answer.**

`WL` / `FL` / `RF` / `CLG` mean nobody has classified the thing, and replacing one is the entire purpose of the command. The defect as first written up said *"when they differ, refuse"* — applied literally that refuses `Exterior_CreamWhite_230 2` (WL, category) and `IntFloor_tile_150` (FL, category), and with them nearly every rename worth making, leaving the tool able to rename only the types that least need it.

So the gate fires only when the existing code came from a **specific** tier (`ProdResolver.IsSpecific` — project / declared / corporate / LPS / sleeve). Both sides are pinned by the fixture:

| Type | Resolves | Proposal declares | Verdict |
|---|---|---|---|
| `stepsr 7` | FSP (corporate) | SLB | **refused** |
| `coping` | WCP (corporate) | WRC | **refused** |
| `CLAY BRICK VILLAGE LARGE` | WBK (corporate) | WBK | stands — same code |
| `Exterior_CreamWhite_230 2` | WL (**category**) | WBK | stands — upgrade |
| `Exterior_BrownWhite_230` | WL (**category**) | WBK | stands — upgrade |
| `IntFloor_tile_150` | FL (**category**) | SLB | stands — upgrade |

## The gate found ten more, in the shipped catalogue

`No_Catalogue_Type_Would_Have_Its_Own_Code_Renamed_Away` walks `STING_PROJECT_BASELINE.json` and found **10 of 27** types whose own planner disagrees with their own name — `PLNS_FSP_RC150-Terrazzo` to `PLNS_SLB_RC150-Terrazzo`, `PLNS_RWL_Retaining250-Tanked` to `PLNS_WRC_RC250-Felt`, `PLNS_CSU_Gypsum9-ConcealedGrid` to `PLNS_CPB_Plasterboard9`, and seven more. All ten are now refused.

## One data fix, separately evidenced

Four wall types on the same model — `Generic - 150/200/300mm Masonry` and `M_Exterior - Brick on CMU` — carry the core material *Concrete Masonry Units* and were all proposed as `PLNS_WRC_*`, **reinforced concrete**, because the substance table saw the word "concrete" and had no longer needle above it. `concrete masonry unit`, `masonry unit` and `cmu` now sit above `concrete` — the same ordering rule the material-class table next door already used. Cast in-situ concrete still reads RC, pinned as the control row.

## Two claims in the brief did not survive contact with the data

Stated plainly, because building on them would have been the failure this run exists to remove. **Neither is implemented.**

- **`Exterior_CreamWhite_230 2` to `PLNS_WBK_ClayBrick205-Plastered`**, described as *"clay brick proposed for a 230 render wall"*. The rename plan's own reason column says the core material is **`Brick, Common(1)`**. The proposal is the planner doing exactly what it promises — reading the substance off the model's own core material.
- **`IntFloor_tile_150` to `PLNS_SLB_RC500-CeramicTiled`**, described as *"a 500 mm core on a type named 150"*. The size comes from the core **layer**, which is 500. The planner's header already says it will not repeat whatever number the old name happened to carry. The name is what is wrong.

Both now pass the gate as legitimate upgrades from a category default.

(`Blockwork` and `flagstone`, predicted as W1 regressions, also turned out not to be in that corpus — see #890.)

## RED then GREEN

Proved against the planner with the new fields plumbed in but **no refusal logic and no CMU needles**:

| Gate | RED | GREEN |
|---|---:|---:|
| `No_Rename_Replaces_A_Code_That_Already_Resolves_Specifically` | **2 of 6** fixture rows (`stepsr 7`, `coping` — exactly the two the brief named) | 0 |
| `No_Catalogue_Type_Would_Have_Its_Own_Code_Renamed_Away` | **10 of 27** catalogue types | 0 |
| `A_Concrete_Masonry_Unit_Is_Blockwork_Not_Reinforced_Concrete` | **4 of 5** cases | 0 |
| `The_Refusal_Says_Which_Code_Would_Have_Been_Lost` | failed | passes |
| `The_Reconstructed_Layers_Reproduce_The_Names_The_Run_Proposed` | failed — the fixture's finish material was wrong, and was fixed rather than worked around | passes |
| whole file | **7 failed / 5 passed of 12** | **14 of 14** |

Two of the fourteen run **before** any verdict and are the reason the rest mean anything:

- `The_Test_Resolver_Reproduces_What_The_Model_Actually_Resolved` — the test's own wiring of `ProdResolver` must produce the code *and source* the Revit run recorded in `prod_coverage_20260908_221546.csv`. A mis-wired harness would otherwise be measuring itself.
- `The_Reconstructed_Layers_Reproduce_The_Names_The_Run_Proposed` — the fixture's core material and thickness must compose the same names `type_rename_plan_20260908_221907.csv` recorded, or the refusals are proved against a different type.

Full runs:

- Tags: 732 passed, 0 failed
- Boq: 1249 passed, 0 failed
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors
- `tools/check_workflow_wiring.ps1` — Tier 4 buttons dispatching to nothing: 0
- `tools/check_path_discipline.ps1` — OK

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- **`Baseline_RenameTypes` was not run.** The whole command path — collector, dialog, transaction, the widened CSV — is unexercised.
- **`HostObjAttributes.FamilyName` is read for the first time here.** If it returns something other than the `Basic Wall` / `Floor` / `Basic Roof` the coverage audit recorded, the resolver gets a different name and the gate could fire, or fail to fire, wrongly. Guarded with a logged try/catch, but unverified.
- **`TagConfig.ResolveProdForNames` is new.** Its project-overlay branch has never run against a real `_BIM_COORD/prod_codes.csv`.
- The catalogue gate uses `"Compound Ceiling"` as the Revit family name for ceiling types; the coverage CSV had no ceiling row to confirm it against.

**`Baseline_RenameTypes` is still not safe to apply on the strength of this alone.** The gate stops the downgrade it was built for. Whether every *remaining* proposed name is right is a separate question, and W5 of the brief holds the parts of it that are the user's to answer.

## Unrelated pre-existing failure

`tools/check_dispatch_parity.ps1` fails on `Hvac_FanStaticReport` — **also on clean `origin/main`** (verified at `7f1fc9d07`). Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
