### PR TITLE
An exact family name is additive, because it cannot misfire (W5f)

### DIFF
--- a/StingTools.Tags.Tests/ProdExclusionTests.cs
+++ b/StingTools.Tags.Tests/ProdExclusionTests.cs
@@ -326,14 +326,111 @@ namespace StingTools.Tags.Tests
             // protectedCategories survives too — a door called "Opening" is still a door.
             Assert.Equal(ExclusionVerdict.Included, ex.Classify("Doors", "Opening Door", ""));
 
-            // And the corporate families list is REPLACED, not merged — which is the
-            // documented contract, and worth seeing rather than assuming. The corporate
-            // entry that stops being matched is Revit's stock wall-void family, whose
-            // absence a project taking this override should know about.
-            Assert.Equal(ExclusionVerdict.Included,
+            // And the corporate families list is UNIONED, not replaced. This assertion
+            // read the other way when this test was written, on the grounds that replace
+            // was "the documented contract, worth seeing rather than assuming". Seeing it
+            // was the point: three days later a real project wrote exactly this override
+            // and three wall voids returned to the coverage denominator. An exact family
+            // name cannot misfire, so there was nothing for replace-semantics to protect.
+            Assert.Equal(ExclusionVerdict.ByFamily,
                 ex.Classify("Windows", "Window-Square Opening", ""));
             Assert.Equal(ExclusionVerdict.ByFamily,
                 Shipped().Classify("Windows", "Window-Square Opening", ""));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Which keys union, and which must not
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Naming_One_Family_Does_Not_Un_Name_The_Corporate_Ones()
+        {
+            // Measured 2026-09-09. prod_coverage_20260908_221546.csv has 414 rows and NO
+            // Window-Square Opening row. After a project override declaring only the
+            // entourage car, prod_coverage_20260909_075229.csv has 416 and THREE of them —
+            // the SUV left and three wall voids arrived, and the only visible trace was a
+            // total moving by +2. A denominator has no error state.
+            var corp = ProdExclusionPolicy.Parse(
+                "{\"notAProductFamilies\":[\"Window-Square Opening\"]}", out _);
+            var proj = ProdExclusionPolicy.Parse(
+                "{\"notAProductFamilies\":[\"A_Revit_Suv_3d_car\"]}", out _);
+
+            var ex = ProdExclusionPolicy.Build(corp, proj);
+
+            Assert.Equal(ExclusionVerdict.ByFamily, ex.Classify("Site", "A_Revit_Suv_3d_car", ""));
+            Assert.Equal(ExclusionVerdict.ByFamily, ex.Classify("Windows", "Window-Square Opening", ""));
+        }
+
+        [Fact]
+        public void A_Family_Named_On_Both_Sides_Is_Named_Once()
+        {
+            // The user's own repair on 2026-09-09 was to list BOTH families in the project
+            // file. That must stay correct after this change rather than becoming a
+            // duplicate — and the union must not care about case or padding, because the
+            // two lists are maintained by different people.
+            var corp = ProdExclusionPolicy.Parse(
+                "{\"notAProductFamilies\":[\"Window-Square Opening\"]}", out _);
+            var proj = ProdExclusionPolicy.Parse(
+                "{\"notAProductFamilies\":[\" window-square opening \",\"A_Revit_Suv_3d_car\"]}", out _);
+
+            var ex = ProdExclusionPolicy.Build(corp, proj);
+            Assert.Equal(2, ex.FamilyCount);
+            Assert.Equal(ExclusionVerdict.ByFamily, ex.Classify("Windows", "Window-Square Opening", ""));
+            Assert.Equal(ExclusionVerdict.ByFamily, ex.Classify("Site", "A_Revit_Suv_3d_car", ""));
+        }
+
+        [Fact]
+        public void An_Empty_Families_List_No_Longer_Clears_The_Corporate_One()
+        {
+            // The cost of unioning, stated rather than discovered. A project CANNOT switch
+            // a corporate family back on by declaring [] — the escape hatch that
+            // replace-semantics gave it is gone, on purpose: an exact family name is not a
+            // pattern and cannot misfire, so there is no legitimate use for that hatch, and
+            // the one project that reached for it did so by accident.
+            var corp = ProdExclusionPolicy.Parse(
+                "{\"notAProductFamilies\":[\"Window-Square Opening\"]}", out _);
+            var cleared = ProdExclusionPolicy.Build(corp,
+                ProdExclusionPolicy.Parse("{\"notAProductFamilies\":[]}", out _));
+
+            Assert.Equal(ExclusionVerdict.ByFamily,
+                cleared.Classify("Windows", "Window-Square Opening", ""));
+        }
+
+        [Fact]
+        public void Patterns_And_Categories_Still_REPLACE_Because_They_Can_Misfire()
+        {
+            // The half that must not follow families. A pattern matches names nobody
+            // anticipated — "opening" once ate a real window type — and a category holds
+            // whatever a project models in it. Both need a project to be able to say
+            // "not that one", so both keep replace-semantics.
+            var corp = ProdExclusionPolicy.Parse(
+                "{\"notAProductCategories\":[\"Rooms\",\"Areas\"],"
+              + "\"notAProductPatterns\":[\"opening\",\"muntin\"],"
+              + "\"protectedCategories\":[\"Doors\",\"Windows\"]}", out _);
+
+            var narrowed = ProdExclusionPolicy.Build(corp, ProdExclusionPolicy.Parse(
+                "{\"notAProductCategories\":[\"Rooms\"],\"notAProductPatterns\":[\"muntin\"],"
+              + "\"protectedCategories\":[\"Doors\"]}", out _));
+
+            Assert.Equal(ExclusionVerdict.ByCategory, narrowed.Classify("Rooms", "", ""));
+            Assert.Equal(ExclusionVerdict.Included, narrowed.Classify("Areas", "", ""));
+            Assert.Equal(ExclusionVerdict.ByPattern, narrowed.Classify("Walls", "Muntin", ""));
+            Assert.Equal(ExclusionVerdict.Included, narrowed.Classify("Walls", "Opening", ""));
+            // Windows is no longer protected, so the pattern list — which no longer holds
+            // "opening" — is what decides. Nothing here reaches for a family.
+            Assert.Equal(ExclusionVerdict.Included, narrowed.Classify("Windows", "Opening Window", ""));
+        }
+
+        [Fact]
+        public void With_No_Project_File_At_All_Nothing_Changes()
+        {
+            // The union must not invent a families list where neither side stated one, or
+            // "no file deployed" stops being distinguishable from "a file excluding
+            // nothing" — the distinction Parse exists to preserve.
+            var corp = ProdExclusionPolicy.Parse("{\"notAProductCategories\":[\"Rooms\"]}", out _);
+            var ex = ProdExclusionPolicy.Build(corp, null);
+            Assert.Equal(0, ex.FamilyCount);
+            Assert.Equal(ExclusionVerdict.ByCategory, ex.Classify("Rooms", "", ""));
         }
     }
 }

