### PR TITLE
The BEP template had the same defect, and the gate I just added could not see it

### DIFF
--- a/GUIDES/KUT_BEP_TEMPLATE.md
+++ b/GUIDES/KUT_BEP_TEMPLATE.md
@@ -135,15 +135,15 @@
 
 ### 4.2 File / container naming convention
 `[Project]-[Originator]-[Volume/System]-[Level]-[Type]-[Role]-[Number]`
-Example: `KUT-PLNS-ZZ-XX-M3-A-0001`
+Example: `KUT-SMB-ZZ-XX-M3-A-0001`  *(the originator field is exactly 3 characters)*
 | Field | Codes |
 |---|---|
 | Project | `KUT` |
-| Originator | `[FILL: PLNS, SYM, …per firm]` |
-| Volume/System | `[FILL: ZZ, Z1…]` |
+| Originator | `[FILL: 3 characters, per firm, from the originator register]` |
+| Volume/System | `01`–`06` per building · `00` site-wide · `ZZ` all volumes · `XX` not applicable |
 | Level | `[FILL: GF, 01, ZZ]` |
 | Type | `[FILL: M3, DR, SH, SP…]` |
-| Role | A, S, M, E, P, FP, G, Z |
+| Role | `A`, `C`, `E`, `I`, `M`, `P`, `Q`, `S`, `W`, `X`, `Y`, `Z` |
 | Number | 0001… |
 
 ### 4.3 CDE states & suitability codes

--- a/tools/check_kut_documents.py
+++ b/tools/check_kut_documents.py
@@ -868,6 +868,69 @@ _NOTE_RX = re.compile(r"<!--\s*maintainer-note\s*-->.*?<!--\s*/maintainer-note\s
                       re.S | re.I)
 
 
+def _check_withdrawn(root: Path, f: Findings, verbose: bool):
+    """No client-facing source may name a withdrawn code or a wrong-length originator.
+
+    The table reader in check_source_code_tables walks rows. The BEP states its
+    role set as a prose list inside ONE cell, so a row-based reader cannot see it
+    -- which is exactly how `A, S, M, E, P, FP, G, Z` survived a migration that
+    removed FP and G and added six roles.
+
+    ORIGINATOR_LENGTH is read rather than hardcoded: the register is unissued, and
+    when it lands the length is the thing most likely to be revisited.
+    """
+    valid = ({c for c, _ in N.ROLES} | {c for c, _ in N.CONTAINER_ONLY_ROLES}
+             | {c for c, _ in N.TYPES})
+    # Codes the NA withdrew that this project used to carry. Named explicitly
+    # rather than derived, because "not in the adopted set" also matches every
+    # ordinary English word in the prose around them.
+    withdrawn = {"FP": "fire protection -- now Y",
+                 "LV": "low voltage -- now Y",
+                 "G": "land surveyor in the standard -- civil is C",
+                 "SC": "schedule -- now SH",
+                 "CA": "calculation -- now RP",
+                 "MS": "method statement -- now RP"}
+    for rel in CLIENT_FACING_SOURCES:
+        p = root / rel
+        if not p.exists():
+            continue
+        text = p.read_text(encoding="utf-8", errors="replace")
+        # Blank the maintainer note IN PLACE. Removing it shifted every line
+        # number after it by the ten lines it occupies, so the first run of this
+        # check reported two innocent table rows.
+        text = _NOTE_RX.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+        for line_no, line in enumerate(text.splitlines(), 1):
+            # A blockquote is commentary, not a statement of the permitted set --
+            # and these documents now carry blockquotes that name the withdrawn
+            # codes precisely in order to explain them. The permitted set is
+            # always a table row.
+            if line.lstrip().startswith(">"):
+                continue
+            # Extract the codes the line STATES, then test membership. Matching
+            # each code as a pattern against free text instead makes "G" hit
+            # every stray capital in prose, and the first attempt at this
+            # excluded backticked spans -- `FP` -- which is the only form these
+            # tables actually use.
+            stated = set(re.findall(r"`([A-Z]{1,2})`", line))
+            if re.search(r"\|\s*(Role|Type|Discipline)\s*\|", line) or \
+                    re.search(r"^\s*\|\s*[A-Z][A-Za-z/ ]*\s*\|", line):
+                stated |= {t.strip() for t in re.split(r"[,|]", line)
+                           if re.fullmatch(r"[A-Z]{1,2}", t.strip())}
+            for code in sorted(stated & set(withdrawn)):
+                f.fail("%s:%d" % (Path(rel).name, line_no),
+                       "states the withdrawn code %s (%s)" % (code, withdrawn[code]))
+        for m in re.finditer(r"KUT-([A-Z]{2,6})-", text):
+            got = m.group(1)
+            if len(got) != N.ORIGINATOR_LENGTH:
+                f.fail(Path(rel).name,
+                       "uses the originator %r in an example: %d characters, but the "
+                       "convention is exactly %d. A container built to it fails the "
+                       "compliance check." % (got, len(got), N.ORIGINATOR_LENGTH))
+        f.ok()
+        if verbose:
+            print("  no withdrawn codes / bad originators in %s" % Path(rel).name)
+
+
 def check_source_code_tables(root: Path, f: Findings, verbose: bool):
     """The playbook markdown's role and type tables must be the adopted set.
 
@@ -881,6 +944,11 @@ def check_source_code_tables(root: Path, f: Findings, verbose: bool):
     names containers against a set the audit rejects, and the leakage check that
     already scans this file had no view on whether its content was true.
     """
