### PR TITLE
A new PROD tier is a red test; the material corpus grows by being dropped in; an unsaved write stops reading as a colleague's decision

### DIFF
--- a/StingTools.Tags.Tests/MaterialClassCorpusTests.cs
+++ b/StingTools.Tags.Tests/MaterialClassCorpusTests.cs
@@ -178,7 +178,8 @@ namespace StingTools.Tags.Tests
                 string want = r.Expect == "NONE" ? null : r.Expect;
                 string got = MaterialClassPlanner.Plan(r.Material, "").ProposedClass;
                 if (!string.Equals(want, got, StringComparison.Ordinal))
-                    misses.Add($"[{r.Source}] {r.Material}  want={want ?? "(blank)"}  got={got ?? "(blank)"}");
+                    misses.Add($"[{r.Source}] {r.Material}  want={want ?? "(blank)"}  got={got ?? "(blank)"}"
+                             + $"   ({r.File})");
             }
 
             if (misses.Count == 0) return;
@@ -210,9 +211,13 @@ namespace StingTools.Tags.Tests
         [Fact]
         public void The_Fixture_Is_The_Whole_Run_Not_A_Sample()
         {
-            // 1,815 materials is what the plan reported. A fixture that quietly shrank
-            // would make this whole file weaker without failing anything.
-            var rows = Corpus();
+            // 1,815 materials is what the 2026-09-08 plan reported. A fixture that quietly
+            // shrank would make this whole file weaker without failing anything.
+            //
+            // Scoped to THAT file by name, deliberately. The loader now globs, and a
+            // union-wide count would move every time a corpus is added — which is exactly
+            // the assertion that stops meaning anything. Per-file counts do not move.
+            var rows = Corpus().Where(r => r.File == "material_names_20260908.csv").ToList();
             Assert.Equal(1815, rows.Count);
 
             var bySource = rows.GroupBy(r => r.Source).ToDictionary(g => g.Key, g => g.Count());
@@ -223,6 +228,24 @@ namespace StingTools.Tags.Tests
             // 120 writes and 171 refusals, exactly as the plan reported them.
             Assert.Equal(120, bySource["correction"] + bySource["plan-write"]);
             Assert.Equal(171, bySource["plan-refusal"] + bySource["named-substance"]);
+        }
+
+        [Fact]
+        public void Every_Corpus_File_In_Fixtures_Is_Actually_Being_Read()
+        {
+            // The point of globbing: dropping the next project's list in must strengthen
+            // this file without anybody editing it. So assert that what is ON DISK is what
+            // was read — a glob that silently matched nothing, or matched one of three,
+            // would leave the tests passing on less evidence than the repo contains.
+            var onDisk = Directory.GetFiles(FixtureDir(), "material_names_*.csv")
+                                  .Select(Path.GetFileName).OrderBy(f => f).ToList();
+            Assert.Equal(onDisk, CorpusFiles());
+            Assert.Contains("material_names_20260908.csv", CorpusFiles());
+
+            // And every file contributes pinned rows, or it is decoration.
+            foreach (string f in CorpusFiles())
+                Assert.True(Corpus().Any(r => r.File == f && r.Expect != "ANY"),
+                    f + " contributes no pinned row — it asserts nothing.");
         }
 
         [Fact]
@@ -242,30 +265,66 @@ namespace StingTools.Tags.Tests
         private sealed class Row
         {
             public string Material, Expect, Source;
+            /// <summary>Which fixture file it came from, so a failure names the corpus.</summary>
+            public string File;
         }
 
         private static List<Row> _corpus;
+        private static List<string> _corpusFiles;
 