--- a/StingTools/Core/ProdExclusionPolicy.cs
+++ b/StingTools/Core/ProdExclusionPolicy.cs
@@ -8,6 +8,7 @@
 // ══════════════════════════════════════════════════════════════════════════
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace StingTools.Core
@@ -50,23 +51,65 @@ namespace StingTools.Core
         /// <summary>
         /// Layer a project override over the corporate baseline and build the matcher.
         ///
-        /// <para>An override REPLACES a list it declares and leaves the others alone —
-        /// a null list means "not stated", an empty list means "exclude nothing". The
-        /// two must stay distinguishable or the key becomes impossible to override,
-        /// which is the trap <c>excludedCategories</c> already documents in the
-        /// visibility presets.</para>
+        /// <para><b>Three keys REPLACE; one UNIONS, and the difference is not a
+        /// convenience.</b></para>
+        ///
+        /// <para><c>notAProductCategories</c>, <c>notAProductPatterns</c> and
+        /// <c>protectedCategories</c> replace the list they declare — a null list means
+        /// "not stated", an empty list means "exclude nothing", and the two must stay
+        /// distinguishable or the key becomes impossible to override (the trap
+        /// <c>excludedCategories</c> already documents in the visibility presets). Those
+        /// three are all fuzzy or sweeping: a PATTERN can misfire on a name nobody
+        /// anticipated and a CATEGORY holds whatever a project models in it, so a project
+        /// must be able to say "not that one".</para>
+        ///
+        /// <para><c>notAProductFamilies</c> UNIONS. It is an EXACT family name — the
+        /// reason the corporate file allows it to override <c>protectedCategories</c> at
+        /// all — so it cannot misfire, and there is no coherent reason for a project to
+        /// need Revit's stock wall-void family counted as a product. Replace-semantics
+        /// here meant naming one family silently un-named every other:</para>
+        ///
+        /// <para>Measured 2026-09-09. A project override was written declaring only
+        /// <c>A_Revit_Suv_3d_car</c>, to stop an entourage car being counted. It dropped
+        /// the corporate <c>Window-Square Opening</c>, and <b>three wall voids returned to
+        /// the PROD coverage denominator</b> — visible in the audit only as the total
+        /// moving 414 → 416 while one row left and three arrived. Nothing reported it,
+        /// because a denominator has no error state.</para>
+        ///
+        /// <para>A project that genuinely wants a corporate family back in the count must
+        /// say so in the corporate file, where the argument can be had once.</para>
         /// </summary>
         public static ProductExclusion Build(ProdExclusionDocument corporate, ProdExclusionDocument project)
         {
-            List<string> Pick(Func<ProdExclusionDocument, List<string>> f)
+            List<string> Replace(Func<ProdExclusionDocument, List<string>> f)
                 => (project != null && f(project) != null) ? f(project)
                  : (corporate != null ? f(corporate) : null);
 
             return ProductExclusion.Build(
-                Pick(d => d.NotAProductCategories),
-                Pick(d => d.NotAProductPatterns),
-                Pick(d => d.ProtectedCategories),
-                Pick(d => d.NotAProductFamilies));
+                Replace(d => d.NotAProductCategories),
+                Replace(d => d.NotAProductPatterns),
+                Replace(d => d.ProtectedCategories),
+                Union(corporate?.NotAProductFamilies, project?.NotAProductFamilies));
+        }
+
+        /// <summary>
+        /// Corporate ∪ project, order-preserving and case-insensitively de-duplicated.
+        /// Returns null when NEITHER side states anything, so "no file" stays
+        /// distinguishable from "an empty list" — the same reason
+        /// <see cref="Parse"/> returns null rather than an empty document.
+        /// </summary>
+        private static List<string> Union(List<string> corporate, List<string> project)
+        {
+            if (corporate == null && project == null) return null;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var outList = new List<string>();
+            foreach (var src in new[] { corporate, project })
+                foreach (string s in src ?? Enumerable.Empty<string>())
+                {
+                    if (string.IsNullOrWhiteSpace(s)) continue;
+                    if (seen.Add(s.Trim())) outList.Add(s.Trim());
+                }
+            return outList;
         }
     }
 }

