### PR TITLE
PLNS becomes SMB, and the file that goes to every appointed party gets gated

### DIFF
--- a/GUIDES/KUT_BIM_MANAGER_PLAYBOOK.md
+++ b/GUIDES/KUT_BIM_MANAGER_PLAYBOOK.md
@@ -434,13 +434,13 @@ Derived from ISO 19650 + the KUT scope documents. These live in your **KUT owner
 Fields separated by hyphens — **Project-Originator-Volume/System-Level-Type-Role-Number**:
 
 ```
-KUT - PLNS - ZZ - XX - M3 - A - 0001
+KUT - SMB - ZZ - XX - M3 - A - 0001
  │     │      │    │    │    │    └ number
  │     │      │    │    │    └ role/discipline (A=Arch, S=Struct, M=Mech…)
  │     │      │    │    └ type (M3=3D model, DR=drawing, SH=sheet…)
  │     │      │    └ level (GF, 01, ZZ=all)
  │     │      └ volume/zone (ZZ=whole)
- │     └ originator (PLNS = Planscape; each firm gets a code)
+ │     └ originator (SMB = Planscape; each firm gets a code)
  └ project code (KUT)
 ```
 
@@ -592,7 +592,7 @@ Most of these STINGTOOLS can **generate or export** — don't build from scratch
 ## 8.3 Transmittal — template
 | Field | Value |
 |---|---|
-| Transmittal no. | KUT-PLNS-TR-0001 |
+| Transmittal no. | KUT-SMB-TR-0001 |
 | Date | |
 | From / To | |
 | Purpose / suitability | S2 / A1 … |
@@ -733,7 +733,7 @@ You'll be judged on whether the **team** can follow the system, not just you. Ke
 `WIP → SHARED (S0–S4) → PUBLISHED (A1/B1) → ARCHIVED` · Rev `P0x` (prelim) / `C0x` (contractual)
 
 ## 11.3 File name pattern
-`KUT-PLNS-ZZ-XX-M3-A-0001` = Project-Originator-Volume-Level-Type-Role-Number
+`KUT-SMB-ZZ-XX-M3-A-0001` = Project-Originator-Volume-Level-Type-Role-Number
 
 ## 11.4 The weekly loop
 `Share → Clash (ACC+STING) → Coordinate → Issue → Report`

--- a/GUIDES/KUT_MIDP_TEMPLATE.csv
+++ b/GUIDES/KUT_MIDP_TEMPLATE.csv
@@ -1,18 +1,18 @@
 Ref,Discipline,Originator,Deliverable,Type,Stage,LOD,Format,Suitability,CDE State,Planned Rel Month,Planned Date,Actual Date,Responsible,TIDP Ref,RAG,Notes
-Z-000,BIM/Info Mgmt,PLNS,BIM Execution Plan (BEP),Document,Mobilisation,NA,DOCX/PDF,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Baseline at mobilisation
-Z-001,BIM/Info Mgmt,PLNS,Master Information Delivery Plan (MIDP),Document,Mobilisation,NA,XLSX/CSV,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Aggregated from all TIDPs
-Z-002,BIM/Info Mgmt,PLNS,Responsibility matrix (RACI),Document,Mobilisation,NA,XLSX,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,
-Z-003,BIM/Info Mgmt,PLNS,Federated coordination model,Model,2.1 BOD,200,NWC/IFC,S1,Shared,M1,,,BIM Coordinator,TIDP-Z,,First federation
+Z-000,BIM/Info Mgmt,SMB,BIM Execution Plan (BEP),Document,Mobilisation,NA,DOCX/PDF,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Baseline at mobilisation
+Z-001,BIM/Info Mgmt,SMB,Master Information Delivery Plan (MIDP),Document,Mobilisation,NA,XLSX/CSV,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,Aggregated from all TIDPs
+Z-002,BIM/Info Mgmt,SMB,Responsibility matrix (RACI),Document,Mobilisation,NA,XLSX,A1,Published,M0,,,Mayanja Davis,TIDP-Z,,
+Z-003,BIM/Info Mgmt,SMB,Federated coordination model,Model,2.1 BOD,200,NWC/IFC,S1,Shared,M1,,,BIM Coordinator,TIDP-Z,,First federation
 A-100,Architecture,FILL,Architectural model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,Arch lead,TIDP-A,,Massing + generic
 S-100,Structure,FILL,Structural model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,Struct lead,TIDP-S,,Generic frame
 M-100,Mechanical,FILL,Mechanical (HVAC) model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-M,,Generic systems
 E-100,Electrical,FILL,Electrical model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-E,,Generic systems
 P-100,Public Health,FILL,Plumbing/drainage model,Model,2.1 BOD,200,RVT/IFC,S2,Shared,M1,,,MEP lead,TIDP-P,,Generic systems
