### PR TITLE
Pin the families-only PROD exclusion override, and write the one the Herring project needed

### DIFF
--- a/StingTools.Tags.Tests/ProdExclusionTests.cs
+++ b/StingTools.Tags.Tests/ProdExclusionTests.cs
@@ -269,5 +269,71 @@ namespace StingTools.Tags.Tests
             Assert.Equal(ExclusionVerdict.Included, cleared.Classify("Rooms", "", ""));
             Assert.Equal(ExclusionVerdict.ByPattern, cleared.Classify("Walls", "Opening", ""));
         }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The shape a real project override actually has
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>The exact file written for the Herring project on 2026-09-08, at
+        /// &lt;project&gt;/_data/coord/prod_exclusions.json. Copied verbatim: a test against
+        /// a paraphrase of the file would not be a test of the file.</summary>
+        private const string HerringOverride =
+            "{\n  \"notAProductFamilies\": [\"A_Revit_Suv_3d_car\"]\n}\n";
+
+        [Fact]
+        public void The_Entourage_Car_Was_Counted_As_A_Product_And_Corporate_Is_Right_Not_To_Fix_It()
+        {
+            // prod_coverage_20260908_221546.csv, verbatim:
+            //     Site,A_Revit_Suv_3d_car,A_Revit_Suv_3d_car,STE-GLZ,category,N
+            // A supplier's entourage car, counted in the denominator and reported as a
+            // product with no specific code. The corporate list DELIBERATELY does not
+            // name it — its own comment says a family that exists in one project belongs
+            // in that project's override — so this asserts the omission rather than
+            // treating it as a gap somebody forgot.
+            Assert.Equal(ExclusionVerdict.Included,
+                Shipped().Classify("Site", "A_Revit_Suv_3d_car", "A_Revit_Suv_3d_car"));
+        }
+
+        [Fact]
+        public void A_Families_Only_Override_Excludes_The_Car_And_Inherits_Everything_Else()
+        {
+            // The risk this pins is not the car. It is that a two-line override declaring
+            // ONE list could quietly replace the other three — and the audit would then
+            // report a large, plausible, wrong coverage figure with the 1,187 wall voids
+            // back in the denominator and Doors no longer protected. Nothing in the run
+            // would say so.
+            var corp = ProdExclusionPolicy.Parse(
+                File.ReadAllText(Path.Combine(DataDir(), "STING_PROD_EXCLUSIONS.json")), out string err);
+            Assert.True(corp != null, "STING_PROD_EXCLUSIONS.json did not parse: " + err);
+
+            var proj = ProdExclusionPolicy.Parse(HerringOverride, out string perr);
+            Assert.True(proj != null, "the override did not parse: " + perr);
+
+            var ex = ProdExclusionPolicy.Build(corp, proj);
+
+            // What the override says.
+            Assert.Equal(ExclusionVerdict.ByFamily,
+                ex.Classify("Site", "A_Revit_Suv_3d_car", "A_Revit_Suv_3d_car"));
+
+            // Everything it does NOT say, still inherited from corporate.
+            Assert.Equal(ExclusionVerdict.ByCategory, ex.Classify("Rooms", "", ""));
+            Assert.Equal(ExclusionVerdict.ByCategory, ex.Classify("Detail Items", "Filled region", ""));
+            Assert.Equal(ExclusionVerdict.ByPattern,
+                ex.Classify("Generic Models", "M_GM_OpeningWall_Instance", "Opening"));
+            Assert.Equal(ExclusionVerdict.ByPattern,
+                ex.Classify("Generic Models", "M_Muntin Pattern_2x2", ""));
+
+            // protectedCategories survives too — a door called "Opening" is still a door.
+            Assert.Equal(ExclusionVerdict.Included, ex.Classify("Doors", "Opening Door", ""));
+
+            // And the corporate families list is REPLACED, not merged — which is the
+            // documented contract, and worth seeing rather than assuming. The corporate
+            // entry that stops being matched is Revit's stock wall-void family, whose
+            // absence a project taking this override should know about.
+            Assert.Equal(ExclusionVerdict.Included,
+                ex.Classify("Windows", "Window-Square Opening", ""));
+            Assert.Equal(ExclusionVerdict.ByFamily,
+                Shipped().Classify("Windows", "Window-Square Opening", ""));
+        }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
+
+`prod_coverage_20260908_221546.csv` still carries
+
+    Site,A_Revit_Suv_3d_car,A_Revit_Suv_3d_car,STE-GLZ,category,N
+
+— a supplier's entourage car, counted in the PROD denominator and reported as a
+product with no specific code. **The corporate list is right not to name it.**
+`STING_PROD_EXCLUSIONS.json` says so in its own comment: a family that exists in
+one project belongs in that project's `_data/coord/prod_exclusions.json`. The
+override simply did not exist yet, and now does — **written outside this
+repository**, at
+`D:\Work 2026\Trokon\AMANDA S. HERRING\PROJECTN\_data\coord\prod_exclusions.json`,
+two lines declaring `notAProductFamilies` only.
+
+**The risk worth testing is not the car.** A two-line override that declares ONE
+list could quietly replace the other three, and the audit would then report a
+large, plausible, wrong coverage figure — with the 1,187 wall voids back in the
+denominator and Doors no longer protected — with nothing in the run to say so.
+`ProdExclusionPolicy.Build` already gets this right (null = inherit, `[]` =
+exclude nothing) and `A_Project_Override_Replaces_Only_The_List_It_Declares`
+already pinned the general rule, but **not the shape a real override has**:
+families-only, layered over the shipped corporate file.
+
+Two tests close that. One asserts the omission — the shipped corporate policy
+does NOT exclude the car, deliberately — so a later reader sees a decision
+rather than a gap somebody forgot. The other layers the exact override text over
+the real `STING_PROD_EXCLUSIONS.json` and asserts the car is excluded **and**
+that Rooms, Detail Items, the `opening` and `muntin` patterns and the Doors
+protection all survive. It also asserts the one thing the override COSTS:
+`notAProductFamilies` is replaced, not merged, so `Window-Square Opening` stops
+being excluded by family — the documented contract, now visible rather than
+assumed.
+
+**RED by sabotage, since the behaviour under test was already correct.** There is
+no honest before-state for a gate over code that works, so the gate was broken
+instead: dropping the `f(project) != null` guard in `ProdExclusionPolicy.Build`
+made a families-only override null the other three lists, and **2 of 21**
+exclusion tests failed — the new one and the general one it complements. Guard
+restored, 21 of 21 pass. A gate only ever seen passing is not evidence.
+
+**Not verified in Revit.** `Prod_CoverageAudit` was not re-run, so the SUV is
+still in the last audit on disk; the override takes effect the next time it runs
+against that project. The file is on the D: drive and is not, and should not be,
+in this repository.
+
 #### Completed (Phase 255 — the specific rule wins, and a stem matches a word)
 
 Asked to review product-code automation for consistency. The **logic** turned


