### PR TITLE
Refuse the other two IndexOf swaps, and ship the gate that proves why (W5a, W5b)

### DIFF
--- a/StingTools.Boq.Tests/SupplierUnitStemTests.cs
+++ b/StingTools.Boq.Tests/SupplierUnitStemTests.cs
@@ -1,0 +1,116 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  SupplierUnitStemTests.cs — W5a. The supplier patterns are PREFIX STEMS, and
+//  this drives the real resolver so that swapping the matcher fails HERE.
+//
+//  The brief listed SupplierUnitConverter:191,228 as the #863 shape and said to
+//  construct the false positive first. Over 1,810 real names there is not one:
+//  every substring-only hit is either correct, or in a category the rule's own
+//  `matchCategories` already excludes. What the swap WOULD do is lose 93 hits,
+//  including two names this plugin generates itself.
+//
+//  The dangerous part, and the reason this file drives `Resolve` rather than
+//  `PatternMatch`: making that swap breaks NOTHING in either test project as it
+//  stood. 827 Tags tests and 1,249 Boq tests all pass with both call sites
+//  converted. A change that silently rounds a roof into the wrong supplier unit,
+//  or into none, is a quantity on an order — and nothing was watching.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    public class SupplierUnitStemTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_SUPPLIER_UNITS.json")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static SupplierUnitTable _table;
+
+        /// <summary>The SHIPPED rules, read from source. A hand-built table would test the
+        /// resolver against itself; the point here is the shipped patterns.</summary>
+        private static SupplierUnitTable Shipped()
+            => _table ??= JsonConvert.DeserializeObject<SupplierUnitTable>(
+                   File.ReadAllText(Path.Combine(DataDir(), "STING_SUPPLIER_UNITS.json")))
+               ?? throw new InvalidOperationException("STING_SUPPLIER_UNITS.json did not deserialise");
+
+        [Fact]
+        public void The_Shipped_Table_Actually_Loaded()
+        {
+            // An empty table would make every assertion below vacuous — the
+            // empty-list-standing-in-for-an-error shape.
+            Assert.True(Shipped().Rules.Count >= 20, "only " + Shipped().Rules.Count + " rules loaded");
+            Assert.Contains(Shipped().Rules, r => r.CommodityKey == "roof-sheet");
+            Assert.Contains(Shipped().Rules, r => r.CommodityKey == "roof-tile");
+        }
+
+        [Theory]
+        // material name                          category   expected commodity
+        [InlineData("Corrugated Iron Sheet IT4", "Roofs", "roof-sheet")]
+        [InlineData("Steel - Galvanised Sheet G28", "Roofs", "roof-sheet")]
+        [InlineData("Steel - Galvanized Sheet G30", "Roofs", "roof-sheet")]
+        public void A_PREFIX_Stem_Still_Resolves_Its_Rule(string material, string category, string commodity)
+        {
+            // corrugat / galvanis / galvaniz are prefixes of words, not words. Whole-word
+            // matching cannot express them, and these three rows are what it would cost.
+            var res = Shipped().Resolve(null, category, "probe", material);
+            Assert.NotNull(res.Rule);
+            Assert.Equal(commodity, res.Rule.CommodityKey);
+        }
+
+        [Theory]
+        [InlineData("PLNS_RTL_StoneCoatedTileRoof1")]
+        [InlineData("PLNS_RTL_ClayTileRoof14")]
+        public void A_Compacted_ISO_Type_Name_Still_Resolves(string typeName)
+        {
+            // The argument that settles W5a. TypeRenamePlanner composes these names, and
+            // this converter is then asked about them. They contain no word boundary at
+            // all, so a whole-word matcher can never see inside one — and the roof would
+            // resolve to no supplier unit rather than to the wrong one, which is a row
+            // that quietly stays in m² on an order priced per tile.
+            var res = Shipped().Resolve(null, "Roofs", typeName);
+            Assert.NotNull(res.Rule);
+            Assert.Equal("roof-tile", res.Rule.CommodityKey);
+        }
+
+        [Fact]
+        public void The_Category_Gate_Is_What_Stops_The_Substring_False_Positives()
+        {
+            // GALVANIZED STEEL PIPE and CORRUGATED HDPE PIPE both match the roof-sheet
+            // rule's material patterns as substrings. They are not roofs, and
+            // matchCategories is what says so — not the matcher. Asserted because the
+            // refusal to make these whole-word rests on this gate doing the work.
+            foreach (string mat in new[] { "GALVANIZED STEEL PIPE 100MM (4 INCH)",
+                                           "CORRUGATED HDPE PIPE 300MM" })
+            {
+                var roof = Shipped().Resolve(null, "Roofs", "probe", mat);
+                Assert.Equal("roof-sheet", roof.Rule?.CommodityKey);      // reachable on a roof
+
+                var pipe = Shipped().Resolve(null, "Pipes", "probe", mat);
+                Assert.True(pipe.Rule == null || pipe.Rule.CommodityKey != "roof-sheet",
+                    mat + " reached the roof-sheet rule from the Pipes category — the "
+                        + "category gate is what makes substring matching safe here.");
+            }
+        }
+
+        [Fact]
+        public void The_Shipped_Note_Says_These_Are_Stems()
+        {
+            // So the next person to reach for "tidy these into whole words" reads it in the
+            // data file, not in a changelog.
+            string json = File.ReadAllText(Path.Combine(DataDir(), "STING_SUPPLIER_UNITS.json"));
+            Assert.Contains("DELIBERATE PREFIX STEMS", json, StringComparison.Ordinal);
+            Assert.Contains("MatcherSwapRefusalTests", json, StringComparison.Ordinal);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/MatcherSwapRefusalTests.cs
+++ b/StingTools.Tags.Tests/MatcherSwapRefusalTests.cs
@@ -1,0 +1,336 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MatcherSwapRefusalTests.cs — W5a and W5b: the two remaining `IndexOf` sites
+//  are NOT swapped for whole-word matching, and this is why.
+//
+//  The brief listed three `IndexOf` sites as "the #863 shape — substring where a
+//  whole word was meant", and told me to construct the false positive FIRST and
+//  prove it RED. That instruction is what saved these two. The third site
+//  (TypeRenamePlanner.Match) had a real false positive and a real fix, and is
+//  swapped in its own PR. These two do not, and are not.
+//
+//  ── W5a  SupplierUnitConverter:191,228 ─────────────────────────────────────
+//
+//  Its patterns are DELIBERATE PREFIX STEMS, and two of them have to match names
+//  this plugin generates itself:
+//
+//      corrugat   catches corrugated / corrugation
+//      galvanis   catches galvanised / galvanized
+//      galvaniz
+//      profil     catches profile / profiled
+//      stonecoat  catches PLNS_RTL_StoneCoatedTileRoof1
+//      clay       catches PLNS_RTL_ClayTileRoof14
+//
+//  The last two are the argument that settles it. `PatternMatch` treats letters
+//  and digits as word characters, so it can NEVER match inside a compacted ISO
+//  22014 name — and compacted ISO 22014 names are what `TypeRenamePlanner`
+//  produces and what this converter is then asked about. Whole-word matching is
+//  structurally incompatible with the names the plugin makes.
+//
+//  Measured over the 1,810 names this repository carries (the register plus every
+//  corpus fixture): 93 substring-only hits, and not one of them is a false
+//  positive that the rules' own `matchCategories` gate does not already stop.
+//  Widened with the type and family names from the 2026-09-09 model it is 111 of
+//  2,038 — same answer, and only the in-repo figure is reproducible here.
+//
+//  ── W5b  ProductExclusion:148 ──────────────────────────────────────────────
+//
+//  This one I got wrong first and the measurement corrected me. Reading only the
+//  FAMILY name, `opening` is not a whole word in `M_GM_OpeningWall_Instance`, and
+//  swapping the matcher looked like it would return 1,187 wall voids to the PROD
+//  denominator. It does not: `Classify` matches against `description + " " +
+//  typeName`, and the type name on all 1,187 is literally `Opening`.
+//
+//  Replayed over the real 1,688-row audit, substring and whole-word give the
+//  IDENTICAL verdict on every row. So the swap is measurably neutral today — and
+//  it is strictly more fragile tomorrow, because it makes the exclusion depend on
+//  a word boundary in a joined haystack nobody controls: the same family with a
+//  blank type name stops being excluded, and `Air Openings` (plural) stops being
+//  excluded. Neither has an error state; both would show up as a coverage
+//  percentage moving.
+//
+//  A change with no measured benefit and an unmeasured downside is not a fix.
+//  What ships instead is this file, so the next person to reach for the swap
+//  finds the measurement rather than repeating it.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using StingTools.Core;
+using StingTools.Core.MaterialSchedule;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class MatcherSwapRefusalTests
+    {
+        private readonly ITestOutputHelper _out;
+        public MatcherSwapRefusalTests(ITestOutputHelper output) => _out = output;
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "STING_SUPPLIER_UNITS.json")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static JObject Data(string file)
+            => JObject.Parse(File.ReadAllText(Path.Combine(DataDir(), file)));
+
+        /// <summary>Substring, as the two sites under discussion actually match.</summary>
+        private static bool Substring(string hay, string pattern)
+            => (hay ?? "").IndexOf((pattern ?? "").Trim(), StringComparison.OrdinalIgnoreCase) >= 0;
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  W5a — the supplier patterns are stems, and two must match camelCase
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static List<string> SupplierPatterns(string key)
+            => Data("STING_SUPPLIER_UNITS.json")["rules"]
+               .SelectMany(r => (r[key] as JArray) ?? new JArray())
+               .Select(p => p.ToString().Trim())
+               .Where(p => p.Length > 0)
+               .Distinct(StringComparer.OrdinalIgnoreCase)
+               .OrderBy(p => p, StringComparer.Ordinal)
+               .ToList();
+
+        [Fact]
+        public void The_Supplier_Patterns_Include_Deliberate_PREFIX_Stems()
+        {
+            // If these ever stop being stems the refusal below should be revisited — so the
+            // reason is asserted against the shipped data rather than described in a comment.
+            var all = SupplierPatterns("matchMaterialPatterns")
+                      .Concat(SupplierPatterns("matchTypePatterns")).ToList();
+
+            foreach (string stem in new[] { "corrugat", "galvanis", "galvaniz", "profil", "stonecoat" })
+                Assert.Contains(stem, all, StringComparer.OrdinalIgnoreCase);
+
+            // Each is a prefix of a real word and is NOT itself one — which is exactly what
+            // whole-word matching cannot express.
+            Assert.True(Substring("CORRUGATED IRON SHEET", "corrugat"));
+            Assert.False(PatternMatch.Contains("CORRUGATED IRON SHEET", "corrugat"));
+            Assert.True(Substring("GALVANIZED STEEL SHEET G28", "galvaniz"));
+            Assert.False(PatternMatch.Contains("GALVANIZED STEEL SHEET G28", "galvaniz"));
+        }
+
+        [Fact]
+        public void Whole_Word_Matching_Cannot_See_Inside_The_Names_This_Plugin_Generates()
+        {
+            // The argument that settles W5a. TypeRenamePlanner composes compacted ISO 22014
+            // names, and SupplierUnitConverter is then asked about those names. PatternMatch
+            // treats letters and digits as word characters, so there is no boundary to find.
+            foreach (var (name, pattern) in new[]
+            {
+                ("PLNS_RTL_StoneCoatedTileRoof1", "stonecoat"),
+                ("PLNS_RTL_ClayTileRoof14", "clay"),
+                ("PLNS_RSH_Timber50-Tiled", "tile"),
+            })
+            {
+                Assert.True(Substring(name, pattern), $"'{pattern}' should be a substring of {name}");
+                Assert.False(PatternMatch.Contains(name, pattern),
+                    $"'{pattern}' unexpectedly matches {name} as a whole word — if compacted ISO "
+                  + "names have gained separators, W5a is worth revisiting.");
+            }
+        }
+
+        [Fact]
+        public void No_Supplier_Pattern_Has_A_False_Positive_Its_Category_Gate_Does_Not_Stop()
+        {
+            // The brief said: construct the false positive first, prove it RED. Over 2,038
+            // real names there is not one. Every substring-only hit is either a correct
+            // match (GALVANIZED STEEL SHEET) or an element in a category the rule's own
+            // matchCategories excludes (GALVANIZED STEEL PIPE is a Pipe, not a Roof).
+            //
+            // Listed rather than counted, so the claim can be checked rather than believed.
+            var pool = NamePool();
+            var patterns = SupplierPatterns("matchMaterialPatterns")
+                           .Concat(SupplierPatterns("matchTypePatterns"))
+                           .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            int substringOnly = 0;
+            foreach (string p in patterns)
+            {
+                var only = pool.Where(n => Substring(n, p) && !PatternMatch.Contains(n, p)).ToList();
+                if (only.Count == 0) continue;
+                substringOnly += only.Count;
+                _out.WriteLine($"'{p}' — {only.Count} substring-only: {string.Join(" | ", only.Take(4))}");
+            }
+
+            _out.WriteLine($"\n{substringOnly} substring-only hits across {patterns.Count} patterns "
+                         + $"and {pool.Count} names.");
+            Assert.True(substringOnly > 50,
+                "Whole-word matching now loses almost nothing here, so the refusal in this "
+              + "file should be re-examined against fresh data.");
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  W5b — measurably neutral, and more fragile
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Wall_Voids_Are_Excluded_By_Their_TYPE_Name_Not_Their_Family_Name()
+        {
+            // The correction. Read as a family name alone, `opening` is not a whole word in
+            // M_GM_OpeningWall_Instance — which is what made the swap look catastrophic.
+            // Classify matches description + " " + typeName, and the type name is `Opening`.
+            const string family = "M_GM_OpeningWall_Instance";
+            Assert.False(PatternMatch.Contains(family, "opening"));
+
+            string hay = family + " " + "Opening";
+            Assert.True(PatternMatch.Contains(hay, "opening"));
+            Assert.True(Substring(hay, "opening"));
+
+            // And through the real matcher, both ways round.
+            var ex = ProductExclusion.Build(null, new[] { "opening", "muntin" }, null, null);
+            Assert.Equal(ExclusionVerdict.ByPattern, ex.Classify("Generic Models", family, "Opening"));
+        }
+
+        [Fact]
+        public void Whole_Word_Would_Break_The_Cases_The_Joined_Haystack_Currently_Carries()
+        {
+            // The fragility the measurement does not show, because this model happens not to
+            // contain them. Both are one keystroke away in any project.
+            //
+            //   a blank type name  — the family alone no longer matches
+            //   a plural family    — "Air Openings" is a real material name in this register
+            foreach (var (family, typeName) in new[]
+            {
+                ("M_GM_OpeningWall_Instance", ""),
+                ("Air Openings", ""),
+            })
+            {
+                string hay = family + " " + typeName;
+                Assert.True(Substring(hay, "opening"),
+                    $"'{hay}' is excluded today by substring matching");
+                Assert.False(PatternMatch.Contains(hay, "opening"),
+                    $"'{hay}' would STOP being excluded if this matcher became whole-word — "
+                  + "and a denominator has no error state.");
+            }
+        }
+
+        [Fact]
+        public void The_Real_Exclusion_Call_Site_Still_Catches_A_Plural_And_A_Blank_Type()
+        {
+            // Driving ProductExclusion.Classify, not PatternMatch — so that MAKING the swap
+            // fails here. It has to: converting both call sites breaks NOTHING in either
+            // test project as they stood (827 Tags + 1,249 Boq all pass), and a wall void
+            // returning to the PROD denominator has no error state.
+            var ex = ProductExclusion.Build(
+                new[] { "Rooms" }, new[] { "opening", "muntin" }, new[] { "Windows", "Doors" }, null);
+
+            // A blank type name: the family alone must still carry the exclusion.
+            Assert.Equal(ExclusionVerdict.ByPattern,
+                ex.Classify("Generic Models", "M_GM_OpeningWall_Instance", ""));
+
+            // A plural family: "Air Openings" is a real name in the shipped register.
+            Assert.Equal(ExclusionVerdict.ByPattern,
+                ex.Classify("Generic Models", "Air Openings", ""));
+
+            // And the case the delivered model actually had, which survives either matcher.
+            Assert.Equal(ExclusionVerdict.ByPattern,
+                ex.Classify("Generic Models", "M_GM_OpeningWall_Instance", "Opening"));
+        }
+
+        [Fact]
+        public void The_Exclusion_Patterns_Are_Long_Enough_That_Substring_Is_Safe()
+        {
+            // Why substring is tolerable HERE and was not in TypeRenamePlanner: "opening"
+            // and "muntin" are seven and six letters and appear inside no unrelated English
+            // word, where "tile" and "rc" appear inside dozens. The historical false
+            // positive on this list — a real window type — was fixed by protectedCategories,
+            // not by the matcher, and that protection is still what does the work.
+            var patterns = (Data("STING_PROD_EXCLUSIONS.json")["notAProductPatterns"] as JArray)
+                           .Select(p => p.ToString()).ToList();
+            Assert.Equal(new[] { "opening", "muntin" }, patterns);
+            Assert.All(patterns, p => Assert.True(p.Length >= 6,
+                $"'{p}' is short enough to appear inside an unrelated word — a short pattern "
+              + "is where substring matching stops being safe, and this file's refusal with it."));
+
+            // The protection, still doing the work.
+            var ex = ProductExclusion.Build(null, patterns, new[] { "Windows", "Doors" }, null);
+            Assert.Equal(ExclusionVerdict.Included, ex.Classify("Windows", "Opening Window", ""));
+            Assert.Equal(ExclusionVerdict.ByPattern, ex.Classify("Generic Models", "Wall Opening", ""));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static List<string> _pool;
+
+        /// <summary>Every real name available: register MAT_NAMEs, the material corpus, and
+        /// the type and family names from the delivered model.</summary>
+        private static List<string> NamePool()
+        {
+            if (_pool != null) return _pool;
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            var root = new DirectoryInfo(DataDir()).Parent.Parent;
+
+            foreach (string f in new[] { "BLE_MATERIALS.csv", "MEP_MATERIALS.csv" })
+                foreach (string n in Column(Path.Combine(DataDir(), f), "MAT_NAME")) set.Add(n);
+
+            string fixtures = Path.Combine(root.FullName, "StingTools.Tags.Tests", "Fixtures");
+            foreach (string f in Directory.GetFiles(fixtures, "material_names_*.csv"))
+                foreach (string n in FirstColumn(f)) set.Add(n);
+            foreach (string f in Directory.GetFiles(fixtures, "type_rename_*.csv"))
+                foreach (string n in Column(f, "CurrentName")) set.Add(n);
+            foreach (string f in Directory.GetFiles(fixtures, "type_rename_*.csv"))
+                foreach (string n in Column(f, "RecordedProposal")) set.Add(n);
+
+            // The two compacted ISO names the argument turns on must be in the pool even if
+            // no fixture happens to carry them, or this test could pass on their absence.
+            set.Add("PLNS_RTL_StoneCoatedTileRoof1");
+            set.Add("PLNS_RTL_ClayTileRoof14");
+
+            Assert.True(set.Count > 1500, "only " + set.Count + " names pooled");
+            return _pool = set.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        }
+
+        private static IEnumerable<string> FirstColumn(string path)
+            => File.ReadAllLines(path).Skip(1)
+                   .Where(l => !string.IsNullOrWhiteSpace(l))
+                   .Select(l => Split(l).FirstOrDefault())
+                   .Where(s => !string.IsNullOrWhiteSpace(s));
+
+        private static IEnumerable<string> Column(string path, string column)
+        {
+            var lines = File.ReadAllLines(path)
+                            .Where(l => !string.IsNullOrWhiteSpace(l) && !l.TrimStart().StartsWith("#"))
+                            .ToList();
+            if (lines.Count < 2) yield break;
+            var header = Split(lines[0]);
+            int i = header.FindIndex(h => string.Equals((h ?? "").Trim().TrimStart('﻿'), column,
+                                                        StringComparison.OrdinalIgnoreCase));
+            if (i < 0) yield break;
+            foreach (string line in lines.Skip(1))
+            {
+                var c = Split(line);
+                if (i < c.Count && !string.IsNullOrWhiteSpace(c[i])) yield return c[i].Trim();
+            }
+        }
+
+        private static List<string> Split(string line)
+        {
+            var fields = new List<string>();
+            var cur = new System.Text.StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < (line ?? "").Length; i++)
+            {
+                char ch = line[i];
+                if (quoted)
+                {
+                    if (ch != '"') { cur.Append(ch); continue; }
+                    if (i + 1 < line.Length && line[i + 1] == '"') { cur.Append('"'); i++; continue; }
+                    quoted = false;
+                }
+                else if (ch == '"' && cur.Length == 0) quoted = true;
+                else if (ch == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(ch);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+    }
+}

--- a/StingTools/Data/STING_SUPPLIER_UNITS.json
+++ b/StingTools/Data/STING_SUPPLIER_UNITS.json
@@ -1,6 +1,6 @@
 {
  "schemaVersion": "1.0",
- "note": "Corporate baseline. Project override: <project>/_data/coord/supplier_units.json (merged by commodityKey).",
+ "note": "Corporate baseline. Project override: <project>/_data/coord/supplier_units.json (merged by commodityKey). MATCHING IS SUBSTRING, AND SOME PATTERNS ARE DELIBERATE PREFIX STEMS - corrugat, galvanis, galvaniz, profil, stonecoat, clay. Do not \"tidy\" them into whole words: stonecoat and clay have to match PLNS_RTL_StoneCoatedTileRoof1 and PLNS_RTL_ClayTileRoof14, which this plugin generates itself in compacted ISO 22014 form and which contain no word boundaries at all. Measured 2026-09-09 over 1,810 real names: whole-word matching would lose 93 hits and fix nothing. See StingTools.Tags.Tests/MatcherSwapRefusalTests.cs.",
  "rules": [
   {
    "commodityKey": "cement",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 259 — two of the three IndexOf sites are refused, with the measurement that refuses them)
+
+The brief listed three `IndexOf` sites as the #863 shape and said to **construct
+the false positive first and prove it RED**. That instruction is what saved two
+of them. The third (`TypeRenamePlanner.Match`) had a real false positive and a
+real fix and is swapped elsewhere; these two do not, and are not.
+
+**W5a — `SupplierUnitConverter:191,228`. The patterns are deliberate PREFIX
+STEMS**, and two of them have to match names this plugin generates itself:
+
+    corrugat   catches corrugated / corrugation
+    galvanis   catches galvanised          galvaniz  catches galvanized
+    profil     catches profile / profiled
+    stonecoat  catches PLNS_RTL_StoneCoatedTileRoof1
+    clay       catches PLNS_RTL_ClayTileRoof14
+
+The last two settle it. `PatternMatch` treats letters and digits as word
+characters, so it can **never** match inside a compacted ISO 22014 name — and
+compacted ISO 22014 names are exactly what `TypeRenamePlanner` composes and what
+this converter is then asked about. Whole-word matching is structurally
+incompatible with the names the plugin makes.
+
+Measured over the 1,810 names this repository carries: **93 substring-only hits,
+and not one is a false positive the rules' own `matchCategories` gate does not
+already stop.** `GALVANIZED STEEL PIPE` matches the roof-sheet rule's material
+patterns and is a Pipe, not a Roof — the category gate is what does that work,
+not the matcher.
+
+**W5b — `ProductExclusion:148`. I got this wrong first, and the measurement
+corrected me.** Reading only the FAMILY name, `opening` is not a whole word in
+`M_GM_OpeningWall_Instance`, and the swap looked like it would return 1,187 wall
+voids to the PROD denominator. It does not: `Classify` matches
+`description + " " + typeName`, and the type name on all 1,187 is literally
+`Opening`. Replayed over the real 1,688-row audit, substring and whole-word give
+the **identical verdict on every row**.
+
+So the swap is measurably neutral today and strictly more fragile tomorrow: it
+makes the exclusion depend on a word boundary in a joined haystack nobody
+controls. The same family with a blank type name stops being excluded, and
+`Air Openings` — a real name in the shipped register — stops being excluded.
+Neither has an error state. A change with no measured benefit and an unmeasured
+downside is not a fix.
+
+**THE PART THAT MATTERED MOST: making both swaps broke NOTHING.** With both call
+sites converted, 827 Tags tests and 1,249 Boq tests all passed. A roof silently
+resolving to the wrong supplier unit — or to none, staying in m² on an order
+priced per tile — had nothing watching it.
+
+So what ships is the gate. `SupplierUnitStemTests` drives the real
+`SupplierUnitTable.Resolve` against the SHIPPED rules, and
+`MatcherSwapRefusalTests` drives the real `ProductExclusion.Classify` — both at
+the call site, not at the matcher, so that MAKING the swap fails.
+
+*RED, with both swaps applied:* **1 of 7** in Tags
+(`The_Real_Exclusion_Call_Site_Still_Catches_A_Plural_And_A_Blank_Type`) and
+**5 of 8** in Boq (both compacted ISO names, both galvanis/galvaniz stems, and
+the category-gate assertion). Reverted: 7 of 7 and 8 of 8.
+
+`STING_SUPPLIER_UNITS.json`'s own `note` now says the patterns are stems, why,
+and where the measurement lives — so the next person reads it in the data file
+rather than repeating the work.
+
+Tags 828 passed (baseline 821), Boq 1257 passed (baseline 1249), plugin builds
+0 warnings / 0 errors. **No production line was changed in this PR** — the two
+`IndexOf` sites are exactly as they were.
+
 #### Completed (Phase 258 — the entourage car leaves the denominator, and the override that does it is pinned)
 
 `prod_coverage_20260908_221546.csv` still carries


### PR DESCRIPTION
W5a and W5b from `HANDOVER_MATERIAL_ALIGNMENT.md`. Branched from `origin/main` (`7a5fcf05d`).

**Neither swap is made.** The brief said to *construct the false positive first and prove it RED*, and that instruction is what saved these two: the false positive does not exist, and the swap costs real hits. What ships is the measurement and the gate that pins it.

The third `IndexOf` site — `TypeRenamePlanner.Match` — did have a real false positive and a real fix, and is swapped in **#907**.

## W5a — the supplier patterns are deliberate prefix stems

```
corrugat   catches corrugated / corrugation
galvanis   catches galvanised           galvaniz  catches galvanized
profil     catches profile / profiled
stonecoat  catches PLNS_RTL_StoneCoatedTileRoof1
clay       catches PLNS_RTL_ClayTileRoof14
```

**The last two settle it.** `PatternMatch` treats letters *and digits* as word characters, so it can **never** match inside a compacted ISO 22014 name — and compacted ISO 22014 names are exactly what `TypeRenamePlanner` composes and what this converter is then asked about. Whole-word matching is structurally incompatible with the names the plugin generates for itself.

Measured over the **1,810 names this repository carries** (register + every corpus fixture): **93 substring-only hits, and not one of them is a false positive** that the rules' own `matchCategories` gate does not already stop. `GALVANIZED STEEL PIPE 100MM` does match the roof-sheet rule's material patterns — and is a Pipe, not a Roof. The **category gate** is what makes substring matching safe here, and that is asserted rather than assumed.

(Widened with the type and family names from the 2026-09-09 model it is 111 of 2,038 — same answer. Only the in-repo figure is reproducible from this checkout, so that is the one in the header.)

## W5b — I got this wrong first, and the measurement corrected me

Reading only the **family** name, `opening` is not a whole word in `M_GM_OpeningWall_Instance`, and the swap looked like it would return **1,187 wall voids** to the PROD denominator — the exact rows this exclusion list was built for.

It does not. `Classify` matches `description + " " + typeName`, and the type name on all 1,187 is literally `Opening`. Replayed over the real 1,688-row audit (`prod_coverage_20260908_143253.csv`), substring and whole-word give the **identical verdict on every row**:

```
substring : Included 417 · ByPattern 1209 · ByCategory 62
whole-word: Included 417 · ByPattern 1209 · ByCategory 62      0 rows change
```

So the swap is **measurably neutral today and strictly more fragile tomorrow**. It makes the exclusion depend on a word boundary in a joined haystack nobody controls:

| case | substring | whole-word |
|---|---|---|
| `M_GM_OpeningWall_Instance` + type `Opening` | excluded | excluded |
| `M_GM_OpeningWall_Instance` + **blank type** | excluded | **included** |
| `Air Openings` (a real register name) + blank type | excluded | **included** |

Neither has an error state; both would surface only as a coverage percentage moving. A change with no measured benefit and an unmeasured downside is not a fix.

## The part that mattered most

**Making both swaps broke nothing.** With both call sites converted to `PatternMatch.Contains`:

```
Tags: 827 passed, 0 failed
Boq : 1249 passed, 0 failed
```

A roof silently resolving to the wrong supplier unit — or to none, staying in m² on an order priced per tile — had **nothing watching it**. That is the finding, and it is why a refusal alone would not have been enough.

## So what ships is the gate

Both new test files drive the **real call site**, not the matcher, so that *making* the swap fails:

- `StingTools.Boq.Tests/SupplierUnitStemTests.cs` → `SupplierUnitTable.Resolve` against the **shipped** `STING_SUPPLIER_UNITS.json`
- `StingTools.Tags.Tests/MatcherSwapRefusalTests.cs` → `ProductExclusion.Classify`

| Gate | RED (both swaps applied) | GREEN (reverted) |
|---|---:|---:|
| `MatcherSwapRefusalTests` | **1 of 7** — `The_Real_Exclusion_Call_Site_Still_Catches_A_Plural_And_A_Blank_Type` | **7 of 7** |
| `SupplierUnitStemTests` | **5 of 8** — both compacted ISO names, both `galvanis`/`galvaniz` stems, and the category-gate assertion | **8 of 8** |

`No_Supplier_Pattern_Has_A_False_Positive_Its_Category_Gate_Does_Not_Stop` is a **reverse** gate: it fails if the 93 substring-only hits ever drop below 50, i.e. if the argument for this refusal stops holding. Same for `Whole_Word_Matching_Cannot_See_Inside_The_Names_This_Plugin_Generates`, which fails if compacted ISO names ever gain separators.

`STING_SUPPLIER_UNITS.json`'s own `note` now says the patterns are stems, why, and where the measurement lives — so the next person to reach for "tidy these into whole words" reads it in the data file rather than repeating the work.

- Tags: 828 passed, 0 failed (baseline 821)
- Boq: 1257 passed, 0 failed (baseline 1249)
- `dotnet build StingTools/StingTools.csproj -c Debug` — 0 warnings, 0 errors
- **No production line was changed.** `git diff` outside the tests is one line: the JSON note.

## NOT verified in Revit

`deploy.bat` was not run and nothing here executed in a Revit session.

- The 1,688-row replay is a **re-implementation of `Classify`'s rules in a script** against the real audit CSV, not the shipped `ProductExclusion` walking a document. The shipped class is exercised directly in the tests, on the specific rows the argument turns on.
- `SupplierUnitTable.Resolve` is exercised against the shipped JSON but not against a Revit element; `constituentKind` (which wins over both pattern routes) is not in play in these tests.
- No supplier unit, quantity or order was regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCsYLA9TmuDC1F2DDTx26
