### PR TITLE
Read the material register as data; refuse it as an oracle (W1, W2, W4)

### DIFF
--- a/StingTools.Tags.Tests/HostTypeRegisterAuditTests.cs
+++ b/StingTools.Tags.Tests/HostTypeRegisterAuditTests.cs
@@ -1,0 +1,260 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  HostTypeRegisterAuditTests.cs — W4. The audit that names the 87.
+//
+//  The fixture is the real thing: type names taken from
+//  type_rename_plan_20260909_075110.csv (the 87 rows that all proposed
+//  PLNS_SLB_RC100), their modelled build-up taken from that plan's own Reason
+//  column ("core 'Concrete, Cast-in-Place gray'"), and the expected build-up
+//  read from the SHIPPED register rather than restated here.
+//
+//  The assertion that matters is the sentence the brief asked for, verbatim in
+//  substance:
+//
+//      STANDARD CEMENT SCREED 50MM: register says 1 × 50 mm CEMENT SCREED,
+//      model has 1 × 100 mm Concrete, Cast-in-Place gray
+//
+//  and the assertion that keeps it honest is the one below it: a type NOT named
+//  after a register row must produce no finding at all. An audit that reported
+//  every type as a mismatch would be right about the 87 and useless.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Materials;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class HostTypeRegisterAuditTests
+    {
+        private readonly ITestOutputHelper _out;
+        public HostTypeRegisterAuditTests(ITestOutputHelper output) => _out = output;
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static MaterialRegistry _reg;
+        private static MaterialRegistry Registry()
+            => _reg ??= MaterialRegistry.Parse(
+                   File.ReadAllText(Path.Combine(DataDir(), "BLE_MATERIALS.csv")),
+                   File.ReadAllText(Path.Combine(DataDir(), "MEP_MATERIALS.csv")));
+
+        /// <summary>What the 2026-09-09 model actually had on every one of the 87: one
+        /// 100 mm layer of a Revit stock material, whatever the type was called.</summary>
+        private static ModelledHostType Flat(string typeName, int instances = 4)
+            => new ModelledHostType
+            {
+                Category = "Floors", TypeName = typeName, InstanceCount = instances,
+                Layers = new List<ModelledLayer>
+                {
+                    new ModelledLayer
+                    {
+                        MaterialName = "Concrete, Cast-in-Place gray",
+                        ThicknessMm = 100, Function = "Structure",
+                    },
+                },
+            };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The sentence the brief asked for
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Flattened_Type_Says_What_The_Register_Declares_And_What_The_Model_Has()
+        {
+            var rows = HostTypeRegisterAudit.Audit(
+                new[] { Flat("STANDARD CEMENT SCREED 50MM") }, Registry());
+
+            var r = Assert.Single(rows);
+            _out.WriteLine(r.Detail);
+
+            Assert.Equal("FLR-001", r.RegisterCode);
+            Assert.True(r.IsFinding);
+            Assert.Contains("register says", r.Detail);
+            Assert.Contains("50 mm CEMENT SCREED", r.Detail);
+            Assert.Contains("model has", r.Detail);
+            Assert.Contains("100 mm Concrete, Cast-in-Place gray", r.Detail);
+        }
+
+        [Fact]
+        public void A_Register_Row_With_Layers_Flattened_To_One_Is_Its_Own_Verdict()
+        {
+            // Separated from "Differs" because it has a single cause — the layer columns
+            // were never read — where Differs can be any of a dozen things. A register row
+            // declaring TWO layers modelled as one is Flattened; a row declaring one is
+            // merely Differs. Both are findings; only the first points at the seeding bug.
+            //
+            // Both rows are SELECTED from the register, not named. The first version of this
+            // test named SOLID BAMBOO 14MM as the single-layer case and failed: it declares
+            // BAMBOO PLANK 14 mm plus FINISH-SEAL 0.5 mm, so it is a two-layer row. The data
+            // corrected the test, which is the direction that means something.
+            var multi = Registry().Rows.First(x => x.Code.StartsWith("FLR-") && x.Layers.Count >= 2);
+            var single = Registry().Rows.First(x => x.Code.StartsWith("FLR-") && x.Layers.Count == 1);
+            _out.WriteLine($"multi:  {multi.Code} {multi.Name} ({multi.Layers.Count} layers)");
+            _out.WriteLine($"single: {single.Code} {single.Name} ({single.Layers.Count} layer)");
+
+            var rows = HostTypeRegisterAudit.Audit(
+                new[] { Flat(multi.Name), Flat(single.Name) }, Registry());
+
+            Assert.Equal(RegisterAuditVerdict.Flattened, rows[0].Verdict);
+            Assert.Equal(RegisterAuditVerdict.Differs, rows[1].Verdict);
+        }
+
+        [Fact]
+        public void A_Type_Not_Named_After_A_Register_Row_Is_Not_A_Finding()
+        {
+            // The assertion that stops this being noise. Most type names are not register
+            // MAT_NAMEs, and an audit that flagged them would bury the 86 that are — which
+            // is the reason "Concrete 100mm", the 87th of the 87, is correctly silent here.
+            var rows = HostTypeRegisterAudit.Audit(new[]
+            {
+                Flat("Concrete 100mm"),
+                Flat("Generic - 225mm"),
+                Flat("PLNS_WBL_Blockwork200-Plastered"),
+            }, Registry());
+
+            Assert.All(rows, r =>
+            {
+                Assert.Equal(RegisterAuditVerdict.NotInRegister, r.Verdict);
+                Assert.False(r.IsFinding);
+            });
+        }
+
+        [Fact]
+        public void A_Type_Built_As_The_Register_Declares_Passes()
+        {
+            // Built from the register row itself, so this cannot pass by the comparison
+            // being permissive — if the tolerance or the name rule were broken, the row
+            // constructed from the register's own numbers would fail.
+            var reg = Registry().ByName("STANDARD CEMENT SCREED 50MM");
+            var t = new ModelledHostType
+            {
+                Category = "Floors", TypeName = reg.Name, InstanceCount = 2,
+                Layers = reg.Layers.Select(l => new ModelledLayer
+                {
+                    MaterialName = l.Material, ThicknessMm = l.ThicknessMm, Function = l.Function,
+                }).ToList(),
+            };
+
+            var r = Assert.Single(HostTypeRegisterAudit.Audit(new[] { t }, Registry()));
+            Assert.Equal(RegisterAuditVerdict.Matches, r.Verdict);
+            Assert.False(r.IsFinding);
+        }
+
+        [Fact]
+        public void Revits_Duplicate_Name_Suffix_Does_Not_Read_As_A_Different_Material()
+        {
+            // The model's material is CREATED from the register's layer material, and Revit
+            // appends " (1)" or " 2" on a name clash — which happens constantly, because the
+            // same layer material appears on dozens of rows. Equality would report every
+            // such type as a mismatch, which is a wrong finding rather than a missing one.
+            Assert.True(HostTypeRegisterAudit.NameAgrees("CEMENT SCREED", "CEMENT SCREED (1)"));
+            Assert.True(HostTypeRegisterAudit.NameAgrees("CEMENT SCREED", "Cement Screed 2"));
+            Assert.False(HostTypeRegisterAudit.NameAgrees("CEMENT SCREED", "Concrete, Cast-in-Place gray"));
+
+            // And it is a WHOLE-WORD containment, not a substring: the #863 shape would make
+            // every "…TILE…" material agree with every other.
+            Assert.False(HostTypeRegisterAudit.NameAgrees("TILE", "DUCTILE IRON"));
+        }
+
+        [Fact]
+        public void A_Millimetre_Of_Rounding_Is_Not_A_Mismatch()
+        {
+            // Revit stores feet. 50 mm round-trips through 304.8 and does not land on 50.
+            var reg = Registry().ByName("STANDARD CEMENT SCREED 50MM");
+            var t = new ModelledHostType
+            {
+                Category = "Floors", TypeName = reg.Name,
+                Layers = new List<ModelledLayer>
+                {
+                    new ModelledLayer { MaterialName = "CEMENT SCREED", ThicknessMm = 50.0000001 },
+                },
+            };
+            Assert.Equal(RegisterAuditVerdict.Matches,
+                HostTypeRegisterAudit.Audit(new[] { t }, Registry())[0].Verdict);
+
+            // But 10 mm is.
+            t.Layers[0].ThicknessMm = 60;
+            Assert.Equal(RegisterAuditVerdict.Differs,
+                HostTypeRegisterAudit.Audit(new[] { t }, Registry())[0].Verdict);
+        }
+
+        [Fact]
+        public void A_Type_With_No_Compound_Structure_Is_Reported_Not_Skipped()
+        {
+            var rows = HostTypeRegisterAudit.Audit(new[]
+            {
+                new ModelledHostType { Category = "Floors", TypeName = "STANDARD CEMENT SCREED 50MM" },
+            }, Registry());
+            Assert.Equal(RegisterAuditVerdict.NoStructure, rows[0].Verdict);
+            Assert.True(rows[0].IsFinding);
+            Assert.Contains("no compound structure", rows[0].Detail);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. The 87, as a set
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Every FLR-* register row, modelled the way the 2026-09-09 run found them. This is
+        /// the shape of the defect at full size: 95 types that claim to be 95 different floor
+        /// build-ups and are one.
+        /// </summary>
+        [Fact]
+        public void The_Whole_Flr_Family_Modelled_As_One_Layer_Is_Reported_Type_By_Type()
+        {
+            var flr = Registry().Rows
+                        .Where(r => r.Code.StartsWith("FLR-", StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+            Assert.Equal(95, flr.Count);
+
+            var rows = HostTypeRegisterAudit.Audit(flr.Select(r => Flat(r.Name)), Registry());
+
+            Assert.Equal(95, rows.Count);
+            Assert.Empty(rows.Where(r => r.Verdict == RegisterAuditVerdict.NotInRegister));
+            Assert.Empty(rows.Where(r => r.Verdict == RegisterAuditVerdict.Matches));
+            Assert.Equal(95, rows.Count(r => r.IsFinding));
+
+            // 28 of the 95 declare two or three layers, so 28 are FLATTENED and 67 DIFFER.
+            Assert.Equal(28, rows.Count(r => r.Verdict == RegisterAuditVerdict.Flattened));
+            Assert.Equal(67, rows.Count(r => r.Verdict == RegisterAuditVerdict.Differs));
+
+            _out.WriteLine(HostTypeRegisterAudit.Summary(rows));
+            foreach (var r in rows.Take(6)) _out.WriteLine("  " + r.Detail);
+        }
+
+        [Fact]
+        public void The_Summary_Does_Not_Report_Nothing_To_Compare_As_Nothing_Wrong()
+        {
+            // A model whose type names are all its own is a NORMAL answer, and must not read
+            // as a clean bill of health. The empty-list-standing-in-for-an-error shape.
+            var rows = HostTypeRegisterAudit.Audit(new[] { Flat("Some Project Type 200") }, Registry());
+            string s = HostTypeRegisterAudit.Summary(rows);
+            Assert.Contains("are named after a register row", s);
+            Assert.Contains("nothing here to compare", s);
+            Assert.Contains("normal answer, not a failure", s);
+            Assert.DoesNotContain("match the register's build-up", s);
+        }
+
+        [Fact]
+        public void The_Csv_Carries_Every_Type_Including_The_Ones_With_No_Finding()
+        {
+            var rows = HostTypeRegisterAudit.Audit(new[]
+            {
+                Flat("STANDARD CEMENT SCREED 50MM"), Flat("Concrete 100mm"),
+            }, Registry());
+            var csv = HostTypeRegisterAudit.ToCsv(rows);
+            Assert.Equal(3, csv.Count);
+            Assert.StartsWith("Verdict,Category,TypeName,", csv[0]);
+            Assert.Contains(csv, l => l.StartsWith("NotInRegister,"));
+        }
+    }
+}

--- a/StingTools.Tags.Tests/MaterialRegisterReconciliationTests.cs
+++ b/StingTools.Tags.Tests/MaterialRegisterReconciliationTests.cs
@@ -1,0 +1,208 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialRegisterReconciliationTests.cs — W2. The register and the needle
+//  table checked against each other, neither treated as the answer, and the
+//  disagreements PRINTED so a human can act on them.
+//
+//  This gate is a COUNT CEILING, not a zero. Zero is not reachable: 85 of the
+//  1,279 rows are genuine two-opinion conflicts and settling each one is a
+//  judgement about a governed data file, not a code change. A gate that demanded
+//  zero would be switched off within a week; a gate that fails when the count
+//  GROWS catches the thing that actually goes wrong — somebody adding a needle,
+//  or a register row, that disagrees with the other side by accident.
+//
+//  The ceilings below are the measured counts on 2026-09-09. Lower them when
+//  rows are settled. If one RISES, the run prints exactly which rows moved.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using StingTools.Core.Materials;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class MaterialRegisterReconciliationTests
+    {
+        private readonly ITestOutputHelper _out;
+        public MaterialRegisterReconciliationTests(ITestOutputHelper output) => _out = output;
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static List<ReconcileRow> _rows;
+
+        private static List<ReconcileRow> Rows()
+            => _rows ??= MaterialRegisterReconciliation.Reconcile(MaterialRegistry.Parse(
+                   File.ReadAllText(Path.Combine(DataDir(), "BLE_MATERIALS.csv")),
+                   File.ReadAllText(Path.Combine(DataDir(), "MEP_MATERIALS.csv"))));
+
+        // Measured 2026-09-09 over all 1,279 shipped rows.
+        private const int Conflicts = 85;
+        private const int OnlyRegister = 342;
+        private const int OnlyNeedles = 352;
+        private const int Agree = 348;
+
+        [Fact]
+        public void The_Reconciliation_Covers_Every_Register_Row_Exactly_Once()
+        {
+            var rows = Rows();
+            Assert.Equal(1279, rows.Count);
+            Assert.Equal(1279, rows.Select(r => r.Code + "|" + r.Name).Distinct().Count());
+            // Every row lands in exactly one bucket — the enum is exhaustive by construction,
+            // so this is really asserting nothing silently fell out of the loop.
+            Assert.Equal(1279, Enum.GetValues(typeof(ReconcileVerdict)).Cast<ReconcileVerdict>()
+                                   .Sum(v => rows.Count(r => r.Verdict == v)));
+        }
+
+        [Fact]
+        public void The_Disagreement_Count_Has_Not_Grown()
+        {
+            var rows = Rows();
+            int conflict = rows.Count(r => r.Verdict == ReconcileVerdict.Conflict);
+            int onlyReg = rows.Count(r => r.Verdict == ReconcileVerdict.OnlyRegister);
+            int onlyNdl = rows.Count(r => r.Verdict == ReconcileVerdict.OnlyNeedles);
+            int agree = rows.Count(r => r.Verdict == ReconcileVerdict.Agree);
+
+            _out.WriteLine(MaterialRegisterReconciliation.Summary(rows));
+            _out.WriteLine("");
+            _out.WriteLine("── CONFLICTS: both have an opinion and they differ ──");
+            foreach (var r in rows.Where(x => x.Verdict == ReconcileVerdict.Conflict)
+                                  .OrderBy(x => x.NeedleClass).ThenBy(x => x.RegisterClass).ThenBy(x => x.Name))
+                _out.WriteLine($"  needles={r.NeedleClass,-11} register={r.RegisterClass,-11} "
+                             + $"(raw {r.RegisterClassRaw,-10} {r.Code,-13}) {r.Name}");
+
+            Assert.True(conflict <= Conflicts,
+                $"conflicts grew {Conflicts} → {conflict}. A new needle or a new register row now "
+                + "contradicts the other side. The full list is in this test's output.");
+            Assert.True(onlyReg <= OnlyRegister, $"register-only answers grew {OnlyRegister} → {onlyReg}");
+            Assert.True(onlyNdl <= OnlyNeedles, $"needle-only answers grew {OnlyNeedles} → {onlyNdl}");
+            Assert.True(agree >= Agree,
+                $"agreement FELL {Agree} → {agree}. Something that used to be settled no longer is.");
+        }
+
+        [Fact]
+        public void The_Conflicts_Are_Not_One_Side_Being_Wrong()
+        {
+            // The finding that stopped the register being wired in as the answer, pinned as
+            // four named rows rather than left in a commit message. Two where the register
+            // is right, two where it classifies by trade and the needle table is right.
+            var by = Rows().ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
+
+            // Register right: masonry PAINT is paint; cement plaster is cementitious, not gypsum.
+            Assert.Equal("Paint", by["MASONRY PAINT WHITE"].RegisterClass);
+            Assert.Equal("Masonry", by["MASONRY PAINT WHITE"].NeedleClass);
+            Assert.Equal("Concrete", by["CEMENT PLASTER FINISH 12MM"].RegisterClass);
+            Assert.Equal("Gypsum", by["CEMENT PLASTER FINISH 12MM"].NeedleClass);
+
+            // Needles right: a skirting is "Wood" in the register whatever it is made of,
+            // and a lightweight screed is "Metal".
+            Assert.Equal("Wood", by["GRANITE SKIRTING 100MM"].RegisterClass);
+            Assert.Equal("Stone", by["GRANITE SKIRTING 100MM"].NeedleClass);
+            Assert.Equal("Metal", by["LIGHTWEIGHT SCREED 40MM"].RegisterClass);
+            Assert.Equal("Concrete", by["LIGHTWEIGHT SCREED 40MM"].NeedleClass);
+
+            foreach (string n in new[]
+            {
+                "MASONRY PAINT WHITE", "CEMENT PLASTER FINISH 12MM",
+                "GRANITE SKIRTING 100MM", "LIGHTWEIGHT SCREED 40MM",
+            })
+                Assert.Equal(ReconcileVerdict.Conflict, by[n].Verdict);
+        }
+
+        [Fact]
+        public void Agreement_Rate_Does_Not_Identify_The_Trustworthy_Classes()
+        {
+            // The measurement that rules out every mechanical rule: if agreement rate
+            // tracked correctness, a whitelist would be safe. It does not. Concrete agrees
+            // least and is mostly RIGHT where it differs; Wood agrees well and is wrong.
+            // Asserted so that a future author reaching for "just trust the classes that
+            // usually agree" fails here first.
+            var rows = Rows().Where(r => r.Verdict == ReconcileVerdict.Agree
+                                      || r.Verdict == ReconcileVerdict.Conflict).ToList();
+
+            double Rate(string raw)
+            {
+                var g = rows.Where(r => string.Equals(r.RegisterClassRaw, raw, StringComparison.OrdinalIgnoreCase)).ToList();
+                Assert.NotEmpty(g);
+                return (double)g.Count(r => r.Verdict == ReconcileVerdict.Agree) / g.Count;
+            }
+
+            double concrete = Rate("Concrete");
+            double wood = Rate("Wood");
+            _out.WriteLine($"Concrete agreement {concrete:P0} (mostly right where it differs)");
+            _out.WriteLine($"Wood     agreement {wood:P0} (wrong where it differs — skirtings, paving)");
+
+            Assert.True(concrete < 0.60, $"Concrete agreement is now {concrete:P0}");
+            Assert.True(wood > 0.75, $"Wood agreement is now {wood:P0}");
+            Assert.True(wood > concrete,
+                "The premise of this file is that agreement rate and correctness point in "
+              + "OPPOSITE directions here. If that stops being true, the refusal to consume "
+              + "the class column should be reconsidered on the new evidence.");
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The cheapest edits to propose
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Rows_Whose_Own_Name_Contradicts_Their_Class_Are_Listed()
+        {
+            // The brief started from 31 GYPSUM-named rows classed Generic and said to expect
+            // more. There are 352 — every row where the NAME states a substance the needle
+            // table recognises and the class column names none. That is the cheapest set to
+            // propose data edits for, because the evidence is inside the row.
+            var rows = MaterialRegisterReconciliation.NameSaysMoreThanClassDoes(Rows());
+
+            _out.WriteLine($"{rows.Count} rows where MAT_NAME states a substance and "
+                         + "BLE_APP-IDENTITY-CLASS names none:");
+            foreach (var g in rows.GroupBy(r => r.RegisterClassRaw).OrderByDescending(g => g.Count()))
+            {
+                _out.WriteLine($"  {g.Key}: {g.Count()}");
+                foreach (var r in g.OrderBy(x => x.Code).Take(60))
+                    _out.WriteLine($"      {r.Code,-13} {r.Name,-52} name says {r.NeedleClass}");
+            }
+
+            Assert.Equal(OnlyNeedles, rows.Count);
+
+            // The 31 the brief named, still there and still the clearest case.
+            var gypsum = rows.Where(r => r.Name.IndexOf("GYPSUM", StringComparison.OrdinalIgnoreCase) >= 0
+                                      && string.Equals(r.RegisterClassRaw, "Generic", StringComparison.OrdinalIgnoreCase))
+                             .ToList();
+            Assert.Equal(31, gypsum.Count);
+            Assert.Contains(gypsum, r => r.Name == "GYPSUM BOARD STANDARD 9.5MM");
+            Assert.All(gypsum, r => Assert.Equal("Gypsum", r.NeedleClass));
+        }
+
+        [Fact]
+        public void The_Report_Csv_Carries_Every_Row_Including_The_Agreements()
+        {
+            // A report showing only disagreements hides its own denominator, which is how a
+            // reader concludes 85 problems out of 85 rather than out of 1,279.
+            var csv = MaterialRegisterReconciliation.ToCsv(Rows());
+            Assert.Equal(1280, csv.Count);                       // header + 1,279
+            Assert.StartsWith("Verdict,Code,Name,", csv[0]);
+            Assert.Contains(csv, l => l.StartsWith("Agree,"));
+            Assert.Contains(csv, l => l.StartsWith("Conflict,"));
+            Assert.Contains(csv, l => l.StartsWith("OnlyNeedles,"));
+            Assert.Contains(csv, l => l.StartsWith("OnlyRegister,"));
+        }
+
+        [Fact]
+        public void The_Summary_Says_Both_Sides_Are_Challengers()
+        {
+            string s = MaterialRegisterReconciliation.Summary(Rows());
+            Assert.Contains("1279 register row(s)", s);
+            Assert.Contains("CONFLICT", s);
+            Assert.Contains("reports and does not write", s);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/MaterialRegisterTests.cs
+++ b/StingTools.Tags.Tests/MaterialRegisterTests.cs
@@ -1,0 +1,287 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialRegisterTests.cs — the shipped register, asserted; and the reason it
+//  is a CHALLENGER rather than the answer, asserted too.
+//
+//  The reader had no tests. The 1,279 rows it reads had none either, and they
+//  carry the layer build-ups that a project catalogue was seeded WITHOUT — which
+//  is how 87 floor types all became one 100 mm layer of concrete.
+//
+//  The most important assertions in this file are the ones that pin what the
+//  register must NOT be allowed to decide. They are written as facts about the
+//  shipped data, so that if somebody cleans the class column the tests fail and
+//  the refusal can be revisited on evidence rather than on memory.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class MaterialRegisterTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static MaterialRegistry _shipped;
+
+        /// <summary>The register as it SHIPS, read from source rather than a copy — a stale
+        /// copy passing while the shipped file is wrong is the failure this exists to stop.</summary>
+        private static MaterialRegistry Shipped()
+            => _shipped ??= MaterialRegistry.Parse(
+                   File.ReadAllText(Path.Combine(DataDir(), "BLE_MATERIALS.csv")),
+                   File.ReadAllText(Path.Combine(DataDir(), "MEP_MATERIALS.csv")));
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. It reads the whole register
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Whole_Register_Loads_With_No_Warnings()
+        {
+            var r = Shipped();
+            Assert.Equal(1279, r.Count);
+            Assert.Equal(815, r.Rows.Count(x => x.Source == "BLE"));
+            Assert.Equal(464, r.Rows.Count(x => x.Source == "MEP"));
+
+            // Checked rather than assumed, because the brief said to check: there are NO
+            // duplicate MAT_NAMEs, within either file or across the two. If that ever
+            // changes the loader reports it instead of last-wins, and this fails.
+            Assert.True(r.Warnings.Count == 0,
+                "register load warnings:\n  " + string.Join("\n  ", r.Warnings));
+            Assert.Equal(1279, r.Rows.Select(x => x.Name.Trim().ToUpperInvariant()).Distinct().Count());
+        }
+
+        [Fact]
+        public void Every_Row_Carries_An_Identity_Class_And_A_Name()
+        {
+            var r = Shipped();
+            Assert.Empty(r.Rows.Where(x => string.IsNullOrWhiteSpace(x.Name)));
+            Assert.Empty(r.Rows.Where(x => string.IsNullOrWhiteSpace(x.IdentityClass)));
+        }
+
+        [Fact]
+        public void The_Layer_Columns_Are_Read_And_Not_Discarded()
+        {
+            // The whole point. Whatever seeded 87 single-layer floor types from this file
+            // used the NAME column and dropped these.
+            var r = Shipped();
+            var flr = r.Rows.Where(x => x.Code.StartsWith("FLR-", StringComparison.OrdinalIgnoreCase)).ToList();
+            Assert.Equal(95, flr.Count);
+            Assert.Equal(95, flr.Count(x => x.Layers.Count >= 1));   // every FLR row declares layer 1
+            Assert.Equal(28, flr.Count(x => x.Layers.Count >= 2));
+
+            var screed = r.ByName("STANDARD CEMENT SCREED 50MM");
+            Assert.NotNull(screed);
+            Assert.Equal("FLR-001", screed.Code);
+            Assert.Single(screed.Layers);
+            Assert.Equal("CEMENT SCREED", screed.Layers[0].Material);
+            Assert.Equal(50.0, screed.Layers[0].ThicknessMm);
+            Assert.Equal(50.0, screed.ThicknessMm);
+            Assert.Contains("SUBSTRATE", screed.Layers[0].Function);
+        }
+
+        [Fact]
+        public void Lookup_Is_By_Trimmed_Case_Insensitive_Name()
+        {
+            var r = Shipped();
+            Assert.NotNull(r.ByName("  solid bamboo 14mm "));
+            Assert.Equal("FLR-028", r.ByName("SOLID BAMBOO 14MM").Code);
+            Assert.Null(r.ByName("A MATERIAL THAT DOES NOT EXIST"));
+            Assert.Null(r.ByName(null));
+            Assert.Null(r.ByName("   "));
+        }
+
+        [Fact]
+        public void A_Missing_File_Is_Reported_Not_Silently_Empty()
+        {
+            // "not deployed" and "deployed and empty" are different problems, and a
+            // register that answered "not in the register" to everything without saying
+            // why is how a coverage figure quietly halves.
+            var r = MaterialRegistry.Parse(null, null);
+            Assert.Equal(0, r.Count);
+            Assert.Equal(2, r.Warnings.Count);
+            Assert.Contains(r.Warnings, w => w.Contains("BLE_MATERIALS.csv is not deployed"));
+            Assert.Contains(r.Warnings, w => w.Contains("MEP_MATERIALS.csv is not deployed"));
+        }
+
+        [Fact]
+        public void A_Duplicate_Name_Is_Reported_And_The_First_Wins()
+        {
+            // Not last-wins, and not silent. Two rows claiming one name is a data question.
+            const string header = "MAT_CODE,MAT_NAME,MAT_CATEGORY,MAT_THICKNESS_MM,BLE_APP-IDENTITY-CLASS";
+            var r = MaterialRegistry.Parse(
+                header + "\nBLE-1,SHARED NAME,Walls,100,Concrete\n",
+                header + "\nMEP-1,SHARED NAME,Pipes,50,Metal\n");
+
+            Assert.Equal(2, r.Count);
+            Assert.Single(r.Warnings);
+            Assert.Contains("duplicate MAT_NAME 'SHARED NAME'", r.Warnings[0]);
+            Assert.Contains("BLE-1", r.Warnings[0]);
+            Assert.Contains("MEP-1", r.Warnings[0]);
+            Assert.Equal("BLE-1", r.ByName("SHARED NAME").Code);
+        }
+
+        [Fact]
+        public void Columns_Are_Located_By_Name_So_A_New_Column_Does_Not_Shift_Them()
+        {
+            // These files carry 71 columns and grow. A positional reader that shifted by
+            // one would return a colour where a class belongs, and every value would still
+            // look like a plausible string.
+            var r = MaterialRegistry.Parse(
+                "BLE_APP-IDENTITY-CLASS,MAT_NAME,SOMETHING_NEW,MAT_CODE\n"
+              + "Concrete,A MATERIAL,ignored,X-1\n", null);
+            var row = r.ByName("A MATERIAL");
+            Assert.NotNull(row);
+            Assert.Equal("X-1", row.Code);
+            Assert.Equal("Concrete", row.IdentityClass);
+        }
+
+        [Fact]
+        public void A_Comma_Inside_A_Quoted_Cell_Does_Not_Shift_The_Row()
+        {
+            var r = MaterialRegistry.Parse(
+                "MAT_CODE,MAT_NAME,MAT_SPECIFICATIONS,BLE_APP-IDENTITY-CLASS\n"
+              + "X-1,\"BOARD, 12MM\",\"C25/30, 20mm agg\",Concrete\n", null);
+            var row = r.ByName("BOARD, 12MM");
+            Assert.NotNull(row);
+            Assert.Equal("Concrete", row.IdentityClass);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. The class vocabulary, and what is deliberately not mapped
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Registers_Class_Vocabulary_Is_Exactly_What_Is_Accounted_For()
+        {
+            // Neither list is a superset of the other, so an unaccounted-for word would
+            // silently become "names no substance" — a shrug arriving as a refusal.
+            var words = Shipped().Rows.Select(r => r.IdentityClass.Trim())
+                                      .Distinct().OrderBy(x => x, StringComparer.Ordinal).ToList();
+            Assert.Equal(new[]
+            {
+                "Carpet", "Ceiling", "Concrete", "Fabric", "Flooring", "Generic", "Glass",
+                "Insulation", "Lining", "Masonry", "Metal", "Paint", "Plaster", "Plastic", "Wood",
+            }, words);
+
+            foreach (string w in words)
+            {
+                bool mapped = MaterialRegistry.ToRevitClass(w) != null;
+                bool refused = MaterialRegistry.ClassesThatNameNoSubstance
+                                   .Contains(w, StringComparer.OrdinalIgnoreCase);
+                Assert.True(mapped ^ refused,
+                    $"'{w}' is neither mapped to a Revit class nor listed as naming no substance.");
+            }
+        }
+
+        [Theory]
+        [InlineData("Plaster", "Gypsum")]
+        [InlineData("Carpet", "Textile")]
+        [InlineData("Fabric", "Textile")]
+        [InlineData("Concrete", "Concrete")]
+        [InlineData("Masonry", "Masonry")]
+        [InlineData("Metal", "Metal")]
+        [InlineData("Wood", "Wood")]
+        [InlineData("Glass", "Glass")]
+        [InlineData("Plastic", "Plastic")]
+        [InlineData("Paint", "Paint")]
+        [InlineData("Insulation", "Insulation")]
+        public void A_Register_Class_That_Names_A_Substance_Translates(string register, string revit)
+            => Assert.Equal(revit, MaterialRegistry.ToRevitClass(register));
+
+        [Theory]
+        [InlineData("Ceiling")]
+        [InlineData("Flooring")]
+        [InlineData("Lining")]
+        [InlineData("Generic")]
+        public void A_Register_Class_That_Names_A_ROLE_Maps_To_Nothing(string register)
+        {
+            // Ceiling and Flooring are PLACES; Lining is a position in a build-up; Generic
+            // is the absence of an answer. 504 of the 1,279 rows carry one of these, and a
+            // mapping that guessed would import 504 shrugs into the one controlled field
+            // the carbon and cost engines trust.
+            Assert.Null(MaterialRegistry.ToRevitClass(register));
+        }
+
+        [Fact]
+        public void Half_The_Register_Names_No_Substance_At_All()
+        {
+            // The scale of it, asserted so the refusal above reads as proportionate rather
+            // than fussy.
+            var rows = Shipped().Rows;
+            int roleOnly = rows.Count(r => MaterialRegistry.ToRevitClass(r.IdentityClass) == null);
+            Assert.Equal(504, roleOnly);
+            Assert.Equal(775, rows.Count - roleOnly);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. The register challenges; it does not decide
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Register_Is_Recorded_On_The_Proposal_And_Changes_No_Answer()
+        {
+            var reg = Shipped();
+
+            // A row where the two AGREE.
+            var bamboo = MaterialClassPlanner.Plan("SOLID BAMBOO 14MM", "", reg);
+            Assert.Equal("Wood", bamboo.ProposedClass);
+            Assert.Equal("FLR-028", bamboo.RegisterCode);
+            Assert.Equal("Wood", bamboo.RegisterClass);
+            Assert.False(bamboo.RegisterDisagrees);
+
+            // A row where the REGISTER is right and the answer still does not move.
+            var paint = MaterialClassPlanner.Plan("MASONRY PAINT WHITE", "", reg);
+            Assert.Equal("Masonry", paint.ProposedClass);        // the needle table, unchanged
+            Assert.Equal("Paint", paint.RegisterClass);
+            Assert.True(paint.RegisterDisagrees);
+
+            // A row where the NEEDLES are right and the register classifies by trade.
+            var skirting = MaterialClassPlanner.Plan("GRANITE SKIRTING 100MM", "", reg);
+            Assert.Equal("Stone", skirting.ProposedClass);
+            Assert.Equal("Wood", skirting.RegisterClass);        // a skirting is Wood, whatever it is
+            Assert.True(skirting.RegisterDisagrees);
+        }
+
+        [Fact]
+        public void With_No_Registry_The_Planner_Answers_Exactly_As_Before()
+        {
+            // The registry is optional and additive. Every existing caller and every row of
+            // the 1,815-name corpus must be unaffected, or this became a behaviour change
+            // wearing a reader's clothes.
+            foreach (string n in new[]
+            {
+                "SOLID BAMBOO 14MM", "MASONRY PAINT WHITE", "GRANITE SKIRTING 100MM",
+                "CEMENT PLASTER FINISH 12MM", "Render Material 128-128-128", "CARPET TILE",
+            })
+            {
+                var withOut = MaterialClassPlanner.Plan(n, "");
+                var with = MaterialClassPlanner.Plan(n, "", Shipped());
+                Assert.Equal(withOut.ProposedClass, with.ProposedClass);
+                Assert.Equal(withOut.Reason, with.Reason);
+            }
+        }
+
+        [Fact]
+        public void An_Existing_Class_Still_Wins_And_The_Register_Is_Still_Recorded()
+        {
+            // Rule 1 is untouched — but a reviewer looking at an already-classified row is
+            // exactly who wants to know the register disagrees, so provenance is recorded on
+            // the early return too.
+            var p = MaterialClassPlanner.Plan("GRANITE SKIRTING 100MM", "Stone", Shipped());
+            Assert.Null(p.ProposedClass);
+            Assert.Contains("already classified", p.Reason);
+            Assert.Equal("WL-184", p.RegisterCode);
+            Assert.Equal("Wood", p.RegisterClass);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -119,6 +119,12 @@
          Revit-free so its REFUSALS - not reverting a class a human changed since - are
          provable without a host. -->
     <Compile Include="..\StingTools\Core\Materials\MaterialClassRevertPlanner.cs" Link="Core\Materials\MaterialClassRevertPlanner.cs" />
+    <!-- The governed material register (1,279 rows) and the reconciliation that uses it
+         as a CHALLENGER. Both Revit-free: the reader takes CSV TEXT, so the shipped
+         register is asserted against the rules that read it rather than against a copy. -->
+    <Compile Include="..\StingTools\Core\Materials\MaterialRegistry.cs" Link="Core\Materials\MaterialRegistry.cs" />
+    <Compile Include="..\StingTools\Core\Materials\MaterialRegisterReconciliation.cs" Link="Core\Materials\MaterialRegisterReconciliation.cs" />
+    <Compile Include="..\StingTools\Core\Materials\HostTypeRegisterAudit.cs" Link="Core\Materials\HostTypeRegisterAudit.cs" />
     <!-- IM-15: config-driven revision scheme. Kept Revit-free so the P→C default and the
          per-appointment override are provable without a Revit host. -->
     <Compile Include="..\StingTools\Docs\Templates\RevisionScheme.cs" Link="Docs\Templates\RevisionScheme.cs" />

--- a/StingTools/Commands/Materials/RegisterAuditCommand.cs
+++ b/StingTools/Commands/Materials/RegisterAuditCommand.cs
@@ -1,0 +1,177 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  RegisterAuditCommand.cs — Materials_RegisterAudit. READ-ONLY.
+//
+//  Compares every layered host type whose NAME is a register MAT_NAME against
+//  the build-up that register row declares, and reports the mismatches.
+//
+//  It exists because of 87 floor types. On 2026-09-09 Baseline_RenameTypes
+//  proposed the identical name PLNS_SLB_RC100 for all 87; 86 of them are
+//  register MAT_NAMEs verbatim, and every one is modelled as a single 100 mm
+//  layer of "Concrete, Cast-in-Place gray" while the register declares its own
+//  materials and thicknesses. The rename collision was the symptom; this reports
+//  the cause, per type, so it can be seen before anything is decided.
+//
+//  IT WRITES NOTHING TO THE MODEL, and that is a design decision rather than a
+//  first increment. Rebuilding a compound structure moves every element hosted
+//  on that type; doing it for 87 types unattended, from a CSV, on a delivered
+//  model, is a larger and less reversible act than the rename that started this.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Materials;
+
+namespace StingTools.Commands.Materials
+{
+    [Transaction(TransactionMode.ReadOnly)]
+    public class RegisterAuditCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+                Document doc = ctx.Doc;
+
+                var registry = LoadRegistry(out string loadNote);
+                if (registry.Count == 0)
+                {
+                    // A register that loaded nothing must say so, not report "0 mismatches".
+                    TaskDialog.Show("Register Audit",
+                        "The material register did not load, so there is nothing to compare "
+                      + "against:\n\n" + loadNote);
+                    return Result.Failed;
+                }
+
+                var types = ReadHostTypes(doc);
+                var rows = HostTypeRegisterAudit.Audit(types, registry);
+
+                string path = WriteCsv(doc, HostTypeRegisterAudit.ToCsv(rows));
+
+                var findings = rows.Where(r => r.IsFinding)
+                                   .OrderByDescending(r => r.InstanceCount)
+                                   .ThenBy(r => r.TypeName).ToList();
+
+                var sb = new StringBuilder();
+                sb.AppendLine(HostTypeRegisterAudit.Summary(rows));
+                if (!string.IsNullOrEmpty(loadNote)) { sb.AppendLine(loadNote); sb.AppendLine(); }
+                foreach (var r in findings.Take(12))
+                    sb.AppendLine($"  {r.InstanceCount,4} x  {r.TypeName}\n           {r.Detail}");
+                if (findings.Count > 12)
+                    sb.AppendLine($"  … and {findings.Count - 12} more, in the CSV");
+                if (path != null) { sb.AppendLine(); sb.AppendLine("Report: " + path); }
+
+                TaskDialog.Show("Register Audit", sb.ToString());
+                StingLog.Info($"Materials_RegisterAudit: {rows.Count} types, {findings.Count} findings -> {path}");
+                return Result.Succeeded;
+            }
+            catch (OperationCanceledException) { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("Materials_RegisterAudit", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>
+        /// The corporate register from the deployed data folder. Returns an EMPTY registry
+        /// and a note when a file is missing — never null, and never a silent zero.
+        /// </summary>
+        internal static MaterialRegistry LoadRegistry(out string note)
+        {
+            string ble = Read("BLE_MATERIALS.csv");
+            string mep = Read("MEP_MATERIALS.csv");
+            var reg = MaterialRegistry.Parse(ble, mep);
+            note = reg.Warnings.Count == 0
+                ? null
+                : "Register load notes:\n  " + string.Join("\n  ", reg.Warnings.Take(6));
+            return reg;
+        }
+
+        private static string Read(string fileName)
+        {
+            try
+            {
+                string p = StingToolsApp.FindDataFile(fileName);
+                return !string.IsNullOrEmpty(p) && File.Exists(p) ? File.ReadAllText(p) : null;
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn($"Register audit: reading {fileName}: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Every layered host type, reduced to what the audit compares.</summary>
+        private static List<ModelledHostType> ReadHostTypes(Document doc)
+        {
+            var counts = new Dictionary<long, int>();
+            foreach (Element el in new FilteredElementCollector(doc).WhereElementIsNotElementType()
+                                      .OfClass(typeof(HostObject)))
+            {
+                var tid = el.GetTypeId();
+                if (tid == null || tid.Value <= 0) continue;
+                counts.TryGetValue(tid.Value, out int n);
+                counts[tid.Value] = n + 1;
+            }
+
+            var outList = new List<ModelledHostType>();
+            foreach (var t in new FilteredElementCollector(doc).OfClass(typeof(HostObjAttributes))
+                                 .Cast<HostObjAttributes>())
+            {
+                string cat = t.Category?.Name;
+                if (string.IsNullOrEmpty(cat)) continue;
+
+                var mt = new ModelledHostType { Category = cat, TypeName = t.Name };
+                counts.TryGetValue(t.Id.Value, out int used);
+                mt.InstanceCount = used;
+
+                CompoundStructure cs = null;
+                try { cs = t.GetCompoundStructure(); }
+                catch (Exception ex)
+                { StingLog.WarnRateLimited("RegAudit.CS", $"GetCompoundStructure {t.Id}: {ex.Message}"); }
+
+                if (cs != null)
+                {
+                    var layers = cs.GetLayers();
+                    for (int i = 0; i < layers.Count; i++)
+                    {
+                        var l = layers[i];
+                        string name = null;
+                        if (l.MaterialId != null && l.MaterialId.Value > 0)
+                            name = doc.GetElement(l.MaterialId)?.Name;
+                        mt.Layers.Add(new ModelledLayer
+                        {
+                            MaterialName = name ?? "",
+                            ThicknessMm = l.Width * 304.8,
+                            Function = l.Function.ToString(),
+                        });
+                    }
+                }
+                outList.Add(mt);
+            }
+            return outList;
+        }
+
+        private static string WriteCsv(Document doc, IEnumerable<string> rows)
+        {
+            try
+            {
+                string dir = StingPaths.Meta(doc, "_BIM_COORD");
+                Directory.CreateDirectory(dir);
+                string path = Path.Combine(dir, $"register_audit_{DateTime.Now:yyyyMMdd_HHmmss}.csv");
+                File.WriteAllLines(path, rows, Encoding.UTF8);
+                return path;
+            }
+            catch (Exception ex) { StingLog.Warn("register_audit CSV: " + ex.Message); return null; }
+        }
+    }
+}

--- a/StingTools/Core/Materials/HostTypeRegisterAudit.cs
+++ b/StingTools/Core/Materials/HostTypeRegisterAudit.cs
@@ -1,0 +1,234 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  HostTypeRegisterAudit.cs — does the model's build-up match the register row
+//  its type is named after?
+//
+//  WHY. On 2026-09-09 `Baseline_RenameTypes` proposed the identical name
+//  `PLNS_SLB_RC100` for 87 floor types. Verified: 86 of those 87 are register
+//  MAT_NAMEs verbatim, all FLR-* rows (the 87th, "Concrete 100mm", is a Revit
+//  stock type). The register says
+//
+//      STANDARD CEMENT SCREED 50MM  =  1 × 50 mm CEMENT SCREED (SUBSTRATE)
+//
+//  and the model has it as
+//
+//      1 × 100 mm Concrete, Cast-in-Place gray
+//
+//  — and so do the other 85. Every quantity taken off any of them answers
+//  "100 mm of concrete", and the rename collision is a SYMPTOM: the planner
+//  reads the core material, and 86 types share one.
+//
+//  Of the 95 FLR-* rows, 28 declare two or three layers and all 95 declare a
+//  layer-1 material. **The register was read for its NAME column and nothing
+//  else.**
+//
+//  This is the read-only half, and deliberately the ONLY half. Rebuilding 87
+//  types' compound structures from a CSV, unattended, on a delivered model, is a
+//  larger and less reversible act than the rename that started this — and the
+//  audit is what tells a human which of the 87 are wrong before anybody decides
+//  how to fix them.
+//
+//  Revit-free: it compares a plain description of the modelled layers against
+//  the register row, so the comparison rules are provable without a host.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StingTools.Core.Materials
+{
+    /// <summary>One modelled layer, as read off a Revit compound structure.</summary>
+    public sealed class ModelledLayer
+    {
+        public string MaterialName = "";
+        public double ThicknessMm;
+        /// <summary>Revit's function word, or "" when it could not be read.</summary>
+        public string Function = "";
+
+        public override string ToString() => $"{MaterialName} {ThicknessMm:0.#}mm";
+    }
+
+    /// <summary>One host type in the model, reduced to what the audit compares.</summary>
+    public sealed class ModelledHostType
+    {
+        public string Category = "";
+        public string TypeName = "";
+        public int InstanceCount;
+        public List<ModelledLayer> Layers = new List<ModelledLayer>();
+
+        public double TotalThicknessMm => Layers?.Sum(l => Math.Max(0, l.ThicknessMm)) ?? 0;
+    }
+
+    public enum RegisterAuditVerdict
+    {
+        /// <summary>The type's name is not a register MAT_NAME. Not a finding — most
+        /// types are not named after a register row, and calling that a mismatch would
+        /// bury the ones that are.</summary>
+        NotInRegister,
+        /// <summary>Layer count, materials and thicknesses all match.</summary>
+        Matches,
+        /// <summary>The register declares layers and the model has ONE. The 87-type shape.</summary>
+        Flattened,
+        /// <summary>Same layer count, different materials or thicknesses.</summary>
+        Differs,
+        /// <summary>The model type has no compound structure to read.</summary>
+        NoStructure,
+    }
+
+    public sealed class RegisterAuditRow
+    {
+        public string Category = "";
+        public string TypeName = "";
+        public int InstanceCount;
+        public string RegisterCode = "";
+        public RegisterAuditVerdict Verdict;
+        /// <summary>One line, in the words the brief asked for:
+        /// "register says 1 × 50 mm CEMENT SCREED, model has 1 × 100 mm Concrete…".</summary>
+        public string Detail = "";
+
+        public bool IsFinding => Verdict == RegisterAuditVerdict.Flattened
+                              || Verdict == RegisterAuditVerdict.Differs
+                              || Verdict == RegisterAuditVerdict.NoStructure;
+
+        public override string ToString() => $"{Verdict}: {TypeName} — {Detail}";
+    }
+
+    public static class HostTypeRegisterAudit
+    {
+        /// <summary>Thickness agreement tolerance. 1 mm, because Revit stores feet and a
+        /// round trip through 304.8 does not land on the register's integer.</summary>
+        public const double ToleranceMm = 1.0;
+
+        public static List<RegisterAuditRow> Audit(
+            IEnumerable<ModelledHostType> types, MaterialRegistry registry)
+        {
+            var outRows = new List<RegisterAuditRow>();
+            foreach (var t in types ?? Enumerable.Empty<ModelledHostType>())
+            {
+                var row = new RegisterAuditRow
+                {
+                    Category = t.Category, TypeName = t.TypeName, InstanceCount = t.InstanceCount,
+                };
+                var reg = registry?.ByName(t.TypeName);
+                if (reg == null)
+                {
+                    row.Verdict = RegisterAuditVerdict.NotInRegister;
+                    row.Detail = "type name is not a register MAT_NAME";
+                    outRows.Add(row);
+                    continue;
+                }
+
+                row.RegisterCode = reg.Code;
+                var modelled = (t.Layers ?? new List<ModelledLayer>())
+                               .Where(l => l != null).ToList();
+
+                if (modelled.Count == 0)
+                {
+                    row.Verdict = RegisterAuditVerdict.NoStructure;
+                    row.Detail = $"register says {Describe(reg)}, model has no compound structure";
+                    outRows.Add(row);
+                    continue;
+                }
+
+                bool countMatches = modelled.Count == reg.Layers.Count;
+                bool everyLayerMatches = countMatches && reg.Layers
+                    .Zip(modelled, (r, m) => NameAgrees(r.Material, m.MaterialName)
+                                          && Math.Abs(r.ThicknessMm - m.ThicknessMm) <= ToleranceMm)
+                    .All(x => x);
+
+                if (everyLayerMatches)
+                {
+                    row.Verdict = RegisterAuditVerdict.Matches;
+                    row.Detail = $"{modelled.Count} layer(s), as the register declares";
+                }
+                else if (reg.Layers.Count > 1 && modelled.Count == 1)
+                {
+                    // Called out separately because it is the 87-type signature and has a
+                    // single cause — the layer columns were never read — where "Differs"
+                    // can be any of a dozen things.
+                    row.Verdict = RegisterAuditVerdict.Flattened;
+                    row.Detail = $"register says {Describe(reg)}, model has {Describe(modelled)}";
+                }
+                else
+                {
+                    row.Verdict = RegisterAuditVerdict.Differs;
+                    row.Detail = $"register says {Describe(reg)}, model has {Describe(modelled)}";
+                }
+                outRows.Add(row);
+            }
+            return outRows;
+        }
+
+        /// <summary>
+        /// Two material names agree when one contains the other as a whole word run, after
+        /// trimming. Not equality: the model's material is created FROM the register's layer
+        /// material, and Revit appends " (1)", " 2" and similar on a name clash — which it
+        /// does often, because the same layer material appears on dozens of rows.
+        /// </summary>
+        internal static bool NameAgrees(string registerMaterial, string modelMaterial)
+        {
+            string a = (registerMaterial ?? "").Trim();
+            string b = (modelMaterial ?? "").Trim();
+            if (a.Length == 0 || b.Length == 0) return false;
+            if (string.Equals(a, b, StringComparison.OrdinalIgnoreCase)) return true;
+            return MaterialSchedule.PatternMatch.Contains(b, a)
+                || MaterialSchedule.PatternMatch.Contains(a, b);
+        }
+
+        private static string Describe(MaterialRow reg)
+            => string.Join(" + ", reg.Layers.Select(l => $"1 × {l.ThicknessMm:0.#} mm {l.Material}"))
+               is string s && s.Length > 0 ? s : $"a single {reg.ThicknessMm:0.#} mm layer (no layers declared)";
+
+        private static string Describe(List<ModelledLayer> layers)
+            => string.Join(" + ", layers.Select(l => $"1 × {l.ThicknessMm:0.#} mm {l.MaterialName}"));
+
+        public static string Summary(IReadOnlyCollection<RegisterAuditRow> rows)
+        {
+            if (rows == null || rows.Count == 0) return "No layered host types found in this model.";
+            int inReg = rows.Count(r => r.Verdict != RegisterAuditVerdict.NotInRegister);
+            int match = rows.Count(r => r.Verdict == RegisterAuditVerdict.Matches);
+            int flat = rows.Count(r => r.Verdict == RegisterAuditVerdict.Flattened);
+            int diff = rows.Count(r => r.Verdict == RegisterAuditVerdict.Differs);
+            int none = rows.Count(r => r.Verdict == RegisterAuditVerdict.NoStructure);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"{rows.Count} host type(s); {inReg} are named after a register row.");
+            if (inReg == 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("None of this model's type names appears in BLE_MATERIALS.csv or "
+                            + "MEP_MATERIALS.csv, so there is nothing here to compare. That is a "
+                            + "normal answer, not a failure — this audit only speaks about types "
+                            + "that claim to BE a register material.");
+                return sb.ToString();
+            }
+
+            sb.AppendLine($"  {match} match the register's build-up");
+            sb.AppendLine($"  {flat} are FLATTENED — the register declares layers and the model has one");
+            sb.AppendLine($"  {diff} differ in material or thickness");
+            sb.AppendLine($"  {none} have no compound structure at all");
+            sb.AppendLine();
+            sb.AppendLine("This is READ-ONLY and stays that way. A flattened type's geometry is "
+                        + "wrong, but rebuilding it from a CSV also moves every element hosted on "
+                        + "it — so this names them and a human decides.");
+            return sb.ToString();
+        }
+
+        public static List<string> ToCsv(IEnumerable<RegisterAuditRow> rows)
+        {
+            var outLines = new List<string>
+            { "Verdict,Category,TypeName,Instances,RegisterCode,Detail" };
+            foreach (var r in rows ?? Enumerable.Empty<RegisterAuditRow>())
+                outLines.Add(string.Join(",", Csv(r.Verdict.ToString()), Csv(r.Category),
+                    Csv(r.TypeName), r.InstanceCount, Csv(r.RegisterCode), Csv(r.Detail)));
+            return outLines;
+        }
+
+        private static string Csv(string s)
+        {
+            s = s ?? "";
+            return s.IndexOfAny(new[] { ',', '"', '\n' }) >= 0
+                ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialClassPlanner.cs
+++ b/StingTools/Core/Materials/MaterialClassPlanner.cs
@@ -78,6 +78,29 @@ namespace StingTools.Core.Materials
         public string ProposedClass;
         public string Reason = "";
 
+        // ── The register, as a CHALLENGER ────────────────────────────────────
+        // Populated when a registry is passed to Plan. It does NOT change
+        // ProposedClass, on purpose: measured over all 1,279 register rows the
+        // BLE_APP-IDENTITY-CLASS column classifies by TRADE, so a skirting is
+        // "Wood" whatever it is made of and a floor topping is "Concrete" even
+        // when it is epoxy resin. It is right about cement plaster and masonry
+        // paint and wrong about skirtings and screed, and agreement rate does
+        // not separate the two — see MaterialRegistry's header for the numbers.
+        // So it is carried alongside the answer for a reviewer to see, and
+        // MaterialRegisterReconciliation is where the two get settled.
+
+        /// <summary>MAT_CODE of the register row for this name, or null when the register
+        /// does not contain it. Provenance: a reviewer can go and read the row.</summary>
+        public string RegisterCode;
+        /// <summary>What the register's class column says, translated to Revit's
+        /// vocabulary — or null when it names a role rather than a substance.</summary>
+        public string RegisterClass;
+        /// <summary>True when the register has a substance opinion and it differs from
+        /// <see cref="ProposedClass"/>. Not an error; a row for a human to look at.</summary>
+        public bool RegisterDisagrees =>
+            RegisterClass != null && ProposedClass != null
+            && !string.Equals(RegisterClass, ProposedClass, StringComparison.OrdinalIgnoreCase);
+
         public bool WillWrite => !string.IsNullOrEmpty(ProposedClass);
     }
 
@@ -187,13 +210,26 @@ namespace StingTools.Core.Materials
         };
 
         /// <param name="existingClass">What Revit already holds. Non-empty means leave it.</param>
-        public static MaterialClassProposal Plan(string materialName, string existingClass)
+        /// <param name="registry">
+        /// The corporate material register, or null. When given, the row for this material
+        /// is recorded on the proposal as PROVENANCE and as a CHALLENGE — it never becomes
+        /// the answer. See <see cref="MaterialClassProposal.RegisterClass"/>.
+        /// </param>
+        public static MaterialClassProposal Plan(
+            string materialName, string existingClass, MaterialRegistry registry = null)
         {
             var p = new MaterialClassProposal
             {
                 MaterialName = materialName ?? "",
                 ExistingClass = existingClass ?? "",
             };
+
+            var reg = registry?.ByName(materialName);
+            if (reg != null)
+            {
+                p.RegisterCode = reg.Code;
+                p.RegisterClass = MaterialRegistry.ToRevitClass(reg.IdentityClass);
+            }
 
             if (!string.IsNullOrWhiteSpace(existingClass)
                 && !string.Equals(existingClass.Trim(), "Unassigned", StringComparison.OrdinalIgnoreCase))
@@ -227,9 +263,10 @@ namespace StingTools.Core.Materials
         }
 
         public static List<MaterialClassProposal> PlanAll(
-            IEnumerable<(string Name, string ExistingClass)> materials)
+            IEnumerable<(string Name, string ExistingClass)> materials,
+            MaterialRegistry registry = null)
             => (materials ?? Enumerable.Empty<(string, string)>())
-               .Select(m => Plan(m.Name, m.ExistingClass)).ToList();
+               .Select(m => Plan(m.Name, m.ExistingClass, registry)).ToList();
 
         public static string Summary(IReadOnlyCollection<MaterialClassProposal> ps)
         {

--- a/StingTools/Core/Materials/MaterialRegisterReconciliation.cs
+++ b/StingTools/Core/Materials/MaterialRegisterReconciliation.cs
@@ -1,0 +1,183 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialRegisterReconciliation.cs — the register and the needle table, each
+//  used as a challenger to the other, and NEITHER used as the answer.
+//
+//  Two vocabularies answer "what substance is this material". Both are wrong in
+//  places, and — this is the finding — neither is wrong in a way the other can
+//  be trusted to correct automatically:
+//
+//    the register is RIGHT   MASONRY PAINT WHITE → Paint            (needles: Masonry)
+//                            26 × CEMENT PLASTER/RENDER → Concrete  (needles: Gypsum)
+//                            FIBERGLASS ACOUSTIC TILE → Insulation  (needles: Ceramic)
+//                            EXPOSED AGGREGATE 100MM → Concrete     (needles: Stone)
+//    the needles are RIGHT   GRANITE SKIRTING 100MM → Stone         (register: Wood)
+//                            PVC SKIRTING 80MM → Plastic            (register: Wood)
+//                            LIGHTWEIGHT SCREED 40MM → Concrete     (register: Metal)
+//                            EXTERIOR TIMBER CLADDING 35MM → Wood   (register: Metal)
+//                            CORK TILE 6MM → Wood                   (register: Carpet)
+//
+//  The register's class column classifies by TRADE: a skirting is Wood whatever
+//  it is made of, a cladding is Metal, sanitaryware is Glass, a floor topping is
+//  Concrete. That is a coherent thing for it to be — it is a procurement
+//  register — and it is not what MaterialClass means to the carbon and cost
+//  engines.
+//
+//  AND AGREEMENT RATE DOES NOT IDENTIFY THE SAFE CLASSES, which is what kills
+//  every mechanical rule tried here. Measured 2026-09-09 over all 1,279 rows:
+//
+//      register class   agree  conflict   who is right where they differ
+//      Plastic             52         0
+//      Plaster             21         0
+//      Fabric               4         0
+//      Insulation          17         2   register
+//      Masonry             67         9   register (paving units are masonry)
+//      Glass                6         1   register
+//      Wood                48         9   NEEDLES — every conflict is a skirting or paving
+//      Paint               35         8   register (masonry paint is paint)
+//      Metal               66        20   NEEDLES mostly (screed, cladding, conduit, tank)
+//      Concrete            29        35   REGISTER mostly (cement plaster is cementitious)
+//
+//  Concrete agrees least and is mostly right; Wood agrees well and is badly
+//  wrong where it differs. A whitelist keyed on agreement would be exactly
+//  backwards. So this class REPORTS, and a human decides — which is what
+//  "Report disagreements; propose edits separately with evidence attached"
+//  means in practice.
+//
+//  The gate over this is a COUNT REGRESSION, not a zero. Zero disagreements is
+//  not reachable today and pretending otherwise would leave the whole thing
+//  disabled.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StingTools.Core.Materials
+{
+    public enum ReconcileVerdict
+    {
+        /// <summary>Both name the same Revit class.</summary>
+        Agree,
+        /// <summary>Both have an opinion and they differ. The rows a human must settle.</summary>
+        Conflict,
+        /// <summary>The register names a class the needle table has no word for.</summary>
+        OnlyRegister,
+        /// <summary>The needle table answers and the register's class names no substance.</summary>
+        OnlyNeedles,
+        /// <summary>Neither answers. Not a disagreement — a gap in both.</summary>
+        NeitherAnswers,
+    }
+
+    public sealed class ReconcileRow
+    {
+        public string Code = "";
+        public string Name = "";
+        public string Category = "";
+        /// <summary>The register's own word — Plaster / Ceiling / Generic …</summary>
+        public string RegisterClassRaw = "";
+        /// <summary>That word translated to Revit's vocabulary, or null when it names
+        /// no substance.</summary>
+        public string RegisterClass;
+        /// <summary>What MaterialClassPlanner's needle table says, or null.</summary>
+        public string NeedleClass;
+        public ReconcileVerdict Verdict;
+
+        public override string ToString()
+            => $"{Verdict}: {Code} {Name} — register {Show(RegisterClassRaw)}"
+             + $"{(RegisterClass != null && !string.Equals(RegisterClass, RegisterClassRaw, StringComparison.OrdinalIgnoreCase) ? " → " + RegisterClass : "")}"
+             + $", needles {Show(NeedleClass)}";
+
+        private static string Show(string s) => string.IsNullOrWhiteSpace(s) ? "(none)" : s;
+    }
+
+    public static class MaterialRegisterReconciliation
+    {
+        public static List<ReconcileRow> Reconcile(MaterialRegistry registry)
+        {
+            var outRows = new List<ReconcileRow>();
+            foreach (var r in registry?.Rows ?? Enumerable.Empty<MaterialRow>())
+            {
+                string mapped = MaterialRegistry.ToRevitClass(r.IdentityClass);
+                // Planned with a BLANK existing class deliberately: the question is what the
+                // NAME says, not what a document happens to hold.
+                string needle = MaterialClassPlanner.Plan(r.Name, "").ProposedClass;
+
+                ReconcileVerdict v;
+                if (mapped != null && needle != null)
+                    v = string.Equals(mapped, needle, StringComparison.OrdinalIgnoreCase)
+                        ? ReconcileVerdict.Agree : ReconcileVerdict.Conflict;
+                else if (mapped != null) v = ReconcileVerdict.OnlyRegister;
+                else if (needle != null) v = ReconcileVerdict.OnlyNeedles;
+                else v = ReconcileVerdict.NeitherAnswers;
+
+                outRows.Add(new ReconcileRow
+                {
+                    Code = r.Code, Name = r.Name, Category = r.Category,
+                    RegisterClassRaw = r.IdentityClass, RegisterClass = mapped,
+                    NeedleClass = needle, Verdict = v,
+                });
+            }
+            return outRows;
+        }
+
+        /// <summary>
+        /// The rows whose <c>MAT_NAME</c> states a substance the class column contradicts by
+        /// naming nothing at all. Started from the brief's 31 GYPSUM-named <c>Generic</c>
+        /// rows and generalised, because the same shape holds for every substance word the
+        /// needle table knows: if the NAME says it and the class column shrugs, the class
+        /// column is the one that is behind.
+        ///
+        /// <para>These are the cheapest data edits to propose, because the evidence is in
+        /// the row itself. They are still PROPOSED — this returns them, it does not write
+        /// them, and 1,279 rows of governed corporate data are not edited in bulk by a
+        /// tool that found a pattern.</para>
+        /// </summary>
+        public static List<ReconcileRow> NameSaysMoreThanClassDoes(IEnumerable<ReconcileRow> rows)
+            => (rows ?? Enumerable.Empty<ReconcileRow>())
+               .Where(r => r.Verdict == ReconcileVerdict.OnlyNeedles
+                        && MaterialRegistry.ClassesThatNameNoSubstance
+                               .Any(c => string.Equals(c, r.RegisterClassRaw, StringComparison.OrdinalIgnoreCase)))
+               .ToList();
+
+        public static string Summary(IReadOnlyCollection<ReconcileRow> rows)
+        {
+            if (rows == null || rows.Count == 0) return "The register loaded no rows.";
+            var by = rows.GroupBy(r => r.Verdict).ToDictionary(g => g.Key, g => g.Count());
+            int C(ReconcileVerdict v) => by.TryGetValue(v, out int n) ? n : 0;
+            var sb = new StringBuilder();
+            sb.AppendLine($"{rows.Count} register row(s):");
+            sb.AppendLine($"  {C(ReconcileVerdict.Agree)} agree");
+            sb.AppendLine($"  {C(ReconcileVerdict.Conflict)} CONFLICT — both have an opinion and they differ");
+            sb.AppendLine($"  {C(ReconcileVerdict.OnlyRegister)} the register answers, the needle table has no word");
+            sb.AppendLine($"  {C(ReconcileVerdict.OnlyNeedles)} the name says a substance, the class column names none");
+            sb.AppendLine($"  {C(ReconcileVerdict.NeitherAnswers)} neither answers");
+            sb.AppendLine();
+            sb.AppendLine("The conflicts are not one side being wrong: the register is right about "
+                        + "cement plaster and masonry paint, the needle table is right about "
+                        + "skirtings and screed. Each row is a decision, which is why this "
+                        + "reports and does not write.");
+            return sb.ToString();
+        }
+
+        /// <summary>The full report, for humans to act on. One row per register row so the
+        /// agreements are visible too — a report that showed only disagreements would hide
+        /// its own denominator.</summary>
+        public static List<string> ToCsv(IEnumerable<ReconcileRow> rows)
+        {
+            var outLines = new List<string>
+            { "Verdict,Code,Name,Category,RegisterClassRaw,RegisterClassMapped,NeedleClass" };
+            foreach (var r in rows ?? Enumerable.Empty<ReconcileRow>())
+                outLines.Add(string.Join(",", Csv(r.Verdict.ToString()), Csv(r.Code), Csv(r.Name),
+                    Csv(r.Category), Csv(r.RegisterClassRaw), Csv(r.RegisterClass ?? ""),
+                    Csv(r.NeedleClass ?? "")));
+            return outLines;
+        }
+
+        private static string Csv(string s)
+        {
+            s = s ?? "";
+            return s.IndexOfAny(new[] { ',', '"', '\n' }) >= 0
+                ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialRegistry.cs
+++ b/StingTools/Core/Materials/MaterialRegistry.cs
@@ -1,0 +1,354 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialRegistry.cs — the governed material register, read as data.
+//
+//  StingTools ships 1,279 rows of material data — BLE_MATERIALS.csv (815) and
+//  MEP_MATERIALS.csv (464) — carrying per material a code, an ISO 19650 id, a
+//  category, a total thickness, FIVE layer slots (material / thickness /
+//  function), a unit cost, a standard reference, and an identity class. Three
+//  separate parts of the plugin answer "what is this material?" from
+//  hand-written word lists instead, and the layer columns were being discarded
+//  by whatever seeded a project catalogue from the NAME column alone.
+//
+//  This is the reader. It is deliberately not a classifier.
+//
+//  ── WHAT THIS DOES AND DOES NOT CONSUME ────────────────────────────────────
+//
+//  The register's FACTS are dependable and are what this exists to expose:
+//  MAT_CODE, MAT_ISO_19650_ID, MAT_CATEGORY, MAT_THICKNESS_MM, the five layer
+//  slots, MAT_COST_UNIT_UGX, MAT_STANDARD. They are measurements and
+//  identifiers; a wrong one is a typo, not a judgement.
+//
+//  BLE_APP-IDENTITY-CLASS is a JUDGEMENT, and measured against the material
+//  names in the same rows it is a TRADE bucket rather than a substance. That
+//  reading was checked, not assumed (2026-09-09, all 1,279 rows against the
+//  needle table in MaterialClassPlanner):
+//
+//      348 agree · 85 conflict · 342 the register answers where the needles do
+//      not · 504 rows carry Ceiling / Flooring / Lining / Generic, which name a
+//      role or nothing at all
+//
+//  and the 85 conflicts do not fall on one side:
+//
+//      the register is RIGHT   MASONRY PAINT WHITE → Paint (needles: Masonry)
+//                              26 × CEMENT PLASTER / RENDER → Concrete (Gypsum)
+//                              FIBERGLASS ACOUSTIC TILE → Insulation (Ceramic)
+//                              EXPOSED AGGREGATE 100MM → Concrete (Stone)
+//      the register is WRONG   GRANITE SKIRTING 100MM → Wood
+//                              MARBLE SKIRTING 150MM → Wood
+//                              CEMENT SKIRTING PREMIUM 150MM → Wood
+//                              PVC SKIRTING 80MM → Wood
+//                              LIGHTWEIGHT SCREED 40MM → Metal
+//                              EXTERIOR TIMBER CLADDING 35MM → Metal
+//                              FLOOR MOUNTED CLOSE COUPLED WC → Glass
+//                              ANTI-SLIP EPOXY 5MM → Concrete
+//
+//  A skirting is Wood whatever it is made of; a cladding is Metal; sanitaryware
+//  is Glass. Nor does agreement rate identify the safe classes — Concrete agrees
+//  only 45% of the time and is mostly RIGHT, while Wood agrees 84% and is badly
+//  wrong where it differs. **There is no rule derivable from this data that
+//  consumes the class column without importing confident wrong answers**, so
+//  this class exposes <see cref="MaterialRow.IdentityClass"/> and
+//  <see cref="ToRevitClass"/> for RECONCILIATION and refuses to be the answer.
+//  See MaterialRegisterReconciliation, whose CSV is how a human settles it.
+//
+//  ── REVIT-FREE ─────────────────────────────────────────────────────────────
+//  Takes CSV TEXT, not paths, so the shipped register is assertable outside
+//  Revit — the same split ProdExclusionPolicy uses, and the reason its data
+//  defects were catchable at all.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace StingTools.Core.Materials
+{
+    /// <summary>One declared layer of a register row.</summary>
+    public sealed class MaterialRegisterLayer
+    {
+        /// <summary>1..5, as the column is named.</summary>
+        public int Index;
+        public string Material = "";
+        /// <summary>Millimetres. 0 when the column held no usable number.</summary>
+        public double ThicknessMm;
+        /// <summary>The register's own function word — SUBSTRATE, FINISH 1, STRUCTURE …
+        /// Kept verbatim; mapping it to Revit's enum is the caller's business.</summary>
+        public string Function = "";
+
+        public override string ToString()
+            => $"{Index}: {Material} {ThicknessMm:0.#}mm ({Function})";
+    }
+
+    public sealed class MaterialRow
+    {
+        /// <summary>Which file it came from — "BLE" or "MEP". Reported on a duplicate.</summary>
+        public string Source = "";
+        public string Code = "";
+        public string Iso19650Id = "";
+        public string Name = "";
+        public string Category = "";
+        /// <summary>MAT_THICKNESS_MM. 0 when absent.</summary>
+        public double ThicknessMm;
+        /// <summary>The declared build-up, layer 1 first. Empty when the row declares none.</summary>
+        public List<MaterialRegisterLayer> Layers = new List<MaterialRegisterLayer>();
+        /// <summary>MAT_COST_UNIT_UGX. 0 when absent.</summary>
+        public double CostUnitUgx;
+        public string Standard = "";
+        /// <summary>BLE_APP-IDENTITY-CLASS, VERBATIM and in the register's own
+        /// vocabulary — which is not Revit's. Read <see cref="ToRevitClass"/> and the
+        /// file header before treating this as an answer.</summary>
+        public string IdentityClass = "";
+
+        /// <summary>Sum of the declared layers, which is not always MAT_THICKNESS_MM —
+        /// the difference is one of the things the register audit reports.</summary>
+        public double LayerThicknessSumMm => Layers?.Sum(l => Math.Max(0, l.ThicknessMm)) ?? 0;
+
+        public override string ToString() => $"{Code} {Name}";
+    }
+
+    public sealed class MaterialRegistry
+    {
+        private readonly Dictionary<string, MaterialRow> _byName;
+        private readonly Dictionary<string, MaterialRow> _byCode;
+
+        /// <summary>Every row, in file order: BLE then MEP.</summary>
+        public IReadOnlyList<MaterialRow> Rows { get; }
+
+        /// <summary>
+        /// Problems found while loading, reported rather than swallowed. A duplicate
+        /// MAT_NAME is in here, NOT resolved by last-wins: two rows claiming one name is a
+        /// data question, and picking one silently is how a register stops being governed.
+        /// </summary>
+        public IReadOnlyList<string> Warnings { get; }
+
+        public int Count => Rows.Count;
+
+        private MaterialRegistry(List<MaterialRow> rows, List<string> warnings)
+        {
+            Rows = rows;
+            Warnings = warnings;
+            _byName = new Dictionary<string, MaterialRow>(StringComparer.OrdinalIgnoreCase);
+            _byCode = new Dictionary<string, MaterialRow>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in rows)
+            {
+                if (!string.IsNullOrWhiteSpace(r.Name) && !_byName.ContainsKey(r.Name.Trim()))
+                    _byName[r.Name.Trim()] = r;
+                if (!string.IsNullOrWhiteSpace(r.Code) && !_byCode.ContainsKey(r.Code.Trim()))
+                    _byCode[r.Code.Trim()] = r;
+            }
+        }
+
+        /// <summary>An empty register — what a caller gets when the CSVs are not deployed.
+        /// Deliberately not null: every lookup answers "not in the register", which is the
+        /// same thing a missing name means, so no caller needs a null check to be correct.
+        /// The MISSING FILE is reported through <see cref="Warnings"/> instead.</summary>
+        public static MaterialRegistry Empty
+            => new MaterialRegistry(new List<MaterialRow>(), new List<string>());
+
+        /// <param name="bleCsv">Text of BLE_MATERIALS.csv, or null if not deployed.</param>
+        /// <param name="mepCsv">Text of MEP_MATERIALS.csv, or null if not deployed.</param>
+        public static MaterialRegistry Parse(string bleCsv, string mepCsv)
+        {
+            var rows = new List<MaterialRow>();
+            var warnings = new List<string>();
+            var seenName = new Dictionary<string, MaterialRow>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (text, source) in new[] { (bleCsv, "BLE"), (mepCsv, "MEP") })
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    warnings.Add($"{source}_MATERIALS.csv is not deployed — {source} materials "
+                               + "will not be found in the register.");
+                    continue;
+                }
+
+                var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+                var header = FirstDataLine(lines, out int headerIndex);
+                if (header == null)
+                {
+                    warnings.Add($"{source}_MATERIALS.csv has no header row.");
+                    continue;
+                }
+
+                var col = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                var headerFields = SplitCsvLine(header);
+                for (int i = 0; i < headerFields.Count; i++)
+                {
+                    string h = (headerFields[i] ?? "").Trim().TrimStart('﻿');
+                    if (h.Length > 0 && !col.ContainsKey(h)) col[h] = i;
+                }
+
+                // Located by NAME, never by position: these files carry 71 columns and grow.
+                foreach (string need in new[] { "MAT_NAME", "MAT_CODE", "BLE_APP-IDENTITY-CLASS" })
+                    if (!col.ContainsKey(need))
+                        warnings.Add($"{source}_MATERIALS.csv has no '{need}' column — "
+                                   + "rows will load with that field blank.");
+
+                int loaded = 0;
+                for (int i = headerIndex + 1; i < lines.Length; i++)
+                {
+                    string line = lines[i];
+                    if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#")) continue;
+                    var f = SplitCsvLine(line);
+                    if (f.Count < 2) continue;
+
+                    string name = Get(f, col, "MAT_NAME").Trim();
+                    if (name.Length == 0) continue;
+
+                    var row = new MaterialRow
+                    {
+                        Source = source,
+                        Code = Get(f, col, "MAT_CODE").Trim(),
+                        Iso19650Id = Get(f, col, "MAT_ISO_19650_ID").Trim(),
+                        Name = name,
+                        Category = Get(f, col, "MAT_CATEGORY").Trim(),
+                        ThicknessMm = Num(Get(f, col, "MAT_THICKNESS_MM")),
+                        CostUnitUgx = Num(Get(f, col, "MAT_COST_UNIT_UGX")),
+                        Standard = Get(f, col, "MAT_STANDARD").Trim(),
+                        IdentityClass = Get(f, col, "BLE_APP-IDENTITY-CLASS").Trim(),
+                    };
+
+                    for (int n = 1; n <= 5; n++)
+                    {
+                        string lm = Get(f, col, $"MAT_LAYER_{n}_MATERIAL").Trim();
+                        if (lm.Length == 0) continue;
+                        row.Layers.Add(new MaterialRegisterLayer
+                        {
+                            Index = n,
+                            Material = lm,
+                            ThicknessMm = Num(Get(f, col, $"MAT_LAYER_{n}_THICKNESS_MM")),
+                            Function = Get(f, col, $"MAT_LAYER_{n}_FUNCTION").Trim(),
+                        });
+                    }
+
+                    if (seenName.TryGetValue(name, out var prior))
+                        warnings.Add($"duplicate MAT_NAME '{name}': {prior.Source} {prior.Code} "
+                                   + $"and {source} {row.Code}. The FIRST is used for lookups; "
+                                   + "two rows claiming one name is a data question, not a "
+                                   + "precedence one.");
+                    else
+                        seenName[name] = row;
+
+                    rows.Add(row);
+                    loaded++;
+                }
+
+                if (loaded == 0)
+                    warnings.Add($"{source}_MATERIALS.csv has a header and no rows.");
+            }
+
+            return new MaterialRegistry(rows, warnings);
+        }
+
+        /// <summary>The row for a material NAME, trimmed and case-insensitive, or null.
+        /// Name rather than code, because a Revit material and a Revit type carry the name
+        /// and nothing carries the code.</summary>
+        public MaterialRow ByName(string materialName)
+        {
+            if (string.IsNullOrWhiteSpace(materialName)) return null;
+            return _byName.TryGetValue(materialName.Trim(), out var r) ? r : null;
+        }
+
+        public MaterialRow ByCode(string code)
+        {
+            if (string.IsNullOrWhiteSpace(code)) return null;
+            return _byCode.TryGetValue(code.Trim(), out var r) ? r : null;
+        }
+
+        public bool Contains(string materialName) => ByName(materialName) != null;
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Register class → Revit class, declared in one place
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// The register's class vocabulary and Revit's are neither identical nor nested:
+        ///
+        /// <code>
+        ///   register only   Ceiling  Flooring  Lining        (element ROLES, not substances)
+        ///   register only   Plaster  Carpet    Fabric        (translatable — below)
+        ///   Revit only      Gypsum Ceramic Stone Membrane Textile Earth Liquid Gas
+        ///   both            Concrete Masonry Metal Wood Glass Plastic Paint Insulation Generic
+        /// </code>
+        ///
+        /// <para>Returns null for anything that does not name a substance — the three role
+        /// words and <c>Generic</c>. 504 of the 1,279 rows are in that group, which is why
+        /// a mapping that guessed at them would be importing 504 shrugs.</para>
+        /// </summary>
+        public static string ToRevitClass(string registerClass)
+        {
+            string c = (registerClass ?? "").Trim();
+            if (c.Length == 0) return null;
+
+            // Translatable: a different word for the same substance.
+            if (Eq(c, "Plaster")) return "Gypsum";
+            if (Eq(c, "Carpet") || Eq(c, "Fabric")) return "Textile";
+
+            // NOT mappable. A ceiling is a place, a flooring is a place, a lining is a
+            // position in a build-up, and Generic is the absence of an answer.
+            if (Eq(c, "Ceiling") || Eq(c, "Flooring") || Eq(c, "Lining") || Eq(c, "Generic"))
+                return null;
+
+            // Shared vocabulary — same word, same meaning.
+            return MaterialClassPlanner.RevitClasses
+                       .FirstOrDefault(rc => Eq(rc, c));
+        }
+
+        /// <summary>The register class words that <see cref="ToRevitClass"/> deliberately
+        /// refuses. Exposed so a test can assert the refusal rather than restate the list.</summary>
+        public static readonly string[] ClassesThatNameNoSubstance =
+            { "Ceiling", "Flooring", "Lining", "Generic" };
+
+        private static bool Eq(string a, string b)
+            => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  CSV
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static string FirstDataLine(string[] lines, out int index)
+        {
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string l = lines[i];
+                if (string.IsNullOrWhiteSpace(l) || l.TrimStart().StartsWith("#")) continue;
+                index = i;
+                return l;
+            }
+            index = -1;
+            return null;
+        }
+
+        private static string Get(List<string> fields, Dictionary<string, int> col, string name)
+            => col.TryGetValue(name, out int i) && i < fields.Count ? (fields[i] ?? "") : "";
+
+        private static double Num(string s)
+            => double.TryParse((s ?? "").Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double d)
+               ? d : 0;
+
+        /// <summary>RFC 4180. Material names and specification cells carry commas and
+        /// quotes, and these files have 71 columns — a Split(',') shifts every field after
+        /// the first quoted one, silently.</summary>
+        internal static List<string> SplitCsvLine(string line)
+        {
+            var fields = new List<string>();
+            var cur = new System.Text.StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < (line ?? "").Length; i++)
+            {
+                char c = line[i];
+                if (quoted)
+                {
+                    if (c != '"') { cur.Append(c); continue; }
+                    if (i + 1 < line.Length && line[i + 1] == '"') { cur.Append('"'); i++; continue; }
+                    quoted = false;
+                }
+                else if (c == '"' && cur.Length == 0) quoted = true;
+                else if (c == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(c);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+    }
+}

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -800,6 +800,9 @@ namespace StingTools.UI
                     // existing class - including one it wrote itself - so a bad write cannot
                     // be repaired by re-running it.
                     case "Materials_RevertClassPlan": RunCommand<Commands.Baseline.RevertMaterialClassCommand>(app); break;
+                    // Read-only. Compares what the model BUILT against what the register
+                    // DECLARES for the row the type is named after.
+                    case "Materials_RegisterAudit": RunCommand<Commands.Materials.RegisterAuditCommand>(app); break;
                     // Read-only: writes a catalogue pack JSON, never the model.
                     case "Baseline_HarvestTypes": RunCommand<Commands.Baseline.BaselineHarvestTypesCommand>(app); break;
 

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1971,6 +1971,9 @@
                                 <Button Style="{StaticResource OrangeBtn}" Content="Undo a material Class plan (asks first)" Tag="Materials_RevertClassPlan" Click="Cmd_Click"
                                         ToolTip="Puts back the classes a material_class_plan CSV set. Pick the plan file; it reverts ONLY where the material still carries what that plan proposed, so anything you have changed since is reported and left alone. Needed because Set material Class never overwrites an existing class - including one it set itself, which is why re-running it cannot repair a bad write."
                                         HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
+                                <Button Style="{StaticResource BlueBtn}" Content="Register audit (read-only)" Tag="Materials_RegisterAudit" Click="Cmd_Click"
+                                        ToolTip="READ-ONLY. For every host type whose NAME is a row of BLE_MATERIALS.csv / MEP_MATERIALS.csv, compares the modelled compound structure against the layers, materials and thicknesses that register row declares, and writes the mismatches to CSV. Written after 87 floor types named after register rows turned out to be one 100mm layer of concrete each - the register was read for its NAME column and nothing else. Changes NOTHING: rebuilding a compound structure moves every element hosted on the type."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
                             </StackPanel>
                         </Border>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,119 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — the register is read as data, and refused as an oracle)
+
+StingTools ships a governed material register — `BLE_MATERIALS.csv` (815 rows)
+and `MEP_MATERIALS.csv` (464) — carrying per material a code, an ISO 19650 id, a
+category, a total thickness, **five layer slots**, a unit cost, a standard and an
+identity class, populated on **1,279 of 1,279** rows. Three parts of the plugin
+answer "what is this material" from hand-written word lists instead, and whatever
+seeded a project catalogue from this file read the NAME column and nothing else.
+
+Verified before building: 815 / 464 / 1,279 all classed · 253 BLE rows `Generic`
+· **31** GYPSUM-named rows classed `Generic` · 95 `FLR-*` rows of which **28**
+declare 2–3 layers and **all 95** declare a layer-1 material · **87** floor types
+proposed the identical name `PLNS_SLB_RC100` on 2026-09-09 · **no duplicate
+MAT_NAME anywhere**, within either file or across the two.
+
+**`MaterialRegistry` is the reader.** Revit-free (it takes CSV TEXT, like
+`ProdExclusionPolicy`), columns located by NAME so a 72nd column cannot shift
+them, RFC 4180 because these cells carry commas, and a duplicate `MAT_NAME` is
+**reported rather than resolved by last-wins** — two rows claiming one name is a
+data question, and a missing file is a reported warning rather than a silent zero.
+
+**The class column is NOT consumed as an answer, and that is the finding.** The
+brief asked for register-first. Measured over all 1,279 rows against the needle
+table: 348 agree, **85 conflict**, 342 the register answers alone, 352 the name
+says a substance and the class column names none, 152 neither. The 85 do not fall
+on one side:
+
+    the register is RIGHT   MASONRY PAINT WHITE → Paint          (needles: Masonry)
+                            26 × CEMENT PLASTER/RENDER → Concrete (needles: Gypsum)
+                            FIBERGLASS ACOUSTIC TILE → Insulation (needles: Ceramic)
+    the needles are RIGHT   GRANITE SKIRTING 100MM → Stone       (register: Wood)
+                            PVC SKIRTING 80MM → Plastic          (register: Wood)
+                            LIGHTWEIGHT SCREED 40MM → Concrete   (register: Metal)
+                            FLOOR MOUNTED CLOSE COUPLED WC       (register: Glass)
+
+**The class column classifies by TRADE.** A skirting is `Wood` whatever it is
+made of, a cladding is `Metal`, sanitaryware is `Glass`, a floor topping is
+`Concrete` even when it is epoxy resin. That is coherent for a procurement
+register and is not what `MaterialClass` means to the carbon and cost engines.
+
+**And agreement rate points the opposite way to correctness**, which is what kills
+every mechanical rule tried here: `Concrete` agrees **45%** and is mostly right
+where it differs; `Wood` agrees **84%** and is wrong where it differs. A whitelist
+keyed on agreement would be exactly backwards. Pinned by
+`Agreement_Rate_Does_Not_Identify_The_Trustworthy_Classes`, which fails if that
+stops being true — the point at which the refusal should be reconsidered.
+
+So the register CHALLENGES at the point of decision instead. `Plan` takes an
+optional registry and records `RegisterCode` and `RegisterClass` on the proposal —
+including on the already-classified early return, because a reviewer looking at a
+classified row is exactly who wants to know the register disagrees — and
+`RegisterDisagrees` says so. `With_No_Registry_The_Planner_Answers_Exactly_As_
+Before` keeps it additive. `Ceiling`, `Flooring`, `Lining` and `Generic` map to
+nothing at all: **504 of the 1,279 rows** carry one, and a mapping that guessed
+would import 504 shrugs into the one controlled field two engines trust.
+
+**`MaterialRegisterReconciliation` is the report a human acts on** — every row,
+including the agreements, so it cannot be read as 85 problems out of 85. Its gate
+is a **count ceiling, not a zero**: zero is not reachable, and a gate demanding it
+would be switched off within a week. 352 rows state a substance their class column
+does not, and the brief's 31 GYPSUM rows are the clearest of them.
+
+**`Materials_RegisterAudit` (read-only) is the W4 deliverable.** For every host
+type named after a register row it compares the modelled compound structure
+against the declared layers and reports, in the brief's own words:
+
+    STANDARD CEMENT SCREED 50MM: register says 1 × 50 mm CEMENT SCREED,
+    model has 1 × 100 mm Concrete, Cast-in-Place gray
+
+`Flattened` is its own verdict, separate from `Differs`, because it has one cause.
+Modelling all 95 `FLR-*` rows the way 2026-09-09 found them gives **28 Flattened
++ 67 Differs, 0 Matches**. A type NOT named after a register row is **not** a
+finding — an audit that flagged those would be right about the 86 and useless —
+and a model with nothing to compare says so rather than reporting a clean bill.
+**It writes nothing to the model.**
+
+**On W4's "find the writer": `Temp/FamilyCommands.cs` `CreateFloorsCommand` is the
+only shipped command that can produce the shape, and only through its failure
+path.** It DOES read the layer columns and set a compound structure — so on
+success it is not the culprit — but `CreateFloorType` (`:437-442`, and the same in
+the Wall/Ceiling/Roof twins) catches a `SetCompoundStructure` failure, logs a
+warning and **returns `true`**, leaving a type named from the CSV carrying the
+BASE type's build-up. The base type is picked as the first non-foundation
+`FloorType`, which on a stock template is a single ~100 mm layer of
+`Concrete, Cast-in-Place gray`. **Not established as what happened**: the ten logs
+on the live plugin path start 2026-08-17 and contain no type-creation line at all,
+and that path has moved. Recommended separately, not changed here: count and
+report those types instead of only logging them.
+
+**RED then GREEN, each by sabotage where the code is new.**
+`The_Disagreement_Count_Has_Not_Grown` — a needle contradicting the register
+(`ppr` → Metal, where it says Plastic) took conflicts **85 → 94**, 1 of 7 failed.
+Worth recording: a first sabotage adding `skirting` → Wood did **not** trip it,
+correctly — it AGREES with the register, and agreement is not a regression.
+`HostTypeRegisterAuditTests` — folding `Flattened` into `Differs` and swapping
+whole-word name agreement for substring failed **3 of 10**. Restored: 45 of 45
+register tests pass.
+
+**One of my own figures was wrong and the data corrected it.** The reconciliation
+constant for name-says-more-than-class was written as 156 and measured **352**;
+and a test named `SOLID BAMBOO 14MM` as a single-layer row when it declares
+`BAMBOO PLANK 14 mm` + `FINISH-SEAL 0.5 mm`. Both now select from the register
+rather than restating it.
+
+Tags 866 passed (baseline 821), Boq 1249 passed, plugin builds 0 warnings /
+0 errors, workflow-wiring Tier 4 = 0.
+
+**Not verified in Revit.** `Materials_RegisterAudit` has never run in a Revit
+session: `ReadHostTypes`, `GetCompoundStructure`, the CSV write and the dialog are
+all unexercised, and the 28/67 split above is the audit applied to a
+RECONSTRUCTION of the 2026-09-09 model, not to the model. No compound structure
+was rewritten and no register row was edited.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries

--- a/docs/UNREACHABLE_COMMANDS_TRIAGE.md
+++ b/docs/UNREACHABLE_COMMANDS_TRIAGE.md
@@ -19,15 +19,20 @@ python tools/recount_unreachable_commands.py            # report
 python tools/recount_unreachable_commands.py --check    # CI gate
 ```
 
-## Counts — re-derived 2026-09-08 (WF-7)
+## Counts — re-derived 2026-09-09
 
-- **Total IExternalCommand classes**: **1720**
-- **Reached by a dispatch layer**: **1689**
+- **Total IExternalCommand classes**: **1721**
+- **Reached by a dispatch layer**: **1690**
 - **Referenced only from non-dispatch code**: **0**
 - **Named nowhere outside their own file**: **9**
 - **Ambiguous — name declared twice**: **22** (under 11 names)
 
-The four buckets partition all 1720; the script fails if they stop adding up.
+The four buckets partition all 1721; the script fails if they stop adding up.
+
+*+1 on both totals since the 2026-09-08 (WF-7) derivation:*
+`Commands/Materials/RegisterAuditCommand` (`Materials_RegisterAudit`), which is
+dispatched from `StingCommandHandler` and has a button on the SETUP tab — so it
+lands in "reached", not in any of the three problem buckets.
 
 ### What the old 126 was, and why it was wrong
 


### PR DESCRIPTION
W1, W2 and W4 from `HANDOVER_MATERIAL_ALIGNMENT.md`, in one PR because all three need `MaterialRegistry` and the rule is never to stack on an unmerged branch. Branched from `origin/main` (`7a5fcf05d`).

## Figures verified before building

Every number in the brief that this PR uses, re-measured:

| Brief | Measured |
|---|---|
| 815 BLE + 464 MEP = 1,279, all classed | ✅ exactly |
| 253 BLE rows `Generic` | ✅ (MEP adds 120 more; 373 across both) |
| 31 GYPSUM-named rows classed `Generic` | ✅ (of 59 GYPSUM-named in total) |
| 95 `FLR-*` rows, 28 with 2–3 layers, all 95 with a layer-1 material | ✅ exactly |
| `STANDARD CEMENT SCREED 50MM` = 1 × 50 mm `CEMENT SCREED` | ✅ FLR-001, function `SUBSTRATE` |
| 87 floor types proposed `PLNS_SLB_RC100` | ✅ exactly, in `type_rename_plan_20260909_075110.csv` |
| register class vocabulary (15 words) | ✅ exactly |

**One correction.** The brief says the 87 names "are `FLR-*` rows of the register, verbatim". **86 of 87 are.** The 87th is `Concrete 100mm`, a Revit stock type that is not in the register — which matters, because it is the row the audit must stay silent about.

**And one the brief asked me to check rather than assume:** there are **no duplicate `MAT_NAME`s** — none within either file, none across the two, none blank. The loader reports duplicates anyway so that stays true.

## W1 — `MaterialRegistry`, and why the class column is not the answer

The reader is what was asked for: Revit-free (takes CSV **text**, like `ProdExclusionPolicy`), columns located by **name** so a 72nd column cannot shift them, RFC 4180 because these cells carry commas, `Layers` / `ThicknessMm` / `CostUnitUgx` / `Code` / `Iso19650Id` / `Standard` all exposed, duplicates **reported rather than last-wins**, and a missing file a reported warning rather than a silent empty register.

**The part of the brief that did not survive contact with the data is "the register becomes the first answer".** Measured over all 1,279 rows against the needle table:

| | count |
|---|---:|
| agree | 348 |
| **conflict** — both have an opinion and they differ | **85** |
| the register answers, the needles have no word | 342 |
| the name states a substance, the class column names none | 352 |
| neither answers | 152 |

The 85 conflicts do not fall on one side:

```
the register is RIGHT   MASONRY PAINT WHITE          → Paint       (needles: Masonry)
                        26 × CEMENT PLASTER/RENDER   → Concrete    (needles: Gypsum)
                        FIBERGLASS ACOUSTIC TILE     → Insulation  (needles: Ceramic)
                        EXPOSED AGGREGATE 100MM      → Concrete    (needles: Stone)
the needles are RIGHT   GRANITE SKIRTING 100MM       → Wood        (needles: Stone)
                        MARBLE SKIRTING 150MM        → Wood        (needles: Stone)
                        PVC SKIRTING 80MM            → Wood        (needles: Plastic)
                        LIGHTWEIGHT SCREED 40MM      → Metal       (needles: Concrete)
                        EXTERIOR TIMBER CLADDING 35MM→ Metal       (needles: Wood)
                        CORK TILE 6MM                → Carpet      (needles: Wood)
```

**`BLE_APP-IDENTITY-CLASS` classifies by TRADE.** A skirting is `Wood` whatever it is made of; a cladding is `Metal`; sanitaryware is `Glass` (`FLOOR MOUNTED CLOSE COUPLED WC`, `PEDESTAL BASIN`, `BASIN MONO BLOC MIXER TAP`); a floor topping is `Concrete` even when it is `ANTI-SLIP EPOXY 5MM`. That is coherent for a procurement register. It is not what `MaterialClass` means to the carbon and cost engines.

**And agreement rate points the opposite way to correctness**, which is what rules out every mechanical rule I tried:

| register class | agree | conflict | agree % | who is right where they differ |
|---|---:|---:|---:|---|
| Plastic | 52 | 0 | 100% | |
| Plaster | 21 | 0 | 100% | |
| Insulation | 17 | 2 | 89% | register |
| Masonry | 67 | 9 | 88% | register (paving units are masonry) |
| **Wood** | 48 | 9 | **84%** | **NEEDLES** — every conflict is a skirting or paving |
| Paint | 35 | 8 | 81% | register |
| Metal | 66 | 20 | 77% | needles mostly (screed, cladding, conduit, tank) |
| **Concrete** | 29 | 35 | **45%** | **REGISTER** mostly (cement plaster is cementitious) |

A whitelist keyed on agreement would be exactly backwards. `Agreement_Rate_Does_Not_Identify_The_Trustworthy_Classes` pins this and **fails if it stops being true** — which is the point at which the refusal should be reconsidered, on evidence rather than on memory.

**So the register challenges at the point of decision instead.** `Plan(name, existing, registry)` records `RegisterCode`, `RegisterClass` and `RegisterDisagrees` on the proposal — including on the already-classified early return, because a reviewer looking at a classified row is exactly who wants to know the register disagrees — and **changes no answer**. `With_No_Registry_The_Planner_Answers_Exactly_As_Before` keeps it additive.

`Ceiling`, `Flooring`, `Lining` and `Generic` map to nothing: **504 of the 1,279 rows** carry one, and mapping them would import 504 shrugs into the one controlled field two engines trust.

## W2 — the reconciliation

Every row, **including the agreements**, so the report cannot be read as 85 problems out of 85. The gate is a **count ceiling, not a zero**: zero is not reachable — each of the 85 is a judgement about governed data — and a gate demanding zero gets switched off within a week. A gate that fails when a count **grows** catches what actually goes wrong.

`The_Rows_Whose_Own_Name_Contradicts_Their_Class_Are_Listed` prints all **352** rows where the name states a substance the class column does not, grouped, with the brief's 31 GYPSUM rows asserted by name as the clearest subset. **No register row was edited**; these are proposals with the evidence in the row.

## W4 — `Materials_RegisterAudit`, read-only

For every host type named after a register row, compares the modelled compound structure against the declared layers and says, in the brief's own words:

```
STANDARD CEMENT SCREED 50MM: register says 1 × 50 mm CEMENT SCREED,
model has 1 × 100 mm Concrete, Cast-in-Place gray
```

- `Flattened` is its **own verdict**, separate from `Differs`, because it has one cause — the layer columns were never read — where `Differs` can be a dozen things. All 95 `FLR-*` rows modelled the way 2026-09-09 found them: **28 Flattened + 67 Differs + 0 Matches**.
- A type **not** named after a register row is **not a finding**. An audit that flagged those would be right about the 86 and useless — and `Concrete 100mm`, the 87th, is correctly silent.
- Material names agree by **whole-word containment**, not equality: Revit appends ` (1)` and ` 2` on a name clash, which happens constantly here. Not substring either — `TILE` must not agree with `DUCTILE IRON`.
- A model with nothing to compare **says so** rather than reporting a clean bill of health.
- **It writes nothing to the model.** Rebuilding 87 compound structures from a CSV, unattended, on a delivered model, is a larger and less reversible act than the rename that started this.

### "Find the writer" — identified, not changed

`ProjectBaselineCommands.BuildStructure` applies layers, as the brief suspected. So does `Temp/FamilyCommands.cs` `CreateFloorsCommand`: it reads `MAT_LAYER_*` and calls `SetCompoundStructure`, so **on success it is not the culprit**.

But `CreateFloorType` (`FamilyCommands.cs:437-442`, and the identical Wall / Ceiling / Roof twins at `:400`, `:472`, `:507`) catches a `SetCompoundStructure` failure, logs a rate-limited warning, and **returns `true`** — leaving a type named from the CSV carrying the **base type's** build-up. The base type is picked as the first non-foundation `FloorType`, which on a stock template is a single ~100 mm layer of `Concrete, Cast-in-Place gray`. That is the observed shape exactly, produced by the failure path of the only shipped writer that can produce it.

**Not established as what happened.** The ten logs on the live plugin path start 2026-08-17 and contain **no type-creation line at all**, and the `.addin` `<Assembly>` has pointed at several folders. Absence there is not evidence.

**Recommended and deliberately not done here:** count those types and name them in the command's dialog instead of only logging them — a type created without its layers is a partial success being reported as a success. It is a Revit-only path I cannot exercise, in a PR that already carries three work items, so it belongs in its own change.

## RED then GREEN

New code has no "before", so each gate was proved by sabotage.

| Gate | RED | GREEN |
|---|---:|---:|
| `The_Disagreement_Count_Has_Not_Grown` | **1 of 7** — a needle contradicting the register (`ppr` → Metal, where it says Plastic) took conflicts **85 → 94** | 0 |
| `HostTypeRegisterAuditTests` | **3 of 10** — folding `Flattened` into `Differs`, and swapping whole-word name agreement for substring | 0 |
| register tests as a whole | | **45 of 45** |

**Worth recording, because it shows the gate measures the right thing:** a first sabotage adding `skirting` → Wood did **not** trip the conflict ceiling. It AGREES with the register, and agreement is not a regression. The second sabotage had to create a genuine contradiction.

**Two of my own figures were wrong, and the data corrected them.** The reconciliation constant for name-says-more-than-class was written as 156 and measures **352**. And a test named `SOLID BAMBOO 14MM` as a single-layer register row; it declares `BAMBOO PLANK 14 mm` **+ `FINISH-SEAL 0.5 mm`**. Both now select from the register rather than restating it.

- Tags: 866 passed, 0 failed (baseline 821)
- Boq: 1249 passed, 0 failed
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors
- `tools/check_workflow_wiring.ps1` — Tier 4 buttons dispatching to nothing: 0
- `tools/check_path_discipline.ps1` — OK

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- **`Materials_RegisterAudit` has never run.** `ReadHostTypes`, `GetCompoundStructure`, the CSV write, the dialog and the new SETUP-tab button are all unexercised. The wiring gate proves the tag dispatches; it does not prove the click.
- **The 28 / 67 split is the audit applied to a RECONSTRUCTION** of the 2026-09-09 model — the 95 register rows modelled as one 100 mm concrete layer each, which is what the rename plan's own `Reason` column records — not to the model itself. Running it on the model is the first thing worth doing with this.
- `StingToolsApp.FindDataFile` resolving both register CSVs from the deployed `data/` folder is inferred from the csproj's `Data\**\*` copy rule, not observed.
- **No compound structure was rewritten and no register row was edited.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
