### PR TITLE
One timber vocabulary for three consumers, and the matcher swap that needed stems (W3, W5c)

### DIFF
--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -28,6 +28,10 @@
     <Compile Include="..\StingTools\BOQ\MeasuredAddition.cs" Link="MeasuredAddition.cs" />
     <Compile Include="..\StingTools\UI\MaterialLookupParser.cs" Link="UI\MaterialLookupParser.cs" />
     <Compile Include="..\StingTools\BOQ\BiogenicCarbon.cs" Link="BiogenicCarbon.cs" />
+    <!-- W3: BiogenicCarbon no longer keeps its own timber word-list; it reads the one
+         shared with MaterialClassPlanner and TypeRenamePlanner. Two copies of that list
+         disagreed on 85 of 1,808 real material names, on a carbon figure. -->
+    <Compile Include="..\StingTools\Core\Materials\SubstanceVocabulary.cs" Link="Core\Materials\SubstanceVocabulary.cs" />
     <!-- CA-1 — Document-free currency converter; pins the no-silent-mis-currency
          invariants headlessly (UGX base, default→UGX, single FX). -->
     <Compile Include="..\StingTools\BOQ\Rates\RateCurrency.cs" Link="Rates\RateCurrency.cs" />

--- a/StingTools.Sustainability.Tests/StingTools.Sustainability.Tests.csproj
+++ b/StingTools.Sustainability.Tests/StingTools.Sustainability.Tests.csproj
@@ -80,6 +80,11 @@
     <!-- WS A3 — pure BOQ waste + biogenic helpers shared with the materials carbon path. -->
     <Compile Include="..\StingTools\BOQ\WasteFactor.cs" Link="Engines\WasteFactor.cs" />
     <Compile Include="..\StingTools\BOQ\BiogenicCarbon.cs" Link="Engines\BiogenicCarbon.cs" />
+    <!-- W3: BiogenicCarbon reads the ONE timber vocabulary now, which needs the
+         whole-word matcher with it. Three copies of that list disagreed on 85 of
+         1,808 real material names, on a carbon figure. -->
+    <Compile Include="..\StingTools\Core\Materials\SubstanceVocabulary.cs" Link="Engines\SubstanceVocabulary.cs" />
+    <Compile Include="..\StingTools\Core\MaterialSchedule\PatternMatch.cs" Link="Engines\PatternMatch.cs" />
     <Compile Include="..\StingTools\Core\Sustainability\IMetricProvider.cs" Link="Engines\IMetricProvider.cs" />
     <Compile Include="..\StingTools\Core\Sustainability\SchemeEvaluator.cs" Link="Engines\SchemeEvaluator.cs" />
     <Compile Include="..\StingTools\Core\Sustainability\EdgeKpiSnapshot.cs" Link="Engines\EdgeKpiSnapshot.cs" />