--- a/StingTools/Core/ProductExclusion.cs
+++ b/StingTools/Core/ProductExclusion.cs
@@ -108,6 +108,10 @@ namespace StingTools.Core
 
         public int CategoryCount => _categories.Count;
         public int PatternCount => _patterns.Count;
+        /// <summary>How many exact family names are excluded. Reported because the
+        /// corporate and project lists now UNION, so the count is the only cheap way to
+        /// see that a project override added to the list rather than replacing it.</summary>
+        public int FamilyCount => _families.Count;
 
         /// <summary>
         /// Classify one element. <paramref name="description"/> and

--- a/StingTools/Data/STING_PROD_EXCLUSIONS.json
+++ b/StingTools/Data/STING_PROD_EXCLUSIONS.json
@@ -24,7 +24,25 @@
     "exactly what the audit is for.",
     "",
     "Project override: <project>/_data/coord/prod_exclusions.json, same shape.",
-    "An override REPLACES a list it declares and leaves the others alone."
+    "",
+    "THREE KEYS REPLACE; ONE ADDS. Which is which is not a convenience:",
+    "",
+    "  notAProductCategories   REPLACE   a category holds whatever a project models",
+    "  notAProductPatterns     REPLACE   a pattern can misfire on a name nobody foresaw",
+    "  protectedCategories     REPLACE   the project decides what is always a thing",
+    "  notAProductFamilies     ADD       an EXACT family name cannot misfire",
+    "",
+    "A project declaring one of the first three replaces that list and leaves the",
+    "others alone (null = not stated, [] = exclude nothing - the two must stay",
+    "distinguishable or the key cannot be overridden at all).",
+    "",
+    "notAProductFamilies is the exception, and it was bought: on 2026-09-09 a project",
+    "override declared only its entourage car, which dropped the corporate",
+    "Window-Square Opening and returned three wall voids to the coverage denominator.",
+    "The audit showed it only as a total moving 414 -> 416. A denominator has no error",
+    "state, so nothing reported it. An exact family name cannot misfire, so there was",
+    "nothing for replace-semantics to protect. A project that genuinely wants a",
+    "corporate family counted must argue it HERE, once, not silently per project."
   ],
 
   "notAProductCategories": [
@@ -71,7 +89,8 @@
     "",
     "Keep this list to families that ship with Revit or a shared library. A family",
     "that exists in one project (a supplier's entourage car, say) belongs in that",
-    "project's _data/coord/prod_exclusions.json, not here."
+    "project's _data/coord/prod_exclusions.json, not here — and since 2026-09-09 the",
+    "two lists UNION, so naming one there no longer un-names the ones here."
   ],
 
   "notAProductFamilies": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — an exact family name is additive, because it cannot misfire)
