### PR TITLE
The playbook markdown was a naming migration behind, and claimed to be the source

### DIFF
--- a/GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md
+++ b/GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md
@@ -4,8 +4,12 @@
 <!-- maintainer-note -->
 > **The issued document is `KUT_Project_Delivery_Playbook.docx`** (repo root), built by
 > `tools/build_team_playbook.py`. This markdown is the working draft used to review content.
-> Edit content here, then regenerate the `.docx` — do not hand-edit the Word file, or the two
-> will drift apart. Everything outside this note is scanned for product, command and parameter
+> **This file is NOT read by the generator.** `tools/build_team_playbook.py` names it in a
+> comment as "source content" and never opens it — the issued text lives in the Python.
+> Editing here changes nothing in the `.docx`, and nothing warned about that until the
+> code tables in section 3 had drifted a whole naming migration behind it. To change the
+> issued playbook, edit `tools/build_team_playbook.py`. The code tables in 3.3 and 3.4 are
+> now derived from `tools/kut_naming.py` and gated by `tools/check_kut_documents.py`. Everything outside this note is scanned for product, command and parameter
 > names by `check_kut_documents.py`; this note is not.
 <!-- /maintainer-note -->
 
@@ -167,35 +171,63 @@ Separator is a hyphen. No spaces. Upper case throughout.
 
 ## 3.3 Role (discipline) codes — the permitted set
 
-Only these eight are valid on KUT. A model or sheet carrying anything else fails the standards audit.
+These 12 are valid on KUT, from **BS EN ISO 19650-2 UK National Annex, Table NA.3**.
+A container carrying anything else fails the standards audit.
 
 | Code | Discipline |
 |---|---|
-| `A` | Architecture / Interiors |
-| `S` | Structural |
-| `M` | Mechanical |
-| `E` | Electrical |
-| `P` | Plumbing / Public Health |
-| `FP` | Fire protection |
-| `LV` | Low voltage / communications |
-| `G` | Civil / site |
+| `A` | Architect |
+| `C` | Civil Engineer |
+| `E` | Electrical Engineer |
+| `I` | Interior Designer — including FF&E and finishes |
+| `M` | Mechanical Engineer |
+| `P` | Public Health Engineer — plumbing and drainage |
+| `Q` | Quantity Surveyor |
+| `S` | Structural Engineer |
+| `W` | Contractor |
+| `X` | Sub-contractor |
+| `Y` | Specialist Designer — fire protection, low voltage and communications |
+| `Z` | General — multi-discipline, federated and management containers |
+
+> **`FP`, `LV` and `G` were withdrawn.** Fire protection and low voltage both issue
+> under `Y` (Specialist Designer), distinguished by the Volume/System field — they were
+> never role codes in the standard. `G` is the Geographical/Land Surveyor; civil is `C`,
+> so a container issued as `-G-` claimed to come from a land surveyor.
+> Register references such as `FP-200` and `LV-200` deliberately keep the old letters:
+> they are internal ids, and renaming them collides (`FP-200` and `LV-200` would both
+> become `Y-200`).
+
 
 ## 3.4 Type codes
 
+From **BS EN ISO 19650-2 UK National Annex, Table NA.2**.
+
 | Code | Meaning |
 |---|---|
+| `CO` | Correspondence |
+| `CP` | Cost plan — including bills of quantities |
+| `CR` | Clash rendition |
+| `DR` | Drawing — including sheets |
+| `IE` | Information exchange — including transmittals |
+| `M2` | 2D model |
 | `M3` | 3D model |
-| `M2` | 2D model / drafting |
-| `DR` | Drawing |
-| `SH` | Sheet |
-| `SC` | Schedule |
-| `SP` | Specification |
-| `RP` | Report |
-| `CA` | Calculation |
-| `RD` | Room data sheet |
-| `MS` | Method statement |
+| `MI` | Minutes or action list |
 | `PP` | Presentation |
-| `CR` | Clash / coordination report |
+| `PR` | Programme |
+| `RD` | Room data sheet |
+| `RI` | Request for information |
+| `RP` | Report — including calculations and method statements |
+| `SH` | Schedule |
+| `SN` | Snagging list |
+| `SP` | Specification |
+| `SU` | Survey |
+| `VS` | Visualisation |
+
+> **`SH` is a Schedule, not a Sheet.** A sheet is a drawing — `DR`. This document
+> previously had it the other way round and invented `SC` for a schedule, so a name like
+> `KUT-SMB-01-GF-SH-A-0100` was valid under both readings and meant different things.
+> `CA` (calculation) and `MS` (method statement) were withdrawn; both are `RP`.
+
 
 ## 3.5 Level codes
 
@@ -259,7 +291,7 @@ Either way, **place rooms before the first coordination share.** Rooms are the s
 |---|---|
 | Temple architectural 3D model, all levels | `KUT-XXX-01-ZZ-M3-A-0001` |
 | Meetinghouse mechanical model | `KUT-XXX-02-ZZ-M3-M-0001` |
-| Temple ground-floor GA plan sheet | `KUT-XXX-01-GF-SH-A-0100` |
+| Temple ground-floor GA plan sheet | `KUT-XXX-01-GF-DR-A-0100` |
 | Site-wide drainage drawing | `KUT-XXX-00-ZZ-DR-P-0050` |
 | Federated coordination model | `KUT-PLN-ZZ-ZZ-M3-Z-0001` |
 | Clash report, cycle 07 | `KUT-PLN-ZZ-ZZ-CR-Z-0007` |