--- a/StingTools.Tags.Tests/Fixtures/type_rename_core_materials_20260909.csv
+++ b/StingTools.Tags.Tests/Fixtures/type_rename_core_materials_20260909.csv
@@ -1,0 +1,295 @@
+Category,CurrentName,CoreMaterial,RecordedProposal,RecordedOutcome
+Ceilings,16mm GWB on Metal Stud,Metal Stud Layer,,cannot name
+Ceilings,16mm GWB on Wood Furring,"Softwood, Lumber",PLNS_CPB_Timber38-Boarded,rename
+Ceilings,600mm x 1200mm ACT System,Default,,cannot name
+Ceilings,600mm x 600mm ACT System,Default,,cannot name
+Floors,ANTI-SLIP EPOXY 5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,ANTI-STATIC FLOOR 5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,BLUESTONE PAVING 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,BROADLOOM CARPET 8MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CARPET TILE 6MM 500X500MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CAST IN-SITU TERRAZZO 30MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CERAMIC MOSAIC 6MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CERAMIC TILES 200X200MM 8MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CERAMIC TILES 300X300MM 10MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CHEVRON PARQUET 15MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CLAY BLOCK PAVING 60MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CLAY BRICK PAVER 50MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CLAY BRICK PAVER 65MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,Concrete 100mm,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,Concrete 100mm w VCT,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100-Tiled,rename
+Floors,Concrete 150mm,"Concrete, Cast-in-Place gray",PLNS_SLB_RC150,rename
+Floors,Concrete 250mm,"Concrete, Cast-in-Place gray",PLNS_SLB_RC250,rename
+Floors,CONCRETE PAVER 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CONCRETE PAVER 50MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CONCRETE PAVER 60MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CONCRETE PAVER 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CORK TILE 6MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,CRAZY PAVING 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,ENGINEERED WOOD 15MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,ENGINEERING BRICK PAVER 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,EPOXY TERRAZZO 12MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,EXPOSED AGGREGATE 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,EXPOSED AGGREGATE POLISHED 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,EXTRA LARGE COBBLESTONE 150MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GLASS MOSAIC 6MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRANITE COBBLESTONE 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRANITE PAVING 30MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRANITE PAVING 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRANITE PAVING 50MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRANITE TILES 20MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,GRASS GRID PAVER 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HARDWOOD DECKING 25MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HEAVY DUTY BLOCK PAVING 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HEAVY DUTY BRICK PAVER 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HEAVY DUTY INTERLOCKING 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HERRINGBONE BLOCK PAVING 65MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HERRINGBONE PARQUET 15MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,HOMOGENEOUS VINYL TILES 2MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,INDUSTRIAL BLOCK PAVING 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,Interior Tile Floor 7,"Concrete, Cast In Situ(1)",PLNS_SLB_RC750-CeramicTiled,rename
+Floors,IntFloor_tile_150,"Concrete, Cast In Situ(1)",PLNS_SLB_RC500-CeramicTiled,rename
+Floors,IntFloor_tile_200,Plaster brown,,cannot name
+Floors,IntFloor_tile_450,"Concrete, Cast In Situ(1)",PLNS_SLB_RC125-CeramicTiled,rename
+Floors,LAMINATE FLOORING 8MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LARGE COBBLESTONE 120MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LIMESTONE FLAGSTONE 50MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LIMESTONE PAVING 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LIMESTONE TILES 20MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LINOLEUM SHEET 2.5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LOOP PILE CARPET 7MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LOW PROFILE ACCESS FLOOR 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LUXURY CUT PILE 10MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,LUXURY VINYL TILE 5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,MARBLE TILES 20MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,MEDIUM COBBLESTONE 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,MICROCEMENT 3MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,MICROCEMENT HEAVY DUTY 5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,MMA RESIN 6MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PERMEABLE INTERLOCKING 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,POLISHED CONCRETE 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PORCELAIN SLABS 800X1600MM 15MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PORCELAIN TILES 600X1200MM 12MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PORCELAIN TILES 600X600MM 10MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PU RESIN FLOOR 4MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,PU SPORTS FLOOR 8MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,RECLAIMED GRANITE SETTS 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,RUBBER SHEET 3MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,RUBBER TILE 6MM 500X500MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SAFETY RUBBER 10MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SAFETY VINYL 3MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SANDSTONE FLAGSTONE 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SANDSTONE PAVING 40MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SELF LEVELING COMPOUND 5MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SELF-LEVELING EPOXY 3MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SHEET VINYL 2MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SLATE PAVING 25MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SLATE TILES 12MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SMALL COBBLESTONE 80MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SOLID BAMBOO 14MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,SOLID HARDWOOD 18MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,STAMPED CONCRETE 100MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,STANDARD ACCESS FLOOR 150MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,STANDARD INTERLOCKING PAVER 60MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,Steel Bar Joist 350mm - Concrete 75mm w VCT,"Structure, Steel Bar Joist Layer",,cannot name
+Floors,STUDDED RUBBER 8MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,TERRAZZO TILES 20MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,TRAVERTINE TILES 15MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,VITRIFIED TILES 600X600MM 10MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,Wood Joist 235mm - Ceramic Tile,"Structure, Wood Joist/Rafter Layer",,cannot name
+Floors,Wood Joist 235mm - Wood Finish,"Structure, Wood Joist/Rafter Layer",,cannot name
+Floors,Wood Truss  Joist 286mm - Carpet Finish,"Structure, Wood Joist/Rafter Layer",,cannot name
+Floors,WOODEN SPORTS FLOOR 22MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Floors,ZIG-ZAG INTERLOCKING PAVER 60MM,"Concrete, Cast-in-Place gray",PLNS_SLB_RC100,rename
+Roofs,ACOUSTIC CEILING TILE 15MM,ACOUSTIC CEILING TILE 15MM,,cannot name
+Roofs,ALUMINUM SHEET 0.7MM,ALUMINUM SHEET 0.7MM,,cannot name
+Roofs,APP MODIFIED BITUMEN 4MM,APP MODIFIED BITUMEN 4MM,,cannot name
+Roofs,BITUMEN MEMBRANE 4MM,BITUMEN MEMBRANE 4MM,,cannot name
+Roofs,BITUMEN MEMBRANE 5MM,BITUMEN MEMBRANE 5MM,,cannot name
+Roofs,BOX PROFILE 0.7MM,BOX PROFILE 0.7MM,,cannot name
+Roofs,BREATHABLE MEMBRANE 0.4MM,BREATHABLE MEMBRANE 0.4MM,,cannot name
+Roofs,CEMENT BOARD DECK 12MM,CEMENT BOARD DECK 12MM,,cannot name
+Roofs,CHIMNEY FLASHING 0.7MM,CHIMNEY FLASHING 0.7MM,,cannot name
+Roofs,CLAY ROOF TILES 12MM,CLAY ROOF TILES 12MM,,cannot name
+Roofs,CLAY TILES PREMIUM 15MM,CLAY TILES PREMIUM 15MM,PLNS_RTL_ClayTileRoof15,rename
+Roofs,COMPOSITE TILES 8MM,COMPOSITE TILES 8MM,,cannot name
+Roofs,CONCRETE ROOF TILES 10MM,CONCRETE ROOF TILES 10MM,PLNS_RCS_RC10,rename
+Roofs,CUSTOM ORB 0.5MM,CUSTOM ORB 0.5MM,,cannot name
+Roofs,DIRECT PLASTER CEILING 12MM,DIRECT PLASTER CEILING 12MM,,cannot name
+Roofs,EAVE DRIP EDGE 0.5MM,EAVE DRIP EDGE 0.5MM,,cannot name
+Roofs,EPDM RUBBER MEMBRANE 1.5MM,EPDM RUBBER MEMBRANE 1.5MM,,cannot name
+Roofs,EPS BOARD 50MM,EPS BOARD 50MM,,cannot name
+Roofs,FIBER CEMENT TILES 6MM,FIBER CEMENT TILES 6MM,,cannot name
+Roofs,FIRE-RATED GYPSUM 15MM,FIRE-RATED GYPSUM 15MM,,cannot name
+Roofs,Generic - 225mm 2,Asphalt Shingle,,cannot name
+Roofs,Generic - 225mm 3,Area Loads,,cannot name
+Roofs,GREEN ROOF MEMBRANE 6MM,GREEN ROOF MEMBRANE 6MM,,cannot name
+Roofs,GRP FIBERGLASS 3MM,GRP FIBERGLASS 3MM,,cannot name
+Roofs,GYPSUM BOARD 12.5MM,GYPSUM BOARD 12.5MM,,cannot name
+Roofs,GYPSUM BOARD 15MM,GYPSUM BOARD 15MM,,cannot name
+Roofs,HEAVY SLATE 10MM,HEAVY SLATE 10MM,,cannot name
+Roofs,ICE & WATER SHIELD 2MM,ICE & WATER SHIELD 2MM,,cannot name
+Roofs,IRON SHEET 26 GAUGE 1.2MM,IRON SHEET 26 GAUGE 1.2MM,,cannot name
+Roofs,IRON SHEET 28 GAUGE 0.9MM,IRON SHEET 28 GAUGE 0.9MM,,cannot name
+Roofs,IRON SHEET 30 GAUGE 0.7MM,IRON SHEET 30 GAUGE 0.7MM,,cannot name
+Roofs,KLIP-LOK PROFILE 0.7MM,KLIP-LOK PROFILE 0.7MM,,cannot name
+Roofs,LEAD SHEET FLASHING 4MM,LEAD SHEET FLASHING 4MM,,cannot name
+Roofs,LIQUID APPLIED MEMBRANE 2MM,LIQUID APPLIED MEMBRANE 2MM,,cannot name
+Roofs,LONGSPAN PROFILE 0.5MM,LONGSPAN PROFILE 0.5MM,,cannot name
+Roofs,M_Insulation on Metal Deck - EPDM,"Concrete, Cast-in-Place gray",PLNS_RCS_RC75,rename
+Roofs,M_Steel Truss - Insulation on Metal Deck - EPDM,"Structure, Steel Bar Joist Layer",,cannot name
+Roofs,METAL BATTEN BRACKET 20MM,METAL BATTEN BRACKET 20MM,,cannot name
+Roofs,METAL PAN CEILING 0.5MM,METAL PAN CEILING 0.5MM,,cannot name
+Roofs,MINERAL FIBER TILE 19MM,MINERAL FIBER TILE 19MM,,cannot name
+Roofs,MINERAL WOOL 100MM,MINERAL WOOL 100MM,,cannot name
+Roofs,MINERAL WOOL 150MM,MINERAL WOOL 150MM,,cannot name
+Roofs,MOISTURE RESISTANT BOARD 12.5MM,MOISTURE RESISTANT BOARD 12.5MM,,cannot name
+Roofs,NATURAL SLATE 8MM,NATURAL SLATE 8MM,,cannot name
+Roofs,OSB DECK 12MM,OSB DECK 12MM,,cannot name
+Roofs,OSB DECK 18MM,OSB DECK 18MM,,cannot name
+Roofs,PARAPET CAPPING 0.7MM,PARAPET CAPPING 0.7MM,,cannot name
+Roofs,PIPE FLASHING 0.5MM,PIPE FLASHING 0.5MM,,cannot name
+Roofs,PIR BOARD 100MM,PIR BOARD 100MM,,cannot name
+Roofs,PIR BOARD 50MM,PIR BOARD 50MM,,cannot name
+Roofs,PIR BOARD 75MM,PIR BOARD 75MM,,cannot name
+Roofs,PLYWOOD DECK 12MM,PLYWOOD DECK 12MM,,cannot name
+Roofs,PLYWOOD DECK 18MM,PLYWOOD DECK 18MM,,cannot name
+Roofs,PVC CEILING PANEL 8MM,PVC CEILING PANEL 8MM,,cannot name
+Roofs,PVC ROOF TILES 4MM,PVC ROOF TILES 4MM,,cannot name
+Roofs,PVC SINGLE PLY 1.5MM,PVC SINGLE PLY 1.5MM,,cannot name
+Roofs,REFLECTIVE FOIL 5MM,REFLECTIVE FOIL 5MM,,cannot name
+Roofs,REFLECTIVE UNDERLAY 5MM,REFLECTIVE UNDERLAY 5MM,,cannot name
+Roofs,RIDGE FLASHING 0.7MM,RIDGE FLASHING 0.7MM,,cannot name
+Roofs,ROOFING FELT 1MM,ROOFING FELT 1MM,,cannot name
+Roofs,SARKING FELT 0.2MM,SARKING FELT 0.2MM,,cannot name
+Roofs,SBS MODIFIED BITUMEN 4MM,SBS MODIFIED BITUMEN 4MM,,cannot name
+Roofs,SELF-ADHESIVE UNDERLAY 1MM,SELF-ADHESIVE UNDERLAY 1MM,,cannot name
+Roofs,SPANISH CLAY TILES 14MM,SPANISH CLAY TILES 14MM,PLNS_RTL_ClayTileRoof14,rename
+Roofs,SPRAY FOAM INSULATION 50MM,SPRAY FOAM INSULATION 50MM,,cannot name
+Roofs,STANDING SEAM 0.7MM,STANDING SEAM 0.7MM,,cannot name
+Roofs,STEEL C-SECTION PURLIN 75MM,STEEL C-SECTION PURLIN 75MM,,cannot name
+Roofs,STEEL ROOF TRUSS 100MM,STEEL ROOF TRUSS 100MM,,cannot name
+Roofs,STEEL ROOF TRUSS 150MM,STEEL ROOF TRUSS 150MM,,cannot name
+Roofs,STEEL Z-SECTION PURLIN 100MM,STEEL Z-SECTION PURLIN 100MM,,cannot name
+Roofs,STONE COATED STEEL 0.5MM,STONE COATED STEEL 0.5MM,PLNS_RTL_StoneCoatedTileRoof1,rename
+Roofs,SYNTHETIC UNDERLAY 0.5MM,SYNTHETIC UNDERLAY 0.5MM,,cannot name
+Roofs,TILE PROFILE METAL 0.5MM,TILE PROFILE METAL 0.5MM,,cannot name
+Roofs,TIMBER BATTEN 25X50MM,TIMBER BATTEN 25X50MM,PLNS_RSH_Timber50,rename
+Roofs,TIMBER BATTEN 38X50MM,TIMBER BATTEN 38X50MM,PLNS_RSH_Timber50,rename
+Roofs,TIMBER BATTEN 50X50MM,TIMBER BATTEN 50X50MM,PLNS_RSH_Timber50,rename
+Roofs,TIMBER BOARD DECK 25MM,TIMBER BOARD DECK 25MM,PLNS_RSH_Timber25,rename
+Roofs,TIMBER CEILING BOARD 12MM,TIMBER CEILING BOARD 12MM,PLNS_RSH_Timber12,rename
+Roofs,TIMBER PURLIN 50X100MM,TIMBER PURLIN 50X100MM,PLNS_RSH_Timber100,rename
+Roofs,TIMBER PURLIN 50X150MM,TIMBER PURLIN 50X150MM,PLNS_RSH_Timber150,rename
+Roofs,TIMBER RAFTER 100X50MM,TIMBER RAFTER 100X50MM,PLNS_RSH_Timber100,rename
+Roofs,TIMBER RAFTER 150X50MM,TIMBER RAFTER 150X50MM,PLNS_RSH_Timber150,rename
+Roofs,TIMBER TRUSS 100X50MM,TIMBER TRUSS 100X50MM,PLNS_RSH_Timber100,rename
+Roofs,TIMBER TRUSS 150X50MM,TIMBER TRUSS 150X50MM,PLNS_RSH_Timber150,rename
+Roofs,TORCH-ON MEMBRANE 3MM,TORCH-ON MEMBRANE 3MM,,cannot name
+Roofs,TORCH-ON MEMBRANE 4MM,TORCH-ON MEMBRANE 4MM,,cannot name
+Roofs,TPO MEMBRANE 1.2MM,TPO MEMBRANE 1.2MM,,cannot name
+Roofs,VALLEY FLASHING 0.7MM,VALLEY FLASHING 0.7MM,,cannot name
+Roofs,VAPOR BARRIER 0.15MM,VAPOR BARRIER 0.15MM,,cannot name
+Roofs,VERGE TRIM 0.5MM,VERGE TRIM 0.5MM,,cannot name
+Roofs,Wood Rafter 184mm - Asphalt Shingle,"Structure, Wood Joist/Rafter Layer, Batt Insulation",,cannot name
+Roofs,Wood Rafter 184mm - Asphalt Shingle - Insulated,"Structure, Wood Joist/Rafter Layer, Batt Insulation",,cannot name
+Roofs,Wood Rafter 235mm - Asphalt Shingle,"Structure, Wood Joist/Rafter Layer, Batt Insulation",,cannot name
+Roofs,Wood Rafter 286mm - Asphalt Shingle,"Structure, Wood Joist/Rafter Layer, Batt Insulation",,cannot name
+Roofs,XPS BOARD 50MM,XPS BOARD 50MM,,cannot name
+Roofs,ZINCALUME SHEET 0.8MM,ZINCALUME SHEET 0.8MM,,cannot name
+Walls,AAC BLOCK 10IN (600×200×250MM),AAC BLOCK 10IN (600×200×250MM),,cannot name
+Walls,AAC BLOCK 4IN (600×200×100MM),AAC BLOCK 4IN (600×200×100MM),,cannot name
+Walls,AAC BLOCK 6IN (600×200×150MM),AAC BLOCK 6IN (600×200×150MM),,cannot name
+Walls,AAC BLOCK 8IN (600×200×200MM),AAC BLOCK 8IN (600×200×200MM),,cannot name
+Walls,BRICK PILLAR UNIT (225×225×75MM),BRICK PILLAR UNIT (225×225×75MM),PLNS_WBK_ClayBrick225,rename
+Walls,CEMENT SAND PLASTER 1-2 (HIGH STRENGTH),CEMENT SAND PLASTER 1-2 (HIGH STRENGTH),,cannot name
+Walls,CEMENT SAND PLASTER 1-3 (STRONG),CEMENT SAND PLASTER 1-3 (STRONG),,cannot name
+Walls,CEMENT SAND PLASTER 1-4 (STANDARD),CEMENT SAND PLASTER 1-4 (STANDARD),,cannot name
+Walls,CEMENT SAND PLASTER 1-5 (ECONOMIC),CEMENT SAND PLASTER 1-5 (ECONOMIC),,cannot name
+Walls,CEMENT SAND PLASTER 1-6 (LIGHT),CEMENT SAND PLASTER 1-6 (LIGHT),,cannot name
+Walls,CEMENT SAND RENDER 1-2 (HEAVY DUTY),CEMENT SAND RENDER 1-2 (HEAVY DUTY),,cannot name
+Walls,CEMENT SAND RENDER 1-3 (EXTERNAL BASE),CEMENT SAND RENDER 1-3 (EXTERNAL BASE),,cannot name
+Walls,CEMENT SAND RENDER 1-4 (EXTERNAL STANDARD),CEMENT SAND RENDER 1-4 (EXTERNAL STANDARD),,cannot name
+Walls,CEMENT SAND RENDER 1-5 (PROTECTED EXTERNAL),CEMENT SAND RENDER 1-5 (PROTECTED EXTERNAL),,cannot name
+Walls,CEMENT SAND RENDER 1-6 (INTERNAL BACKING),CEMENT SAND RENDER 1-6 (INTERNAL BACKING),,cannot name
+Walls,CLAY BRICK ENGINEERING (225×112.5×75MM),CLAY BRICK ENGINEERING (225×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK FACING (225×112.5×75MM),CLAY BRICK FACING (225×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK FIRE-REFRACTORY (225×112.5×75MM),CLAY BRICK FIRE-REFRACTORY (225×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK HALF (112.5×112.5×75MM),CLAY BRICK HALF (112.5×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK PERFORATED (225×112.5×75MM),CLAY BRICK PERFORATED (225×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK STANDARD (225×112.5×75MM),CLAY BRICK STANDARD (225×112.5×75MM),PLNS_WBK_ClayBrick113,rename
+Walls,CLAY BRICK VILLAGE LARGE (295×150×130MM),CLAY BRICK VILLAGE LARGE (295×150×130MM),PLNS_WBK_ClayBrick150,rename
+Walls,CLAY BRICK VILLAGE-ARTISAN (220×110×65MM),CLAY BRICK VILLAGE-ARTISAN (220×110×65MM),PLNS_WBK_ClayBrick110,rename
+Walls,COMPRESSED EARTH BLOCK LARGE (300×150×100MM),COMPRESSED EARTH BLOCK LARGE (300×150×100MM),,cannot name
+Walls,COMPRESSED EARTH BLOCK SMALL (220×105×75MM),COMPRESSED EARTH BLOCK SMALL (220×105×75MM),,cannot name
+Walls,COMPRESSED EARTH BLOCK STANDARD (295×140×100MM),COMPRESSED EARTH BLOCK STANDARD (295×140×100MM),,cannot name
+Walls,Concrete 200mm,"Concrete, Cast-in-Place gray",PLNS_WRC_RC200,rename
+Walls,Concrete 250mm,"Concrete, Cast-in-Place gray",PLNS_WRC_RC250,rename
+Walls,Concrete 300mm,"Concrete, Cast-in-Place gray",PLNS_WRC_RC300,rename
+Walls,Concrete 450mm,"Concrete, Cast-in-Place gray",PLNS_WRC_RC450,rename
+Walls,Concrete 600mm,"Concrete, Cast-in-Place gray",PLNS_WRC_RC600,rename
+Walls,CONCRETE COLUMN BLOCK 12IN (300×300×200MM),CONCRETE COLUMN BLOCK 12IN (300×300×200MM),PLNS_WRC_RC300,rename
+Walls,CONCRETE COLUMN BLOCK 9IN (225×225×200MM),CONCRETE COLUMN BLOCK 9IN (225×225×200MM),PLNS_WRC_RC225,rename
+Walls,DPC POLYTHENE 1000 GAUGE,DPC POLYTHENE 1000 GAUGE,,cannot name
+Walls,DPC POLYTHENE 1200 GAUGE,DPC POLYTHENE 1200 GAUGE,,cannot name
+Walls,Exterior Wall 150,"Brick, Common",PLNS_WBK_ClayBrick125-Plastered,rename
+Walls,Exterior Wall 150 BROWN,"Brick, Common",PLNS_WBK_ClayBrick125-Plastered,rename
+Walls,Exterior_Brown,Plaster brown,,cannot name
+Walls,Exterior_BrownWhite_200,"Brick, Common(1)",PLNS_WBK_ClayBrick175-Plastered,rename
+Walls,Exterior_BrownWhite_230,"Brick, Common(1)",PLNS_WBK_ClayBrick205-Plastered,rename
+Walls,Exterior_CreamWhite_200,"Brick, Common(1)",PLNS_WBK_ClayBrick175-Plastered,rename
+Walls,Exterior_CreamWhite_230 2,"Brick, Common(1)",PLNS_WBK_ClayBrick205-Plastered,rename
+Walls,Exterior_Sone_Plain_200,"Brick, Common(1)",PLNS_WBK_ClayBrick125,rename
+Walls,Foundation - 250mm Concrete,"Concrete, Cast-in-Place gray",PLNS_WRC_RC250,rename
+Walls,Foundation - 300mm Concrete,"Concrete, Cast-in-Place gray",PLNS_WRC_RC300,rename
+Walls,Foundation - 600mm Concrete Footing,"Concrete, Cast-in-Place gray",PLNS_WRC_RC600,rename
+Walls,Foundation - 900mm Concrete Footing,"Concrete, Cast-in-Place gray",PLNS_WRC_RC900,rename
+Walls,Foundation wall,"Brick, Common(2)",PLNS_WBK_ClayBrick200,rename
+Walls,Generic - 100mm Brick,"Brick, Common",PLNS_WBK_ClayBrick100,rename
+Walls,Generic - 150mm Masonry,Concrete Masonry Units,PLNS_WBL_Blockwork150,rename
+Walls,Generic - 200mm Masonry,Concrete Masonry Units,PLNS_WBL_Blockwork200,rename
+Walls,Generic - 300mm Masonry,Concrete Masonry Units,PLNS_WBL_Blockwork300,rename
+Walls,GYPSUM PLASTER PREMIUM,GYPSUM PLASTER PREMIUM,PLNS_WPT_Plasterboard13,rename
+Walls,HOLLOW CONCRETE BLOCK 10IN (250MM),HOLLOW CONCRETE BLOCK 10IN (250MM),PLNS_WBL_Blockwork250,rename
+Walls,HOLLOW CONCRETE BLOCK 4IN (100MM),HOLLOW CONCRETE BLOCK 4IN (100MM),PLNS_WBL_Blockwork100,rename
+Walls,HOLLOW CONCRETE BLOCK 6IN (150MM),HOLLOW CONCRETE BLOCK 6IN (150MM),PLNS_WBL_Blockwork150,rename
+Walls,HOLLOW CONCRETE BLOCK 8IN (200MM),HOLLOW CONCRETE BLOCK 8IN (200MM),PLNS_WBL_Blockwork200,rename
+Walls,HOLLOW CONCRETE BLOCK 9IN (225MM),HOLLOW CONCRETE BLOCK 9IN (225MM),PLNS_WBL_Blockwork225,rename
+Walls,Interior - 114mm Partition,"Softwood, Lumber",PLNS_WPT_Timber89-Boarded,rename
+Walls,Interior - 121mm Partition (1-hr),"Softwood, Lumber",PLNS_WPT_Timber89-Boarded,rename
+Walls,Interior - 125mm Partition,Metal Stud Layer,,cannot name
+Walls,Interior - 125mm Partition (1-hr),Metal Stud Layer,,cannot name
+Walls,Interior - 128mm Partition (2-hr),Metal Stud Layer,,cannot name
+Walls,Interior - 141mm Partition (1-hr),Metal Stud Layer,,cannot name
+Walls,Interior - 157mm Partition (2-hr),Metal Stud Layer,,cannot name
+Walls,Interior - 182mm Partition (1-hr),Metal Stud Layer,,cannot name
+Walls,Interior - 97mm Partition (1-hr),Metal Stud Layer,,cannot name
+Walls,Interior 2 CREAM,"Brick, Common",PLNS_WBK_ClayBrick125-Plastered,rename
+Walls,Interior_cream_200,"Brick, Common",PLNS_WBK_ClayBrick175-Plastered,rename
+Walls,Interior_cream_230,"Brick, Common",PLNS_WBK_ClayBrick205-Plastered,rename
+Walls,INTERLOCKING BLOCK CLC (300×150×100MM),INTERLOCKING BLOCK CLC (300×150×100MM),,cannot name
+Walls,INTERLOCKING BLOCK HYDRAFORM (300×150×100MM),INTERLOCKING BLOCK HYDRAFORM (300×150×100MM),,cannot name
+Walls,INTERLOCKING BLOCK STANDARD (300×150×100MM),INTERLOCKING BLOCK STANDARD (300×150×100MM),,cannot name
+Walls,LIME PLASTER HERITAGE (1-3),LIME PLASTER HERITAGE (1-3),,cannot name
+Walls,M_Exterior - Brick on Mtl. Stud,Metal Stud Layer,,cannot name
+Walls,M_Exterior - CMU Insulated,Concrete Masonry Units,PLNS_WBL_Blockwork290-Boarded,rename
+Walls,M_Exterior - CMU on Mtl. Stud,Metal Stud Layer,,cannot name
+Walls,M_Exterior - EIFS on Mtl. Stud,Metal Stud Layer,,cannot name
+Walls,M_Exterior - Insulated Metal Panel,Metal Stud Layer,,cannot name
+Walls,M_Exterior - Split Face CMU,Concrete Masonry Units,PLNS_WBL_Blockwork190-Boarded,rename
+Walls,M_Exterior - Wood Shingle on Wood Stud,"Softwood, Lumber",PLNS_WPT_Timber140-Boarded,rename
+Walls,M_Exterior - Wood Shingle over Wood Siding on Wood Stud,"Softwood, Lumber",PLNS_WPT_Timber140-Boarded,rename
+Walls,M_Exterior - Wood Siding on Wood Stud,"Softwood, Lumber",PLNS_WPT_Timber140-Boarded,rename
+Walls,plinth copping,Cherry,,cannot name
+Walls,RingBeam,Concrete - Cast-in-Place Concrete,PLNS_WRC_RC205-Plastered,rename
+Walls,RingBeam_CreamWhite_230,"Concrete, Cast In Situ",PLNS_WRC_RC205-Plastered,rename
+Walls,Soffit - 12mm GWB & Metal Stud,Metal Furring,,cannot name
+Walls,SOLID CONCRETE BLOCK 10IN (250MM),SOLID CONCRETE BLOCK 10IN (250MM),PLNS_WBL_Blockwork250,rename
+Walls,SOLID CONCRETE BLOCK 4IN (100MM),SOLID CONCRETE BLOCK 4IN (100MM),PLNS_WBL_Blockwork100,rename
+Walls,SOLID CONCRETE BLOCK 6IN (150MM),SOLID CONCRETE BLOCK 6IN (150MM),PLNS_WBL_Blockwork150,rename
+Walls,SOLID CONCRETE BLOCK 8IN (200MM),SOLID CONCRETE BLOCK 8IN (200MM),PLNS_WBL_Blockwork200,rename
+Walls,SOLID CONCRETE BLOCK 9IN (225MM),SOLID CONCRETE BLOCK 9IN (225MM),PLNS_WBL_Blockwork225,rename
+Walls,STONE ASHLAR DRESSED (450×200×200MM),STONE ASHLAR DRESSED (450×200×200MM),PLNS_WSN_Stone200,rename
+Walls,STONE RUBBLE MASONRY (VARIABLE),STONE RUBBLE MASONRY (VARIABLE),PLNS_WSN_Stone300,rename
+Walls,STONE SLATE CLADDING (VARIABLE),STONE SLATE CLADDING (VARIABLE),PLNS_WSN_Stone25,rename
+Walls,TEXTURED-TYROLEAN RENDER,TEXTURED-TYROLEAN RENDER,,cannot name

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -115,6 +115,12 @@
          half that makes them safe on a delivered model - are provable. -->
     <Compile Include="..\StingTools\Core\Baseline\TypeRenamePlanner.cs" Link="Core\Baseline\TypeRenamePlanner.cs" />
     <Compile Include="..\StingTools\Core\Materials\MaterialClassPlanner.cs" Link="Core\Materials\MaterialClassPlanner.cs" />
+    <!-- W3: the one list of timber-family words, and the two consumers outside
+         Core/Materials that must read it rather than keep their own. BiogenicCarbon
+         is Revit-free by design and already unit-tested in StingTools.Boq.Tests;
+         it is linked HERE too so the three answers can be compared in one place. -->
+    <Compile Include="..\StingTools\Core\Materials\SubstanceVocabulary.cs" Link="Core\Materials\SubstanceVocabulary.cs" />
+    <Compile Include="..\StingTools\BOQ\BiogenicCarbon.cs" Link="BOQ\BiogenicCarbon.cs" />
     <!-- The undo for a plan that was applied before the planner behind it was fixed.
          Revit-free so its REFUSALS - not reverting a class a human changed since - are
          provable without a host. -->

--- a/StingTools.Tags.Tests/SubstanceVocabularyTests.cs
+++ b/StingTools.Tags.Tests/SubstanceVocabularyTests.cs
@@ -1,0 +1,317 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SubstanceVocabularyTests.cs — W3. Timber for one is timber for all.
+//
+//  Three places answered "is this a timber-family material" from three
+//  hand-written lists, and they disagreed on 85 of the 1,808 distinct names in
+//  the register plus the delivered-model corpus. The disagreement lands on a
+//  CARBON figure, because BiogenicCarbon is one of the three.
+//
+//  The corpus is the register (1,279 MAT_NAMEs) UNION the 1,815-name material
+//  plan — every real material name available, rather than a list somebody
+//  thought of. That is what makes the count mean something.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using StingTools.BOQ;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using StingTools.Core.Materials;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class SubstanceVocabularyTests
+    {
+        private readonly ITestOutputHelper _out;
+        public SubstanceVocabularyTests(ITestOutputHelper output) => _out = output;
+
+        private static DirectoryInfo Root()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate the repo root from " + AppContext.BaseDirectory);
+            return dir;
+        }
+
+        private static List<string> _names;
+
+        /// <summary>Every distinct material name available: the shipped register plus every
+        /// corpus fixture. Not a sample — a list somebody thought of is what let three
+        /// vocabularies drift apart in the first place.</summary>
+        private static List<string> Names()
+        {
+            if (_names != null) return _names;
+            var root = Root();
+            var set = new HashSet<string>(StringComparer.Ordinal);
+
+            // Read locally rather than through MaterialRegistry: that reader is on its own
+            // branch (#906) and stacking on an unmerged branch is what orphans a change.
+            // Only the MAT_NAME column is needed here, which is a smaller ask than the
+            // register model — and when the two land, this collapses into it.
+            string data = Path.Combine(root.FullName, "StingTools", "Data");
+            foreach (string f in new[] { "BLE_MATERIALS.csv", "MEP_MATERIALS.csv" })
+                foreach (string name in NameColumn(Path.Combine(data, f), "MAT_NAME"))
+                    set.Add(name);
+
+            string fixtures = Path.Combine(root.FullName, "StingTools.Tags.Tests", "Fixtures");
+            foreach (string f in Directory.GetFiles(fixtures, "material_names_*.csv"))
+                foreach (string line in File.ReadAllLines(f, Encoding.UTF8).Skip(1))
+                {
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+                    var cells = SplitCsv(line);
+                    if (cells.Count > 0 && !string.IsNullOrWhiteSpace(cells[0])) set.Add(cells[0]);
+                }
+
+            Assert.True(set.Count > 1500, "only " + set.Count + " names pooled — the corpus is missing");
+            return _names = set.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        }
+
+
+        /// <summary>One named column of a CSV whose cells carry commas and quotes, located
+        /// by HEADER NAME — these files run to 71 columns and a positional read would return
+        /// a colour where a name belongs.</summary>
+        private static IEnumerable<string> NameColumn(string path, string column)
+        {
+            var lines = File.ReadAllLines(path, Encoding.UTF8)
+                            .Where(l => !string.IsNullOrWhiteSpace(l) && !l.TrimStart().StartsWith("#"))
+                            .ToList();
+            Assert.True(lines.Count > 1, path + " has no rows");
+            var header = SplitCsv(lines[0]);
+            int i = header.FindIndex(h => string.Equals((h ?? "").Trim().TrimStart('﻿'), column,
+                                                        StringComparison.OrdinalIgnoreCase));
+            Assert.True(i >= 0, path + " has no " + column + " column");
+            foreach (string line in lines.Skip(1))
+            {
+                var cells = SplitCsv(line);
+                if (i < cells.Count && !string.IsNullOrWhiteSpace(cells[i])) yield return cells[i].Trim();
+            }
+        }
+
+        private static List<string> SplitCsv(string line)
+        {
+            var fields = new List<string>();
+            var cur = new StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < (line ?? "").Length; i++)
+            {
+                char c = line[i];
+                if (quoted)
+                {
+                    if (c != '"') { cur.Append(c); continue; }
+                    if (i + 1 < line.Length && line[i + 1] == '"') { cur.Append('"'); i++; continue; }
+                    quoted = false;
+                }
+                else if (c == '"' && cur.Length == 0) quoted = true;
+                else if (c == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(c);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+
+        /// <summary>
+        /// Whether TypeRenamePlanner recognises this material as a timber-family substance,
+        /// probed through the real planner rather than by reading its table.
+        ///
+        /// <para>Probed on FLOORS, deliberately. The planner reports a substance word and
+        /// then looks it up in a per-category code table, and only Floors has an entry for
+        /// BOTH "Timber" and "Plywood" — Walls has no Plywood key at all, so a
+        /// plywood-cored wall gets no name. That is a gap in the CODE table, not in the
+        /// vocabulary, and probing on Walls would make this gate report it as one. The
+        /// first version of this test did exactly that and failed on five plywood
+        /// names.</para>
+        ///
+        /// <para>Read off ProposedName, not Reason: a REFUSAL quotes the material name back,
+        /// so "TIMBER BATTEN 25X50MM" would look like a match to a reason-sniffing probe.
+        /// ProposedName is composed by the planner, so its casing is the planner's.</para>
+        /// </summary>
+        private static bool RenamerSaysWood(string name)
+        {
+            var p = TypeRenamePlanner.Plan(new TypeRenameInput
+            {
+                Category = "Floors",
+                FamilyName = "Floor",
+                CurrentName = "probe",
+                InstanceCount = 1,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = name, ThicknessMm = 100, IsStructure = true },
+                },
+            });
+            string proposed = p.ProposedName ?? "";
+            return proposed.IndexOf("Timber", StringComparison.Ordinal) >= 0
+                || proposed.IndexOf("Plywood", StringComparison.Ordinal) >= 0;
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The gate
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Timber_For_One_Is_Timber_For_All()
+        {
+            var disagree = new List<string>();
+            foreach (string n in Names())
+            {
+                bool shared = SubstanceVocabulary.IsWood(n);
+                bool carbon = BiogenicCarbon.IsBiogenic(n);
+                bool renamer = RenamerSaysWood(n);
+                if (shared == carbon && carbon == renamer) continue;
+                disagree.Add($"{n}\n        vocabulary={shared,-6} biogenicCarbon={carbon,-6} renamer={renamer}");
+            }
+
+            if (disagree.Count > 0)
+            {
+                _out.WriteLine($"{disagree.Count} of {Names().Count} names get different answers:");
+                foreach (string d in disagree.Take(120)) _out.WriteLine("    " + d);
+            }
+
+            Assert.True(disagree.Count == 0,
+                $"{disagree.Count} of {Names().Count} names are timber to one consumer and not "
+              + "to another. The full list is in this test's output; the first few:\n    "
+              + string.Join("\n    ", disagree.Take(12)));
+        }
+
+        [Fact]
+        public void The_Two_Names_The_Brief_Named_Are_Settled()
+        {
+            // MDF CEILING PANEL 12MM had a class and a carbon credit and was not timber to
+            // the renamer. SOLID BAMBOO 14MM had a class, no credit, and was not timber to
+            // the renamer. Both are the reason this file exists, so both are pinned by name.
+            foreach (string n in new[] { "MDF CEILING PANEL 12MM", "SOLID BAMBOO 14MM" })
+            {
+                Assert.True(SubstanceVocabulary.IsWood(n), n + " is not wood to the vocabulary");
+                Assert.True(BiogenicCarbon.IsBiogenic(n), n + " earns no biogenic credit");
+                Assert.True(RenamerSaysWood(n), n + " is not timber to the renamer");
+                Assert.Equal("Wood", MaterialClassPlanner.Plan(n, "").ProposedClass);
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  What moved on a carbon figure — named, not summarised
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Three_Names_That_LOSE_A_Biogenic_Credit_Are_Not_Timber()
+        {
+            // BiogenicCarbon matched by substring and carried "ply " with a trailing space.
+            // Across all 1,808 names it matched exactly three, and all three were wrong:
+            // two air diffusers (sup-PLY) and a PVC roofing membrane. A needle that has
+            // never once been right is removed rather than made whole-word.
+            foreach (string n in new[]
+            {
+                "PVC SINGLE PLY 1.5MM",
+                "SUPPLY REGISTER 150X150MM 1-WAY",
+                "SUPPLY REGISTER 200X100MM 2-WAY",
+            })
+            {
+                Assert.Contains(n, Names());
+                Assert.False(SubstanceVocabulary.IsWood(n), n + " is not a timber");
+                Assert.False(BiogenicCarbon.IsBiogenic(n), n + " must not earn a biogenic credit");
+            }
+
+            // And the word that did it is gone rather than tightened.
+            Assert.DoesNotContain("ply", SubstanceVocabulary.Wood, StringComparer.OrdinalIgnoreCase);
+            Assert.Contains("plywood", SubstanceVocabulary.Wood, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void The_Fifteen_Names_That_GAIN_A_Biogenic_Credit_Are_Listed_By_Name()
+        {
+            // A carbon change is not a refactor detail. These fifteen now carry a
+            // sequestration term where they did not, and the two questionable ones are
+            // named in the same breath rather than buried in the count.
+            string[] gained =
+            {
+                "BAMBOO PLANK", "CHEVRON PARQUET 15MM", "CORK TILE", "CORK TILE 6MM",
+                "Cork - Plastic", "FLOOR LAMINATE OAK-DARK", "FLOOR LAMINATE OAK-GREY",
+                "FLOOR LAMINATE OAK-LIGHT", "FLOOR LAMINATE OAK-MEDIUM", "HDF CORE",
+                "HERRINGBONE PARQUET 15MM", "MAPLE FLOORING", "Oak Flooring",
+                "Roca - TENET - 402 City Oak", "SOLID BAMBOO 14MM",
+            };
+            Assert.Equal(15, gained.Length);
+            foreach (string n in gained)
+            {
+                Assert.Contains(n, Names());
+                Assert.True(BiogenicCarbon.IsBiogenic(n), n + " should now earn a biogenic credit");
+            }
+
+            // The two that are a colour rather than a timber. Kept, because the alternative
+            // is special-casing two library appearances out of a lexical rule — but SAID,
+            // because a reviewer should know a carbon term moved on them.
+            Assert.True(BiogenicCarbon.IsBiogenic("Roca - TENET - 402 City Oak"));   // sanitaryware colour
+            Assert.True(BiogenicCarbon.IsBiogenic("Cork - Plastic"));                // cork-look plastic
+        }
+
+        [Fact]
+        public void No_Other_Name_In_The_Corpus_Changed_Its_Carbon_Answer()
+        {
+            // The gains and losses above are exhaustive: 15 + 3 out of 1,808. Anything else
+            // moving means the vocabulary picked up a word nobody measured.
+            var expectedWood = new HashSet<string>(
+                Names().Where(SubstanceVocabulary.IsWood), StringComparer.Ordinal);
+            var carbonWood = new HashSet<string>(
+                Names().Where(BiogenicCarbon.IsBiogenic), StringComparer.Ordinal);
+            Assert.Equal(expectedWood.Count, carbonWood.Count);
+            Assert.True(expectedWood.SetEquals(carbonWood),
+                "BiogenicCarbon and the shared vocabulary now answer differently for: "
+              + string.Join(", ", expectedWood.Except(carbonWood).Concat(carbonWood.Except(expectedWood)).Take(10)));
+            _out.WriteLine($"{carbonWood.Count} of {Names().Count} names are timber-family.");
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The class table keeps its ORDER, which is a separate question
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Name_With_Two_Substances_Is_Still_Decided_By_ORDER_Not_By_This_List()
+        {
+            // "timber for one is timber for all" is a question about the NAME. What an
+            // ordered class table does with a name carrying two substance words is a
+            // precedence decision and stays where it is — Plastic before Wood, because
+            // luxury vinyl printed with a wood grain is vinyl. Asserted so that a reader
+            // does not take the consistency gate to mean IsWood ⇒ class Wood.
+            Assert.True(SubstanceVocabulary.IsWood("VINYL LVT WOOD OAK-DARK"));
+            Assert.Equal("Plastic", MaterialClassPlanner.Plan("VINYL LVT WOOD OAK-DARK", "").ProposedClass);
+
+            Assert.True(SubstanceVocabulary.IsWood("Cork - Plastic"));
+            Assert.Equal("Plastic", MaterialClassPlanner.Plan("Cork - Plastic", "").ProposedClass);
+
+            // But where wood is the only substance named, the class table agrees.
+            Assert.Equal("Wood", MaterialClassPlanner.Plan("BAMBOO PLANK", "").ProposedClass);
+        }
+
+        [Fact]
+        public void Every_Class_Of_Wood_Comes_From_The_Shared_List()
+        {
+            // The direction that must hold: if the class table answers Wood, the name
+            // contains a word this list knows. The reverse is the ordering question above.
+            var wrong = Names()
+                .Where(n => MaterialClassPlanner.Plan(n, "").ProposedClass == "Wood"
+                         && !SubstanceVocabulary.IsWood(n))
+                .ToList();
+            Assert.True(wrong.Count == 0,
+                "classified Wood by a word the shared vocabulary does not have: "
+              + string.Join(", ", wrong.Take(10)));
+        }
+
+        [Fact]
+        public void The_Vocabulary_Is_Whole_Word_And_Has_No_Blank_Entries()
+        {
+            Assert.All(SubstanceVocabulary.Wood, w => Assert.False(string.IsNullOrWhiteSpace(w)));
+            Assert.Equal(SubstanceVocabulary.Wood.Length,
+                SubstanceVocabulary.Wood.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+            // The #863 shape, in the file that removes it from three places at once.
+            Assert.False(SubstanceVocabulary.IsWood("SUPPLY REGISTER 150X150MM 1-WAY"));
+            Assert.False(SubstanceVocabulary.IsWood("Rockwool Insulation"));
+            Assert.True(SubstanceVocabulary.IsWood("BARNWOOD SIDING 22MM"));
+            Assert.True(SubstanceVocabulary.IsWood("WOODEN SPORTS FLOOR 22MM"));
+        }
+    }
+}

--- a/StingTools.Tags.Tests/TypeRenameSubstanceStemTests.cs
+++ b/StingTools.Tags.Tests/TypeRenameSubstanceStemTests.cs
@@ -1,0 +1,253 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  TypeRenameSubstanceStemTests.cs — W5c. The matcher swap needed STEMS, not
+//  just a matcher.
+//
+//  `TypeRenamePlanner.Match` used `IndexOf` — the #863 shape, in a file that
+//  reaches a PROD code. Swapping it for whole-word matching ALONE breaks seven
+//  rows of a delivered model, because the data is plural and the needles were
+//  singular:
+//
+//      5 walls   core "Concrete Masonry Units"   Blockwork → RC   (WBL → WRC)
+//      2 roofs   core "CLAY TILES PREMIUM 15MM"  Clay Tile Roof → nothing at all
+//
+//  Verified before the change, against the plan the 2026-09-09 run actually
+//  wrote. So the swap ships with `concrete masonry units`, `masonry units` and
+//  `clay tiles` beside their singulars, and this file re-runs that corpus and
+//  requires ZERO breakages.
+//
+//  ── THE FIXTURE ────────────────────────────────────────────────────────────
+//  `Fixtures/type_rename_core_materials_20260909.csv` is the 294 rows of
+//  `type_rename_plan_20260909_075110.csv` whose Reason names a core material,
+//  with the proposal that run produced. Reconstructing a type from its CORE
+//  MATERIAL is exactly what the planner does, so re-planning each row and
+//  comparing against the recorded proposal is a like-for-like re-run rather than
+//  a re-statement.
+//
+//  A different fixture from the one #902 adds, deliberately: that PR is
+//  unmerged, and stacking on it is what orphans a change. The two should be
+//  reconciled when both land.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using StingTools.Core;
+using StingTools.Core.Baseline;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class TypeRenameSubstanceStemTests
+    {
+        private readonly ITestOutputHelper _out;
+        public TypeRenameSubstanceStemTests(ITestOutputHelper output) => _out = output;
+
+        private sealed class Row
+        {
+            public string Category, CurrentName, CoreMaterial, RecordedProposal, RecordedOutcome;
+            public override string ToString() => $"{Category}/{CurrentName}";
+        }
+
+        private static List<Row> _rows;
+
+        private static List<Row> Fixture()
+        {
+            if (_rows != null) return _rows;
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools.Tags.Tests",
+                       "Fixtures", "type_rename_core_materials_20260909.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate the rename fixture from " + AppContext.BaseDirectory);
+
+            var rows = new List<Row>();
+            string path = Path.Combine(dir.FullName, "StingTools.Tags.Tests", "Fixtures",
+                                       "type_rename_core_materials_20260909.csv");
+            foreach (string line in File.ReadAllLines(path, Encoding.UTF8).Skip(1))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                var f = SplitCsv(line);
+                Assert.True(f.Count == 5, "Malformed fixture line: " + line);
+                rows.Add(new Row
+                {
+                    Category = f[0], CurrentName = f[1], CoreMaterial = f[2],
+                    RecordedProposal = f[3], RecordedOutcome = f[4],
+                });
+            }
+            Assert.Equal(294, rows.Count);
+            return _rows = rows;
+        }
+
+        private static string Replan(Row r)
+            => TypeRenamePlanner.Plan(new TypeRenameInput
+            {
+                Category = r.Category,
+                FamilyName = r.Category == "Walls" ? "Basic Wall"
+                           : r.Category == "Floors" ? "Floor"
+                           : r.Category == "Roofs" ? "Basic Roof" : "Compound Ceiling",
+                CurrentName = r.CurrentName,
+                InstanceCount = 3,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer
+                    {
+                        Index = 0, MaterialName = r.CoreMaterial,
+                        // The recorded proposal carries the size, so the size is not what is
+                        // under test here; 100 keeps every row comparable on its SUBSTANCE.
+                        ThicknessMm = 100, IsStructure = true,
+                    },
+                },
+            }).ProposedName;
+
+        /// <summary>The substance half of the recorded name — everything up to the size —
+        /// because the fixture flattens every row to one 100 mm layer.</summary>
+        private static string SubstanceOf(string proposedName)
+        {
+            if (string.IsNullOrEmpty(proposedName)) return null;
+            var parts = proposedName.Split('_');
+            if (parts.Length < 3) return proposedName;
+            string subtype = parts[2].Split('-')[0];
+            return parts[1] + "_" + new string(subtype.TakeWhile(c => !char.IsDigit(c)).ToArray());
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Not_One_Row_The_Run_Named_Loses_Its_Substance()
+        {
+            // W5c's number, re-measured: with whole-word matching and the plural stems,
+            // ZERO of the 168 rows the 2026-09-09 run named now resolve to a different
+            // substance or to nothing. Without the stems this list is 7.
+            var broken = new List<string>();
+            foreach (var r in Fixture().Where(x => x.RecordedOutcome == "rename"))
+            {
+                string was = SubstanceOf(r.RecordedProposal);
+                string now = SubstanceOf(Replan(r));
+                if (!string.Equals(was, now, StringComparison.Ordinal))
+                    broken.Add($"{r}: core '{r.CoreMaterial}'  {was ?? "(none)"} → {now ?? "(none)"}");
+            }
+
+            _out.WriteLine($"{Fixture().Count(x => x.RecordedOutcome == "rename")} named rows re-planned, "
+                         + $"{broken.Count} broken.");
+            foreach (string b in broken) _out.WriteLine("    " + b);
+
+            Assert.True(broken.Count == 0,
+                $"{broken.Count} row(s) lost their substance when Match became whole-word:\n  "
+              + string.Join("\n  ", broken));
+        }
+
+        [Theory]
+        [InlineData("Concrete Masonry Units", "Blockwork")]
+        [InlineData("Concrete Masonry Unit", "Blockwork")]
+        [InlineData("Masonry Units", "Blockwork")]
+        [InlineData("CLAY TILES PREMIUM 15MM", "ClayTileRoof")]
+        [InlineData("Clay Tile", "ClayTileRoof")]
+        public void The_Plural_The_Data_Actually_Uses_Still_Matches(string core, string expectSubtype)
+        {
+            // The five names that whole-word matching alone would have dropped, pinned by
+            // the exact string the model carries. "Units" and "TILES" are why this needed
+            // stems and not just a matcher.
+            var p = TypeRenamePlanner.Plan(new TypeRenameInput
+            {
+                Category = core.IndexOf("TILE", StringComparison.OrdinalIgnoreCase) >= 0 ? "Roofs" : "Walls",
+                FamilyName = "probe",
+                CurrentName = "probe",
+                InstanceCount = 1,
+                Layers = new List<MaterialLayer>
+                {
+                    new MaterialLayer { Index = 0, MaterialName = core, ThicknessMm = 200, IsStructure = true },
+                },
+            });
+            Assert.NotNull(p.ProposedName);
+            Assert.Contains(expectSubtype, p.ProposedName, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void The_Five_CMU_Walls_Are_Blockwork_And_Not_Reinforced_Concrete()
+        {
+            // The specific harm: five walls falling back from WBL to WRC means a block wall
+            // priced and carbon-counted as in-situ reinforced concrete.
+            var cmu = Fixture().Where(r => string.Equals(r.CoreMaterial, "Concrete Masonry Units",
+                                                         StringComparison.OrdinalIgnoreCase)).ToList();
+            Assert.Equal(5, cmu.Count);
+            foreach (var r in cmu)
+            {
+                string now = Replan(r);
+                Assert.NotNull(now);
+                Assert.Contains("_WBL_", now, StringComparison.Ordinal);
+                Assert.DoesNotContain("_WRC_", now, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void The_Matcher_Is_Whole_Word_Now()
+        {
+            // The swap itself, at the boundary that motivated it. "PVC SINGLE PLY" must not
+            // read as plywood and "DUCTILE" must not read as a clay tile.
+            foreach (string core in new[] { "PVC SINGLE PLY 1.5MM", "DUCTILE IRON SHEET" })
+            {
+                var p = TypeRenamePlanner.Plan(new TypeRenameInput
+                {
+                    Category = "Floors", FamilyName = "Floor", CurrentName = "probe", InstanceCount = 1,
+                    Layers = new List<MaterialLayer>
+                    {
+                        new MaterialLayer { Index = 0, MaterialName = core, ThicknessMm = 100, IsStructure = true },
+                    },
+                });
+                Assert.Null(p.ProposedName);
+                Assert.Contains("names no substance", p.Reason);
+            }
+        }
+
+        [Fact]
+        public void The_Seven_Rows_That_GAIN_A_Name_Are_Wood_Joists_And_Rafters()
+        {
+            // Sharing the wood vocabulary makes the renamer recognise seven core materials
+            // it used to refuse. Every one is literally called a wood joist or rafter, so
+            // this is the table catching up with the model rather than a new guess — but it
+            // is a behaviour change and it is named rather than counted.
+            var gained = Fixture()
+                .Where(r => r.RecordedOutcome == "cannot name" && Replan(r) != null)
+                .ToList();
+
+            foreach (var r in gained) _out.WriteLine($"    {r}: core '{r.CoreMaterial}' → {Replan(r)}");
+
+            Assert.Equal(7, gained.Count);
+            Assert.All(gained, r => Assert.Contains("Wood Joist", r.CoreMaterial, StringComparison.OrdinalIgnoreCase));
+            Assert.All(gained, r => Assert.Contains("Timber", Replan(r), StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void Every_Other_Refusal_Stays_A_Refusal()
+        {
+            // The other 119 rows the run could not name must still be unnameable. A matcher
+            // change that started naming things is the same defect in the other direction.
+            var stillRefused = Fixture()
+                .Count(r => r.RecordedOutcome == "cannot name" && Replan(r) == null);
+            Assert.Equal(119, stillRefused);
+        }
+
+        private static List<string> SplitCsv(string line)
+        {
+            var fields = new List<string>();
+            var cur = new StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < line.Length; i++)
+            {
+                char c = line[i];
+                if (quoted)
+                {
+                    if (c != '"') { cur.Append(c); continue; }
+                    if (i + 1 < line.Length && line[i + 1] == '"') { cur.Append('"'); i++; continue; }
+                    quoted = false;
+                }
+                else if (c == '"' && cur.Length == 0) quoted = true;
+                else if (c == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(c);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+    }
+}

--- a/StingTools/BOQ/BiogenicCarbon.cs
+++ b/StingTools/BOQ/BiogenicCarbon.cs
@@ -33,16 +33,20 @@ namespace StingTools.BOQ
         /// carbon-content method — species-independent, ≤ 0.</summary>
         public const double TimberBiogenicPerKg = -1.64;
 
-        /// <summary>True for carbon-sequestering (bio-based) materials —
-        /// timber / wood. These are the only rows that carry a biogenic term.</summary>
+        /// <summary>
+        /// True for carbon-sequestering (bio-based) materials. Delegates to
+        /// <see cref="SubstanceVocabulary.IsWood"/>, which is the ONE list — this used to
+        /// keep its own, and the three copies disagreed on 90 of 1,808 real material names.
+        ///
+        /// <para>Two things changed here, and both move a carbon number. The match is now
+        /// WHOLE-WORD, and the needle <c>"ply "</c> is gone: across every name available it
+        /// matched exactly three, and all three were wrong — <c>PVC SINGLE PLY 1.5MM</c> and
+        /// two <c>SUPPLY REGISTER</c> air diffusers were earning a biogenic credit.
+        /// Fifteen genuinely bio-based names gain one; they are listed by name in
+        /// SubstanceVocabularyTests rather than summarised as a count.</para>
+        /// </summary>
         public static bool IsBiogenic(string materialName)
-        {
-            string n = (materialName ?? "").ToLowerInvariant();
-            return n.Contains("timber") || n.Contains("wood")
-                || n.Contains("softwood") || n.Contains("hardwood")
-                || n.Contains("plywood") || n.Contains("ply ") || n.Contains("mdf")
-                || n.Contains("clt") || n.Contains("glulam");
-        }
+            => Core.Materials.SubstanceVocabulary.IsWood(materialName);
 
         /// <summary>
         /// A1-A3 FOSSIL factor (kgCO₂e/kg) — the HEADLINE basis. For bio-based

--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using StingTools.Core.Materials;
 
 namespace StingTools.Core.Baseline
 {
@@ -157,8 +158,13 @@ namespace StingTools.Core.Baseline
         /// "Concrete". Keyed on the MATERIAL name, which is the deliberate half of the
         /// model — nobody renames a material to make a schedule work.
         /// </summary>
-        private static readonly (string Needle, string Word)[] Substance =
+        private static readonly (string Needle, string Word)[] Substance = BuildSubstance();
+
+        private static (string Needle, string Word)[] BuildSubstance()
         {
+            var m = new List<(string Needle, string Word)>();
+            m.AddRange(new (string, string)[]
+            {
             ("hollow concrete block", "Blockwork"), ("solid concrete block", "Blockwork"),
             ("concrete block", "Blockwork"), ("blockwork", "Blockwork"),
             // "Concrete Masonry Units" is the Revit library's name for a block, and it
@@ -167,30 +173,46 @@ namespace StingTools.Core.Baseline
             // M_Exterior - Brick on CMU — were proposed as PLNS_WRC_*: reinforced
             // concrete. The concrete in the name is what the BLOCK is made of, not what
             // the WALL is; same ordering rule as the class table next door.
-            ("concrete masonry unit", "Blockwork"), ("masonry unit", "Blockwork"),
+            ("concrete masonry units", "Blockwork"), ("concrete masonry unit", "Blockwork"),
+            ("masonry units", "Blockwork"), ("masonry unit", "Blockwork"),
             ("cmu", "Blockwork"),
             ("clay brick", "Clay Brick"), ("brick", "Clay Brick"),
             ("screen block", "Screen Block"),
             ("concrete", "RC"),
             ("reinforcement", "RC"),
-            ("timber", "Timber"), ("softwood", "Timber"), ("hardwood", "Timber"),
-            ("plywood", "Plywood"),
+            });
+
+            // ── The one wood list, shared with MaterialClassPlanner and BiogenicCarbon.
+            //    "plywood" keeps its own word because it routes to a different CodeFor key
+            //    than "Timber" does; everything else is Timber. Sharing the list added seven
+            //    proposals this table used to refuse — every one a "Structure, Wood
+            //    Joist/Rafter Layer" floor or roof, which is exactly what it says it is.
+            m.AddRange(SubstanceVocabulary.WoodRows("Timber", plywoodLabel: "Plywood"));
+
+            m.AddRange(new (string, string)[]
+            {
             ("galvanised sheet", "Corrugated Sheet"), ("galvanized sheet", "Corrugated Sheet"),
-            ("clay tile", "Clay Tile Roof"), ("stone coated", "Stone Coated Tile Roof"),
+            ("clay tiles", "Clay Tile Roof"), ("clay tile", "Clay Tile Roof"),
+            ("stone coated", "Stone Coated Tile Roof"),
             ("steel", "Steel"),
             ("gypsum", "Plasterboard"), ("plasterboard", "Plasterboard"),
+            ("cobblestone", "Stone"), ("bluestone", "Stone"), ("flagstone", "Stone"),
             ("stone", "Stone"),
-        };
+            });
+            return m.ToArray();
+        }
 
         /// <summary>Finish words, read off the FINISH layers the same way.</summary>
         private static readonly (string Needle, string Word)[] Finish =
         {
-            ("porcelain", "Porcelain Tiled"), ("ceramic", "Ceramic Tiled"), ("tile", "Tiled"),
+            ("porcelain", "Porcelain Tiled"), ("ceramic", "Ceramic Tiled"),
+            ("tiles", "Tiled"), ("tile", "Tiled"),
             ("terrazzo", "Terrazzo"),
-            ("plaster", "Plastered"), ("render", "Plastered"),
+            ("plastered", "Plastered"), ("plaster", "Plastered"),
+            ("rendered", "Plastered"), ("render", "Plastered"),
             ("gypsum", "Boarded"), ("plasterboard", "Boarded"),
             ("felt", "Felt"), ("bitumen", "Felt"),
-            ("paint", "Painted"), ("screed", "Screed Only"),
+            ("painted", "Painted"), ("paint", "Painted"), ("screed", "Screed Only"),
         };
 
         /// <summary>
@@ -330,11 +352,22 @@ namespace StingTools.Core.Baseline
             return s;
         }
 
+        /// <summary>
+        /// A needle matches a WORD, not a run of letters — the #863 shape, which this file
+        /// carried until 2026-09-09 and which reaches a PROD code from here.
+        ///
+        /// <para>Switching to whole-word matching alone BREAKS SEVEN ROWS on a delivered
+        /// model, because the data is plural and the needles were singular: five walls
+        /// cored with "Concrete Masonry Units" fall back from Blockwork to RC, and two
+        /// roofs cored with "CLAY TILES PREMIUM 15MM" get no name at all. The stems above
+        /// are what makes the swap safe; measured against
+        /// Fixtures/type_rename_core_materials_20260909.csv, 0 rows break.</para>
+        /// </summary>
         private static string Match(string text, (string Needle, string Word)[] table)
         {
             if (string.IsNullOrWhiteSpace(text)) return null;
             foreach (var (needle, word) in table)
-                if (text.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0) return word;
+                if (MaterialSchedule.PatternMatch.Contains(text, needle)) return word;
             return null;
         }
     }

--- a/StingTools/Core/Materials/MaterialClassPlanner.cs
+++ b/StingTools/Core/Materials/MaterialClassPlanner.cs
@@ -112,8 +112,19 @@ namespace StingTools.Core.Materials
         };
 
         // Longest, most specific needle first: "stone coated" must not read as Stone.
-        private static readonly (string Needle, string Class)[] Map =
+        //
+        // W3: the WOOD rows are spliced in from SubstanceVocabulary rather than listed
+        // here, because three separate places used to keep their own copy and they
+        // disagreed on 90 of 1,808 real material names — on a carbon figure, since
+        // BiogenicCarbon was one of them. The ORDER is unchanged and still matters:
+        // wood sits after Plastic, so a vinyl printed with a wood grain is vinyl.
+        private static readonly (string Needle, string Class)[] Map = BuildMap();
+
+        private static (string Needle, string Class)[] BuildMap()
         {
+            var m = new List<(string Needle, string Class)>();
+            m.AddRange(new (string, string)[]
+            {
             ("stone coated", "Metal"), ("galvanised", "Metal"), ("galvanized", "Metal"),
             ("zincalume", "Metal"), ("reinforcement", "Metal"), ("rebar", "Metal"),
             ("steel", "Metal"), ("aluminium", "Metal"), ("aluminum", "Metal"),
@@ -157,11 +168,13 @@ namespace StingTools.Core.Materials
             ("polyvinyl", "Plastic"), ("vinyl", "Plastic"), ("lvt", "Plastic"),
             ("rubber", "Plastic"), ("linoleum", "Plastic"), ("plastic", "Plastic"),
 
-            ("timber", "Wood"), ("hardwood", "Wood"), ("softwood", "Wood"),
-            ("plywood", "Wood"), ("mvule", "Wood"), ("cypress", "Wood"),
-            ("mdf", "Wood"), ("hdf", "Wood"), ("parquet", "Wood"), ("bamboo", "Wood"),
-            ("cork", "Wood"), ("oak", "Wood"), ("maple", "Wood"), ("wood", "Wood"),
+            });
 
+            // ── The one wood list, shared with BiogenicCarbon and TypeRenamePlanner ──
+            m.AddRange(SubstanceVocabulary.WoodRows("Wood"));
+
+            m.AddRange(new (string, string)[]
+            {
             ("glass", "Glass"), ("glazing", "Glass"),
 
             // Textile before stone, or "Textile - Slate Blue" is a rock.
@@ -184,7 +197,9 @@ namespace StingTools.Core.Materials
             //    ceramic tile by convention — the one default this table makes, made
             //    last and in the open rather than by an accident of ordering.
             ("tile", "Ceramic"), ("tiles", "Ceramic"),
-        };
+            });
+            return m.ToArray();
+        }
 
         /// <param name="existingClass">What Revit already holds. Non-empty means leave it.</param>
         public static MaterialClassProposal Plan(string materialName, string existingClass)

--- a/StingTools/Core/Materials/SubstanceVocabulary.cs
+++ b/StingTools/Core/Materials/SubstanceVocabulary.cs
@@ -1,0 +1,117 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SubstanceVocabulary.cs — one list of the words that name a timber-family
+//  material, for the three places that used to keep their own.
+//
+//  THE DEFECT. Four independent word-lists answered "is this timber", and they
+//  disagreed BOTH WAYS on a carbon figure:
+//
+//    Core/Materials/MaterialClassPlanner   timber hardwood softwood plywood mvule
+//                                          cypress wood oak maple bamboo parquet
+//                                          mdf hdf cork
+//    BOQ/BiogenicCarbon                    timber wood softwood hardwood plywood
+//                                          "ply " mdf clt glulam
+//    Core/Baseline/TypeRenamePlanner       timber softwood hardwood plywood
+//    BOQ/UgCarbonFactors                   reads Material.MaterialClass — the
+//                                          controlled field, and therefore right
+//
+//  Measured over the 1,808 distinct names in the register plus the delivered-model
+//  corpus, the three disagreed on 85 of them. Two examples:
+//
+//    MDF CEILING PANEL 12MM   class Wood · biogenic credit YES · not timber to the renamer
+//    SOLID BAMBOO 14MM        class Wood · biogenic credit NO  · not timber to the renamer
+//
+//  ── WHAT CHANGED ON A CARBON NUMBER, NAMED ─────────────────────────────────
+//
+//  `BiogenicCarbon` matched by SUBSTRING and carried `"ply "` with a trailing
+//  space. Across all 1,808 names that needle matched exactly three, and every one
+//  was wrong:
+//
+//      PVC SINGLE PLY 1.5MM              a PVC roofing membrane
+//      SUPPLY REGISTER 150X150MM 1-WAY   an air diffuser   (sup-PLY )
+//      SUPPLY REGISTER 200X100MM 2-WAY   an air diffuser
+//
+//  Two air diffusers and a plastic membrane were earning a biogenic carbon
+//  credit. `ply` is dropped: it has never once been right here, and `plywood`
+//  covers what it was reaching for.
+//
+//  Fifteen names GAIN a credit, all of them bio-based, and the list is short
+//  enough to read: BAMBOO PLANK · CHEVRON PARQUET 15MM · CORK TILE ·
+//  CORK TILE 6MM · Cork - Plastic · FLOOR LAMINATE OAK-DARK/-GREY/-LIGHT/-MEDIUM ·
+//  HDF CORE · HERRINGBONE PARQUET 15MM · MAPLE FLOORING · Oak Flooring ·
+//  Roca - TENET - 402 City Oak · SOLID BAMBOO 14MM.
+//
+//  TWO OF THOSE FIFTEEN ARE QUESTIONABLE AND ARE NOT HIDDEN. `Roca - TENET -
+//  402 City Oak` is a sanitaryware colour, not a timber; `Cork - Plastic` is a
+//  cork-look plastic. Both are the colour-word collision already documented in
+//  MaterialClassPlanner's header, and both are single library appearances rather
+//  than modelled quantities — but a reviewer should know they moved.
+//
+//  ── WHOLE WORDS, WITH STEMS WHERE THE DATA HAS THEM ────────────────────────
+//  Matching is whole-word (PatternMatch), because "sup-PLY" and "bRIDGE" are the
+//  defect this codebase keeps re-finding. Whole-word costs the suffix forms, so
+//  the ones the data actually contains are listed: `wooden` (WOODEN SPORTS FLOOR
+//  22MM) and `barnwood` (BARNWOOD SIDING 22MM) both lost their credit without
+//  them, and both are real timber.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.Core.MaterialSchedule;
+
+namespace StingTools.Core.Materials
+{
+    public static class SubstanceVocabulary
+    {
+        /// <summary>
+        /// Every word that names a timber-family material — the union of what the four
+        /// consumers separately believed, minus <c>ply</c>, which matched nothing true.
+        ///
+        /// <para>Order is irrelevant here: this answers a yes/no, not a precedence.
+        /// The ORDERED tables that decide a Revit class or a PROD code stay where they
+        /// are and draw their wood rows from this.</para>
+        /// </summary>
+        public static readonly string[] Wood =
+        {
+            // generic
+            "timber", "wood", "wooden", "barnwood",
+            // grades and engineered products
+            "hardwood", "softwood", "plywood", "mdf", "hdf", "clt", "glulam",
+            // species and named forms
+            "mvule", "cypress", "oak", "maple", "bamboo", "cork", "parquet",
+        };
+
+        /// <summary>
+        /// True when the name states a timber-family material. Whole-word, so
+        /// "SUPPLY REGISTER" is not plywood and "DUCTILE" is not a tile.
+        ///
+        /// <para>This is a question about the NAME. What an ordered class table then does
+        /// with a name carrying two substance words — "Cork - Plastic", "VINYL LVT WOOD
+        /// OAK-DARK" — is a precedence decision and belongs there, not here.</para>
+        /// </summary>
+        public static bool IsWood(string materialName)
+        {
+            if (string.IsNullOrWhiteSpace(materialName)) return false;
+            foreach (string w in Wood)
+                if (PatternMatch.Contains(materialName, w)) return true;
+            return false;
+        }
+
+        /// <summary>The wood words paired with a caller's own label, so an ordered table
+        /// can splice them in without restating the list. <c>plywood</c> is emitted FIRST
+        /// when <paramref name="plywoodLabel"/> differs, because TypeRenamePlanner routes
+        /// it to a different PROD key than the rest.</summary>
+        public static IEnumerable<(string Needle, string Word)> WoodRows(
+            string label, string plywoodLabel = null)
+        {
+            if (!string.IsNullOrEmpty(plywoodLabel) && plywoodLabel != label)
+                yield return ("plywood", plywoodLabel);
+            foreach (string w in Wood)
+            {
+                if (!string.IsNullOrEmpty(plywoodLabel) && plywoodLabel != label
+                    && string.Equals(w, "plywood", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                yield return (w, label);
+            }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,86 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — one timber vocabulary, and the matcher swap that needed stems)
+
+**Four word-lists answered "is this timber", and they disagreed both ways on a
+carbon figure.** `MaterialClassPlanner` knew fourteen words, `BiogenicCarbon`
+nine, `TypeRenamePlanner` four, and `UgCarbonFactors` read
+`Material.MaterialClass` — the controlled field, and therefore the only one that
+was right by construction. Measured over the **1,808 distinct names** in the
+shipped register plus the delivered-model corpus, the three word-lists gave
+different answers for **85** of them, including the two the brief named:
+
+    MDF CEILING PANEL 12MM   class Wood · biogenic credit YES · not timber to the renamer
+    SOLID BAMBOO 14MM        class Wood · biogenic credit NO  · not timber to the renamer
+
+`SubstanceVocabulary.Wood` is now the one list, and all three read it.
+
+**WHAT MOVED ON A CARBON NUMBER — three names lose a credit, fifteen gain one,
+and all eighteen are named in the tests rather than counted.**
+
+`BiogenicCarbon` matched by SUBSTRING and carried `"ply "` with a trailing space.
+Across all 1,808 names that needle matched **exactly three, and every one was
+wrong**:
+
+    PVC SINGLE PLY 1.5MM              a PVC roofing membrane
+    SUPPLY REGISTER 150X150MM 1-WAY   an air diffuser   (sup-PLY )
+    SUPPLY REGISTER 200X100MM 2-WAY   an air diffuser
+
+Two air diffusers and a plastic membrane were earning a biogenic carbon credit.
+`ply` is **dropped** rather than tightened: it has never once been right, and
+`plywood` covers what it was reaching for.
+
+Fifteen gain one — BAMBOO PLANK, CHEVRON PARQUET 15MM, CORK TILE, CORK TILE 6MM,
+Cork - Plastic, FLOOR LAMINATE OAK-DARK/-GREY/-LIGHT/-MEDIUM, HDF CORE,
+HERRINGBONE PARQUET 15MM, MAPLE FLOORING, Oak Flooring, Roca - TENET - 402 City
+Oak, SOLID BAMBOO 14MM. **Two of those fifteen are questionable and are asserted
+as such**: `Roca - TENET - 402 City Oak` is a sanitaryware colour and
+`Cork - Plastic` is a cork-look plastic. Both are the colour-word collision
+already documented in `MaterialClassPlanner`'s header, both are library
+appearances rather than modelled quantities, and both are said out loud.
+
+Whole-word matching also needed two suffix forms the data actually contains:
+`wooden` (WOODEN SPORTS FLOOR 22MM) and `barnwood` (BARNWOOD SIDING 22MM) both
+lost their credit without them, and both are real timber.
+
+**The consistency gate is a question about the NAME, not about the class table.**
+`A_Name_With_Two_Substances_Is_Still_Decided_By_ORDER_Not_By_This_List` pins that
+`VINYL LVT WOOD OAK-DARK` and `Cork - Plastic` are still Plastic: precedence
+belongs to the ordered table, and only the vocabulary is shared.
+
+**W5c — `TypeRenamePlanner.Match` was the third `IndexOf` site, and the swap needed
+STEMS.** Whole-word matching alone breaks **seven rows** of the 2026-09-09 plan,
+because the data is plural and the needles were singular: five walls cored with
+`Concrete Masonry Units` fall back Blockwork → RC (a block wall priced as in-situ
+reinforced concrete), and two roofs cored with `CLAY TILES PREMIUM 15MM` get no
+name at all. Shipped with `concrete masonry units`, `masonry units` and
+`clay tiles` beside their singulars — plus `cobblestone`, `bluestone`, `flagstone`
+for Stone, and `tiles` / `plastered` / `rendered` / `painted` for the Finish table.
+
+Sharing the wood list also makes the renamer name **seven** core materials it used
+to refuse — every one literally called a "Wood Joist/Rafter Layer". Named, not
+counted.
+
+**RED then GREEN.** `Timber_For_One_Is_Timber_For_All` failed on **85 of 1,808**
+names against the three unmodified consumers, and its failure list names both
+`MDF CEILING PANEL 12MM` and `SOLID BAMBOO 14MM`; 5 of 8 in the file. GREEN 0 of
+1,808, 8 of 8. `Not_One_Row_The_Run_Named_Loses_Its_Substance` failed on **7 of
+168** with the whole-word matcher and the stems removed — the brief's figure,
+reproduced exactly; 5 of 10 in that file. GREEN 0 and 10 of 10.
+
+**A probe defect was found and fixed rather than worked around.** The renamer
+probe first ran on Walls, where `CodeFor` has no `Plywood` key, so five plywood
+names read as "not timber" — a gap in the CODE table being reported as a gap in
+the vocabulary. It probes Floors now, which has both keys, and says why.
+
+Tags 839 passed (baseline 821), Boq 1249 passed, plugin builds 0 warnings /
+0 errors, workflow-wiring Tier 4 = 0.
+
+**Not verified in Revit.** Nothing ran in a Revit session. The carbon figures
+above are the vocabulary's answers over material NAMES; no embodied-carbon report
+was regenerated, and `Baseline_RenameTypes` was not run.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries


### PR DESCRIPTION
W3 and W5c from `HANDOVER_MATERIAL_ALIGNMENT.md`, together because they are the same region of `TypeRenamePlanner`. Branched from `origin/main` (`7a5fcf05d`), independent of #904, #905 and #906.

## W3 — four word-lists, one carbon figure

`MaterialClassPlanner` knew fourteen timber words, `BiogenicCarbon` nine, `TypeRenamePlanner` four, and `UgCarbonFactors` read `Material.MaterialClass` — the controlled field, and therefore the only one right by construction.

Measured over the **1,808 distinct names** in the shipped register plus the delivered-model corpus, the three word-lists gave **different answers for 85** of them, including the two the brief named:

```
MDF CEILING PANEL 12MM   class Wood · biogenic credit YES · not timber to the renamer
SOLID BAMBOO 14MM        class Wood · biogenic credit NO  · not timber to the renamer
```

`SubstanceVocabulary.Wood` is now the one list and all three read it.

## What moved on a carbon number — all eighteen named

**Three names LOSE a credit, and all three should never have had one.** `BiogenicCarbon` matched by **substring** and carried `"ply "` with a trailing space. Across all 1,808 names that needle matched **exactly three**:

```
PVC SINGLE PLY 1.5MM              a PVC roofing membrane
SUPPLY REGISTER 150X150MM 1-WAY   an air diffuser   ← sup-PLY
SUPPLY REGISTER 200X100MM 2-WAY   an air diffuser
```

Two air diffusers and a plastic membrane were earning a biogenic carbon credit. Zero true positives in the entire corpus, so `ply` is **dropped** rather than made whole-word — `plywood` covers what it was reaching for.

**Fifteen names GAIN a credit**, all listed by name in `The_Fifteen_Names_That_GAIN_A_Biogenic_Credit_Are_Listed_By_Name`:

> BAMBOO PLANK · CHEVRON PARQUET 15MM · CORK TILE · CORK TILE 6MM · Cork - Plastic · FLOOR LAMINATE OAK-DARK / -GREY / -LIGHT / -MEDIUM · HDF CORE · HERRINGBONE PARQUET 15MM · MAPLE FLOORING · Oak Flooring · Roca - TENET - 402 City Oak · SOLID BAMBOO 14MM

**Two of those fifteen are questionable, and the test says so rather than burying them in the count.** `Roca - TENET - 402 City Oak` is a sanitaryware colour, not a timber; `Cork - Plastic` is a cork-look plastic. Both are the colour-word collision already documented in `MaterialClassPlanner`'s header, and both are library appearances rather than modelled quantities — but a carbon term moved on them and you should know.

Whole-word matching also costs suffix forms, so the two the data actually contains are listed: `wooden` (`WOODEN SPORTS FLOOR 22MM`) and `barnwood` (`BARNWOOD SIDING 22MM`) both lost their credit without them, and both are real timber.

## The gate is about the NAME, not about the class table

`A_Name_With_Two_Substances_Is_Still_Decided_By_ORDER_Not_By_This_List` pins that `VINYL LVT WOOD OAK-DARK` and `Cork - Plastic` are still **Plastic**. "Timber for one is timber for all" is a lexical question; what an *ordered* class table does with a name carrying two substance words is precedence, and that stays where it is. Only the vocabulary is shared.

## W5c — the matcher swap needed stems, not just a matcher

`TypeRenamePlanner.Match` was the third `IndexOf` site — the #863 shape, in a file that reaches a PROD code. (**Correction to the brief:** it is `TypeRenamePlanner.cs:337` on `main`, not `:446`; the file is 341 lines.)

Swapping it for whole-word matching **alone breaks seven rows** of the 2026-09-09 plan, because the data is plural and the needles were singular:

| | rows | effect |
|---|---:|---|
| walls cored `Concrete Masonry Units` | 5 | Blockwork → RC — a block wall priced and carbon-counted as in-situ reinforced concrete |
| roofs cored `CLAY TILES PREMIUM 15MM` | 2 | `Clay Tile Roof` → no name at all |

Shipped with `concrete masonry units`, `masonry units` and `clay tiles` beside their singulars, plus `cobblestone` / `bluestone` / `flagstone` for Stone and `tiles` / `plastered` / `rendered` / `painted` for the Finish table — measured, not guessed: those are the forms the 1,808 names actually use.

Sharing the wood list also makes the renamer name **seven** core materials it used to refuse. Every one is literally a `Structure, Wood Joist/Rafter Layer`, so this is the table catching up with the model — but it is a behaviour change and `The_Seven_Rows_That_GAIN_A_Name_Are_Wood_Joists_And_Rafters` names them. The other **119** refusals stay refusals, asserted.

## RED then GREEN

| Gate | RED | GREEN |
|---|---:|---:|
| `Timber_For_One_Is_Timber_For_All` (three unmodified consumers) | **85 of 1,808** names — and the failure list **names `MDF CEILING PANEL 12MM` and `SOLID BAMBOO 14MM`**, as required | 0 |
| `SubstanceVocabularyTests` | **5 failed / 3 passed of 8** | **8 of 8** |
| `Not_One_Row_The_Run_Named_Loses_Its_Substance` (whole-word matcher, stems removed) | **7 of 168** — the brief's figure, reproduced exactly | 0 |
| `TypeRenameSubstanceStemTests` | **5 failed / 5 passed of 10** | **10 of 10** |

The W5c RED is the precise claim: the matcher was already whole-word in that run, and only the stems were removed, so the 7 is the cost of the swap and not of something else.

**A probe defect was found and fixed rather than worked around.** The renamer probe first ran on `Walls`, where `CodeFor` has no `Plywood` key — so five plywood names read as "not timber", a gap in the **code table** being reported as a gap in the **vocabulary**. It probes `Floors` now, which has entries for both `Timber` and `Plywood`, and the docstring says why. Reported because it changed the RED count (90 → 85) and an unexplained number is not evidence.

- Tags: 839 passed, 0 failed (baseline 821)
- Boq: 1249 passed, 0 failed — `BiogenicCarbon` is linked there too, so `SubstanceVocabulary` was added to that project's includes
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors
- `tools/check_workflow_wiring.ps1` — Tier 4 = 0; `tools/check_path_discipline.ps1` — OK

## Fixture

`Fixtures/type_rename_core_materials_20260909.csv` — the 294 rows of `type_rename_plan_20260909_075110.csv` whose `Reason` names a core material, with the proposal that run produced. **A different fixture from the `type_rename_20260909.csv` that #902 adds**, deliberately: that PR is unmerged and stacking on it is what orphans a change. The two should be reconciled when both land.

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- **No embodied-carbon report was regenerated.** The eighteen carbon changes above are the vocabulary's answers over material **names**; what they do to a project's kgCO₂e depends on quantities this has not seen.
- `Baseline_RenameTypes` was not run. The seven newly-named types and the five CMU walls are re-planned from the recorded core materials, not observed.
- `MaterialClassPlanner`'s `Map` is now built at static-init rather than declared as a literal. The order is unchanged and the 1,815-name corpus test passes unmoved, but the change is structural and has only been exercised headlessly.

## Expected conflict

This PR and **#906** both edit `MaterialClassPlanner.cs` — #906 adds a registry consult before the needle loop, this one splices the wood rows into the table. Different regions of the same file; whichever merges second will need a small manual resolution. Flagged rather than avoided by stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