+        /// <summary>
+        /// EVERY <c>Fixtures/material_names_*.csv</c>, not one named file.
+        ///
+        /// <para>This used to name <c>material_names_20260908.csv</c> in two places. The
+        /// corpus is the only thing in this file that makes it stronger than a table
+        /// somebody thought of, so the next delivered model's list should strengthen the
+        /// guarantee by being dropped in — not by somebody remembering to edit a string
+        /// here. A gate that has to be widened by hand does not get widened.</para>
+        ///
+        /// <para>Files are read in name order, so a date-stamped name orders itself.</para>
+        /// </summary>
         private static List<Row> Corpus()
         {
             if (_corpus != null) return _corpus;
 
-            var dir = new DirectoryInfo(AppContext.BaseDirectory);
-            while (dir != null && !File.Exists(Path.Combine(
-                       dir.FullName, "StingTools.Tags.Tests", "Fixtures", "material_names_20260908.csv")))
-                dir = dir.Parent;
-            Assert.True(dir != null, "Could not locate the corpus fixture from " + AppContext.BaseDirectory);
+            string dir = FixtureDir();
+            var files = Directory.GetFiles(dir, "material_names_*.csv").OrderBy(f => f).ToList();
+            Assert.True(files.Count > 0,
+                "No material_names_*.csv in " + dir + " — the corpus is what makes this file evidence.");
 
-            string path = Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures", "material_names_20260908.csv");
             var rows = new List<Row>();
-            foreach (string line in File.ReadAllLines(path, Encoding.UTF8).Skip(1))
+            foreach (string path in files)
             {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-                var f = SplitCsv(line);
-                Assert.True(f.Count == 3, "Malformed fixture line: " + line);
-                rows.Add(new Row { Material = f[0], Expect = f[1], Source = f[2] });
+                string name = Path.GetFileName(path);
+                int n = 0;
+                foreach (string line in File.ReadAllLines(path, Encoding.UTF8).Skip(1))
+                {
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+                    var f = SplitCsv(line);
+                    Assert.True(f.Count == 3, $"Malformed line in {name}: {line}");
+                    rows.Add(new Row { Material = f[0], Expect = f[1], Source = f[2], File = name });
+                    n++;
+                }
+                Assert.True(n > 0, name + " has a header and no rows — an empty corpus is not a passing one.");
             }
+            _corpusFiles = files.Select(Path.GetFileName).ToList();
             return _corpus = rows;
+        }
+
+        private static List<string> CorpusFiles()
+        {
+            Corpus();
+            return _corpusFiles;
+        }
+
+        private static string FixtureDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(
+                       dir.FullName, "StingTools.Tags.Tests", "Fixtures")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate the Fixtures directory from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures");
         }
 
         /// <summary>

--- a/StingTools.Tags.Tests/MaterialClassRevertTests.cs
+++ b/StingTools.Tags.Tests/MaterialClassRevertTests.cs
@@ -105,7 +105,80 @@ namespace StingTools.Tags.Tests
             // After the first revert the material carries first.RestoreTo. Feed that back.
             var second = MaterialClassRevertPlanner.Plan(row, first.RestoreTo);
             Assert.False(second.WillRevert);
