### PR TITLE
Re-derive the three role-vocabulary assertions main was missing (from claude/iso19650-role-vocabulary)

### DIFF
--- a/Planscape.Server/tests/Planscape.Tests/Iso19650RoleValidationTests.cs
+++ b/Planscape.Server/tests/Planscape.Tests/Iso19650RoleValidationTests.cs
@@ -290,4 +290,67 @@ public class Iso19650RoleValidationTests
 
         Assert.Equal(18, Iso19650Roles.All.Count);
     }
+
+    // ── Re-derived from claude/iso19650-role-vocabulary ─────────────────────
+    //
+    // That branch is 206 commits behind and its API is gone: it had AllCodes and
+    // All[].Label where main has All and Catalogue[].Label, so its tests could not
+    // be cherry-picked. Of its twelve assertions, nine are renamed equivalents of
+    // ones already here. These three had no counterpart, and are rewritten against
+    // what shipped.
+
+    /// <summary>
+    /// A duplicate or blank code would not throw anywhere. IsCanonical would still
+    /// answer true, the picker would show two identical rows or one empty one, and
+    /// the error payload would offer a code nobody can choose.
+    /// </summary>
+    [Fact]
+    public void Every_code_is_distinct_and_non_blank()
+    {
+        Assert.Equal(Iso19650Roles.All.Count, Iso19650Roles.All.Distinct(
+            StringComparer.OrdinalIgnoreCase).Count());
+        Assert.All(Iso19650Roles.All, c => Assert.False(string.IsNullOrWhiteSpace(c)));
+        Assert.All(Iso19650Roles.Catalogue,
+            r => Assert.False(string.IsNullOrWhiteSpace(r.Label)));
+    }
+
+    /// <summary>
+    /// IsCanonical(null) is false, and that is correct for a MEMBERSHIP test — null
+    /// is not a member of the vocabulary.
+    ///
+    /// <para>It must never be read as "reject". Every write site treats a null
+    /// Iso19650Role as "the caller did not supply this field, leave the stored value
+    /// alone"; a site that guarded with IsCanonical and rejected on false would make
+    /// every partial update fail for anyone whose row is already correct. The
+    /// behavioural half is covered by
+    /// An_edit_that_omits_the_field_leaves_a_stray_row_untouched_and_succeeds; this
+    /// pins the unit contract that sits under it.</para>
+    /// </summary>
+    [Fact]
+    public void Null_is_not_canonical_and_that_must_not_mean_rejected()
+    {
+        Assert.False(Iso19650Roles.IsCanonical(null));
+        Assert.False(Iso19650Roles.IsCanonical(""));
+        Assert.False(Iso19650Roles.IsCanonical("   "));
+    }
+
+    /// <summary>
+    /// The four values found in real ProjectMember rows that this vocabulary does
+    /// NOT contain. "K" and "C" came from a dead gate; "EL" and "S" are strays, "S"
+    /// having leaked from the AppUser role list, which is a different vocabulary.
+    ///
+    /// <para>Pinned because the tempting repair for a stray row is to widen the
+    /// vocabulary until it validates, which resolves the error by accepting the bad
+    /// data. Each of these is one character away from a real code — S/SE/SC, C/CE —
+    /// so widening looks reasonable at the moment somebody does it.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("K")]
+    [InlineData("C")]
+    [InlineData("EL")]
+    [InlineData("S")]
+    public void A_known_stray_is_not_in_the_vocabulary(string stray)
+    {
+        Assert.False(Iso19650Roles.IsCanonical(stray));
+    }
 }


### PR DESCRIPTION
Closes the third of the three blocked branches from the branch-backlog pass. The other two were verified absorbed and deleted; this one was **not** absorbed, and the brief was right to flag it.

## What was actually on that branch

`claude/iso19650-role-vocabulary` is **206 commits behind**, and its API is gone: it had `Iso19650Roles.AllCodes` and `All[].Label` where main has `All` and `Catalogue[].Label`. Nothing on it compiles here, so nothing could be cherry-picked.

Measured against today's main — restricting the diff to the files its own commits touched, which is where the "4 files" figure comes from:

| | |
|---|---|
| its assertions | 12 |
| renamed equivalents already on main | **9** |
| genuinely absent from main | **3** |
| assertions **main has and the branch lacks** | **2** |

Main is ahead on `Validation_is_case_insensitive_like_ProjectRole` and `The_vocabulary_still_contains_every_code_it_shipped_with`. That is why this is a re-derivation and not a merge — merging would have been a net loss.

## The three, rewritten against what shipped

**`Every_code_is_distinct_and_non_blank`** — a duplicate or blank code throws nowhere. `IsCanonical` still answers true, the picker shows two identical rows or one empty one, and the `invalid_project_role` payload offers a code nobody can choose.

**`Null_is_not_canonical_and_that_must_not_mean_rejected`** — `IsCanonical(null)` is false, which is correct for a *membership* test. It must never be read as "reject": every write site treats a null `Iso19650Role` as *"the caller did not supply this field, leave the stored value alone"*. A site that guarded with `IsCanonical` and rejected on false would fail every partial update for anyone whose row is already correct. The behavioural half is already covered; this pins the unit contract underneath it.

**`A_known_stray_is_not_in_the_vocabulary`** (`K`, `C`, `EL`, `S`) — the four values found in real `ProjectMember` rows that this vocabulary does not contain. `K` and `C` came from a dead gate; `S` leaked from the `AppUser` role list, which is a different vocabulary.

Worth pinning because the tempting repair for a stray row is to **widen the vocabulary until it validates** — which resolves the error by accepting the bad data. Each of these is one character from a real code (`S`/`SE`/`SC`, `C`/`CE`), so widening looks reasonable at the moment somebody does it.

## Sabotage

Each mutation proven to have landed first:

```
control - main as committed                              passes  OK
a code is duplicated in the catalogue                    FAILS   OK
a label is blank                                         FAILS   OK
IsCanonical accepts null                                 FAILS   OK
a known stray 'S' is added to the vocabulary             FAILS   OK
```

## Verification

- **No production code changed** — assertions only.
- `Planscape.Tests` **931 passing / 19 skipped**; this class **11 → 17**.
- Plugin builds **0 warnings / 0 errors**.

## What happens to the branch

`claude/iso19650-role-vocabulary` can be deleted once this merges — its three unique assertions are here and main is ahead on everything else. I have left it in place, along with its worktree (`wt-authz-model`, clean), rather than deleting a branch whose content had not yet landed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErB6VuRkLkuWxdNwV7ddSY