+
+A project PROD-exclusion override REPLACED the list it declared. On 2026-09-09 a
+project file was written naming only its entourage car, and it silently dropped
+the corporate `Window-Square Opening`:
+
+    prod_coverage_20260908_221546.csv   414 rows, 0 Window-Square Opening, 1 SUV
+    prod_coverage_20260909_075229.csv   416 rows, 3 Window-Square Opening, 0 SUV
+
+**Three wall voids returned to the coverage denominator, and the only visible
+trace was a total moving by +2.** A denominator has no error state, so nothing
+reported it — the same shape as the 1,187-void figure this exclusion list was
+built to fix in the first place.
+
+**`notAProductFamilies` now UNIONS; the other three keys still REPLACE.** The
+split is not a convenience:
+
+| key | | why |
+|---|---|---|
+| `notAProductCategories` | REPLACE | a category holds whatever a project models in it |
+| `notAProductPatterns` | REPLACE | a pattern can misfire on a name nobody foresaw — "opening" once ate a real window type |
+| `protectedCategories` | REPLACE | the project decides what is always a thing |
+| `notAProductFamilies` | **ADD** | an EXACT family name cannot misfire, which is why the corporate file already lets it override `protectedCategories` |
+
+There was nothing for replace-semantics to protect here, and the one project that
+reached for the escape hatch did so by accident. A project that genuinely wants a
+corporate family counted must argue it in the corporate file, once, rather than
+silently per project — and the JSON's own comment now says which keys are which,
+with the measurement that bought the rule.
+
+**The half that must not follow is asserted beside it.**
+`Patterns_And_Categories_Still_REPLACE_Because_They_Can_Misfire` narrows all
+three replace-keys and checks each narrowing takes effect, so a later reader
+cannot generalise "additive" across the file.
+`With_No_Project_File_At_All_Nothing_Changes` keeps the union from inventing a
+list where neither side stated one — "not deployed" must stay distinguishable
+from "excludes nothing", which is the distinction `Parse` exists to preserve.
+
+**One assertion was reversed, and its old comment is the point.** The test written
+on 2026-09-08 asserted that a families-only override loses the corporate entry,
+"which is the documented contract, and worth seeing rather than assuming". Seeing
+it was worth exactly what it cost: three days.
+
+*RED:* with replace-semantics restored, **3 of 26** exclusion tests fail —
+`Naming_One_Family_Does_Not_Un_Name_The_Corporate_Ones`,
+`An_Empty_Families_List_No_Longer_Clears_The_Corporate_One` and the reversed
+`A_Families_Only_Override_Excludes_The_Car_And_Inherits_Everything_Else`.
+GREEN 26 of 26. `ProductExclusion.FamilyCount` is exposed so the union is
+countable rather than inferred.
+
+Tags 826 passed (baseline 821), Boq 1249 passed, plugin builds 0 warnings /
+0 errors. **Not verified in Revit** — `Prod_CoverageAudit` was not re-run, and the
+414 / 416 figures are read from the CSVs the user's own runs wrote.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries


### PR DESCRIPTION
W5f from `HANDOVER_MATERIAL_ALIGNMENT.md`. Branched from `origin/main` (`7a5fcf05d`), independent of #904.

## What happened

A project PROD-exclusion override **replaced** the list it declared. On 2026-09-09 a project file was written naming only its entourage car, and it silently dropped the corporate `Window-Square Opening`.

Verified against the two audit CSVs from the user's own runs:

```
prod_coverage_20260908_221546.csv   414 rows   0 Window-Square Opening   1 SUV
prod_coverage_20260909_075229.csv   416 rows   3 Window-Square Opening   0 SUV
```

**Three wall voids returned to the coverage denominator, and the only visible trace was a total moving by +2.** A denominator has no error state, so nothing reported it — the same shape as the 1,187-void figure this exclusion list was built to fix in the first place.

## The rule

`notAProductFamilies` now **unions**. The other three keys still **replace**.

| key | | why |
|---|---|---|
| `notAProductCategories` | REPLACE | a category holds whatever a project models in it |
| `notAProductPatterns` | REPLACE | a pattern can misfire on a name nobody foresaw — `opening` once ate a real window type |
| `protectedCategories` | REPLACE | the project decides what is always a thing |
| `notAProductFamilies` | **ADD** | an EXACT family name cannot misfire — which is precisely why the corporate file already lets it override `protectedCategories` |

There was nothing for replace-semantics to protect on the families key, and the one project that reached for the escape hatch did so by accident. A project that genuinely wants a corporate family counted must argue it in the corporate file, once, rather than silently per project.

`STING_PROD_EXCLUSIONS.json`'s own comment now states which keys are which, with the measurement that bought the rule — so the next person editing a project override reads it there rather than in a changelog.

## The half that must not follow, asserted beside it

- `Patterns_And_Categories_Still_REPLACE_Because_They_Can_Misfire` narrows all three replace-keys and checks each narrowing actually takes effect, so a later reader cannot generalise "additive" across the file.
- `With_No_Project_File_At_All_Nothing_Changes` keeps the union from inventing a families list where neither side stated one — "not deployed" must stay distinguishable from "excludes nothing", which is the distinction `Parse` exists to preserve.
- `A_Family_Named_On_Both_Sides_Is_Named_Once` — the user's own repair on 2026-09-09 was to list *both* families in the project file. That must stay correct rather than becoming a duplicate, and the union ignores case and padding because the two lists are maintained by different people.
- `An_Empty_Families_List_No_Longer_Clears_The_Corporate_One` states the **cost** of the change rather than leaving it to be discovered: a project can no longer switch a corporate family back on with `[]`.

## One assertion was reversed, and its old comment is the point

The test written on 2026-09-08 asserted that a families-only override loses the corporate entry, *"which is the documented contract, and worth seeing rather than assuming"*. Seeing it was worth exactly what it cost: three days.

## RED then GREEN

| Gate | RED (replace-semantics restored) | GREEN |
|---|---:|---:|
| `Naming_One_Family_Does_Not_Un_Name_The_Corporate_Ones` | fail | pass |
| `An_Empty_Families_List_No_Longer_Clears_The_Corporate_One` | fail | pass |
| `A_Families_Only_Override_Excludes_The_Car_And_Inherits_Everything_Else` (reversed) | fail | pass |
| `ProdExclusionTests` | **3 failed / 23 passed of 26** | **26 of 26** |

`Patterns_And_Categories_Still_REPLACE…` and `With_No_Project_File_At_All_Nothing_Changes` pass in **both** runs — they are guards against over-applying the change, not gates on it, and that is why they are listed separately here rather than counted as evidence.

`ProductExclusion.FamilyCount` is exposed so the union is countable rather than inferred.

- Tags: 826 passed, 0 failed (baseline 821)
- Boq: 1249 passed, 0 failed
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors
- `STING_PROD_EXCLUSIONS.json` re-parses after the comment edit (asserted in the edit step, and `ProdExclusionTests` reads the shipped file)

## Figures re-measured

The brief's W5f figure — "three rows returned on 2026-09-09" — **verified exactly**: 3 `Window-Square Opening` rows in `prod_coverage_20260909_075229.csv`, 0 in the 2026-09-08 one, and the SUV gone.

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- **`Prod_CoverageAudit` was not re-run.** The expected effect of this change plus the project file already on disk is that the next audit excludes both families: the denominator should drop by 3 from 416, and both `Window-Square Opening` and `A_Revit_Suv_3d_car` should be absent.
- The user has already repaired their project file by hand (both families listed). After this change that file is redundant but harmless — the union de-duplicates it, which is what `A_Family_Named_On_Both_Sides_Is_Named_Once` pins.
- `ProdExclusionPolicy.Build` is exercised only against JSON text here, as designed; the Revit-side loader in `ProdCoverageAuditCommand` is untouched and unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