### PR DESCRIPTION
## What this is

W4 from `HANDOVER_MATERIAL_CLASS_REPAIR.md`. Branched from `origin/main`, independent of #890 and #892.

`prod_coverage_20260908_221546.csv` still counts a supplier's entourage car as a product:

```
Site,A_Revit_Suv_3d_car,A_Revit_Suv_3d_car,STE-GLZ,category,N
```

**The corporate list is right not to name it.** `STING_PROD_EXCLUSIONS.json` says so in its own comment — a family that exists in one project belongs in that project's `_data/coord/prod_exclusions.json`. The override simply did not exist yet.

## The file — written outside this repository

```
D:\Work 2026\Trokon\AMANDA S. HERRING\PROJECTN\_data\coord\prod_exclusions.json
```
```json
{
  "notAProductFamilies": ["A_Revit_Suv_3d_car"]
}
```

Stated explicitly because it is not in this diff and cannot be: it is project data on the D: drive. The path is the one `ProdCoverageAuditCommand.LoadExclusionPolicy` reads via `StingPaths.MetaFile(doc, "_BIM_COORD", "prod_exclusions.json")`.

## The risk worth testing is not the car

A two-line override that declares **one** list could quietly replace the other three. The audit would then report a large, plausible, wrong coverage figure — the 1,187 wall voids back in the denominator, Doors no longer protected — with nothing in the run to say so.

`ProdExclusionPolicy.Build` already gets this right (`null` = inherit, `[]` = exclude nothing), and `A_Project_Override_Replaces_Only_The_List_It_Declares` already pinned the general rule. What was **not** pinned is the shape a real override actually has: families-only, layered over the shipped corporate file. That is the shape this ships.

Two tests close it:

- `The_Entourage_Car_Was_Counted_As_A_Product_And_Corporate_Is_Right_Not_To_Fix_It` — asserts the shipped policy does **not** exclude the car, so a later reader sees a decision rather than a gap somebody forgot.
- `A_Families_Only_Override_Excludes_The_Car_And_Inherits_Everything_Else` — layers the **exact override text** over the real `STING_PROD_EXCLUSIONS.json` and asserts the car is excluded **and** that Rooms, Detail Items, the `opening` and `muntin` patterns and the Doors protection all survive.

It also asserts the one thing the override **costs**: `notAProductFamilies` is replaced, not merged, so `Window-Square Opening` — Revit's stock wall-void family — stops being excluded by family in that project. That is the documented contract; this makes it visible rather than assumed.

## RED by sabotage, because the behaviour was already correct

W4 is a *confirm*, not a fix, so there is no honest before-state — the code works. A gate only ever seen passing is not evidence, so the gate was broken instead: dropping the `f(project) != null` guard in `ProdExclusionPolicy.Build`, so a families-only override nulls the other three lists.

| | RED (guard removed) | GREEN (restored) |
|---|---:|---:|
| `ProdExclusionTests` | **2 failed / 19 passed of 21** — the new test and the general one it complements | 21 of 21 |

The two failures are the right ones: `A_Families_Only_Override_Excludes_The_Car_And_Inherits_Everything_Else` and `A_Project_Override_Replaces_Only_The_List_It_Declares`. The guard was restored and `git diff` on `ProdExclusionPolicy.cs` is empty — no production file changed in this PR.

- Tags: 720 passed, 0 failed
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors

## NOT verified in Revit

- **`Prod_CoverageAudit` was not re-run.** The SUV is still in the last audit on disk. The override takes effect the next time the audit runs against that project — expected effect: one fewer element in the denominator, and one fewer non-specific row.
- `deploy.bat` was not run; nothing here executed in a Revit session.
- The override file's *loading* is proved only headlessly (the parse and layer are exercised against the real corporate file); `StingPaths.MetaFile` resolving `_BIM_COORD` to `_data/coord` on that project is inferred from the evidence CSVs living there, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
