### PR TITLE
Replace the raw NUL byte #902 shipped with the escape it meant

### DIFF
--- a/StingTools/Core/Baseline/TypeRenamePlanner.cs
+++ b/StingTools/Core/Baseline/TypeRenamePlanner.cs
@@ -389,7 +389,7 @@ namespace StingTools.Core.Baseline
             {
                 string held = p.IsProposal ? p.ProposedName : p.CurrentName;
                 if (string.IsNullOrWhiteSpace(held)) continue;
-                string key = (p.Category ?? "") + " " + held.Trim();
+                string key = (p.Category ?? "") + "\u0000" + held.Trim();
                 if (!claims.TryGetValue(key, out var l)) claims[key] = l = new List<TypeRenameProposal>();
                 l.Add(p);
             }


### PR DESCRIPTION
`GateDuplicateNames` joins category and name with a separator that cannot occur in either. The intent was `"\u0000"`. What landed in the file was a **literal 0x00 byte**.

```
b'string key = (p.Category ?? "") + "\x00" + held.Trim();'
```

The code worked. Git did not — a NUL byte makes git classify the file as **binary**, so `TypeRenamePlanner.cs` stopped producing diffs and stopped auto-merging. #907's merge hit it as a whole-file binary conflict and had to be resolved by taking one side and re-applying the other PRs' edits with a script, then grep-verifying that all four survived. **A source file that cannot be diffed cannot be reviewed either**, which is the more serious half.

Mine, from #902. Found by the agent working #913, which flagged it rather than tidying it — correctly, since it was unrelated to that change.

**One character of content.** The large line count is git re-normalising line endings on a file that was binary and is now text again:

```
git diff --ignore-cr-at-eol --stat  →  1 file changed, 1 insertion(+), 1 deletion(-)
```

Build 0 errors / 0 warnings, `StingTools.Tags.Tests` 919/919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)