-            Assert.Contains("changed since", second.Reason);
+
+            // And it says WHY in the words that are true. This assertion used to read
+            // "changed since", which is what the code said and is not what happened —
+            // see A_Write_That_Was_Never_Saved_Is_Not_Somebody_Elses_Decision below.
+            Assert.True(second.AlreadyAsThePlanFoundIt);
+            Assert.Contains("already back", second.Reason);
+            Assert.DoesNotContain("changed since", second.Reason);
+        }
+
+        [Fact]
+        public void A_Write_That_Was_Never_Saved_Is_Not_Somebody_Elses_Decision()
+        {
+            // Run on the Herring model 2026-09-09 07:48: 1,815 rows, 0 reverted, and 120 of
+            // them reported "changed since the plan ran — now 'Unassigned', the plan set
+            // 'Ceramic'. That choice wins". Every one was in fact ALREADY reverted; the
+            // write had simply not been saved. The VERDICT was right — there was nothing to
+            // do — and the SENTENCE described a colleague overwriting the reader's data.
+            //
+            // Two states, one message. The state that is genuinely somebody else's decision
+            // is asserted separately, immediately below, or fixing this would quietly delete
+            // the warning that matters.
+            var p = MaterialClassRevertPlanner.Plan(Row("CARPET TILE", "Unassigned", "Ceramic"), "Unassigned");
+
+            Assert.False(p.WillRevert);
+            Assert.True(p.AlreadyAsThePlanFoundIt);
+            Assert.Contains("already back to no class", p.Reason);
+            Assert.Contains("nothing to undo", p.Reason);
+            Assert.DoesNotContain("That choice wins", p.Reason);
+
+            // Blank and "Unassigned" are the same absence, so both spellings read the same.
+            var blank = MaterialClassRevertPlanner.Plan(Row("CARPET TILE", "Unassigned", "Ceramic"), "");
+            Assert.True(blank.AlreadyAsThePlanFoundIt);
+        }
+
+        [Fact]
+        public void A_Real_Later_Decision_Still_Says_Somebody_Chose_It()
+        {
+            // The half that must NOT be softened by the fix above. Stone is not blank and is
+            // not what the plan set, so a human has been in there.
+            var p = MaterialClassRevertPlanner.Plan(Row("GRANITE TILE", "Unassigned", "Ceramic"), "Stone");
+
+            Assert.False(p.WillRevert);
+            Assert.False(p.AlreadyAsThePlanFoundIt);
+            Assert.Contains("changed since", p.Reason);
+            Assert.Contains("That choice wins", p.Reason);
+        }
+
+        [Fact]
+        public void The_Summary_Does_Not_Report_An_Unsaved_Write_As_A_Contested_One()
+        {
+            // The count is what a reader acts on. Folding already-reverted into
+            // changed-since made a clean second run read as 120 contested materials.
+            var plan = new List<MaterialClassPlanRow>
+            {
+                Row("CARPET TILE",  "Unassigned", "Ceramic"),   // already back
+                Row("SLATE TILE",   "Unassigned", "Ceramic"),   // already back
+                Row("GRANITE TILE", "Unassigned", "Ceramic"),   // genuinely changed
+                Row("Air Openings", "Unassigned", ""),          // never written
+            };
+            var current = new Dictionary<string, string>
+            {
+                ["CARPET TILE"] = "Unassigned",
+                ["SLATE TILE"] = "",
+                ["GRANITE TILE"] = "Stone",
+                ["Air Openings"] = "",
+            };
+
+            string s = MaterialClassRevertPlanner.Summary(
+                MaterialClassRevertPlanner.PlanAll(plan, current));
+
+            Assert.Contains("0 will be put back", s);
+            Assert.Contains("2 already carry what the plan found", s);
+            Assert.Contains("1 have been changed since", s);
+            Assert.Contains("1 were never written", s);
         }
 
         // ══════════════════════════════════════════════════════════════════════

