### PR TITLE
Rename gate: refuse a rename that would give two types the same name

### DIFF
--- a/StingTools.Tags.Tests/Fixtures/type_rename_20260909.csv
+++ b/StingTools.Tags.Tests/Fixtures/type_rename_20260909.csv
@@ -1,0 +1,169 @@
+Category,CurrentName,CoreMaterial,CoreThicknessMm,FinishMaterial,RecordedName
+Ceilings,16mm GWB on Wood Furring,"Softwood, Lumber",38,Gypsum Wall Board,PLNS_CPB_Timber38-Boarded
+Floors,ANTI-SLIP EPOXY 5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,ANTI-STATIC FLOOR 5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,BLUESTONE PAVING 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,BROADLOOM CARPET 8MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CARPET TILE 6MM 500X500MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CAST IN-SITU TERRAZZO 30MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CERAMIC MOSAIC 6MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CERAMIC TILES 200X200MM 8MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CERAMIC TILES 300X300MM 10MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CHEVRON PARQUET 15MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CLAY BLOCK PAVING 60MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CLAY BRICK PAVER 50MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CLAY BRICK PAVER 65MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,Concrete 100mm,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,Concrete 100mm w VCT,"Concrete, Cast-in-Place gray",100,Roof Tile,PLNS_SLB_RC100-Tiled
+Floors,Concrete 150mm,"Concrete, Cast-in-Place gray",150,,PLNS_SLB_RC150
+Floors,Concrete 250mm,"Concrete, Cast-in-Place gray",250,,PLNS_SLB_RC250
+Floors,CONCRETE PAVER 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CONCRETE PAVER 50MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CONCRETE PAVER 60MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CONCRETE PAVER 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CORK TILE 6MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,CRAZY PAVING 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,ENGINEERED WOOD 15MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,ENGINEERING BRICK PAVER 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,EPOXY TERRAZZO 12MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,EXPOSED AGGREGATE 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,EXPOSED AGGREGATE POLISHED 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,EXTRA LARGE COBBLESTONE 150MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GLASS MOSAIC 6MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRANITE COBBLESTONE 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRANITE PAVING 30MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRANITE PAVING 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRANITE PAVING 50MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRANITE TILES 20MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,GRASS GRID PAVER 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HARDWOOD DECKING 25MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HEAVY DUTY BLOCK PAVING 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HEAVY DUTY BRICK PAVER 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HEAVY DUTY INTERLOCKING 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HERRINGBONE BLOCK PAVING 65MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HERRINGBONE PARQUET 15MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,HOMOGENEOUS VINYL TILES 2MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,INDUSTRIAL BLOCK PAVING 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,Interior Tile Floor 7,"Concrete, Cast In Situ(1)",750,Ceramic Tile,PLNS_SLB_RC750-CeramicTiled
+Floors,IntFloor_tile_150,"Concrete, Cast In Situ(1)",500,Ceramic Tile,PLNS_SLB_RC500-CeramicTiled
+Floors,IntFloor_tile_450,"Concrete, Cast In Situ(1)",125,Ceramic Tile,PLNS_SLB_RC125-CeramicTiled
+Floors,LAMINATE FLOORING 8MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LARGE COBBLESTONE 120MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LIMESTONE FLAGSTONE 50MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LIMESTONE PAVING 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LIMESTONE TILES 20MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LINOLEUM SHEET 2.5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LOOP PILE CARPET 7MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LOW PROFILE ACCESS FLOOR 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LUXURY CUT PILE 10MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,LUXURY VINYL TILE 5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,MARBLE TILES 20MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,MEDIUM COBBLESTONE 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,MICROCEMENT 3MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,MICROCEMENT HEAVY DUTY 5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,MMA RESIN 6MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PERMEABLE INTERLOCKING 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,POLISHED CONCRETE 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PORCELAIN SLABS 800X1600MM 15MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PORCELAIN TILES 600X1200MM 12MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PORCELAIN TILES 600X600MM 10MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PU RESIN FLOOR 4MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,PU SPORTS FLOOR 8MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,RECLAIMED GRANITE SETTS 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,RUBBER SHEET 3MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,RUBBER TILE 6MM 500X500MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SAFETY RUBBER 10MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SAFETY VINYL 3MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SANDSTONE FLAGSTONE 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SANDSTONE PAVING 40MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SELF LEVELING COMPOUND 5MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SELF-LEVELING EPOXY 3MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SHEET VINYL 2MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SLATE PAVING 25MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SLATE TILES 12MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SMALL COBBLESTONE 80MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SOLID BAMBOO 14MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,SOLID HARDWOOD 18MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,STAMPED CONCRETE 100MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,STANDARD ACCESS FLOOR 150MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,STANDARD INTERLOCKING PAVER 60MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,STUDDED RUBBER 8MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,TERRAZZO TILES 20MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,TRAVERTINE TILES 15MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,VITRIFIED TILES 600X600MM 10MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,WOODEN SPORTS FLOOR 22MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Floors,ZIG-ZAG INTERLOCKING PAVER 60MM,"Concrete, Cast-in-Place gray",100,,PLNS_SLB_RC100
+Roofs,CLAY TILES PREMIUM 15MM,CLAY TILES PREMIUM 15MM,15,,PLNS_RTL_ClayTileRoof15
+Roofs,CONCRETE ROOF TILES 10MM,CONCRETE ROOF TILES 10MM,10,,PLNS_RCS_RC10
+Roofs,M_Insulation on Metal Deck - EPDM,"Concrete, Cast-in-Place gray",75,,PLNS_RCS_RC75
+Roofs,SPANISH CLAY TILES 14MM,SPANISH CLAY TILES 14MM,14,,PLNS_RTL_ClayTileRoof14
+Roofs,STONE COATED STEEL 0.5MM,STONE COATED STEEL 0.5MM,1,,PLNS_RTL_StoneCoatedTileRoof1
+Roofs,TIMBER BATTEN 25X50MM,TIMBER BATTEN 25X50MM,50,,PLNS_RSH_Timber50
+Roofs,TIMBER BATTEN 38X50MM,TIMBER BATTEN 38X50MM,50,,PLNS_RSH_Timber50
+Roofs,TIMBER BATTEN 50X50MM,TIMBER BATTEN 50X50MM,50,,PLNS_RSH_Timber50
+Roofs,TIMBER BOARD DECK 25MM,TIMBER BOARD DECK 25MM,25,,PLNS_RSH_Timber25
+Roofs,TIMBER CEILING BOARD 12MM,TIMBER CEILING BOARD 12MM,12,,PLNS_RSH_Timber12
+Roofs,TIMBER PURLIN 50X100MM,TIMBER PURLIN 50X100MM,100,,PLNS_RSH_Timber100
+Roofs,TIMBER PURLIN 50X150MM,TIMBER PURLIN 50X150MM,150,,PLNS_RSH_Timber150
+Roofs,TIMBER RAFTER 100X50MM,TIMBER RAFTER 100X50MM,100,,PLNS_RSH_Timber100
+Roofs,TIMBER RAFTER 150X50MM,TIMBER RAFTER 150X50MM,150,,PLNS_RSH_Timber150
+Roofs,TIMBER TRUSS 100X50MM,TIMBER TRUSS 100X50MM,100,,PLNS_RSH_Timber100
+Roofs,TIMBER TRUSS 150X50MM,TIMBER TRUSS 150X50MM,150,,PLNS_RSH_Timber150
+Walls,BRICK PILLAR UNIT (225×225×75MM),BRICK PILLAR UNIT (225×225×75MM),225,,PLNS_WBK_ClayBrick225
+Walls,CLAY BRICK ENGINEERING (225×112.5×75MM),CLAY BRICK ENGINEERING (225×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK FACING (225×112.5×75MM),CLAY BRICK FACING (225×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK FIRE-REFRACTORY (225×112.5×75MM),CLAY BRICK FIRE-REFRACTORY (225×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK HALF (112.5×112.5×75MM),CLAY BRICK HALF (112.5×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK PERFORATED (225×112.5×75MM),CLAY BRICK PERFORATED (225×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK STANDARD (225×112.5×75MM),CLAY BRICK STANDARD (225×112.5×75MM),113,,PLNS_WBK_ClayBrick113
+Walls,CLAY BRICK VILLAGE LARGE (295×150×130MM),CLAY BRICK VILLAGE LARGE (295×150×130MM),150,,PLNS_WBK_ClayBrick150
+Walls,CLAY BRICK VILLAGE-ARTISAN (220×110×65MM),CLAY BRICK VILLAGE-ARTISAN (220×110×65MM),110,,PLNS_WBK_ClayBrick110
+Walls,Concrete 200mm,"Concrete, Cast-in-Place gray",200,,PLNS_WRC_RC200
+Walls,Concrete 250mm,"Concrete, Cast-in-Place gray",250,,PLNS_WRC_RC250
+Walls,Concrete 300mm,"Concrete, Cast-in-Place gray",300,,PLNS_WRC_RC300
+Walls,Concrete 450mm,"Concrete, Cast-in-Place gray",450,,PLNS_WRC_RC450
+Walls,Concrete 600mm,"Concrete, Cast-in-Place gray",600,,PLNS_WRC_RC600
+Walls,CONCRETE COLUMN BLOCK 12IN (300×300×200MM),CONCRETE COLUMN BLOCK 12IN (300×300×200MM),300,,PLNS_WRC_RC300
+Walls,CONCRETE COLUMN BLOCK 9IN (225×225×200MM),CONCRETE COLUMN BLOCK 9IN (225×225×200MM),225,,PLNS_WRC_RC225
+Walls,Exterior Wall 150,"Brick, Common",125,"Plaster, Cement",PLNS_WBK_ClayBrick125-Plastered
+Walls,Exterior Wall 150 BROWN,"Brick, Common",125,"Plaster, Cement",PLNS_WBK_ClayBrick125-Plastered
+Walls,Exterior_BrownWhite_200,"Brick, Common(1)",175,"Plaster, Cement",PLNS_WBK_ClayBrick175-Plastered
+Walls,Exterior_BrownWhite_230,"Brick, Common(1)",205,"Plaster, Cement",PLNS_WBK_ClayBrick205-Plastered
+Walls,Exterior_CreamWhite_200,"Brick, Common(1)",175,"Plaster, Cement",PLNS_WBK_ClayBrick175-Plastered
+Walls,Exterior_CreamWhite_230 2,"Brick, Common(1)",205,"Plaster, Cement",PLNS_WBK_ClayBrick205-Plastered
+Walls,Exterior_Sone_Plain_200,"Brick, Common(1)",125,,PLNS_WBK_ClayBrick125
+Walls,Foundation - 250mm Concrete,"Concrete, Cast-in-Place gray",250,,PLNS_WRC_RC250
+Walls,Foundation - 300mm Concrete,"Concrete, Cast-in-Place gray",300,,PLNS_WRC_RC300
+Walls,Foundation - 600mm Concrete Footing,"Concrete, Cast-in-Place gray",600,,PLNS_WRC_RC600
+Walls,Foundation - 900mm Concrete Footing,"Concrete, Cast-in-Place gray",900,,PLNS_WRC_RC900
+Walls,Foundation wall,"Brick, Common(2)",200,,PLNS_WBK_ClayBrick200
+Walls,Generic - 100mm Brick,"Brick, Common",100,,PLNS_WBK_ClayBrick100
+Walls,Generic - 150mm Masonry,Concrete Masonry Units,150,,PLNS_WBL_Blockwork150
+Walls,Generic - 200mm Masonry,Concrete Masonry Units,200,,PLNS_WBL_Blockwork200
+Walls,Generic - 300mm Masonry,Concrete Masonry Units,300,,PLNS_WBL_Blockwork300
+Walls,GYPSUM PLASTER PREMIUM,GYPSUM PLASTER PREMIUM,13,,PLNS_WPT_Plasterboard13
+Walls,HOLLOW CONCRETE BLOCK 10IN (250MM),HOLLOW CONCRETE BLOCK 10IN (250MM),250,,PLNS_WBL_Blockwork250
+Walls,HOLLOW CONCRETE BLOCK 4IN (100MM),HOLLOW CONCRETE BLOCK 4IN (100MM),100,,PLNS_WBL_Blockwork100
+Walls,HOLLOW CONCRETE BLOCK 6IN (150MM),HOLLOW CONCRETE BLOCK 6IN (150MM),150,,PLNS_WBL_Blockwork150
+Walls,HOLLOW CONCRETE BLOCK 8IN (200MM),HOLLOW CONCRETE BLOCK 8IN (200MM),200,,PLNS_WBL_Blockwork200
+Walls,HOLLOW CONCRETE BLOCK 9IN (225MM),HOLLOW CONCRETE BLOCK 9IN (225MM),225,,PLNS_WBL_Blockwork225
+Walls,Interior - 114mm Partition,"Softwood, Lumber",89,Gypsum Wall Board,PLNS_WPT_Timber89-Boarded
+Walls,Interior - 121mm Partition (1-hr),"Softwood, Lumber",89,Gypsum Wall Board,PLNS_WPT_Timber89-Boarded
+Walls,Interior 2 CREAM,"Brick, Common",125,"Plaster, Cement",PLNS_WBK_ClayBrick125-Plastered
+Walls,Interior_cream_200,"Brick, Common",175,"Plaster, Cement",PLNS_WBK_ClayBrick175-Plastered
+Walls,Interior_cream_230,"Brick, Common",205,"Plaster, Cement",PLNS_WBK_ClayBrick205-Plastered
+Walls,M_Exterior - CMU Insulated,Concrete Masonry Units,290,Gypsum Wall Board,PLNS_WBL_Blockwork290-Boarded
+Walls,M_Exterior - Split Face CMU,Concrete Masonry Units,190,Gypsum Wall Board,PLNS_WBL_Blockwork190-Boarded
+Walls,M_Exterior - Wood Shingle on Wood Stud,"Softwood, Lumber",140,Gypsum Wall Board,PLNS_WPT_Timber140-Boarded
+Walls,M_Exterior - Wood Shingle over Wood Siding on Wood Stud,"Softwood, Lumber",140,Gypsum Wall Board,PLNS_WPT_Timber140-Boarded
+Walls,M_Exterior - Wood Siding on Wood Stud,"Softwood, Lumber",140,Gypsum Wall Board,PLNS_WPT_Timber140-Boarded
+Walls,RingBeam,Concrete - Cast-in-Place Concrete,205,"Plaster, Cement",PLNS_WRC_RC205-Plastered
+Walls,RingBeam_CreamWhite_230,"Concrete, Cast In Situ",205,"Plaster, Cement",PLNS_WRC_RC205-Plastered
+Walls,SOLID CONCRETE BLOCK 10IN (250MM),SOLID CONCRETE BLOCK 10IN (250MM),250,,PLNS_WBL_Blockwork250
+Walls,SOLID CONCRETE BLOCK 4IN (100MM),SOLID CONCRETE BLOCK 4IN (100MM),100,,PLNS_WBL_Blockwork100
+Walls,SOLID CONCRETE BLOCK 6IN (150MM),SOLID CONCRETE BLOCK 6IN (150MM),150,,PLNS_WBL_Blockwork150
+Walls,SOLID CONCRETE BLOCK 8IN (200MM),SOLID CONCRETE BLOCK 8IN (200MM),200,,PLNS_WBL_Blockwork200
+Walls,SOLID CONCRETE BLOCK 9IN (225MM),SOLID CONCRETE BLOCK 9IN (225MM),225,,PLNS_WBL_Blockwork225
+Walls,STONE ASHLAR DRESSED (450×200×200MM),STONE ASHLAR DRESSED (450×200×200MM),200,,PLNS_WSN_Stone200
+Walls,STONE RUBBLE MASONRY (VARIABLE),STONE RUBBLE MASONRY (VARIABLE),300,,PLNS_WSN_Stone300
+Walls,STONE SLATE CLADDING (VARIABLE),STONE SLATE CLADDING (VARIABLE),25,,PLNS_WSN_Stone25

--- a/StingTools.Tags.Tests/TypeRenameCodeGateTests.cs
+++ b/StingTools.Tags.Tests/TypeRenameCodeGateTests.cs
@@ -363,17 +363,34 @@ namespace StingTools.Tags.Tests
         [Fact]
         public void The_Summary_Separates_Cannot_Name_From_Held_Back()
         {
-            // "cannot be named from the model" and "would have changed a correct code" are
-            // different problems with different fixes, and a reader who sees one count for
-            // both will read the refusals as the tool failing.
+            // "cannot be named from the model", "would have changed a correct code" and
+            // "would have duplicated another type's name" are three different problems with
+            // three different fixes, and a reader who sees one count for all of them will
+            // read the refusals as the tool failing.
+            //
+            // This asserted "4 can be renamed" until 2026-09-09, when the uniqueness gate
+            // landed and found that two of those four — Exterior_CreamWhite_230 2 and
+            // Exterior_BrownWhite_230, both 'Brick, Common(1)' at 205 mm with a plaster
+            // finish — compose the SAME name, PLNS_WBK_ClayBrick205-Plastered. They are the
+            // pair that actually collided on the delivered model, carrying 6 and 5 live
+            // elements. The old number was not a stricter expectation; it was this fixture
+            // reproducing the defect and nothing checking for it.
             var ps = TypeRenamePlanner.PlanAll(
                 Fixture().Select(r => r.ToInput()).ToList(), Resolve);
 
             string s = TypeRenamePlanner.Summary(ps);
-            Assert.Contains("4 can be renamed", s);
+            Assert.Contains("2 can be renamed", s);
             Assert.Contains("0 cannot be named", s);
             Assert.Contains("A further 2 were held back", s);
             Assert.Contains("DIFFERENT product code", s);
+            Assert.Contains("same name", s);
+
+            var clashed = ps.Where(x => x.RefusedAsDuplicate).Select(x => x.CurrentName).ToList();
+            Assert.Equal(
+                new[] { "Exterior_BrownWhite_230", "Exterior_CreamWhite_230 2" },
+                clashed.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+            Assert.All(ps.Where(x => x.RefusedAsDuplicate),
+                x => Assert.Equal("PLNS_WBK_ClayBrick205-Plastered", x.WithheldName));
         }
 
         // ══════════════════════════════════════════════════════════════════════

--- a/StingTools.Tags.Tests/TypeRenameUniquenessTests.cs
+++ b/StingTools.Tags.Tests/TypeRenameUniquenessTests.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    /// <summary>
+    /// A rename must not give two types the same name.
+    ///
+    /// <para><b>What happened.</b> On 2026-09-09 <c>Baseline_RenameTypes</c> was applied to a
+    /// delivered model. The log recorded <c>168/168 renamed, 0 failed</c>. Of those 168,
+    /// <b>137 collided onto 19 names</b> — and the largest group was <b>87 floor types all
+    /// named <c>PLNS_SLB_RC100</c></b>: every screed, tile, carpet, paver and resin in the
+    /// project's floor-finish catalogue. Revit's API accepted every duplicate without
+    /// throwing, so the per-type <c>try/catch</c> in the command reported total success.
+    /// Nothing failed. Everything broke.</para>
+    ///
+    /// <para><b>Why it collided, and why the answer is to refuse rather than to
+    /// disambiguate.</b> All 87 gave the same reason: <c>core 'Concrete, Cast-in-Place gray'
+    /// → SLB; no finish layer to read</c>. They are one 100 mm slab of grey concrete wearing
+    /// 87 names. The distinction was never in the model — only in the string. A planner that
+    /// appended <c>-2</c>, <c>-3</c> … would have manufactured a difference the build-ups do
+    /// not contain and made the duplication permanent and invisible; the same objection that
+    /// retired every other guess in this codebase. So the gate refuses, and says which peers
+    /// it collided with. The refusal is the finding: <b>these types are named, not
+    /// modelled</b>, and every quantity taken off them — area, volume, embodied carbon, cost
+    /// — has been answering "100 mm of concrete" regardless of what the name promised.</para>
+    ///
+    /// <para><b>The fixture is the run.</b> <c>Fixtures/type_rename_20260909.csv</c> carries
+    /// all 168 proposals from that model: category, current name, the core material and
+    /// thickness the planner read, the finish layer where there was one, and the name it
+    /// actually produced. <see cref="The_Fixture_Reproduces_The_Recorded_Run"/> asserts the
+    /// reconstruction still composes the recorded name — so if this file ever stops
+    /// describing reality, that test fails first and the rest cannot quietly pass against
+    /// invented data.</para>
+    /// </summary>
+    public class TypeRenameUniquenessTests
+    {
+        // ══════════════════════════════════════════════════════════════════════
+        //  Fixture
+        // ══════════════════════════════════════════════════════════════════════
+
+        private sealed class Row
+        {
+            public string Category, CurrentName, CoreMaterial, FinishMaterial, RecordedName;
+            public double CoreThicknessMm;
+        }
+
+        private static string FixtureDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools.Tags.Tests/Fixtures");
+            return Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures");
+        }
+
+        private static List<Row> Fixture()
+        {
+            string path = Path.Combine(FixtureDir(), "type_rename_20260909.csv");
+            Assert.True(File.Exists(path), "missing fixture: " + path);
+
+            var rows = new List<Row>();
+            foreach (string line in File.ReadAllLines(path).Skip(1))
+            {
+                var f = SplitCsv(line);
+                if (f.Count < 6) continue;
+                rows.Add(new Row
+                {
+                    Category = f[0],
+                    CurrentName = f[1],
+                    CoreMaterial = f[2],
+                    CoreThicknessMm = double.Parse(f[3], CultureInfo.InvariantCulture),
+                    FinishMaterial = f[4],
+                    RecordedName = f[5],
+                });
+            }
+            Assert.True(rows.Count == 168,
+                $"the fixture is the 2026-09-09 run and that run proposed 168 names; found {rows.Count}");
+            return rows;
+        }
+
+        /// <summary>
+        /// Rebuild the compound structure the planner read: a structural core, plus a finish
+        /// layer where the run recorded one. Nothing else was used to compose the name.
+        /// </summary>
+        private static TypeRenameInput InputFor(Row r)
+        {
+            var layers = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = r.CoreMaterial,
+                                    ThicknessMm = r.CoreThicknessMm, IsStructure = true },
+            };
+            if (!string.IsNullOrEmpty(r.FinishMaterial))
+                layers.Add(new MaterialLayer { Index = 1, MaterialName = r.FinishMaterial,
+                                               ThicknessMm = 10, IsStructure = false });
+
+            return new TypeRenameInput
+            {
+                Category = r.Category,
+                FamilyName = r.Category == "Walls" ? "Basic Wall"
+                           : r.Category == "Roofs" ? "Basic Roof" : r.Category.TrimEnd('s'),
+                CurrentName = r.CurrentName,
+                Originator = "PLNS",
+                Layers = layers,
+                InstanceCount = 0,
+            };
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  0. The fixture still describes the run
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The guard on every other test in this file. If the reconstruction stops composing
+        /// the name the delivered model actually produced, the fixture has drifted from
+        /// reality and no assertion built on it means anything.
+        /// </summary>
+        [Fact]
+        public void The_Fixture_Reproduces_The_Recorded_Run()
+        {
+            var wrong = new List<string>();
+            foreach (var r in Fixture())
+            {
+                var p = TypeRenamePlanner.Plan(InputFor(r));
+                string got = p.ProposedName ?? p.WithheldName;
+                if (!string.Equals(got, r.RecordedName, StringComparison.Ordinal))
+                    wrong.Add($"{r.Category}/{r.CurrentName}: recorded '{r.RecordedName}', composed '{got ?? "(none)"}'");
+            }
+            Assert.True(wrong.Count == 0,
+                "The fixture no longer reproduces the 2026-09-09 run, so it is describing a planner "
+                + "that no longer exists. Fix the fixture before reading anything else in this file:\n  "
+                + string.Join("\n  ", wrong.Take(12)));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The gate
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The whole point. After planning, no two types in a category may hold the same name
+        /// — counting both the names being proposed and the names being kept.
+        /// </summary>
+        [Fact]
+        public void No_Two_Types_In_A_Category_End_Up_With_The_Same_Name()
+        {
+            var rows = Fixture();
+            var plans = TypeRenamePlanner.PlanAll(rows.Select(InputFor));
+
+            var claims = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in plans)
+            {
+                string held = p.IsProposal ? p.ProposedName : p.CurrentName;
+                string key = p.Category + " " + held;
+                if (!claims.TryGetValue(key, out var l)) claims[key] = l = new List<string>();
+                l.Add(p.CurrentName);
+            }
+
+            var clashes = claims.Where(kv => kv.Value.Count > 1)
+                                .OrderByDescending(kv => kv.Value.Count).ToList();
+
+            Assert.True(clashes.Count == 0,
+                $"{clashes.Count} name(s) would be held by more than one type. Revit's API does not "
+                + "refuse a duplicate type name — it accepted all 137 of these on 2026-09-09 and the "
+                + "command reported 0 failures — so this gate is the only thing standing between a "
+                + "rename and a catalogue collapsing into one name:\n  "
+                + string.Join("\n  ", clashes.Take(8).Select(kv =>
+                    $"{kv.Key.Replace(' ', '/')}  <- {kv.Value.Count} types: "
+                    + string.Join(", ", kv.Value.Take(4)) + (kv.Value.Count > 4 ? ", …" : ""))));
+        }
+
+        /// <summary>
+        /// The 87. Named explicitly because a count can be satisfied by refusing everything,
+        /// and because this group is the reason the gate exists.
+        /// </summary>
+        [Fact]
+        public void The_Eighty_Seven_Identical_Floor_Types_Are_All_Refused()
+        {
+            var rows = Fixture();
+            var plans = TypeRenamePlanner.PlanAll(rows.Select(InputFor));
+
+            var group = rows.Where(r => r.RecordedName == "PLNS_SLB_RC100").Select(r => r.CurrentName).ToList();
+            Assert.True(group.Count == 87, $"the fixture should hold 87 of these; it holds {group.Count}");
+
+            var leaked = plans.Where(p => group.Contains(p.CurrentName) && p.IsProposal).ToList();
+            Assert.True(leaked.Count == 0,
+                $"{leaked.Count} of the 87 identical floor types would still be renamed. They are one "
+                + "100 mm slab of grey concrete under 87 names; renaming any of them destroys the only "
+                + "record of what the finish was: "
+                + string.Join(", ", leaked.Take(5).Select(p => p.CurrentName)));
+
+            var sample = plans.First(p => p.CurrentName == group[0]);
+            Assert.True(sample.RefusedAsDuplicate,
+                "refused, but not as a duplicate — the reader needs to know it is a collision and not "
+                + "a model that says too little, because the remedy is different");
+            Assert.Contains("share", sample.Reason, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("PLNS_SLB_RC100", sample.WithheldName);
+        }
+
+        /// <summary>
+        /// A gate that refuses everything passes the test above and is useless. The 31
+        /// proposals that were unique in that run must survive.
+        /// </summary>
+        [Fact]
+        public void A_Name_Claimed_By_Exactly_One_Type_Is_Still_Proposed()
+        {
+            var rows = Fixture();
+            var plans = TypeRenamePlanner.PlanAll(rows.Select(InputFor));
+
+            var once = rows.GroupBy(r => r.Category + " " + r.RecordedName)
+                           .Where(g => g.Count() == 1).Select(g => g.First()).ToList();
+            Assert.True(once.Count >= 25,
+                $"the run produced {once.Count} uniquely-named proposals; too few to prove anything");
+
+            var lost = plans.Where(p => once.Any(r => r.CurrentName == p.CurrentName && r.Category == p.Category)
+                                     && !p.IsProposal).ToList();
+            Assert.True(lost.Count == 0,
+                $"{lost.Count} uniquely-named type(s) were refused anyway, which would make the gate a "
+                + "way of doing nothing: " + string.Join(", ", lost.Take(6).Select(p => p.CurrentName)));
+        }
+
+        /// <summary>
+        /// The collision the corpus does not contain: a rename landing on a name that some
+        /// OTHER type is keeping. Revit sees no difference between this and two renames
+        /// colliding — it is the same duplicate — but a planner that only compared proposals
+        /// against each other would miss it entirely.
+        /// </summary>
+        [Fact]
+        public void A_Rename_Onto_A_Name_Another_Type_Is_Keeping_Is_Refused()
+        {
+            var willRename = new TypeRenameInput
+            {
+                Category = "Walls", FamilyName = "Basic Wall", CurrentName = "Party Wall 200",
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Concrete, Cast-in-Place gray",
+                                        ThicknessMm = 200, IsStructure = true },
+                },
+            };
+
+            // Says nothing the planner can read, so it keeps its name — which happens to be
+            // the name the first one wants.
+            var willKeep = new TypeRenameInput
+            {
+                Category = "Walls", FamilyName = "Basic Wall", CurrentName = "PLNS_WRC_RC200",
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Unobtainium", ThicknessMm = 200, IsStructure = true },
+                },
+            };
+
+            var plans = TypeRenamePlanner.PlanAll(new[] { willRename, willKeep });
+            var mover = plans.First(p => p.CurrentName == "Party Wall 200");
+
+            Assert.False(mover.IsProposal,
+                "'Party Wall 200' would be renamed onto 'PLNS_WRC_RC200', which another wall type is "
+                + "keeping. Comparing proposals only against other proposals misses this, and Revit "
+                + "will not catch it either.");
+            Assert.True(mover.RefusedAsDuplicate);
+            Assert.Contains("PLNS_WRC_RC200", mover.Reason, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Two types in DIFFERENT categories may share a name — Revit scopes type names per
+        /// category, and refusing across categories would block correct renames for no reason.
+        /// </summary>
+        [Fact]
+        public void The_Same_Name_In_Two_Different_Categories_Is_Not_A_Collision()
+        {
+            TypeRenameInput Slab(string category, string family, string current) => new TypeRenameInput
+            {
+                Category = category, FamilyName = family, CurrentName = current,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Concrete, Cast-in-Place gray",
+                                        ThicknessMm = 150, IsStructure = true },
+                },
+            };
+
+            var plans = TypeRenamePlanner.PlanAll(new[]
+            {
+                Slab("Floors", "Floor", "Slab A"),
+                Slab("Roofs", "Basic Roof", "Deck A"),
+            });
+
+            Assert.All(plans, p => Assert.True(p.IsProposal,
+                $"'{p.CurrentName}' ({p.Category}) was refused: {p.Reason}"));
+
+            // Same substance, same thickness, different category — and both keep the name.
+            Assert.Equal(2, plans.Count);
+            Assert.All(plans, p => Assert.False(p.RefusedAsDuplicate));
+        }
+
+        /// <summary>
+        /// A type that already carries the conforming name is not "colliding with itself".
+        /// Re-running the command must be a no-op, not a run that refuses everything it did
+        /// last time.
+        /// </summary>
+        [Fact]
+        public void Re_Running_After_A_Successful_Rename_Refuses_Nothing()
+        {
+            var input = new TypeRenameInput
+            {
+                Category = "Floors", FamilyName = "Floor", CurrentName = "PLNS_SLB_RC150",
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Concrete, Cast-in-Place gray",
+                                        ThicknessMm = 150, IsStructure = true },
+                },
+            };
+
+            var p = TypeRenamePlanner.PlanAll(new[] { input }).Single();
+            Assert.True(p.AlreadyConforms, "the name already matches what would be proposed");
+            Assert.False(p.RefusedAsDuplicate, "a type does not collide with itself");
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. What the refusal has to tell the reader
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// A collision and a model that says too little are different problems with different
+        /// remedies — model the layers, versus rename the material — so the summary must not
+        /// pour them into one number. On the 2026-09-09 run that would have hidden 137 types
+        /// inside a "cannot be named" count.
+        /// </summary>
+        [Fact]
+        public void The_Summary_Counts_Collisions_Separately_From_Silence()
+        {
+            var plans = TypeRenamePlanner.PlanAll(Fixture().Select(InputFor));
+            string s = TypeRenamePlanner.Summary(plans);
+
+            int dup = plans.Count(p => p.RefusedAsDuplicate);
+            Assert.True(dup >= 100, $"the run collided 137 types; the gate caught {dup}");
+            Assert.Contains(dup.ToString(CultureInfo.InvariantCulture), s, StringComparison.Ordinal);
+            Assert.Contains("same name", s, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. The silent failure found while building this
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// <see cref="TypeRenamePlanner.Plan"/> wraps the caller's resolver in a bare
+        /// <c>catch</c>. That is right — an unavailable resolver must not abort the plan — but
+        /// it means a resolver that throws for EVERY type disables the product-code gate
+        /// completely and reports a clean run. The counted flag is what makes the difference
+        /// visible; without it, "0 refusals" reads identically whether the gate examined every
+        /// type or none of them.
+        /// </summary>
+        [Fact]
+        public void A_Resolver_That_Always_Throws_Is_Reported_Not_Swallowed()
+        {
+            var input = new TypeRenameInput
+            {
+                Category = "Walls", FamilyName = "Basic Wall", CurrentName = "Some Wall",
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = "Concrete, Cast-in-Place gray",
+                                        ThicknessMm = 200, IsStructure = true },
+                },
+            };
+
+            var p = TypeRenamePlanner.PlanAll(
+                new[] { input },
+                _ => throw new InvalidOperationException("no rules loaded")).Single();
+
+            Assert.True(p.ExistingLookupFailed,
+                "the resolver threw and the plan carried on as though it had simply not been asked. "
+                + "A dead product-code gate must not look like a gate that found nothing.");
+            Assert.Contains("could not be checked", TypeRenamePlanner.Summary(new[] { p }),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static List<string> SplitCsv(string line)
+        {
+            var o = new List<string>(); var c = new System.Text.StringBuilder(); bool q = false;
+            for (int i = 0; i < line.Length; i++)
+            {
+                char ch = line[i];
+                if (ch == '"')
+                {
+                    if (q && i + 1 < line.Length && line[i + 1] == '"') { c.Append('"'); i++; }
+                    else q = !q;
+                }
+                else if (ch == ',' && !q) { o.Add(c.ToString()); c.Clear(); }
+                else c.Append(ch);
+            }
+            o.Add(c.ToString());
+            return o;
+        }
+    }
+}

--- a/StingTools/Commands/Baseline/StandardiseCommands.cs
+++ b/StingTools/Commands/Baseline/StandardiseCommands.cs
@@ -145,12 +145,18 @@ namespace StingTools.Commands.Baseline
                 }
 
                 var rows = new List<string>
-                { "Category,CurrentName,ProposedName,Instances,Outcome,ExistingCode,ExistingSource,DeclaredCode,Reason" };
+                { "Category,CurrentName,ProposedName,WithheldName,Instances,Outcome,ExistingCode,ExistingSource,DeclaredCode,Reason" };
                 foreach (var p in plans.OrderBy(x => x.Category).ThenBy(x => x.CurrentName))
                     rows.Add(string.Join(",", Standardise.Csv(p.Category), Standardise.Csv(p.CurrentName),
-                        Standardise.Csv(p.ProposedName ?? ""), p.InstanceCount,
+                        Standardise.Csv(p.ProposedName ?? ""),
+                        // What a gate rejected. An empty ProposedName with no record of what
+                        // was withheld tells the reader nothing about which refusal they are
+                        // looking at, or whether the name would have been reasonable.
+                        Standardise.Csv(p.IsProposal ? "" : (p.WithheldName ?? "")),
+                        p.InstanceCount,
                         p.AlreadyConforms ? "conforms"
                             : p.IsProposal ? "rename"
+                            : p.RefusedAsDuplicate ? "refused - would duplicate another type's name"
                             : p.RefusedToProtectCode ? "refused - would change the product code"
                             : "cannot name",
                         Standardise.Csv(p.Existing?.Code ?? ""), Standardise.Csv(p.Existing?.Source ?? ""),
@@ -190,13 +196,44 @@ namespace StingTools.Commands.Baseline
                 {
                     t.Start();
                     // Name by name, so one clash does not lose the rest.
+                    //
+                    // Revit's API does not refuse a duplicate type name — on 2026-09-09 it
+                    // accepted 137 of them and this loop logged "0 failed" — so the two
+                    // checks below are not belt-and-braces over an API guard. There is no
+                    // API guard. TypeRenamePlanner's uniqueness gate is the first line and
+                    // this is the last, because a plan can be stale by the time it is
+                    // applied: a type added, renamed or deleted between plan and Yes.
+                    var hosts = new FilteredElementCollector(doc).OfClass(typeof(HostObjAttributes))
+                                    .ToList();
+                    bool SameCategory(Element e, string cat)
+                        => string.Equals(e.Category?.Name, cat, StringComparison.OrdinalIgnoreCase);
+
                     foreach (var p in todo)
                     {
-                        var type = new FilteredElementCollector(doc).OfClass(typeof(HostObjAttributes))
-                            .FirstOrDefault(e => string.Equals(e.Name, p.CurrentName, StringComparison.Ordinal)
-                                              && string.Equals(e.Category?.Name, p.Category, StringComparison.OrdinalIgnoreCase));
-                        if (type == null) { failed.Add($"{p.CurrentName} — no longer present"); continue; }
-                        try { type.Name = p.ProposedName; done++; }
+                        var matches = hosts.Where(e => string.Equals(e.Name, p.CurrentName, StringComparison.Ordinal)
+                                                    && SameCategory(e, p.Category)).ToList();
+                        if (matches.Count == 0)
+                        { failed.Add($"{p.CurrentName} — no longer present"); continue; }
+                        if (matches.Count > 1)
+                        {
+                            // Already duplicated before this run. Renaming an arbitrary one
+                            // of them would be a coin toss recorded as a success.
+                            failed.Add($"{p.CurrentName} — {matches.Count} {p.Category} types already share "
+                                     + "this name, so there is no way to tell which one the plan meant");
+                            continue;
+                        }
+
+                        var taken = hosts.FirstOrDefault(e => !ReferenceEquals(e, matches[0])
+                                                           && SameCategory(e, p.Category)
+                                                           && string.Equals(e.Name, p.ProposedName, StringComparison.OrdinalIgnoreCase));
+                        if (taken != null)
+                        {
+                            failed.Add($"{p.CurrentName} → {p.ProposedName} — another {p.Category} type already "
+                                     + "holds that name. Revit would accept the duplicate silently; this does not.");
+                            continue;
+                        }
+
+                        try { matches[0].Name = p.ProposedName; done++; }
                         catch (Exception ex) { failed.Add($"{p.CurrentName} — {ex.Message}"); }
                     }
                     t.Commit();

--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -85,6 +85,21 @@ namespace StingTools.Core.Baseline
         /// resolves to. A different thing from "the model does not say enough".</summary>
         public bool RefusedToProtectCode;
 
+        /// <summary>True when a name was composed and withheld because another type in the
+        /// same category would end up holding it. Distinct from both other refusals: the
+        /// model said enough, the code was right, and the answer still collided.</summary>
+        public bool RefusedAsDuplicate;
+
+        /// <summary>The name that WAS composed, kept even when a gate withheld it, so the
+        /// CSV can show what was rejected instead of an empty cell. Equal to
+        /// <see cref="ProposedName"/> whenever a proposal stands.</summary>
+        public string WithheldName;
+
+        /// <summary>True when the caller's existing-code resolver threw. The product-code
+        /// gate cannot fire for this type, and a run where that happened everywhere must not
+        /// read the same as a run where the gate examined every type and found nothing.</summary>
+        public bool ExistingLookupFailed;
+
         public bool IsProposal => !string.IsNullOrEmpty(ProposedName);
         /// <summary>True when the current name already matches what would be proposed.</summary>
         public bool AlreadyConforms =>
@@ -253,10 +268,15 @@ namespace StingTools.Core.Baseline
             // between components inside a field, no spaces anywhere.
             p.ProdCode = prod;
             p.DeclaredCode = prod;
+            // An unavailable resolver must not abort the plan — but it must not vanish
+            // either. A resolver that throws for every type disables the code gate below
+            // completely, and "0 held back" then means "the gate never ran", which reads
+            // identically to "the gate found nothing wrong".
             try { p.Existing = resolveExisting?.Invoke(input); }
-            catch (Exception) { p.Existing = null; }   // an unavailable resolver is not a proposal
+            catch (Exception) { p.Existing = null; p.ExistingLookupFailed = resolveExisting != null; }
 
             string composed = ProdNameCode.Compose(p.Originator, prod, substance + size, finish);
+            p.WithheldName = composed;
 
             // ── The code gate. ───────────────────────────────────────────────────
             // ProdResolver puts a code DECLARED in a type name above the corporate
@@ -304,8 +324,84 @@ namespace StingTools.Core.Baseline
         public static List<TypeRenameProposal> PlanAll(
             IEnumerable<TypeRenameInput> inputs,
             Func<TypeRenameInput, ExistingProdCode> resolveExisting = null)
-            => (inputs ?? Enumerable.Empty<TypeRenameInput>())
-               .Select(i => Plan(i, resolveExisting)).ToList();
+        {
+            var plans = (inputs ?? Enumerable.Empty<TypeRenameInput>())
+                        .Select(i => Plan(i, resolveExisting)).ToList();
+            GateDuplicateNames(plans);
+            return plans;
+        }
+
+        /// <summary>
+        /// ── The uniqueness gate. ─────────────────────────────────────────────
+        ///
+        /// <para><b>Revit does not stop you.</b> Its UI refuses a duplicate type name; its
+        /// API does not. On 2026-09-09 this command renamed 168 types on a delivered model
+        /// and logged <c>168/168 renamed, 0 failed</c> — while <b>137 of them landed on 19
+        /// names</b>. Eighty-seven floor types, the whole finish catalogue, became
+        /// <c>PLNS_SLB_RC100</c>. Every <c>type.Name = …</c> succeeded, so the per-type
+        /// try/catch had nothing to report. This gate is the only thing between a rename and
+        /// that outcome.</para>
+        ///
+        /// <para><b>Refuse; never disambiguate.</b> Appending <c>-2</c>, <c>-3</c> … was the
+        /// obvious repair and is the wrong one. Those 87 types are one 100 mm layer of grey
+        /// concrete under 87 names: a numeric suffix would invent a distinction the build-ups
+        /// do not contain, and — unlike the collision — it would look deliberate forever
+        /// after. The refusal is worth more than the rename, because it names the real
+        /// finding: those types are named, not modelled, and every quantity taken off them
+        /// (area, volume, embodied carbon, cost) has been answering "100 mm of concrete"
+        /// whatever the label said.</para>
+        ///
+        /// <para><b>Names being KEPT count too.</b> A rename landing on the name of a type
+        /// that is not being renamed is the same duplicate to Revit. Comparing proposals only
+        /// against other proposals would let that through, so the claim set is
+        /// <c>ProposedName ?? CurrentName</c> for every type in the run.</para>
+        ///
+        /// <para><b>Scope is the category.</b> Revit scopes type names per category, so a
+        /// floor and a roof may both be <c>PLNS_SLB_RC150</c>; gating across categories would
+        /// refuse correct renames for a clash that cannot happen.</para>
+        /// </summary>
+        private static void GateDuplicateNames(List<TypeRenameProposal> plans)
+        {
+            var claims = new Dictionary<string, List<TypeRenameProposal>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in plans)
+            {
+                string held = p.IsProposal ? p.ProposedName : p.CurrentName;
+                if (string.IsNullOrWhiteSpace(held)) continue;
+                string key = (p.Category ?? "") + " " + held.Trim();
+                if (!claims.TryGetValue(key, out var l)) claims[key] = l = new List<TypeRenameProposal>();
+                l.Add(p);
+            }
+
+            foreach (var group in claims.Values)
+            {
+                if (group.Count < 2) continue;
+
+                foreach (var p in group)
+                {
+                    // A type that already carries the name is not colliding with itself, and
+                    // one that is keeping its name is not doing anything to collide WITH.
+                    // Only a move can be refused.
+                    if (!p.IsProposal || p.AlreadyConforms) continue;
+
+                    var peers = group.Where(o => !ReferenceEquals(o, p))
+                                     .Select(o => o.CurrentName)
+                                     .OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+
+                    string named = string.Join(", ", peers.Take(3));
+                    if (peers.Count > 3) named += $", and {peers.Count - 3} more";
+
+                    p.RefusedAsDuplicate = true;
+                    p.ProposedName = null;
+                    p.Reason = $"'{p.WithheldName}' would also be taken by {peers.Count} other "
+                             + $"{p.Category} type(s) — {named}. Revit's API accepts a duplicate type "
+                             + "name without complaint, so nothing downstream would report it. They "
+                             + "share a name because they share a build-up: same core material, same "
+                             + "thickness, same finish. As modelled they are one type, and the "
+                             + "difference lives only in the names a rename would erase — so give them "
+                             + "different layers, or leave them named.";
+                }
+            }
+        }
 
         /// <summary>
         /// One line per outcome, so a reader sees the shape of the run before opening
@@ -317,7 +413,9 @@ namespace StingTools.Core.Baseline
             int conform = ps.Count(x => x.AlreadyConforms);
             int propose = ps.Count(x => x.IsProposal && !x.AlreadyConforms);
             int guarded = ps.Count(x => x.RefusedToProtectCode);
-            int cannot = ps.Count(x => !x.IsProposal) - guarded;
+            int clashed = ps.Count(x => x.RefusedAsDuplicate);
+            int unchecked_ = ps.Count(x => x.ExistingLookupFailed);
+            int cannot = ps.Count(x => !x.IsProposal) - guarded - clashed;
             string s = $"{ps.Count} type(s): {conform} already conform, {propose} can be renamed, "
                      + $"{cannot} cannot be named from the model. The {cannot} are not failures of this "
                      + "tool — their materials do not say what they are, and a rename that guessed would "
@@ -327,6 +425,17 @@ namespace StingTools.Core.Baseline
                    + "DIFFERENT product code from the one the type already resolves to — those are "
                    + "listed in the CSV with both codes, and the answer is usually to fix the name by "
                    + "hand rather than to let a rename overwrite a correct classification.";
+            if (clashed > 0)
+                s += $" And {clashed} were held back because two or more types would have ended up "
+                   + "with the same name — Revit's API permits that silently, so the rename would "
+                   + "have looked like a clean run. Types collide here when the model gives them "
+                   + "identical build-ups, which means the distinction their old names carry is not "
+                   + "in the model at all: their areas, volumes, carbon and cost are already being "
+                   + "answered as though they were one type.";
+            if (unchecked_ > 0)
+                s += $" NOTE: {unchecked_} type(s) could not be checked against the product-code "
+                   + "rules because the resolver failed, so the code gate did not run for them. "
+                   + "Treat any rename among those as unverified rather than approved.";
             return s;
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — a rename that would give two types one name is refused)
+
+`Baseline_RenameTypes` was applied to a delivered model on 2026-09-09. The log
+recorded `168/168 renamed, 0 failed`. **137 of those 168 landed on 19 names.**
+The largest group was 87 floor types — the whole finish catalogue, every screed,
+tile, carpet, paver and resin — all renamed `PLNS_SLB_RC100`.
+
+**Revit's API does not refuse a duplicate type name.** Its UI does; the API does
+not. Every `type.Name = ...` returned without throwing, so the command's
+per-type try/catch had nothing to report and the run looked clean. Nothing
+failed. Everything broke. Only the fact that the model was never saved kept this
+off disk.
+
+**Why they collided.** All 87 gave the same reason: `core 'Concrete,
+Cast-in-Place gray' -> SLB; no finish layer to read`. They are one 100 mm slab of
+grey concrete wearing 87 names. The distinction was never modelled — it lived in
+the string alone, and the rename would have erased the only record of it.
+
+**Refuse, never disambiguate.** Appending `-2`, `-3` ... was the obvious repair
+and is the wrong one: it manufactures a difference the build-ups do not contain
+and, unlike the collision, looks deliberate forever after. The refusal is worth
+more than the rename, because it names the real finding — those types are named,
+not modelled, and every quantity taken off them (area, volume, embodied carbon,
+cost) has been answering "100 mm of concrete" whatever the label promised.
+
+`TypeRenamePlanner.GateDuplicateNames` runs as a second pass in `PlanAll`. The
+claim set is `ProposedName ?? CurrentName` for every type, so a rename landing on
+a name another type is KEEPING is caught too — Revit sees no difference between
+that and two renames colliding. Scope is the category, because Revit scopes type
+names per category and gating wider would refuse correct renames for a clash that
+cannot happen.
+
+A second guard sits in the command, because a plan can be stale by the time it is
+applied: it refuses when the current name matches more than one type (no way to
+tell which the plan meant) and when the proposed name is already held.
+
+**RED before GREEN.** `TypeRenameUniquenessTests` drives
+`Fixtures/type_rename_20260909.csv` — all 168 proposals from that run, with the
+core material, thickness and finish the planner read. Against the pre-gate
+planner: 5 of 9 failing, reporting 19 collisions over 137 types, matching the
+model exactly. After: 9 of 9. `The_Fixture_Reproduces_The_Recorded_Run` asserts
+the reconstruction still composes the recorded name, so the fixture cannot
+quietly drift into describing a planner that no longer exists.
+
+**It immediately found the same defect in #892's own fixture.**
+`TypeRenameCodeGateTests.The_Summary_Separates_Cannot_Name_From_Held_Back`
+asserted "4 can be renamed". Two of those four — `Exterior_CreamWhite_230 2` and
+`Exterior_BrownWhite_230`, both `Brick, Common(1)` at 205 mm with a plaster
+finish — compose the same name. They are the pair that actually collided on the
+delivered model, carrying 6 and 5 live elements. The old number was not a
+stricter expectation; it was that fixture reproducing the defect with nothing
+checking for it.
+
+**A silent failure fixed alongside.** `Plan` wraps the caller's existing-code
+resolver in a bare `catch`, which is right — an unavailable resolver must not
+abort the plan — but a resolver that throws for every type disabled the
+product-code gate completely and reported a clean run. `ExistingLookupFailed` is
+now carried per proposal and counted in `Summary`, so a dead gate no longer reads
+identically to a gate that found nothing.
+
+The plan CSV gains a `WithheldName` column: a refusal with an empty
+`ProposedName` and no record of what was rejected tells the reader nothing about
+which gate fired or whether the name would have been reasonable.
+
+**Known and deliberately not fixed here.** `TypeRenamePlanner.Match` still uses
+`IndexOf`, the #863 shape removed from the class planner in Phase 256. The new
+corpus was used to test the switch rather than guess at it, and it breaks 7 rows:
+`Concrete Masonry Units` and `CLAY TILES PREMIUM` are plurals, and the needles
+are singular, so whole-word matching sends the CMU walls back to `WRC` and drops
+the clay-tile roofs entirely. The remedy is plural-tolerant stems, proven against
+this fixture, in its own change.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries


### PR DESCRIPTION
## What happened

`Baseline_RenameTypes` was applied to a delivered model on 2026-09-09. The plugin log:

```
Baseline_RenameTypes: 168/168 renamed, 0 failed
```

**137 of those 168 landed on 19 names.** The largest group was **87 floor types all renamed `PLNS_SLB_RC100`** — every screed, tile, carpet, paver and resin in the project's floor-finish catalogue.

**Revit's API does not refuse a duplicate type name.** Its UI does; the API does not. Every `type.Name = …` returned without throwing, so the command's per-type try/catch had nothing to report. Nothing failed. Everything broke. Only the fact that the model was never saved kept this off disk.

## Why they collided

All 87 gave the same reason: `core 'Concrete, Cast-in-Place gray' → SLB; no finish layer to read`. They are one 100 mm slab of grey concrete wearing 87 names. The distinction was never modelled — it lived in the string alone.

That is why the gate **refuses and never disambiguates.** A `-2`, `-3` … suffix was the obvious repair and is the wrong one: it manufactures a difference the build-ups do not contain and, unlike a collision, looks deliberate forever after. The refusal is worth more than the rename, because it names the real finding — those types are named, not modelled, and every quantity taken off them (area, volume, embodied carbon, cost) has been answering "100 mm of concrete" whatever the label promised.

## The gate

`TypeRenamePlanner.GateDuplicateNames`, a second pass in `PlanAll`:

- claim set is `ProposedName ?? CurrentName` for **every** type, so a rename landing on a name another type is *keeping* is caught — Revit sees no difference between that and two renames colliding;
- scope is the **category**, because Revit scopes type names per category and gating wider would refuse correct renames for a clash that cannot happen;
- a type that already conforms is not colliding with itself, so re-running is a no-op.

A second guard in the command covers a plan gone stale before the user presses Yes: it refuses when the current name matches more than one type, and when the proposed name is already held.

## RED → GREEN

`TypeRenameUniquenessTests` drives `Fixtures/type_rename_20260909.csv` — all 168 proposals from that run with the core material, thickness and finish the planner read.

| | RED | GREEN |
|---|---|---|
| `TypeRenameUniquenessTests` | **5 of 9 failing** — reporting 19 collisions over 137 types, matching the model exactly | 9 of 9 |
| `StingTools.Tags.Tests` | — | 830 of 830 |
| `StingTools.Boq.Tests` | — | 1249 of 1249 |
| Build | — | 0 errors, 0 warnings |

`The_Fixture_Reproduces_The_Recorded_Run` asserts the reconstruction still composes the recorded name, so the fixture cannot drift into describing a planner that no longer exists.

## It found the same defect in #892's fixture

`TypeRenameCodeGateTests.The_Summary_Separates_Cannot_Name_From_Held_Back` asserted `4 can be renamed`. Two of those four — `Exterior_CreamWhite_230 2` and `Exterior_BrownWhite_230`, both `Brick, Common(1)` at 205 mm with a plaster finish — compose the same name. They are the pair that actually collided on the delivered model, carrying 6 and 5 live elements. The old number was not a stricter expectation; it was that fixture reproducing the defect with nothing checking for it. Updated with the reason recorded in the test.

## A silent failure fixed alongside

`Plan` wraps the caller's existing-code resolver in a bare `catch` — right, because an unavailable resolver must not abort the plan, but a resolver that throws for *every* type disabled the product-code gate completely and reported a clean run. `ExistingLookupFailed` is now carried per proposal and counted in `Summary`.

The plan CSV gains a `WithheldName` column: a refusal with an empty `ProposedName` and no record of what was rejected tells the reader nothing about which gate fired.

## Known, and deliberately not fixed here

`TypeRenamePlanner.Match` still uses `IndexOf` — the #863 shape removed from the class planner in Phase 256. I used the new corpus to **test** the switch rather than guess at it, and it breaks 7 rows: `Concrete Masonry Units` and `CLAY TILES PREMIUM` are plurals against singular needles, so whole-word matching sends the CMU walls back to `WRC` and drops the clay-tile roofs entirely. The remedy is plural-tolerant stems, proven against this fixture, in its own change.

## Not verified in Revit

`deploy.bat` was not run. The planner and both gates are exercised by tests; the command's stale-plan guards and the new CSV column are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)