--- a/tools/check_kut_documents.py
+++ b/tools/check_kut_documents.py
@@ -868,6 +868,63 @@ _NOTE_RX = re.compile(r"<!--\s*maintainer-note\s*-->.*?<!--\s*/maintainer-note\s
                       re.S | re.I)
 
 
+def check_source_code_tables(root: Path, f: Findings, verbose: bool):
+    """The playbook markdown's role and type tables must be the adopted set.
+
+    Nothing regenerates GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md, and its own
+    header used to claim the .docx was built from it. It was not -- so the file
+    drifted a whole naming migration behind the pack it appears to describe,
+    still listing the withdrawn roles FP, LV and G, and the withdrawn types SC,
+    CA and MS with SH defined as "Sheet" where NA.2 makes it a Schedule.
+
+    A stale copy of a code table is worse than no copy: a reader who trusts it
+    names containers against a set the audit rejects, and the leakage check that
+    already scans this file had no view on whether its content was true.
+    """
+    path = root / "GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md"
+    if not path.exists():
+        f.fail(str(path), "missing -- the leakage check and this one both read it")
+        return
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    want_roles = {c for c, _ in N.ROLES} | {c for c, _ in N.CONTAINER_ONLY_ROLES}
+    want_types = {c for c, _ in N.TYPES}
+
+    for label, want, header in (("role", want_roles, "## 3.3 Role"),
+                                ("type", want_types, "## 3.4 Type")):
+        i = text.find(header)
+        if i < 0:
+            f.fail("KUT_PROJECT_DELIVERY_PLAYBOOK.md",
+                   "has no %s section (%r) for the code table check" % (label, header))
+            continue
+        # Bound at the NEXT heading. A fixed-width window spilled 3.3 into 3.4
+        # and 3.4 into the suitability codes, so the check reported every
+        # neighbouring table as withdrawn.
+        nxt = text.find("\n## ", i + 1)
+        block = text[i:nxt if nxt > 0 else len(text)]
+        got = set(re.findall(r"^\|\s*`([A-Z0-9]{1,2})`\s*\|", block, re.M))
+        if not got:
+            f.fail("KUT_PROJECT_DELIVERY_PLAYBOOK.md",
+                   "%s table parsed to nothing -- the reader is wrong, not the file"
+                   % label)
+            continue
+        withdrawn = got - want
+        missing = want - got
+        if withdrawn:
+            f.fail("KUT_PROJECT_DELIVERY_PLAYBOOK.md",
+                   "%s table lists %s, which tools/kut_naming.py does not define. "
+                   "A withdrawn code here is named on containers that then fail the "
+                   "audit." % (label, ", ".join(sorted(withdrawn))))
+        if missing:
+            f.fail("KUT_PROJECT_DELIVERY_PLAYBOOK.md",
+                   "%s table omits %s, which the adopted set defines."
+                   % (label, ", ".join(sorted(missing))))
+        if not withdrawn and not missing:
+            f.ok()
+            if verbose:
+                print("  %s codes agree with kut_naming.py (%d)" % (label, len(got)))
+
+
 def check_no_leakage(root: Path, f: Findings, verbose: bool):
     for name in tuple(K.ISSUED) + CLIENT_FACING_SOURCES:
         # This loop mixes two kinds of path. The issued documents live in
@@ -1095,6 +1152,7 @@ def main() -> int:
     check_references(root, f, args.verbose)
     check_roles(bep_t, pb_t, midp_path, f, args.verbose)
     check_tiers(root, bep_t, pb_t, f, args.verbose)
+    check_source_code_tables(root, f, args.verbose)
     check_no_leakage(root, f, args.verbose)
     counts = check_placeholders(root, f, args.verbose)
 


### PR DESCRIPTION
`GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md` still listed the **pre-migration** code sets.

| | markdown said | adopted |
|---|---|---|
| roles | 8, incl. **`FP` `LV` `G`** | 11 + `Z` |
| types | 12, incl. **`SC` `CA` `MS`**, `SH` = *Sheet* | 18, `SH` = *Schedule* |

Every one of those is a container someone would name and the audit would then reject. `FP` and `LV` were never role codes — both issue under `Y`, distinguished by the Volume/System field. `G` is the Geographical/Land Surveyor, so a container issued as `-G-` claimed to come from a land surveyor rather than a civil engineer.

## Why it drifted

Nothing regenerates this file, and its own maintainer note said *"Edit content here, then regenerate the `.docx`"*. **That is not true.** `build_team_playbook.py` names it in a comment as "source content" and never opens it — the issued text lives in the Python.

So the file looked authoritative, was read as authoritative, changed nothing when edited, and nothing warned about any of it. The note now says so plainly.

## The fix

- Both tables **re-derived from `tools/kut_naming.py`**, not retyped.
- `check_source_code_tables()` fails when either table lists a code `kut_naming.py` does not define, or omits one it does. The leakage check already scanned this file for product names; nothing had a view on whether its *content* was true.
- The worked example for a ground-floor GA plan sheet cited `KUT-XXX-01-GF-SH-A-0100` — the withdrawn reading of `SH`. A sheet is a drawing, `DR`.

## Sabotages

| | |
|---|---|
| restore `G` to the role table | fails by name ✅ |
| delete `SH` from the type table | fails by name ✅ |

My first version used a fixed 2,600-character window, which spilled §3.3 into §3.4 and §3.4 into the suitability codes, reporting every neighbouring table as withdrawn. It now bounds at the next heading.

**KUT document gate: OK — 94 assertions** (was 92).

## Not changed

The worked examples mix originator `XXX` and `PLN` within one table while the issued pack uses `SMB`. That is a placeholder question tied to the unissued originator register, not a code error, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)