--- a/StingTools.Tags.Tests/ProdResolverSourceTotalityTests.cs
+++ b/StingTools.Tags.Tests/ProdResolverSourceTotalityTests.cs
@@ -1,0 +1,114 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ProdResolverSourceTotalityTests.cs — a source tier nobody classified must
+//  be a failing test, not a gate that quietly opens.
+//
+//  `ProdResolver.IsSpecific` is a WHITELIST of five tiers that returns false
+//  for everything else, and it has two consumers with OPPOSITE safe defaults:
+//
+//    Prod_CoverageAudit          false ⇒ counted as generic ⇒ coverage % is
+//                                UNDERSTATED. Conservative; a reader chasing a
+//                                low number finds the truth.
+//    TypeRenamePlanner code-gate false ⇒ "no answer to protect" ⇒ the refusal
+//                                DOES NOT FIRE and a correctly-resolved product
+//                                code is renamed away. There is no signal at
+//                                all: the CSV row reads "rename", the same as
+//                                every legitimate one.
+//
+//  Two tiers were added to `Sources` after `IsSpecific` was written — `declared`
+//  and `sleeve` — and both happen to be listed. The next one need not be, and
+//  nothing in the build would say so. That is the whole defect: not a wrong
+//  answer today, an open trapdoor for the next author.
+//
+//  So the split is now declared in BOTH directions and this reflects over the
+//  consts to prove it is total. Deliberately reflection and not a hand-written
+//  list of the seven: a list would need the same edit the whitelist needs, and
+//  would therefore fail to catch the same omission.
+// ══════════════════════════════════════════════════════════════════════════
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using StingTools.Core;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class ProdResolverSourceTotalityTests
+    {
+        /// <summary>Every public string const on <c>ProdResolver.Sources</c>, by
+        /// reflection — so adding one is enough to be covered.</summary>
+        private static List<(string Name, string Value)> DeclaredSources()
+            => typeof(ProdResolver.Sources)
+               .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+               .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+               .Select(f => (f.Name, (string)f.GetRawConstantValue()))
+               .OrderBy(x => x.Name)
+               .ToList();
+
+        [Fact]
+        public void There_Are_Source_Tiers_To_Classify_At_All()
+        {
+            // Reflection returning nothing would make every assertion below vacuously
+            // true — the empty-list-standing-in-for-an-error shape this codebase keeps
+            // finding. Six is the count at the time of writing minus room to shrink.
+            var all = DeclaredSources();
+            Assert.True(all.Count >= 6, "only " + all.Count + " source consts found by reflection");
+            Assert.Contains("project", all.Select(x => x.Value));
+            Assert.Contains("category", all.Select(x => x.Value));
+        }
+
+        [Fact]
+        public void Every_Source_Tier_Is_Either_Specific_Or_Generic_And_Never_Both()
+        {
+            var unclassified = new List<string>();
+            var both = new List<string>();
+
+            foreach (var (name, value) in DeclaredSources())
+            {
+                bool s = ProdResolver.IsSpecific(value);
+                bool g = ProdResolver.IsGeneric(value);
+                if (!s && !g) unclassified.Add($"Sources.{name} = \"{value}\"");
+                if (s && g) both.Add($"Sources.{name} = \"{value}\"");
+            }
+
+            Assert.True(unclassified.Count == 0,
+                "These source tiers are in NEITHER IsSpecific nor IsGeneric. Until they are, "
+              + "TypeRenamePlanner's code-gate treats them as 'nothing to protect' and will "
+              + "rename a correctly-resolved product code away with no signal:\n  "
+              + string.Join("\n  ", unclassified));
+
+            Assert.True(both.Count == 0,
+                "These source tiers are in BOTH sets, so the two functions disagree about "
+              + "what they mean:\n  " + string.Join("\n  ", both));
+        }
+
+        [Theory]
+        [InlineData("project", true)]
+        [InlineData("declared", true)]
+        [InlineData("corporate", true)]
+        [InlineData("lps", true)]
+        [InlineData("sleeve", true)]
+        [InlineData("category", false)]
+        [InlineData("gen", false)]
+        public void The_Split_Puts_Each_Tier_Where_The_Resolver_Means_It(string source, bool specific)
+        {
+            // The values, spelled out, so a change of MEANING (moving "declared" to
+            // generic, say) fails here as well as in the totality gate above — which
+            // would still pass, because a moved tier is still classified exactly once.
+            Assert.Equal(specific, ProdResolver.IsSpecific(source));
+            Assert.Equal(!specific, ProdResolver.IsGeneric(source));
+        }
+
+        [Fact]
+        public void A_Tier_That_Does_Not_Exist_Is_In_Neither_Set()
+        {
+            // Both functions are whitelists, so an unknown string must fall out of both —
+            // which is what makes the totality gate above meaningful rather than an
+            // identity. If IsGeneric were written as !IsSpecific this would fail, and so
+            // would the whole point of the file.
+            Assert.False(ProdResolver.IsSpecific("some-new-tier"));
+            Assert.False(ProdResolver.IsGeneric("some-new-tier"));
+            Assert.False(ProdResolver.IsSpecific(null));
+            Assert.False(ProdResolver.IsGeneric(null));
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialClassRevertPlanner.cs
+++ b/StingTools/Core/Materials/MaterialClassRevertPlanner.cs
@@ -57,6 +57,11 @@ namespace StingTools.Core.Materials
         public string RestoreTo = "";
         public string Reason = "";
 
+        /// <summary>True when the material already carries what the plan found — a second
+        /// revert run, or a write that was never saved. Distinct from "somebody changed it
+        /// since", which the message used to conflate it with.</summary>
+        public bool AlreadyAsThePlanFoundIt { get; internal set; }
+
         public bool WillRevert { get; internal set; }
     }
 
@@ -83,6 +88,26 @@ namespace StingTools.Core.Materials
 
             if (currentClass == null)
             { p.Reason = "no longer in this model"; return p; }
+
+            // ALREADY BACK is not CHANGED SINCE, and conflating them alarms the reader.
+            //
+            // Run on the Herring model 2026-09-09 07:48: 1,815 rows, 0 reverted, and 120
+            // of them reported "changed since the plan ran — now 'Unassigned', the plan set
+            // 'Ceramic'. That choice wins". Every one of those 120 was in fact ALREADY
+            // reverted — the write had not been saved — so the message described a
+            // colleague overwriting the reader's data when nothing of the sort had
+            // happened. The verdict was right and the sentence was wrong, which is the
+            // harder half to notice.
+            if (string.Equals(Normalise(currentClass), p.RestoreTo, StringComparison.OrdinalIgnoreCase))
+            {
+                p.AlreadyAsThePlanFoundIt = true;
+                p.Reason = p.RestoreTo.Length == 0
+                    ? $"already back to no class, which is how the plan found it — nothing to undo "
+                    + $"(the plan set '{p.PlannedClass}')"
+                    : $"already back to '{p.RestoreTo}', which is how the plan found it — nothing to "
+                    + $"undo (the plan set '{p.PlannedClass}')";
+                return p;
+            }
 
             if (!string.Equals(Normalise(currentClass), p.PlannedClass, StringComparison.OrdinalIgnoreCase))
             {
@@ -120,12 +145,17 @@ namespace StingTools.Core.Materials
             int revert = ps.Count(x => x.WillRevert);
             int nothingSet = ps.Count(x => x.PlannedClass.Length == 0);
             int gone = ps.Count(x => x.CurrentClass == null && x.PlannedClass.Length > 0);
-            int moved = ps.Count - revert - nothingSet - gone;
+            int already = ps.Count(x => x.AlreadyAsThePlanFoundIt);
+            int moved = ps.Count - revert - nothingSet - gone - already;
             var sb = new StringBuilder();
             sb.AppendLine($"{ps.Count} row(s) in that plan: {revert} will be put back as they were.");
-            sb.AppendLine($"{nothingSet} were never written, {gone} are no longer in the model, and "
-                        + $"{moved} have been changed since the plan ran — those {moved} are left alone, "
-                        + "because somebody chose them after the tool did.");
+            sb.AppendLine($"{nothingSet} were never written and {gone} are no longer in the model.");
+            if (already > 0)
+                sb.AppendLine($"{already} already carry what the plan found, so there is nothing to "
+                            + "undo — either this has already been run, or that write was never saved.");
+            if (moved > 0)
+                sb.AppendLine($"{moved} have been changed since the plan ran and are left alone, "
+                            + "because somebody chose them after the tool did.");
             return sb.ToString();
         }
 

--- a/StingTools/Core/ProdResolver.cs
+++ b/StingTools/Core/ProdResolver.cs
@@ -44,6 +44,28 @@ namespace StingTools.Core
             || source == Sources.Corporate
             || source == Sources.Lps || source == Sources.Sleeve;
 
+        /// <summary>
+        /// True when a source tier is the GENERIC last resort — the category default, or
+        /// the GEN fallback when even that is missing.
+        ///
+        /// <para><b>Why this is its own whitelist and not <c>!IsSpecific</c>.</b>
+        /// <see cref="IsSpecific"/> names five tiers and returns false for anything else,
+        /// which is the right default for the coverage audit — an unknown tier merely
+        /// understates coverage. It is the WRONG default for the rename code-gate in
+        /// <c>TypeRenamePlanner</c>, which refuses a rename only when the existing code is
+        /// specific: there, an unrecognised tier reads as "no answer to protect" and the
+        /// gate silently stops firing. Two consumers of one function with opposite safe
+        /// defaults, and <c>declared</c> and <c>sleeve</c> were both added to
+        /// <see cref="Sources"/> after that function was written.</para>
+        ///
+        /// <para>Declaring both halves makes the split TOTAL and therefore checkable:
+        /// <c>ProdResolverSourceTotalityTests</c> reflects over <see cref="Sources"/> and
+        /// fails when a const is in neither set. A new tier is then a red test rather than
+        /// a gate that quietly opens.</para>
+        /// </summary>
+        public static bool IsGeneric(string source)
+            => source == Sources.Category || source == Sources.Gen;
+
         /// <param name="familyName">Element family name (may be null/empty).</param>
         /// <param name="typeName">Element type/symbol name (may be null).</param>
         /// <param name="categoryName">Revit category name.</param>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — a new PROD tier is a red test, the corpus grows by being dropped in, and an unsaved write stops reading as a colleague's decision)
+
+Three small independent fixes, each proved RED before GREEN.
+
+**A source tier nobody classified used to open a gate silently.**
+`ProdResolver.IsSpecific` is a whitelist of five tiers returning false for
+everything else, and it has two consumers with **opposite safe defaults**:
+`Prod_CoverageAudit` merely understates coverage, while `TypeRenamePlanner`'s
+code-gate reads an unknown tier as "no answer to protect" and lets a
+correctly-resolved product code be renamed away — with the CSV row reading
+`rename`, exactly like every legitimate one. Two tiers (`declared`, `sleeve`)
+were added to `Sources` after that function was written; both happen to be
+listed, and the next one need not have been.
+
+`IsGeneric` is now declared as its own whitelist — **not** `!IsSpecific`, which
+would make the split trivially total and prove nothing — and
+`ProdResolverSourceTotalityTests` reflects over the `Sources` consts to assert
+every one is in exactly one set. Reflection rather than a hand-written list of
+seven, because a list needs the same edit the whitelist needs and would miss the
+same omission.
+
+*RED by sabotage:* adding an eighth const `Harvested = "harvested"` failed **1 of
+10**, naming `Sources.Harvested`. Removed; 10 of 10.
+
+**`MaterialClassCorpusTests` was pinned to one filename in two places.** The
+1,815-name corpus is the only thing that makes that file stronger than a table
+somebody thought of, so the next delivered model's list should strengthen it by
+being dropped into `Fixtures/` — not by somebody remembering to edit a string.
+The loader now globs `material_names_*.csv` in name order, every miss names the
+file it came from, and `Every_Corpus_File_In_Fixtures_Is_Actually_Being_Read`
+compares what is on disk against what was read, so a glob that matched one of
+three cannot pass quietly. The exact per-source counts stay **scoped to
+`material_names_20260908.csv` by name** — a union-wide count would move every
+time a corpus is added, which is the assertion that stops meaning anything.
+
+*RED by sabotage:* a second fixture with one wrong row moved the pinned count
+697 → **698** and failed **1 of 50**, naming the new file. Removed; 50 of 50.
+
+**An unsaved write was reported as a colleague's decision.** Run on the Herring
+model 2026-09-09 07:48, `Materials_RevertClassPlan` reported 1,815 rows, 0
+reverted, and **120 of them** as
+
+    changed since the plan ran — now 'Unassigned', the plan set 'Ceramic'.
+    That choice wins; not reverted.
+
+Every one of those 120 was in fact already reverted — the 2026-09-08 write had
+not been saved. **The verdict was right and the sentence was wrong**, which is
+the harder half to notice: it describes somebody overwriting the reader's data
+when nothing of the sort happened, on a tool whose entire purpose is to be
+trusted with a bulk undo.
+
+Already-back is now its own outcome (`AlreadyAsThePlanFoundIt`), checked before
+changed-since, and `Summary` counts the two separately. The half that must NOT be
+softened — a class a human genuinely changed afterwards — is asserted in its own
+test beside it, so the warning that matters cannot be deleted by fixing the one
+that did not.
+
+*RED:* the existing `Running_It_Twice_Does_Nothing_The_Second_Time` asserted the
+misleading wording and failed **1 of 13** the moment the message changed —
+the test had encoded the defect. Disabling the new branch failed **3 of 16**.
+GREEN 16 of 16.
+
+Tags 835 passed (baseline 821), Boq 1249 passed, plugin builds 0 warnings /
+0 errors. **Nothing was run in Revit**; the 120-row figure is read from the CSV
+the user's own run wrote, not reproduced here.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries


### PR DESCRIPTION
W5d + W5e from `HANDOVER_MATERIAL_ALIGNMENT.md`, plus one defect found while verifying the brief's figures. Branched from `origin/main` (`7a5fcf05d`).

## W5d — a new PROD source tier used to open a gate silently

`ProdResolver.IsSpecific` is a whitelist of five tiers that returns `false` for everything else, and it has **two consumers with opposite safe defaults**:

| Consumer | `false` means | Consequence |
|---|---|---|
| `Prod_CoverageAudit` | counted as generic | coverage % **understated** — conservative, and a reader chasing a low number finds the truth |
| `TypeRenamePlanner` code-gate | "no answer to protect" | the refusal **does not fire**, a correctly-resolved product code is renamed away, and the CSV row reads `rename` like every legitimate one |

Two tiers — `declared` and `sleeve` — were added to `Sources` after `IsSpecific` was written. Both happen to be listed. The next one need not be, and nothing in the build would say so.

`IsGeneric` is now declared as **its own whitelist**, deliberately not `!IsSpecific` — the complement would make the split trivially total and the gate would prove nothing (asserted: `A_Tier_That_Does_Not_Exist_Is_In_Neither_Set`). `ProdResolverSourceTotalityTests` reflects over the `Sources` consts and requires each to be in exactly one set. Reflection rather than a hand-written list of the seven, because a list needs the same edit the whitelist needs and would miss the same omission.

| Gate | RED | GREEN |
|---|---:|---:|
| `Every_Source_Tier_Is_Either_Specific_Or_Generic_And_Never_Both` | **1 of 10** — sabotage added an eighth const `Harvested = "harvested"`; the failure names `Sources.Harvested` | 0 |
| whole file | 1 failed / 9 passed of 10 | **10 of 10** |

The sabotage was removed; `git diff` on `ProdResolver.cs` shows only the `IsGeneric` addition.

## W5e — the corpus was pinned to one filename

`MaterialClassCorpusTests` named `material_names_20260908.csv` in two places. The 1,815-name corpus is the only thing that makes that file stronger than a table somebody thought of, so the next delivered model's list should strengthen it **by being dropped into `Fixtures/`** — not by somebody remembering to edit a string. A gate that has to be widened by hand does not get widened.

- loader globs `material_names_*.csv` in name order
- every miss now names the file it came from
- `Every_Corpus_File_In_Fixtures_Is_Actually_Being_Read` compares what is on disk against what was loaded, and requires every file to contribute at least one pinned row — a glob that matched one of three, or a decorative file, cannot pass quietly
- the exact per-source counts stay **scoped to `material_names_20260908.csv` by name**. A union-wide count would move every time a corpus is added, which is precisely the assertion that stops meaning anything.

| Gate | RED | GREEN |
|---|---:|---:|
| `Every_Pinned_Row_In_The_Corpus_Holds` | **1 of 50** — sabotage dropped in a second fixture with one wrong row; pinned rows moved **697 → 698** and the failure named `material_names_29991231.csv` | 0 |

The pinned count moving is the part that matters: it proves the second file was actually read, not just tolerated. Sabotage fixture deleted.

**No second real corpus exists yet**, so today this mechanism guards nothing extra — that is the point of shipping it now rather than when there is one.

## Third fix — an unsaved write was reported as a colleague's decision

Not in the brief. Found because verifying its figures meant reading the CSVs from the user's 2026-09-09 session, which include a real run of the revert command I shipped yesterday.

`material_class_revert_20260909_074847.csv` — 1,815 rows, **0 reverted**, and **120 of them** reported as:

```
changed since the plan ran — now 'Unassigned', the plan set 'Ceramic'.
That choice wins; not reverted.
```

Every one of those 120 was in fact **already reverted** — the 2026-09-08 write had not been saved. **The verdict was right and the sentence was wrong**, which is the harder half to notice: it tells the reader a colleague overwrote their data, on a tool whose whole purpose is being trusted with a bulk undo. And it hid the useful fact, which is "there is nothing to do here".

Already-back is now its own outcome (`AlreadyAsThePlanFoundIt`), checked **before** changed-since, and `Summary` counts the two separately. The half that must **not** be softened — a class a human genuinely changed afterwards — is asserted in its own test immediately beside it, so fixing the wrong warning cannot delete the right one.

| Gate | RED | GREEN |
|---|---:|---:|
| `Running_It_Twice_Does_Nothing_The_Second_Time` | **1 of 13** — the existing assertion read `Assert.Contains("changed since", …)`, so the test had encoded the defect | 0 |
| `A_Write_That_Was_Never_Saved_Is_Not_Somebody_Elses_Decision` + `A_Real_Later_Decision_Still_Says_Somebody_Chose_It` + `The_Summary_Does_Not_Report_An_Unsaved_Write_As_A_Contested_One` | **3 of 16** with the new branch disabled (`if (false)`) | 0 |
| whole file | | **16 of 16** |

## Figures I re-measured that differ from the brief

Reported here because they matter to later work items, not as bookkeeping.

| Brief says | Measured on `7a5fcf05d` |
|---|---|
| Tags baseline **830** passing | **821**. (Consistent with the brief having been measured on a branch carrying #902's 9 `TypeRenameUniquenessTests`.) |
| `TypeRenamePlanner.cs:446` is the third `IndexOf` site | line **337**; the file is 341 lines on `main` |

Everything else in the brief that this PR touches verified exactly: `IsSpecific` names 5 of 7 `Sources` consts; `SupplierUnitConverter.cs:191,228` and `ProductExclusion.cs:148` are exactly where E5 says; Boq 1249; build 0/0.

The remaining figures (register counts, the 87-type collision, the 7 broken rows, the 3 returned `Window-Square Opening` rows) were also verified and are reported with the PRs that use them.

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- The 120-row figure behind the third fix is **read from the CSV the user's own run wrote** — I did not reproduce it. What is proved headlessly is that the planner now classifies that state differently and says so.
- `Materials_RevertClassPlan`'s dialog and transaction remain unexercised; only the Revit-free planner and its `Summary` are proved.
- `ProdResolver.IsGeneric` has **no production caller yet**. It is a declaration whose only consumer today is the totality gate. Wiring `TypeRenamePlanner`'s code-gate to fail closed on an unknown tier is a behaviour change and is deliberately left out of a PR whose other two items are test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