+    # The BEP template shares this failure mode and was missed when the playbook
+    # was gated: it carried FP and G, and the four-character originator PLNS that
+    # the playbook's own 3.1 warns about by name. Both files are scanned.
+    _check_withdrawn(root, f, verbose)
+
     path = root / "GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md"
     if not path.exists():
         f.fail(str(path), "missing -- the leakage check and this one both read it")


### PR DESCRIPTION
#916 gated the playbook markdown and stopped there. `GUIDES/KUT_BEP_TEMPLATE.md` carried the same failure and more, unseen.

| line | said | wrong because |
|---|---|---|
| 146 | `A, S, M, E, P, FP, G, Z` | `FP` and `G` withdrawn; six adopted roles missing |
| 138, 142 | `KUT-PLNS-…` and `[FILL: PLNS, SYM…]` | **four**-character originator; the convention is exactly three |
| 143 | `[FILL: ZZ, Z1…]` | `Z1` is not in the adopted volume set |

The originator one is the sharpest: the playbook's own §3.1 warns *"Earlier draft guidance used a four-character example, and any container built to it fails the check."* **The guidance it warns about was still in the pack, two lines apart in a sibling document.**

Gating one of two files that share a failure mode is how the second survives. `check_source_code_tables` now scans both `CLIENT_FACING_SOURCES`.

The BEP states its role set as a prose list inside **one table cell**, so the row-based table reader cannot see it — hence a separate withdrawn-code scan across both files. `ORIGINATOR_LENGTH` is read from `kut_naming` rather than hardcoded; the register is unissued and the length is the thing most likely to be revisited when it lands.

## Three defects in my own check, each found by sabotaging it

**It could not see the format it guards.** The detector required the code *not* be preceded by a backtick — and these tables write every code as `` `FP` ``. The one form that matters was the one form excluded, so restoring `FP` or `G` **passed**. It now extracts the codes a line states and tests membership: *"which codes does this line state"* is answerable; *"does this line contain these two letters"* matches prose.

**It reported the wrong line.** The maintainer note was removed before the lines were enumerated, so every number after it was short by ten, pointing at two innocent table rows. A checker that sends a reader to an innocent line spends their trust. The note is now blanked in place.

**Its real hits were the explanations.** The offending lines were the blockquotes this pack now carries to *explain* the withdrawals. A document that documents a withdrawn code must be able to name it; the permitted set is always a table row, so blockquotes are skipped. The previous exemption keyed on the word "withdrawn" appearing in the line — which neither offending line contained.

## Sabotages

| | |
|---|---|
| `FP` back in the role list | fails by name ✅ *(was blind)* |
| `G` back in the role list | fails by name ✅ *(was blind)* |
| four-character `PLNS` | fails by name ✅ |
| inject at file line 200 | reported at **line 200** ✅ |

**KUT document gate: OK — 96 assertions** (was 94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)