-Z-110,BIM/Info Mgmt,PLNS,Basis of Design (BOD) report,Document,2.1 BOD,200,DOCX/PDF,S3,Shared,M1,,,Lead AP,TIDP-Z,,Design intent
+Z-110,BIM/Info Mgmt,SMB,Basis of Design (BOD) report,Document,2.1 BOD,200,DOCX/PDF,S3,Shared,M1,,,Lead AP,TIDP-Z,,Design intent
 A-200,Architecture,FILL,Architectural model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,Arch lead,TIDP-A,,Developed design
 A-201,Architecture,FILL,GA plans/sections/elevations (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,Arch lead,TIDP-A,,
 A-202,Architecture,FILL,Door/window schedules,Schedule,2.2 Deliverable B,300,PDF/XLSX,S2,Shared,M4,,,Arch lead,TIDP-A,,
-A-203,Architecture,FILL,Room data sheets (key spaces),Document,2.2 Deliverable B,300,PDF,S2,Shared,M4,,,Arch lead,TIDP-A,,STINGTOOLS RDS
+A-203,Architecture,FILL,Room data sheets (key spaces),Document,2.2 Deliverable B,300,PDF,S2,Shared,M4,,,Arch lead,TIDP-A,,Room data sheet export
 S-200,Structure,FILL,Structural model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,Struct lead,TIDP-S,,
 S-201,Structure,FILL,General arrangement drawings (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,Struct lead,TIDP-S,,
 M-200,Mechanical,FILL,Mechanical model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-M,,
@@ -20,9 +20,9 @@ M-201,Mechanical,FILL,HVAC layouts (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S
 E-200,Electrical,FILL,Electrical model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-E,,
 E-201,Electrical,FILL,Power/lighting layouts (50%),Drawing,2.2 Deliverable B,300,PDF/DWG,S2,Shared,M4,,,MEP lead,TIDP-E,,
 P-200,Public Health,FILL,Plumbing/drainage model,Model,2.2 Deliverable B,300,RVT/IFC,S2,Shared,M4,,,MEP lead,TIDP-P,,
-Z-210,BIM/Info Mgmt,PLNS,Clash/coordination report,Document,2.2 Deliverable B,300,PDF/BCF,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,Zero high-priority clashes
-Z-211,BIM/Info Mgmt,PLNS,Federated model,Model,2.2 Deliverable B,300,NWC/IFC,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,
-Z-212,QS/Cost,FILL,Bill of Quantities (preliminary),Schedule,2.2 Deliverable B,300,XLSX,S2,Shared,M4,,,QS,TIDP-Z,,STINGTOOLS BOQ/NRM2
+Z-210,BIM/Info Mgmt,SMB,Clash/coordination report,Document,2.2 Deliverable B,300,PDF/BCF,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,Zero high-priority clashes
+Z-211,BIM/Info Mgmt,SMB,Federated model,Model,2.2 Deliverable B,300,NWC/IFC,S2,Shared,M4,,,BIM Coordinator,TIDP-Z,,
+Z-212,QS/Cost,FILL,Bill of Quantities (preliminary),Schedule,2.2 Deliverable B,300,XLSX,S2,Shared,M4,,,QS,TIDP-Z,,Model-derived BOQ, NRM2 sections
 A-300,Architecture,FILL,Architectural model,Model,2.3 Deliverable C,350,RVT/IFC,S4,Shared,M8,,,Arch lead,TIDP-A,,Technical design
 A-301,Architecture,FILL,Full drawing set (100%) + details,Drawing,2.3 Deliverable C,350,PDF/DWG,S4,Shared,M8,,,Arch lead,TIDP-A,,
 S-300,Structure,FILL,Structural model,Model,2.3 Deliverable C,350,RVT/IFC,S4,Shared,M8,,,Struct lead,TIDP-S,,Connections resolved
@@ -33,19 +33,19 @@ E-300,Electrical,FILL,Electrical model + drawings (100%),Model/Drawing,2.3 Deliv
 P-300,Public Health,FILL,Plumbing model + drawings (100%),Model/Drawing,2.3 Deliverable C,350,RVT/PDF,S4,Shared,M8,,,MEP lead,TIDP-P,,
 FP-300,Fire,FILL,Fire strategy + model,Model/Document,2.3 Deliverable C,350,RVT/PDF,S4,Shared,M8,,,Fire lead,TIDP-FP,,
 Z-310,QS/Cost,FILL,Bill of Quantities (tender),Schedule,2.3 Deliverable C,350,XLSX,S4,Shared,M8,,,QS,TIDP-Z,,
-Z-311,BIM/Info Mgmt,PLNS,Specifications,Document,2.3 Deliverable C,350,PDF,S4,Shared,M8,,,Lead AP,TIDP-Z,,
+Z-311,BIM/Info Mgmt,SMB,Specifications,Document,2.3 Deliverable C,350,PDF,S4,Shared,M8,,,Lead AP,TIDP-Z,,
 FF-300,FF&E,FILL,FF&E specifications (initial),Schedule,2.3 Deliverable C,350,Fohlio/PDF,S4,Shared,M8,,,FF&E lead,TIDP-FF,,Fohlio Option A
-Z-400,BIM/Info Mgmt,PLNS,Tender documents,Document,2.4 Tender,NA,PDF,A1,Published,M9,,,Lead AP,TIDP-Z,,
-Z-401,BIM/Info Mgmt,PLNS,Conformed set / construction documentation,Drawing,2.5 Conformed,350,PDF/DWG,A1,Published,M11,,,Lead AP,TIDP-Z,,Post-award addenda
+Z-400,BIM/Info Mgmt,SMB,Tender documents,Document,2.4 Tender,NA,PDF,A1,Published,M9,,,Lead AP,TIDP-Z,,
+Z-401,BIM/Info Mgmt,SMB,Conformed set / construction documentation,Drawing,2.5 Conformed,350,PDF/DWG,A1,Published,M11,,,Lead AP,TIDP-Z,,Post-award addenda
 ALL-500,All disciplines,FILL,Construction-stage models (LOD 400),Model,3.1 Construction,400,RVT/IFC,A1,Published,M12-M43,,,Task teams,TIDP-ALL,,Ongoing; revisions tracked
-Z-510,BIM/Info Mgmt,PLNS,RFI/submittal register,Document,3.1 Construction,400,XLSX,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,ACC Issues
-Z-511,BIM/Info Mgmt,PLNS,Monthly model-health/KPI report,Document,3.1 Construction,400,PDF/HTML,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,STINGTOOLS KPI dashboard
-M-520,Mechanical,FILL,BMS points export (Niagara),Document,3.1 Construction,400,CSV,S2,Shared,M40,,,MEP lead,TIDP-M,,Niagara_ExportPoints
+Z-510,BIM/Info Mgmt,SMB,RFI/submittal register,Document,3.1 Construction,400,XLSX,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,ACC Issues
+Z-511,BIM/Info Mgmt,SMB,Monthly model-health/KPI report,Document,3.1 Construction,400,PDF/HTML,S2,Shared,M12-M43,,,Info Mgr,TIDP-Z,,Model-health and compliance KPIs
+M-520,Mechanical,FILL,BMS points export (Niagara),Document,3.1 Construction,400,CSV,S2,Shared,M40,,,MEP lead,TIDP-M,,Point list exported from the model for the controls contractor
 FF-600,FF&E,FILL,FF&E final schedule + procurement,Schedule,3.2 FF&E,400,Fohlio/XLSX,A1,Published,M43,,,FF&E lead,TIDP-FF,,
 A-700,Architecture,FILL,As-built architectural model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,Arch lead,TIDP-A,,Verified as-built
 S-700,Structure,FILL,As-built structural model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,Struct lead,TIDP-S,,
 M-700,MEP,FILL,As-built MEP model,Model,3.3 Deliverable D,500,RVT/IFC,A1,Published,M45,,,MEP lead,TIDP-M,,
-Z-700,BIM/Info Mgmt,PLNS,COBie handover dataset,Schedule,3.3 Deliverable D,500,XLSX,A1,Published,M45,,,Info Mgr,TIDP-Z,,STINGTOOLS COBie 2.4
-Z-701,BIM/Info Mgmt,PLNS,O&M / asset data pack,Document,3.3 Deliverable D,500,Fohlio/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,
-Z-702,BIM/Info Mgmt,PLNS,Digital twin baseline (model reconciled to BMS),Document,3.3 Deliverable D,500,CSV/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,Niagara_Reconcile
-Z-703,BIM/Info Mgmt,PLNS,Final handover transmittal + archive,Document,3.3 Deliverable D,500,PDF,A1,Archived,M45,,,Info Mgr,TIDP-Z,,
+Z-700,BIM/Info Mgmt,SMB,COBie handover dataset,Schedule,3.3 Deliverable D,500,XLSX,A1,Published,M45,,,Info Mgr,TIDP-Z,,COBie 2.4 handover export
+Z-701,BIM/Info Mgmt,SMB,O&M / asset data pack,Document,3.3 Deliverable D,500,Fohlio/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,
+Z-702,BIM/Info Mgmt,SMB,Digital twin baseline (model reconciled to BMS),Document,3.3 Deliverable D,500,CSV/PDF,A1,Published,M45,,,Info Mgr,TIDP-Z,,Model equipment and points reconciled against the live station
+Z-703,BIM/Info Mgmt,SMB,Final handover transmittal + archive,Document,3.3 Deliverable D,500,PDF,A1,Archived,M45,,,Info Mgr,TIDP-Z,,

--- a/tools/check_kut_documents.py
+++ b/tools/check_kut_documents.py
@@ -859,6 +859,9 @@ LEAKS = [
 CLIENT_FACING_SOURCES = (
     "GUIDES/KUT_BEP_TEMPLATE.md",
     "GUIDES/KUT_PROJECT_DELIVERY_PLAYBOOK.md",
+    # The playbook says this one is "issued at mobilisation" to every
+    # discipline. It was never scanned, and carried four product references.
+    "GUIDES/KUT_MIDP_TEMPLATE.csv",
 )
 
 # A maintainer note tells whoever edits the file which generator to run, so it
@@ -919,6 +922,26 @@ def _check_withdrawn(root: Path, f: Findings, verbose: bool):
             for code in sorted(stated & set(withdrawn)):
                 f.fail("%s:%d" % (Path(rel).name, line_no),
                        "states the withdrawn code %s (%s)" % (code, withdrawn[code]))
+        # The MIDP template states its originator in a COLUMN, not in a
+        # container-name example, so the pattern below cannot see it. Sixteen
+        # rows of a four-character code passed this gate until this was added.
+        if rel.endswith(".csv"):
+            rows = [ln.split(",") for ln in text.splitlines() if ln.strip()]
+            if rows and "Originator" in rows[0]:
+                col = rows[0].index("Originator")
+                for i, r in enumerate(rows[1:], 2):
+                    if len(r) <= col:
+                        continue
+                    got = r[col].strip()
+                    # FILL is the appointed party's own entry, made on receipt.
+                    if not got or got in ("FILL", "[FILL]"):
+                        continue
+                    if len(got) != N.ORIGINATOR_LENGTH:
+                        f.fail("%s:%d" % (Path(rel).name, i),
+                               "Originator %r is %d characters; the convention is "
+                               "exactly %d." % (got, len(got), N.ORIGINATOR_LENGTH))
+                f.ok()
+
         for m in re.finditer(r"KUT-([A-Z]{2,6})-", text):
             got = m.group(1)
             if len(got) != N.ORIGINATOR_LENGTH:


### PR DESCRIPTION
Twenty `PLNS` across the KUT surface become `SMB` — sixteen in the Originator column of `GUIDES/KUT_MIDP_TEMPLATE.csv`, four in the BIM Manager playbook. `PLNS` is also **four** characters against a convention of exactly three, so every one would have failed the compliance check. The Kibale playbook is a different project and is untouched.

## The larger finding

The Project Delivery Playbook says of that CSV: *"A starter file with these columns and the project's baseline rows is **issued at mobilisation**."* It goes to every appointed party — and it was **never in `CLIENT_FACING_SOURCES`**, so the leakage check had never read it.

It carried **six** references to the tooling:

| | found by |
|---|---|
| 4 × the product name | a grep |
| 2 × **command tags** (`Niagara_ExportPoints`, `Niagara_Reconcile`) | only the gate, once the file was added to the scan |

A grep for the product name doesn't match a command tag. **The scan I could not have written by hand is the one that reads the file.**

All six now express the obligation instead — the Appointing Party is entitled to require that the point list is exported and the station reconciled, not to name the instrument.

## Not changed

`KUT_BIM_MANAGER_PLAYBOOK.md` keeps its 75 product references. Its own header: *"Personal working reference. It is not a project document and is not issued."* The leakage rule has always exempted the internal playbook by name.

## Two blind spots in the gate, both found by sabotage

**The originator check couldn't see a column.** It reads `KUT-XXX-` patterns out of prose; this CSV states its originator in a *column*. Restoring `PLNS` to sixteen rows passed cleanly — the file was newly scanned for product names and still unscanned for this. A column-aware check now covers it, allowing `FILL`, which is the entry each appointed party makes on receipt.

**Adding the file to the scan is what found the command tags.** I fixed four references by grep and thought I was done.

## Sabotages

| | |
|---|---|
| product name restored to the CSV | fails by name ✅ |
| `PLNS` restored to the Originator column | fails with the row number ✅ |

**KUT document gate: OK — 99 assertions** (was 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)