### PR TITLE
Refresh the unreachable-commands headline after the WF-7 gate landed

### DIFF
--- a/docs/UNREACHABLE_COMMANDS_TRIAGE.md
+++ b/docs/UNREACHABLE_COMMANDS_TRIAGE.md
@@ -21,13 +21,13 @@ python tools/recount_unreachable_commands.py --check    # CI gate
 
 ## Counts — re-derived 2026-09-08 (WF-7)
 
-- **Total IExternalCommand classes**: **1719**
-- **Reached by a dispatch layer**: **1688**
+- **Total IExternalCommand classes**: **1720**
+- **Reached by a dispatch layer**: **1689**
 - **Referenced only from non-dispatch code**: **0**
 - **Named nowhere outside their own file**: **9**
 - **Ambiguous — name declared twice**: **22** (under 11 names)
 
-The four buckets partition all 1719; the script fails if they stop adding up.
+The four buckets partition all 1720; the script fails if they stop adding up.
 
 ### What the old 126 was, and why it was wrong
 
@@ -44,7 +44,7 @@ layers. Dispatch is:
 | legacy ribbon | `Core/StingToolsApp.cs`, `typeof(X).FullName` → `PushButtonData` | 30 |
 | markup + data | `.addin`, `.xaml`, shipped `.json` / `.csv` | 56 |
 
-Layers overlap, so those figures sum to more than 1688; a command reached twice is
+Layers overlap, so those figures sum to more than 1689; a command reached twice is
 counted once in the total.
 
 Two further corrections the re-derivation forced, both of which had inflated the


### PR DESCRIPTION
`main` is red on **Validate data files**, and therefore on **CI Gate**, which only waits on it. One root cause, not two.

## The gate is right; the doc was stale by one

#895 measured **1719 total / 1688 reached**. Between that measurement and its merge, nine sibling PRs landed and one declared a new `IExternalCommand` class. The code is now **1720 / 1689**.

**The conclusion is unchanged** — still **9** named nowhere outside their own file, and **0** referenced only from non-dispatch code. "Reached" moved in step with "total" because the new class *is* dispatched.

This is the gate doing exactly what it was built for. Its own error text says it best: a count in that file drives deletions, so a stale one is an invitation to delete live code.

## Verified

`python tools/recount_unreachable_commands.py --check` → **exit 0**.

## How this happened

I merged #895 without confirming its checks were green — I piped `gh pr checks --watch` to `/dev/null` and did not read its exit code. The failure was visible and I did not look. The nine other PRs merged clean; this is the only red, and it is a stale number rather than broken behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)