### PR TITLE
KUT readiness: what Fohlio, Niagara and ACC would actually do on Monday

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -160,6 +160,11 @@ on a row, and check `CHANGELOG.md` for what has since landed.
 2026-08-01; row L2 is marked closed in the document itself) ·
 [`ROLE_MODEL_MIGRATION_PROPOSAL.md`](ROLE_MODEL_MIGRATION_PROPOSAL.md), with the reconciliation
 query at `Planscape.Server/tools/role-reconciliation-sheet.sql` ·
+[`KUT_INTEGRATION_READINESS_2026-09.md`](KUT_INTEGRATION_READINESS_2026-09.md) (measured
+2026-09-10 @ `d318dcbee`) — per-integration verdicts for Fohlio / Niagara / ACC against what the
+issued KUT documents promise: ACC and Niagara **wired but unproven**, Fohlio's contracted CSV tier
+**works**. Names the one credential and the five offline fixes that stand between the pack and a
+proven coordination cycle ·
 [`PHASE6B_CAPABILITY_VERIFICATION.md`](PHASE6B_CAPABILITY_VERIFICATION.md) ·
 [`MEP_PRINT_READY_PUNCHLIST_RUNNER.md`](MEP_PRINT_READY_PUNCHLIST_RUNNER.md) (work prompt)
 
@@ -175,53 +180,103 @@ query at `Planscape.Server/tools/role-reconciliation-sheet.sql` ·
 - [G-8 Type vs Instance binding](G8_TYPE_VS_INSTANCE_BINDING.md) ✅ — proposal, not applied
 - [Tagging workflow analysis](TAGGING_WORKFLOW_ANALYSIS.md) ⛔ SUPERSEDED
 - [Universal tag badge/glyph guide](UNIVERSAL_TAG_BADGE_GLYPH_GUIDE.md) ⛔ SUPERSEDED
-
-## Unclassified — indexed, not yet triaged
-
-**These are listed so they are not invisible, not because anyone has read them.**
-Every other section marks a document ✅ current or ⛔ superseded. Nobody has made
-that call for the files below, and guessing would be worse than saying so: a wrong
-✅ sends a reader to act on a stale plan.
-
-They were named nowhere in this index until 2026-09-09, which meant a reader
-checking whether a document existed concluded it did not. `tools/check_docs_index.py`
-now fails when a `docs/*.md` is named nowhere here, so the list cannot grow silently.
-
-**This section should only shrink.** Moving a file out of it — into the section it
-belongs to, with a ✅ or ⛔ — is the work; it needs someone who knows whether the
-document still describes the code.
-
-- `BOQ_5D_ENHANCED_REBUILD_PROMPT.md`
-- `BOQ_5D_ENHANCEMENTS_PROMPT.md`
-- `BOQ_LOOKUP_FORMULA_AUDIT.md`
-- `CLIENT_SERVER_VOCABULARY_PROPOSALS.md`
-- `DOCUMENT_MANAGER_GAPS_RUNNER.md`
-- `HVAC_GAP_ANALYSIS.md`
-- `HVAC_GAP_REMEDIATION_PROMPT.md`
-- `KIBALE_REVIT_VERIFICATION.md`
-- `KNP26_READINESS.md`
-- `MATERIAL_SCHEDULE_BASELINE_LAYER2_LAYER3_SPEC.md`
-- `MATERIAL_SCHEDULE_GAPS_RUNNER_PROMPT.md`
-- `MATERIAL_SCHEDULE_T6_FAMILY_MATERIALS_PROPOSAL.md`
-- `NATIVE_TYPE_MIGRATION_ANALYSIS.md`
-- `OPERATOR_SESSION_KIBALE.md`
-- `PERFECT_PLACEMENT_PROMPT.md`
-- `PLACEMENT_CENTRE_REVIEW_AND_FIX_PROMPT.md`
-- `PLACEMENT_LIBRARY_TAB_AND_DWG_BRIDGE_PROMPT.md`
-- `PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md`
-- `PROMPT_BRANCH_AND_WORKSPACE_TRIAGE.md`
-- `PROMPT_KUT_LIFECYCLE_INTEGRATION.md`
-- `PROMPT_KUT_MOBILISATION_HARDENING.md`
-- `RESEARCH_PROMPT_livekit_and_corporate_ui.md`
-- `ROUND_TRIP_R1_R2_SPEC.md`
-- `UNIVERSAL_TAG_FIELDLIST_ADD_ORDER.md`
-- `UNIVERSAL_TAG_FINALIZE_RUNNER.md`
-- `UNIVERSAL_TAG_INTEGRATION_RUNNER.md`
-- `UNIVERSAL_TAG_LABEL_BUILD_SHEET.md`
-- `UNIVERSAL_TAG_TASK4_STEP2_PATCH.md`
-- `UNIVERSAL_TAG_TEARDOWN_RUNNER.md`
-- `VERIFY_PHASE1.md`
-- `VISIBILITY_CENTER_ENHANCEMENTS_RUNNER.md`
-- `VISIBILITY_CENTER_RUNNER.md`
-- `WIRE_ELEMENT_ANNOTATION_SCOPE.md`
-- `archicad-zone-mapping-guide.md`
+
+
+## Unclassified — indexed, not yet triaged
+
+
+
+**These are listed so they are not invisible, not because anyone has read them.**
+
+Every other section marks a document ✅ current or ⛔ superseded. Nobody has made
+
+that call for the files below, and guessing would be worse than saying so: a wrong
+
+✅ sends a reader to act on a stale plan.
+
+
+
+They were named nowhere in this index until 2026-09-09, which meant a reader
+
+checking whether a document existed concluded it did not. `tools/check_docs_index.py`
+
+now fails when a `docs/*.md` is named nowhere here, so the list cannot grow silently.
+
+
+
+**This section should only shrink.** Moving a file out of it — into the section it
+
+belongs to, with a ✅ or ⛔ — is the work; it needs someone who knows whether the
+
+document still describes the code.
+
+
+
+- `BOQ_5D_ENHANCED_REBUILD_PROMPT.md`
+
+- `BOQ_5D_ENHANCEMENTS_PROMPT.md`
+
+- `BOQ_LOOKUP_FORMULA_AUDIT.md`
+
+- `CLIENT_SERVER_VOCABULARY_PROPOSALS.md`
+
+- `DOCUMENT_MANAGER_GAPS_RUNNER.md`
+
+- `HVAC_GAP_ANALYSIS.md`
+
+- `HVAC_GAP_REMEDIATION_PROMPT.md`
+
+- `KIBALE_REVIT_VERIFICATION.md`
+
+- `KNP26_READINESS.md`
+
+- `MATERIAL_SCHEDULE_BASELINE_LAYER2_LAYER3_SPEC.md`
+
+- `MATERIAL_SCHEDULE_GAPS_RUNNER_PROMPT.md`
+
+- `MATERIAL_SCHEDULE_T6_FAMILY_MATERIALS_PROPOSAL.md`
+
+- `NATIVE_TYPE_MIGRATION_ANALYSIS.md`
+
+- `OPERATOR_SESSION_KIBALE.md`
+
+- `PERFECT_PLACEMENT_PROMPT.md`
+
+- `PLACEMENT_CENTRE_REVIEW_AND_FIX_PROMPT.md`
+
+- `PLACEMENT_LIBRARY_TAB_AND_DWG_BRIDGE_PROMPT.md`
+
+- `PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md`
+
+- `PROMPT_BRANCH_AND_WORKSPACE_TRIAGE.md`
+
+- `PROMPT_KUT_LIFECYCLE_INTEGRATION.md`
+
+- `PROMPT_KUT_MOBILISATION_HARDENING.md`
+
+- `RESEARCH_PROMPT_livekit_and_corporate_ui.md`
+
+- `ROUND_TRIP_R1_R2_SPEC.md`
+
+- `UNIVERSAL_TAG_FIELDLIST_ADD_ORDER.md`
+
+- `UNIVERSAL_TAG_FINALIZE_RUNNER.md`
+
+- `UNIVERSAL_TAG_INTEGRATION_RUNNER.md`
+
+- `UNIVERSAL_TAG_LABEL_BUILD_SHEET.md`
+
+- `UNIVERSAL_TAG_TASK4_STEP2_PATCH.md`
+
+- `UNIVERSAL_TAG_TEARDOWN_RUNNER.md`
+
+- `VERIFY_PHASE1.md`
+
+- `VISIBILITY_CENTER_ENHANCEMENTS_RUNNER.md`
+
+- `VISIBILITY_CENTER_RUNNER.md`
+
+- `WIRE_ELEMENT_ANNOTATION_SCOPE.md`
+
+- `archicad-zone-mapping-guide.md`
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -165,6 +165,10 @@ query at `Planscape.Server/tools/role-reconciliation-sheet.sql` ·
 issued KUT documents promise: ACC and Niagara **wired but unproven**, Fohlio's contracted CSV tier
 **works**. Names the one credential and the five offline fixes that stand between the pack and a
 proven coordination cycle ·
+[`PROMPT_KUT_INTEGRATION_BUILD.md`](PROMPT_KUT_INTEGRATION_BUILD.md) (work prompt, written
+2026-09-10) — the build that closes what the readiness report found, ordered by what unblocks KUT
+soonest. Eight offline tasks, each with the command that proves it and the sabotage that must break
+it; three third-party-blocked items are quarantined in their own section ·
 [`PHASE6B_CAPABILITY_VERIFICATION.md`](PHASE6B_CAPABILITY_VERIFICATION.md) ·
 [`MEP_PRINT_READY_PUNCHLIST_RUNNER.md`](MEP_PRINT_READY_PUNCHLIST_RUNNER.md) (work prompt)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -184,103 +184,53 @@ it; three third-party-blocked items are quarantined in their own section ·
 - [G-8 Type vs Instance binding](G8_TYPE_VS_INSTANCE_BINDING.md) ✅ — proposal, not applied
 - [Tagging workflow analysis](TAGGING_WORKFLOW_ANALYSIS.md) ⛔ SUPERSEDED
 - [Universal tag badge/glyph guide](UNIVERSAL_TAG_BADGE_GLYPH_GUIDE.md) ⛔ SUPERSEDED
-
-
-## Unclassified — indexed, not yet triaged
-
-
-
-**These are listed so they are not invisible, not because anyone has read them.**
-
-Every other section marks a document ✅ current or ⛔ superseded. Nobody has made
-
-that call for the files below, and guessing would be worse than saying so: a wrong
-
-✅ sends a reader to act on a stale plan.
-
-
-
-They were named nowhere in this index until 2026-09-09, which meant a reader
-
-checking whether a document existed concluded it did not. `tools/check_docs_index.py`
-
-now fails when a `docs/*.md` is named nowhere here, so the list cannot grow silently.
-
-
-
-**This section should only shrink.** Moving a file out of it — into the section it
-
-belongs to, with a ✅ or ⛔ — is the work; it needs someone who knows whether the
-
-document still describes the code.
-
-
-
-- `BOQ_5D_ENHANCED_REBUILD_PROMPT.md`
-
-- `BOQ_5D_ENHANCEMENTS_PROMPT.md`
-
-- `BOQ_LOOKUP_FORMULA_AUDIT.md`
-
-- `CLIENT_SERVER_VOCABULARY_PROPOSALS.md`
-
-- `DOCUMENT_MANAGER_GAPS_RUNNER.md`
-
-- `HVAC_GAP_ANALYSIS.md`
-
-- `HVAC_GAP_REMEDIATION_PROMPT.md`
-
-- `KIBALE_REVIT_VERIFICATION.md`
-
-- `KNP26_READINESS.md`
-
-- `MATERIAL_SCHEDULE_BASELINE_LAYER2_LAYER3_SPEC.md`
-
-- `MATERIAL_SCHEDULE_GAPS_RUNNER_PROMPT.md`
-
-- `MATERIAL_SCHEDULE_T6_FAMILY_MATERIALS_PROPOSAL.md`
-
-- `NATIVE_TYPE_MIGRATION_ANALYSIS.md`
-
-- `OPERATOR_SESSION_KIBALE.md`
-
-- `PERFECT_PLACEMENT_PROMPT.md`
-
-- `PLACEMENT_CENTRE_REVIEW_AND_FIX_PROMPT.md`
-
-- `PLACEMENT_LIBRARY_TAB_AND_DWG_BRIDGE_PROMPT.md`
-
-- `PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md`
-
-- `PROMPT_BRANCH_AND_WORKSPACE_TRIAGE.md`
-
-- `PROMPT_KUT_LIFECYCLE_INTEGRATION.md`
-
-- `PROMPT_KUT_MOBILISATION_HARDENING.md`
-
-- `RESEARCH_PROMPT_livekit_and_corporate_ui.md`
-
-- `ROUND_TRIP_R1_R2_SPEC.md`
-
-- `UNIVERSAL_TAG_FIELDLIST_ADD_ORDER.md`
-
-- `UNIVERSAL_TAG_FINALIZE_RUNNER.md`
-
-- `UNIVERSAL_TAG_INTEGRATION_RUNNER.md`
-
-- `UNIVERSAL_TAG_LABEL_BUILD_SHEET.md`
-
-- `UNIVERSAL_TAG_TASK4_STEP2_PATCH.md`
-
-- `UNIVERSAL_TAG_TEARDOWN_RUNNER.md`
-
-- `VERIFY_PHASE1.md`
-
-- `VISIBILITY_CENTER_ENHANCEMENTS_RUNNER.md`
-
-- `VISIBILITY_CENTER_RUNNER.md`
-
-- `WIRE_ELEMENT_ANNOTATION_SCOPE.md`
-
-- `archicad-zone-mapping-guide.md`
-
+
+## Unclassified — indexed, not yet triaged
+
+**These are listed so they are not invisible, not because anyone has read them.**
+Every other section marks a document ✅ current or ⛔ superseded. Nobody has made
+that call for the files below, and guessing would be worse than saying so: a wrong
+✅ sends a reader to act on a stale plan.
+
+They were named nowhere in this index until 2026-09-09, which meant a reader
+checking whether a document existed concluded it did not. `tools/check_docs_index.py`
+now fails when a `docs/*.md` is named nowhere here, so the list cannot grow silently.
+
+**This section should only shrink.** Moving a file out of it — into the section it
+belongs to, with a ✅ or ⛔ — is the work; it needs someone who knows whether the
+document still describes the code.
+
+- `BOQ_5D_ENHANCED_REBUILD_PROMPT.md`
+- `BOQ_5D_ENHANCEMENTS_PROMPT.md`
+- `BOQ_LOOKUP_FORMULA_AUDIT.md`
+- `CLIENT_SERVER_VOCABULARY_PROPOSALS.md`
+- `DOCUMENT_MANAGER_GAPS_RUNNER.md`
+- `HVAC_GAP_ANALYSIS.md`
+- `HVAC_GAP_REMEDIATION_PROMPT.md`
+- `KIBALE_REVIT_VERIFICATION.md`
+- `KNP26_READINESS.md`
+- `MATERIAL_SCHEDULE_BASELINE_LAYER2_LAYER3_SPEC.md`
+- `MATERIAL_SCHEDULE_GAPS_RUNNER_PROMPT.md`
+- `MATERIAL_SCHEDULE_T6_FAMILY_MATERIALS_PROPOSAL.md`
+- `NATIVE_TYPE_MIGRATION_ANALYSIS.md`
+- `OPERATOR_SESSION_KIBALE.md`
+- `PERFECT_PLACEMENT_PROMPT.md`
+- `PLACEMENT_CENTRE_REVIEW_AND_FIX_PROMPT.md`
+- `PLACEMENT_LIBRARY_TAB_AND_DWG_BRIDGE_PROMPT.md`
+- `PLACEMENT_SEEDS_SWAP_IMPLEMENTATION_PROMPT.md`
+- `PROMPT_BRANCH_AND_WORKSPACE_TRIAGE.md`
+- `PROMPT_KUT_LIFECYCLE_INTEGRATION.md`
+- `PROMPT_KUT_MOBILISATION_HARDENING.md`
+- `RESEARCH_PROMPT_livekit_and_corporate_ui.md`
+- `ROUND_TRIP_R1_R2_SPEC.md`
+- `UNIVERSAL_TAG_FIELDLIST_ADD_ORDER.md`
+- `UNIVERSAL_TAG_FINALIZE_RUNNER.md`
+- `UNIVERSAL_TAG_INTEGRATION_RUNNER.md`
+- `UNIVERSAL_TAG_LABEL_BUILD_SHEET.md`
+- `UNIVERSAL_TAG_TASK4_STEP2_PATCH.md`
+- `UNIVERSAL_TAG_TEARDOWN_RUNNER.md`
+- `VERIFY_PHASE1.md`
+- `VISIBILITY_CENTER_ENHANCEMENTS_RUNNER.md`
+- `VISIBILITY_CENTER_RUNNER.md`
+- `WIRE_ELEMENT_ANNOTATION_SCOPE.md`
+- `archicad-zone-mapping-guide.md`

--- a/docs/KUT_INTEGRATION_READINESS_2026-09.md
+++ b/docs/KUT_INTEGRATION_READINESS_2026-09.md
@@ -1,0 +1,488 @@
+# KUT Integration Readiness — Fohlio · Niagara · ACC
+
+**Measured 2026-09-10** on `claude/kut-integration-readiness-497572`, base `main` @ `d318dcbee` (0 commits behind).
+Build verified on this machine: `dotnet build StingTools/StingTools.csproj -c Debug` → **0 errors, 0 warnings** (1m16s).
+
+This is a research report. **No behaviour was changed.** Every claim carries a `file:line`.
+Where this report and `CLAUDE.md` / `docs/` disagree, the code wins and the disagreement is named.
+
+> Naming note: this is an internal `docs/` file, not a KUT-issued document, so product and
+> parameter names appear freely here. They must not appear in anything issued to the Owner.
+
+---
+
+## 1. Verdicts
+
+| Integration | Verdict | One-line basis |
+|---|---|---|
+| **ACC** (Autodesk Construction Cloud) | **WIRED BUT UNPROVEN** | Four real HTTP clients, complete 3-legged OAuth, dispatch complete on all three layers — and by the code's own admission never run against a live Autodesk tenant. Zero tests. |
+| **Fohlio** | **WORKS** (CSV tier — the contracted route) | Five commands, real file I/O both ways, parameters defined + universally bound, 72 passing tests, and a data gate that validates the *real* shipped KUT map. The REST tier is a SHELL, and is explicitly out of contract scope. |
+| **Niagara** (Tridium) | **WIRED BUT UNPROVEN** | The file-mediated path the playbook actually promises is built, dispatched and honest about empty results; the live oBIX client is a real transport that has never met a station and **ships no connection template anywhere**. BACnet/OPC-UA readback is a SHELL. |
+
+Headline: **nothing here is ABSENT, and nothing fabricates data.** The gap is proof, not construction.
+
+---
+
+## 2. ACC — WIRED BUT UNPROVEN
+
+### 2.1 Transport: real, in four places
+
+| Client | Lines | Real send site | Endpoint base |
+|---|---|---|---|
+| `V6/AccIssueSync.cs` | 326 | `_http.SendAsync` at **100, 146, 222, 258** | `authentication/v2/token`, `construction/issues/v1` |
+| `V6/AccOAuthFlow.cs` | 219 | `_http.SendAsync` at **135** | `authentication/v2/authorize` + token exchange |
+| `V6/AccModelCoordSync.cs` | 289 | `_http.SendAsync` at **226, 245** | `bim360/modelset/v3`, `bim360/clash/v3` |
+| `V6/AccModelUpload.cs` | 332 | `_http.SendAsync` at **207, 226, 324** | `data/v1`, `project/v1`, `oss/v2` (signed-S3) |
+
+These are the documented APS paths, not invented ones. `AccIssueSync.cs:77` uses
+`construction/issues/v1` — the current ACC Issues API, not the retired BIM360 shape.
+
+### 2.2 Authentication: complete, and correctly absent from the assembly
+
+`AccOAuthFlow.SignInAsync` is a full 3-legged flow — authorize URL (`:76`), loopback
+`TcpListener` on `http://localhost:8910/callback` (`:50`, `:85`), CSRF `state` compared on
+return (`:122`), `authorization_code` exchange (`:127`), tokens persisted (`:149`).
+`AccIssueSync.EnsureAuthAsync` then refreshes silently (`:93`).
+
+Credentials live at `%APPDATA%\Planscape\acc_credentials.json` (`AccIssueSync.cs:297-299`).
+**No Autodesk secret is baked into the assembly** — correct, and it means the KUT team
+must supply their own APS app. What they must produce:
+
+| Needed | Where it goes | Who can supply it |
+|---|---|---|
+| APS Client ID + Secret ("Traditional Web App") | BCC ACC card → Save Credentials | Owner / Autodesk account holder |
+| `http://localhost:8910/callback` registered in the APS app | Autodesk APS console | same |
+| Issues container id (`b.<guid>`) | `ProjectId` | ACC project admin |
+| Model Coordination container id (if different) | `CoordContainerId` | ACC project admin |
+
+`IssueTypeId` does **not** need hand-entry — `EnsureIssueTypeAsync` (`:136-187`) resolves it
+from the container, prefers a Clash/Coordination type, and caches it.
+
+### 2.3 Reachability: complete across all three layers
+
+| Tag | XAML button | Handler case | `ResolveCommand` |
+|---|---|---|---|
+| `ACCPublish` | `StingDockPanel.xaml:5373` (combo item) | `:2863` | `:1937` |
+| `ACC_PullClashes` / `AccPullClashes` | `StingDockPanel.xaml:3134` | `:2873-2874` (both spellings) | `:1989` |
+| `ACC_SyncIssueStatus` / `AccSyncIssueStatus` | `StingDockPanel.xaml:3136` | `:2875-2876` (both spellings) | `:1991` |
+| `KUT_PushLifecycleGapsToAcc` | `StingDockPanel.xaml:3797` | `:3849` | `:1608` |
+
+Plus a registry entry for `ACCPublish` at `UI/Modules/BimCommandModule.cs:160`.
+
+The buttons use the `ACC_`-prefixed spelling while the BIM Coordination Center card uses the
+`Acc` spelling; **both are deliberately accepted** (`StingCommandHandler.cs:2866-2872` explains
+why). I checked this specifically because an alias mismatch here would have left the visible
+buttons dead while workflows worked. It is sound.
+
+The richest surface is the BCC → Platforms → **ACC** card (`BIMCoordinationCenter.cs:5428`
+`BuildAccDetail`), which is special-cased away from the generic placeholder panel and offers:
+Sign in with Autodesk (button `:5506`, call `:5516`), Save Credentials (`:5524`/`:5527`),
+Test/Refresh (`:5532`, calling `EnsureAuthAsync` at `:5542`),
+Pull Clashes / Sync Issue Status / ACC Publish (`:5560-5562`), and a live
+**Upload Model to ACC** (`:5581` → `AccModelUpload.UploadAsync`).
+
+### 2.4 What is wrong
+
+**(a) `ACCPublish` does not publish to ACC.** It builds a local ZIP and says so:
+`PlatformLinkCommands.cs:1230` — *"Upload the ZIP file to ACC/BIM 360 document management."*
+The UI is honest (the card tooltip at `BIMCoordinationCenter.cs:5562` says *"local ACC-ready
+bundle (manual upload)"*). **The KUT workflow is not**:
+`WORKFLOW_KUT_CoordinationCycle.json` step 6 reads *"Publish coordination data to ACC"*.
+An operator following the fortnightly cycle will believe publication happened. Meanwhile the
+*real* uploader (`AccModelUpload`) is reachable only from the BCC card and is not in any workflow.
+
+**(b) The 429 retry in `PushIssueAsync` cannot execute — verified empirically, not inferred.**
+The `HttpRequestMessage` is built once at `AccIssueSync.cs:215`, outside the loop, and re-sent
+at `:222`. I reproduced the exact shape against a local always-429 listener on .NET **8.0.23**,
+the runtime the plugin targets:
+
+```
+attempt 0: HTTP 429
+attempt 1: THREW InvalidOperationException: The request message was already sent.
+           Cannot send the same request message multiple times.
+```
+
+Consequence is bounded, because the call site catches (`AccPullClashesCommand.cs:178`): the
+issue is **dropped**, not retried, and the log reads `ACC 429 — retrying in 1s` immediately
+followed by the exception — a log that claims a retry that never happened. Bulk-escalating
+clashes to ACC Issues is precisely the workload that provokes 429s, and it is the one path
+that cannot survive one. `PullIssuesAsync` builds its request *inside* the loop (`:255`) and is
+correct — the asymmetry shows this is an oversight, not a decision.
+
+**(c) A wrong endpoint path is indistinguishable from a clean model.**
+`AccModelCoordSync.cs:40-42` states the residual honestly: *"the exact clash-service sub-paths
+(tests / resources) live inside the APS SDK; confirm with one live pull… A wrong path fails
+soft (logs the HTTP status, returns empty) — never throws."*
+`AccPullClashesCommand.cs:87-93` then reports zero clashes as *"Either the model set is
+clash-clean, or a clash test has not completed in ACC yet"* and returns **`Result.Succeeded`**.
+It names two causes and not the third. So on a wrong container id or a changed sub-path, the
+fortnightly Coordination Cycle **passes, reporting no clashes**. This is the house failure mode
+CLAUDE.md describes — an empty list standing in for an error — surviving in the one place it
+costs a coordination cycle.
+
+**(d) `Clash/AccIssuesClient.cs` is dead code.** 45 lines, a real `SendAsync` at `:37`, and
+**zero callers** — `grep` for the type and for `PostBcfAsync` finds only its own definition.
+I verified the instrument on `AccIssueSync`, which returns 20+ call sites, so the absence is
+real. Worse, its endpoint (`bim360/docs/v1/projects/{id}/issues/bulk`, `:28`) does not match the
+live client's `construction/issues/v1`. It is a second, orphaned, differently-shaped ACC path
+that will mislead the next reader. Delete it or wire it.
+
+**(e) Zero test coverage.** No test in any of the 13 `StingTools.*.Tests` projects or
+`Planscape.Server/tests` references `AccIssueSync`, `AccOAuthFlow`, `AccModelUpload`,
+`AccModelCoordSync`, `AccIssuesClient` or `AccPullClashes`.
+
+**(f) `AccPullClashes` needs an operator.** It opens a model-set picker
+(`AccPullClashesCommand.cs:76`), so the Coordination Cycle cannot run unattended. Not a
+defect — an operational fact worth knowing before anyone schedules it.
+
+### 2.5 What is right
+
+No-credential handling is exemplary and worth preserving as the pattern:
+`AccPullClashesCommand.cs:48-58` names the file, the four required fields and the container
+distinction, then returns `Result.Cancelled`. Request failures surface the actual error
+(`:64-65`, `:85`). Nothing is fabricated anywhere in the ACC path.
+
+---
+
+## 3. Fohlio — WORKS (CSV tier)
+
+### 3.1 The contracted route is the CSV route
+
+This is not an interpretation — both KUT documents say it:
+
+- `GUIDES/KUT_BEP_TEMPLATE.md:326` risk row: *"Fohlio API delay | Medium | Low | **Use
+  file/Add-in route now (Option A)** | Info Mgr"*
+- `project-templates/KUT/README.md:148-150`: *"Stay on the shipped CSV/XLSX link… **The REST
+  tier stays stubbed — no API key needed for this contract**."*
+
+So the missing REST transport is a **disclosed, mitigated risk**, not an undeclared exposure.
+That materially changes the contractual reading and it would have been missed by reading code alone.
+
+### 3.2 Transport and reachability
+
+Five commands, all dispatched on all three layers:
+
+| Tag | XAML button | Handler | `ResolveCommand` |
+|---|---|---|---|
+| `Fohlio_Export` | `StingDockPanel.xaml:3809` | `:3840` | `:1599` |
+| `Fohlio_Import` | `:3811` | `:3841` | `:1600` |
+| `Fohlio_Audit` | `:3813` | `:3842` | `:1601` |
+| `Fohlio_ExportFinishes` | `:3815` | `:3843` | `:1602` |
+| `Fohlio_ImportFinishes` | `:3817` | `:3844` | `:1603` |
+
+Real file I/O, no network needed. `Fohlio_Export` writes CSV
+(`FohlioCommands.cs:64`); `Fohlio_Import` previews a diff then writes back
+(`:87-259`); `Fohlio_ExportFinishes` emits one row per placed room keyed by **room number**
+(`FohlioFinishesCommands.cs:75`).
+
+### 3.3 The write-back target is real — checked, because a named parameter is the classic silent no-op
+
+| Check | Result |
+|---|---|
+| `FOHLIO_REF_TXT` defined | `Data/MR_PARAMETERS.txt:1774`, GUID `0ecf2056-1239-52bc-87f8-17c281e67209` |
+| GUID agrees with code | `Core/ParamRegistry.cs:217-218` — identical |
+| In the JSON registry | `Data/PARAMETER_REGISTRY.json:14910` |
+| Actually **bound** | Yes — `UniversalParams` (`ParamRegistry.cs:2702`), so every category |
+| `FOHLIO_UNIT_COST_NR` / `FOHLIO_CURRENCY_TXT` | Authored; previously *undefined* and silently unreadable — closed as ROADMAP `LIFE-5` |
+
+Absence from `CATEGORY_BINDINGS.csv` is **not** evidence of unbinding — that file is the legacy
+fallback. `RESOLVED_BINDINGS.csv` is the source of truth. (ROADMAP `LIFE-5` records an earlier
+audit that got this exact point wrong.)
+
+### 3.4 Two suspicions I raised and then disproved
+
+Recording these because a report that only lists confirmed faults hides how much was checked.
+
+- **`$FohlioQty` / `$FohlioLeadDays`** appear in the KUT map but not in
+  `FohlioMap.ResolveValue`'s `switch` (`FohlioLink.cs:120-135`), which looked like a data/code
+  mismatch that would silently export blanks. They are **handled** — on the import side, by
+  header lookup at `FohlioCommands.cs:137-138`. No defect.
+- **`ffe-fohlio-ref`** is declared in `project-templates/KUT/_BIM_COORD/owner_standards.json:40`
+  and no `.cs` file mentions that id, which looked runtime-dead. It is dispatched **by type**,
+  and `"paramRequired"` is implemented at `Core/Validation/OwnerStandardsPack.cs:151`. Live, at
+  severity WARN as documented. No defect.
+
+### 3.5 Test coverage — and a gate that is genuinely not circular
+
+Run on this machine, `StingTools.Boq.Tests` (1311 passing overall, 0 failing):
+
+| Suite | Cases |
+|---|---|
+| `NiagaraPointParserTests` | 43 pass |
+| `FfeTreatmentTests` | 15 pass |
+| `FohlioParameterBindingTests` | 10 pass |
+| `ShippedFohlioMapTests` | 4 pass |
+
+`ShippedFohlioMapTests` validates the **real** KUT file — `StingTools.Boq.Tests.csproj:184-186`
+links `..\project-templates\KUT\_BIM_COORD\fohlio_map.json` into the test output rather than
+keeping a copy, so the data and the gate cannot drift apart. That is the right shape.
+
+### 3.6 What is wrong
+
+**(a) `FohlioRestTransport.TestConnection()` is a false green.** `FohlioLink.cs:190-195`
+returns `true` whenever `BaseUrl` and `ApiKey` are merely non-empty — **no network call at
+all**. `ListItems` / `GetItem` / `UpdateItem` throw `NotImplementedException` (`:198-204`).
+Mitigating fact, confirmed by grep: **`FohlioRestTransport` and `FohlioConnection` have zero
+callers**, so the false green cannot currently reach a user. It is a loaded gun on a shelf —
+the first person to wire the button inherits a connection test that passes against a typo.
+
+**(b) The "Test connection gate" described in the code does not exist.** `FohlioLink.cs:19-21`
+and `:183` describe a gate behind which REST sits; there is no such UI anywhere.
+
+**(c) `docs/examples/KUT/fohlio_connection.json.example` configures a path that cannot run.**
+It is honestly labelled *"the **future** REST transport"*, so this is low-severity, but it is a
+KUT-facing example file for an unimplemented transport.
+
+**(d) Unverifiable from the repo:** the playbook's mobilisation obligation is that the field
+mapping is *"agreed with Fohlio"* (`KUT_PROJECT_DELIVERY_PLAYBOOK.md:708`). The shipped map is
+STING-authored; nothing in the repo evidences Interior-Designer sign-off. That is a meeting,
+not a code task, and it is on the mobilisation critical path.
+
+---
+
+## 4. Niagara (Tridium) — WIRED BUT UNPROVEN
+
+### 4.1 CLAUDE.md understates this one
+
+`CLAUDE.md` says only that *"`TwinReadback` BACnet / OPC-UA transports are abstract stubs."*
+**True** — `Core/Twin/TwinReadback.cs:39` and `:46` both `return Array.Empty<TwinSnapshot>()`.
+But it omits that a **separate, real** Niagara client exists, so the doc reads as "Niagara is
+absent" when two-thirds of it is built. Corrected here.
+
+### 4.2 Three paths, three different maturities
+
+| Path | Files | State |
+|---|---|---|
+| **File-mediated** (what the playbook promises) | `Commands/Twin/NiagaraCommands.cs` (228) | Real. Exports a point list, reconciles a station export. |
+| **Live oBIX/JSON over HTTP** | `Core/Twin/NiagaraJsonClient.cs` (5.9 KB) | Real transport — `Http.SendAsync` at **:98**, Bearer *or* Basic auth (`:91-97`). Never run against a station. |
+| **BACnet / OPC-UA readback** | `Core/Twin/TwinReadback.cs` | **SHELL** — no-op by design, documented as plug-in points. |
+
+All six Twin commands dispatch on all three layers:
+
+| Tag | XAML | Handler | `ResolveCommand` |
+|---|---|---|---|
+| `Niagara_ExportPoints` | `:3829` | `:3845` | `:1604` |
+| `Niagara_Reconcile` | `:3831` | `:3846` | `:1605` |
+| `KUT_ValuationFromBms` | `:3795` | `:3847` | `:1606` |
+| `KUT_LifecycleReconcile` | `:3793` | `:3848` | `:1607` |
+| `KUT_PushLifecycleGapsToAcc` | `:3797` | `:3849` | `:1608` |
+| `Healthcare_IoTRegistry` | `:5782`, `:5796` | `:319` | `:2161` |
+
+### 4.3 The promise is file-mediated, which is the built part
+
+`KUT_PROJECT_DELIVERY_PLAYBOOK.md:720-730` commits to exactly two things, and both land late:
+
+| Stage | Commitment | Served by |
+|---|---|---|
+| **3.1 (~M40)** | *"Commissioning point list exported from the model for the controls contractor to load — model-driven, not hand-built"* | `Niagara_ExportPoints` ✅ |
+| **3.3** | *"Reconcile: model equipment and points vs the live station"* | `Niagara_Reconcile` (against a station export) ✅ |
+
+So **no Niagara obligation falls due at mobilisation**, and the live HTTP client is an *extra*
+(it feeds `KUT_ValuationFromBms` for 5D commissioning valuation), not a playbook promise.
+
+### 4.4 What is wrong
+
+**(a) No connection template exists anywhere.** A case-insensitive sweep of all `*.json`,
+`*.example`, `*.md` and `*.csv` finds Niagara named only in docs, guides and one workflow —
+**there is no `niagara_connection.json` or `.example` in `project-templates/KUT/_BIM_COORD/`,
+in `docs/examples/KUT/`, or anywhere else.** Fohlio ships one; Niagara does not. The required
+shape exists only as a code comment (`NiagaraJsonClient.cs:11-13`). Anyone trying to enable the
+live path at Stage 3.1 must read the source to learn the field names.
+
+**(b) `pointsPath` defaults to `"/obix"`** (`NiagaraJsonClient.cs:33`), which is station-specific
+and essentially certain to need changing. With no template, that is an undocumented guess.
+
+**(c) Never exercised against a station**, by the code's own admission
+(`NiagaraJsonClient.cs:15-17`): *"NETWORK CODE — not exercised in the dev sandbox (no live
+station)… verify against a real Niagara station before production use."*
+
+**(d) The point list will be empty until the MEP team populates BMS data.** `IoTDeviceRegistry`
+harvests elements carrying `ICT_HEALTHIOT_DEVICE_ID_TXT` (`Data/MR_PARAMETERS.txt:3087`). On a
+fresh KUT model nothing carries it, so `Niagara_ExportPoints` produces nothing. This is correct
+per the playbook (BMS data is a Stage 2.3 activity) and it is reported honestly, not faked —
+*"No BMS/IoT points found"* (`NiagaraCommands.cs:49`).
+
+### 4.5 What is right
+
+`Core/Twin/CommissioningSource.cs` is the best-built thing in this review. It resolves
+live → cached → none (`:66-87`) and reports provenance explicitly (`:40-53`): `"live (captured
+…)"`, `"CACHED … (station unreachable — last good read)"`, `"no BMS data"`. A valuation can
+never silently run on stale points. And `FetchPoints` returns `null` on transport failure but an
+empty dictionary for an empty station (`:82-109`), so the two are distinguishable — with
+`ParsePoints` logging `SkippedNoId` (`:75-76`) precisely so a feed naming its id field something
+unexpected cannot masquerade as an empty station. That is the CLAUDE.md failure mode being
+actively designed out, and 43 tests hold it.
+
+---
+
+## 5. KUT workflows — all 97 steps resolve
+
+Checked mechanically with a gate that I deliberately broke first.
+
+```
+ResolveCommand case labels : 607      StingCommandHandler cases : 1993
+_allKnownCommandTags       : 222      XAML Cmd_Click button tags : 1592
+
+GATE SELF-TEST
+  known-good "Fohlio_Export"                    in ResolveCommand : True   (expect True)
+  nonsense   "Fohlio_ExportZZZ_NOT_A_REAL_TAG"  in ResolveCommand : False  (expect False)
+  gate discriminates correctly
+```
+
+| File | Steps | Resolve |
+|---|---|---|
+| `WORKFLOW_KUT_CoordinationCycle.json` | 8 | 8/8 (100%) |
+| `WORKFLOW_KUT_DeliverableA.json` | 8 | 8/8 (100%) |
+| `WORKFLOW_KUT_DeliverableB.json` | 15 | 15/15 (100%) |
+| `WORKFLOW_KUT_DeliverableC.json` | 18 | 18/18 (100%) |
+| `WORKFLOW_KUT_DeliverableD.json` | 13 | 13/13 (100%) |
+| `WORKFLOW_KUT_FFESync.json` | 3 | 3/3 (100%) |
+| `WORKFLOW_KUT_GateAudit.json` | 8 | 8/8 (100%) |
+| `WORKFLOW_KUT_LifecycleReconcile.json` | 11 | 11/11 (100%) |
+| `WORKFLOW_KUT_Mobilisation.json` | 5 | 5/5 (100%) |
+| `WORKFLOW_KUT_MonthlyReport.json` | 8 | 8/8 (100%) |
+| **Total** | **97** | **97/97 (100%)** |
+
+Every step uses the correct `commandTag` + `label` field names — no step silently does nothing.
+`_allKnownCommandTags` is a clean subset of `ResolveCommand` (0 false-known tags).
+
+Because a false *pass* would be the worst outcome here, I confirmed the extraction window
+(`WorkflowEngine.cs:1395-2244`) contains **exactly one** `switch` — at `:1397`, closing with
+`default: return null;` at `:2240`. No foreign `case` labels inflate the resolvable set.
+
+**The one workflow defect is semantic, not structural:** `CoordinationCycle` step 6 labels
+`ACCPublish` *"Publish coordination data to ACC"* when it produces a local ZIP (§2.4a).
+
+---
+
+## 6. What breaks on day one, in order
+
+> **"Day one" has already passed.** `docs/INDEX.md:125-126` records that mobilisation began the
+> **week of 25 August 2026** and that the issued pack "[is] relied on now". As of this measurement
+> that is ~2 weeks elapsed, so the first fortnightly coordination cycle is due about now. The ACC
+> credential below is therefore **overdue, not upcoming** — it is the single most time-critical item
+> in this report, and it is the one item nobody on the STING side can close alone.
+
+Mobilisation itself is clean: `WORKFLOW_KUT_Mobilisation.json` is five local steps
+(`LoadSharedParams`, `CreateWorksets`, `CreateFilters`, `GenerateBEP`, `CDEStatus`) and touches
+**none** of the three integrations. Kick-off is not blocked.
+
+| # | When | What happens | Severity | Blocked on |
+|---|---|---|---|---|
+| 1 | First fortnightly Coordination Cycle (Stage 2.2) | `ACC_PullClashes` stops at a dialog naming the four missing credential fields and returns `Cancelled`. Honest, but the step does not run. | **High** — the CDE rhythm is the project's spine | **Third party** — an APS app from the Owner's Autodesk account + callback registration + container ids |
+| 2 | Same cycle, step 6 | `ACCPublish` writes a local ZIP while the step says it published to ACC. Operator believes the drop reached the CDE. | **High** — a false belief about an issued container | Nobody. Text + wiring fix, offline |
+| 3 | First live ACC pull, whenever credentials arrive | A wrong container id or changed clash sub-path returns empty; the cycle reports **success, no clashes**. Indistinguishable from a clean federation. | **High** — silently skipped coordination | Nobody for the fix; one live pull to confirm paths |
+| 4 | First bulk clash escalation | Under ACC rate-limiting, issues are dropped one-by-one; the log claims retries that never ran (§2.4b). | Medium | Nobody. Two-line fix, offline |
+| 5 | First FF&E cycle (Stage 2.2) | Works — *provided* `fohlio_map.json` has been copied to `<project>/_BIM_COORD/` and the mapping is agreed with the Interior Designer. | Medium | Deployment: nobody. Agreement: **Interior Designer** |
+| 6 | Stage 3.1 (~M40) | `Niagara_ExportPoints` exports nothing until the MEP team has populated `ICT_HEALTHIOT_*` from Stage 2.3. Reported honestly. | Low (months away) | MEP team's 2.3 authoring |
+| 7 | Stage 3.1–3.3, only if the live BMS read is wanted | No `niagara_connection.json` template exists; the shape must be read out of source. | Low (months away) | Controls contractor for the station URL/credentials |
+
+---
+
+## 7. Promise vs. code
+
+| KUT document promise | Code reality | Exposure |
+|---|---|---|
+| `BEP:171` CDE platform = ACC; `:175` *"Transmittals issued through the CDE"* | ACC is a product the team drives directly in its own web UI. The plugin only **feeds** it, and `ACCPublish` feeds it by hand. | **None on the promise** — ACC is the CDE regardless of the plugin. The exposure is that plugin automation is unproven, not that the CDE is missing. |
+| `BEP:174`, `:220` *"ACC Issues and Reviews; BCF to ACC Issues"* | `ClashBcfExport` writes BCF 2.1 locally for manual import; `AccIssueSync.PushIssueAsync` pushes issues directly. Both real; the direct push is unproven and 429-fragile. | **Low** — two routes exist, one of them manual and reliable. |
+| `BEP:268` *"Clash-free (high-priority) via ACC Model Coordination before every data drop"* | `ACC_PullClashes` is real but unproven, and an empty result reads as clean (§2.4c). | **Medium** — a gate that can pass without having checked. Fix #3 before the first drop. |
+| `Playbook:709` Fohlio cycle: export → enrich → *"imported back, matched by **Room Number**, with a diff preview before anything is written"* | Exactly what the code does — `FohlioFinishesCommands.cs:75` keys on room number; `Fohlio_Import` previews a diff. | **None.** Unusually precise alignment. |
+| `Playbook:711` *"Monthly currency check — model vs Fohlio — as a KPI line"* | `Fohlio_Audit` computes linked % / missing-ref / stale; surfaced in the monthly dashboard (`project-templates/KUT/README.md:115-116`). | **None.** |
+| `BEP:326` *"Fohlio API delay → use file/Add-in route now"* | The CSV route is built and tested; REST is stubbed. | **None — already disclosed and mitigated in the issued BEP.** |
+| `Playbook:726` Stage 3.1 *"Commissioning point list exported from the model"* | `Niagara_ExportPoints`. | **None** (timing: needs 2.3 data first). |
+| `Playbook:727` Stage 3.3 *"model equipment and points vs the live station"* | `Niagara_Reconcile` against a station export taken from the live station. | **None** — satisfies the intent; no live transport required. |
+| `BEP:70` *"Model reconciled to live points at handover"*; `:110` AIR *"Niagara at handover"* | Met by the Stage 3.3 file reconcile. The live HTTP client is an optional extra. | **Low**, and not due for ~3 years of programme time. |
+
+**Net:** one medium exposure (#3, a coordination gate that can pass blind) and one high-severity
+internal mislabel (#2, inside a STING workflow rather than an issued document). Everything else
+the documents promise is either built or explicitly disclosed. **No promise in an issued KUT
+document is contradicted by the code.** That is a better position than the 646 stub markers in
+`CLAUDE.md` would lead anyone to expect.
+
+---
+
+## 8. Is it ready to start the KUT project?
+
+**Yes — start. Not all-or-nothing, and the parts that are ready are the parts mobilisation needs.**
+
+**Ready now, no credential required**
+- Mobilisation end to end — all five steps local, 100% resolvable.
+- The entire Fohlio FF&E / finishes stream (the contracted CSV route): 5 commands, real I/O,
+  parameters bound, 72 tests, a non-circular data gate, and an Owner-standards WARN check.
+- Niagara's file-mediated point-list and reconcile commands — built and dispatched, and not
+  due until ~M40 anyway.
+- All 10 KUT workflows resolve; 97/97 steps.
+- The plugin builds 0/0.
+
+**Ready on arrival of one credential**
+- The whole ACC automation surface. It needs an APS app (Client ID + Secret), the
+  `http://localhost:8910/callback` URL registered, and the ACC container ids. Then
+  *one live pull* settles the only genuine unknown — the clash sub-paths. The KUT README
+  already prescribes this: *"do one live pull during mobilisation"*
+  (`project-templates/KUT/README.md:142-143`).
+
+**Fix before the first coordination cycle — all offline, no third party**
+1. Make an empty ACC clash result distinguishable from a clean one (#3). Highest value here:
+   it is the difference between a gate and the appearance of one.
+2. Correct the `CoordinationCycle` step-6 label, and decide whether the real `AccModelUpload`
+   should be in the cycle instead of a manual ZIP (#2).
+3. Move the `PushIssueAsync` request construction inside the retry loop (#4) — two lines.
+4. Delete or wire `AccIssuesClient.cs` (§2.4d).
+5. Ship a `niagara_connection.json.example` (§4.4a) — cheap now, and it removes a
+   source-reading task from someone at M40.
+
+**Not ready, and correctly so**
+- Live BMS readback over BACnet/OPC-UA. Stubbed by design, an FM add-on, not promised.
+- Fohlio REST. Stubbed, and the BEP already mitigates it.
+
+The honest summary: this is not a prototype wearing a product's documentation. The transports
+are real, the failure paths mostly tell the truth, and the internal documents
+(`project-templates/KUT/README.md`, `docs/ROADMAP.md`) describe the state accurately. What is
+missing is **one Autodesk credential and one live pull** — plus five small offline fixes, of
+which only the first is load-bearing.
+
+---
+
+## 9. Corrections to existing documentation
+
+Measured against the code on 2026-09-10; each is a doc fix, not a code fix.
+
+| Claim | Where | Measured | Which is right |
+|---|---|---|---|
+| *"`TwinReadback` BACnet / OPC-UA transports are abstract stubs"* presented as the whole Niagara story | `CLAUDE.md` Healthcare Pack caveat 3 | True of `TwinReadback.cs:39,46`, but omits `NiagaraJsonClient` (real HTTP, `:98`) and the file-mediated `NiagaraCommands.cs` | **Code.** The statement is true but reads as "Niagara is absent"; two of three paths are built. |
+| `StingTools.Boq.Tests` — *"121 declared / 196 cases"* | `CLAUDE.md` §3 test table (dated 2026-08-06) | **1311 passing, 0 failing** on this checkout | **Code.** The table is a month stale and understates by ~6.7×. |
+| *"9 `WORKFLOW_KUT_*.json` files"* | this task's brief | **10** files | **Code.** `DeliverableA`–`D`, `CoordinationCycle`, `FFESync`, `GateAudit`, `LifecycleReconcile`, `Mobilisation`, `MonthlyReport`. |
+| Repo-wide matches: *Fohlio 271 files, ACC 209, Niagara 86, Tridium 26* | this task's brief | Fohlio **76**, "Autodesk Construction Cloud" **53**, Niagara **32**, Tridium **11** (excluding `bin`/`obj`/`node_modules`/`.git`). Including build output: 107 / 65 / 47 / 11. Occurrence counts: Fohlio 996, Niagara 274, Tridium 17. | **Neither reproducible.** I could not reconstruct the brief's figures by file count, by including build artefacts, or by occurrence count. It does not affect any verdict — I enumerated the logic files directly rather than reasoning from counts. Recorded so the next person does not chase it. |
+
+The brief's warning against searching bare `ACC` is well founded: it matches **1842** files in
+this tree (`accept`, `access`, `according`, `accumulate`). Every ACC count above uses
+`AccIssueSync` / `AccOAuthFlow` / `AccModelUpload` / `AccModelCoordSync` / `ACCPublish` /
+`AutodeskConstruction` or the full product name. Note that `Core/Validation/AccessibilityAuditor.cs`
+matches an `Acc*.cs` filename glob and is **not** ACC-related — a trap for the next file-name sweep.
+
+---
+
+## 10. Method — how to re-measure
+
+```bash
+# Build (safe; does NOT touch the Revit add-in manifest — never run deploy.bat for this)
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary
+
+# Fohlio + Niagara test evidence
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --filter "FullyQualifiedName~FohlioParameterBindingTests"
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --filter "FullyQualifiedName~ShippedFohlioMapTests"
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --filter "FullyQualifiedName~NiagaraPointParserTests"
+
+# Dead-code / caller checks (verify the instrument on a type you know IS used first)
+grep -rn "AccIssuesClient" --include="*.cs" . | grep -v /obj/ | grep -v /bin/   # expect: definition only
+grep -rn "AccIssueSync"   --include="*.cs" . | grep -v /obj/ | grep -v /bin/   # expect: 20+ call sites
+grep -rn "FohlioRestTransport\|FohlioConnection" --include="*.cs" . | grep -v /obj/
+
+# Workflow resolve rate (the gate self-tests before reporting)
+#   ResolveCommand window = WorkflowEngine.cs:1395-2244, verified to hold exactly one switch:
+awk 'NR>=1395 && NR<=2245 && /switch[[:space:]]*\(/ {print NR": "$0}' StingTools/Core/WorkflowEngine.cs
+```
+
+The 429 reproduction is a ~40-line console app: an `HttpListener` answering 429, and a single
+`HttpRequestMessage` re-sent in a loop exactly as `AccIssueSync.cs:215-229` does it. On
+.NET 8.0.23 attempt 1 throws `InvalidOperationException`.

--- a/docs/PROMPT_KUT_INTEGRATION_BUILD.md
+++ b/docs/PROMPT_KUT_INTEGRATION_BUILD.md
@@ -1,0 +1,545 @@
+# Work prompt — close the KUT integration gaps (Fohlio · Niagara · ACC)
+
+**For an agent executing autonomously with no further input.** You cannot ask questions. Everything
+you need is here. Where something is genuinely unknowable, the task says to leave it blank with a
+marker and report it — never to guess.
+
+Derived from `docs/KUT_INTEGRATION_READINESS_2026-09.md` (measured 2026-09-10 @ `d318dcbee`). Read
+that report first; it carries the `file:line` evidence behind every task below.
+
+---
+
+## 0. Non-negotiable rules
+
+**Worktree.** Several agents share `C:\Dev\STINGTOOLS`. **Do not work in it.** Create your own
+worktree and do everything there:
+
+```bash
+git worktree add C:/Dev/wt-kut-build -b claude/kut-integration-build origin/main
+cd C:/Dev/wt-kut-build
+```
+
+Branch from `origin/main`, never from another unmerged branch. If you are already in an isolated
+worktree provided by the harness, use that one rather than creating a second.
+
+**Never run `deploy.bat`.** It rewrites the live Revit add-in manifest to point at whichever
+checkout ran it, which silently hijacks the add-in slot from every other agent and from the user.
+`build.bat` is safe. `dotnet build` is safe. **Do not open Revit.**
+
+**Never force-push.** Not with `--force`, not with `--force-with-lease`. If a push is rejected,
+rebase or merge and push again.
+
+**Never commit secrets.** No API key, client secret, refresh token, station password or credential
+of any kind enters the repo — not in code, not in a test, not in an example file, not in a commit
+message. Example files carry `REPLACE_WITH_...` placeholders only.
+
+**Never invent data.** If a mapping, code, URL, container id, parameter name or credential is
+unknown, leave it blank with a `REPLACE_WITH_...` or `TODO(KUT):` marker and say so in your final
+report. A guessed value that reaches an issued container has to be renumbered afterwards, and the
+number is already in transmittals. Guessing is worse than leaving a hole, because a wrong value
+looks supplied.
+
+**Never delete a deprecated shared parameter or its GUID.** Parameters are append-only here.
+
+---
+
+## 1. Standing project constraints
+
+These hold for everything you touch.
+
+- **The tooling is never named in any KUT-issued document** — no product name, command name,
+  parameter prefix (`ASS_`, `COM_`, `PRJ_`, …), file path, or `.py` / `.json` extension. The issued
+  set is `KUT_BIM_Execution_Plan.docx`, `KUT_Project_Delivery_Playbook.docx`,
+  `KUT_Master_Information_Delivery_Plan.xlsx` and the mobilisation/document guides.
+  `KUT_BIM_MANAGER_PLAYBOOK_INTERNAL_STINGTOOLS.docx` is the **sole** exception and is never
+  shared. Internal `docs/` files (including this one) may name anything.
+- **Never hand-edit a generated document.** Edit the generator under `tools/` and regenerate. The
+  gate `tools/check_kut_documents.py` (100 assertions, 5 documents) must stay green.
+- **Speckle / "Speck-Link" is private.** Never name it as a dependency or a CDE in anything issued.
+- **Documents carry no AI attribution.** PR bodies may.
+- **Close Microsoft Word** before any git operation touching a `.docx`.
+- End commit messages with `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`; end PR bodies
+  with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+---
+
+## 2. Context you do not have
+
+The Kampala Uganda Temple (KUT) project is live — `docs/INDEX.md` records mobilisation as having
+begun the week of **25 August 2026**. Three external integrations are named in the issued KUT
+documents and are therefore promises:
+
+| Integration | Role on KUT | Measured state |
+|---|---|---|
+| **ACC** (Autodesk Construction Cloud) | The CDE; clash and issue exchange | **WIRED BUT UNPROVEN** — four real HTTP clients, full 3-legged OAuth, dispatch complete, never run against a live tenant, **zero tests** |
+| **Fohlio** | FF&E / finishes register, round-tripped against Revit rooms | **WORKS** on the contracted CSV tier; the REST tier is a dead stub the BEP already declares out of scope |
+| **Niagara** (Tridium) | BMS / digital-twin readback at handover | **WIRED BUT UNPROVEN** — the file-mediated path the playbook promises is built; the live oBIX client has never met a station and ships no config template |
+
+Where the code lives:
+
+```
+StingTools/V6/AccIssueSync.cs          ACC Issues push/pull + token refresh   (Revit-free)
+StingTools/V6/AccOAuthFlow.cs          3-legged OAuth sign-in                 (Revit-free)
+StingTools/V6/AccModelCoordSync.cs     Model Coordination clash read          (Revit-free)
+StingTools/V6/AccModelUpload.cs        ACC Docs upload                        (Revit-free)
+StingTools/Clash/AccIssuesClient.cs    DEAD — zero callers
+StingTools/Clash/AccPullClashesCommand.cs     command shell (Revit-bound)
+StingTools/Clash/AccSyncIssueStatusCommand.cs command shell (Revit-bound)
+StingTools/ExLink/FohlioLink.cs        Fohlio map + dead REST stub
+StingTools/ExLink/FohlioCommands.cs    Fohlio_Export / _Import / _Audit
+StingTools/ExLink/FohlioFinishesCommands.cs   Fohlio_ExportFinishes / _ImportFinishes
+StingTools/Core/Twin/NiagaraJsonClient.cs     live oBIX client (Revit-free)
+StingTools/Core/Twin/NiagaraPointParser.cs    pure parser, log-free, already unit-tested
+StingTools/Core/Twin/CommissioningSource.cs   live→cached→none resolver
+StingTools/Commands/Twin/NiagaraCommands.cs   Niagara_ExportPoints / _Reconcile
+```
+
+**Dispatch is three layers and all three matter.** A command needs all of:
+1. a `case "Tag":` in `StingTools/UI/StingCommandHandler.cs` (so a button works),
+2. a `case "Tag":` in `WorkflowEngine.ResolveCommand` — `StingTools/Core/WorkflowEngine.cs`,
+   lines 1395–2244, exactly one `switch` (so a workflow step works),
+3. a `<Button ... Tag="Tag" Click="Cmd_Click"/>` in `StingTools/UI/StingDockPanel.xaml`
+   (so the button exists at all).
+
+Some commands are additionally registered in `StingTools/UI/Modules/*.cs`. One-layer audits have
+twice produced large false-positive figures on this repo — check all three.
+
+**Testing pattern.** Revit-free plugin sources are pulled into a test project with
+`<Compile Include="..\StingTools\...\X.cs" Link="X.cs" />`. See
+`StingTools.Boq.Tests/StingTools.Boq.Tests.csproj:22-29`. **Do not try to link
+`StingTools/Core/StingLog.cs`** — it drags in `StingTools.Core.Drawing`. Follow the
+`NiagaraPointParser` precedent instead: put the pure decision in a log-free file, link that, and
+leave the logging in the caller. `.github/workflows/stingtools-unit-tests.yml` globs
+`StingTools.*.Tests/*.csproj`, so a new test project is picked up with no workflow edit.
+
+---
+
+## 3. How to work
+
+**Build the gate before the feature, and break your own gate once.**
+
+Every gate written on this project so far was wrong on its first run, and only deliberate sabotage
+revealed it. So for each task that names a gate:
+
+1. Write the gate (test / checker) **first**.
+2. Run it. If it passes before you have written the fix, **the gate is wrong** — a gate that passes
+   against the unfixed code proves nothing. Fix the gate.
+3. Write the fix. Run the gate; it must now pass.
+4. **Sabotage deliberately:** re-break the thing the gate is supposed to catch (revert one line,
+   rename one key), run the gate, and confirm it **fails**. Restore.
+5. Record in your final report, per gate: the command, the pass result, and what sabotage you used
+   and that it failed.
+
+The two gate faults that survive casual reading are **circular expectations** (the gate asserts
+what the code does rather than what is required) and **alternative-path escapes** (the gate checks
+one route while the code has two). Check for both explicitly.
+
+**An absent side effect never tells you why.** A silent no-op looks identical to a wrong fix, a bad
+credential and a call that never ran. If something reportedly works, get the observable proof; if it
+doesn't, get the error rather than inferring one.
+
+**Assert on non-empty data.** A test that passes against an empty result set proves nothing. Show
+the count.
+
+---
+
+## 4. SECTION A — work you can complete offline
+
+No credential, no third party, no network. Do these in order; the ordering is by what unblocks KUT
+soonest, not by interest or effort.
+
+**A1–A5 are the five fixes the readiness report flags as needed before the first coordination
+cycle.** A1 is the only load-bearing one — the rest are small. **A6–A8 are additional offline work**
+that does not block the cycle: removing a latent false green, making the workflow check reusable, and
+authoring the runbook for the blocked items in Section B. If you run short of time, A1–A5 in full
+beats all eight half-done.
+
+---
+
+### A1 — Make an empty ACC clash result distinguishable from a failed one
+
+**Why first.** This is the one defect that can make a coordination gate *pass without having
+checked*. `AccModelCoordSync.cs:40-42` says a wrong sub-path "fails soft (logs the HTTP status,
+returns empty)". `AccPullClashesCommand.cs:87-93` then reports zero clashes as *"Either the model
+set is clash-clean, or a clash test has not completed in ACC yet"* and returns
+**`Result.Succeeded`**. On a wrong container id or a changed APS sub-path, the fortnightly KUT
+Coordination Cycle reports a clean federation. KUT runs that cycle every two weeks.
+
+**Files to touch**
+- NEW `StingTools/V6/AccFetchOutcome.cs` — Revit-free and **log-free** (so it links into tests).
+  An outcome discriminator plus a result carrier. At minimum it must distinguish:
+  `Ok` (request succeeded, payload parsed) · `EmptyOk` (succeeded, genuinely nothing) ·
+  `AuthFailed` · `NotFound` · `TransportFailed` (HTTP error, network error, or unparseable body).
+- `StingTools/V6/AccModelCoordSync.cs` — `ListModelSetsAsync` and `GetClashesAsync` return the
+  outcome alongside the data instead of a bare empty list. Keep the existing logging where it is.
+- `StingTools/Clash/AccPullClashesCommand.cs` — branch on the outcome:
+  - `EmptyOk` → keep today's "clash-clean or test not completed" message, `Result.Succeeded`.
+  - Anything else → say which failure it was, name the container id that was used, and return
+    **`Result.Failed`**. It must be impossible for a non-`Ok` outcome to read as a clean cycle.
+- NEW `StingTools.Acc.Tests/` (project + `.csproj`), linking the Revit-free ACC sources.
+
+**Done means**
+- No code path reports "no clashes" for a request that did not succeed.
+- A transport failure returns `Result.Failed`, so a workflow step fails instead of passing.
+- The new test project compiles and contains real tests (an empty test project is a false coverage
+  signal — do not create one without tests).
+
+**Prove it**
+
+```bash
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
+```
+
+Must report a non-zero passing count with 0 failing. Required cases, at minimum:
+- a pure mapping test: HTTP 401 → `AuthFailed`; 404 → `NotFound`; 500 → `TransportFailed`;
+  200 with `{"modelSets":[]}` → `EmptyOk`; 200 with one set → `Ok`.
+- **at least one loopback test** against a local `System.Net.HttpListener` you start in the test,
+  proving end-to-end that a 404 does **not** produce `EmptyOk`. A pure-function test alone is an
+  alternative-path escape — it would not catch the real client mapping a 404 to empty.
+
+**Sabotage to run and report:** make the 404 branch return `EmptyOk`, confirm the suite fails,
+restore. Then confirm the suite fails a second way: make `GetClashesAsync` swallow a thrown
+`HttpRequestException` and return `EmptyOk`.
+
+Also run, and paste the last 5 lines:
+
+```bash
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
+```
+
+Must stay **0 errors, 0 warnings**.
+
+---
+
+### A2 — Fix the 429 retry in `AccIssueSync.PushIssueAsync`
+
+**Why.** The retry cannot execute. The `HttpRequestMessage` is built once at
+`AccIssueSync.cs:215`, outside the loop, and re-sent at `:222`; on .NET 8 the second send throws
+`InvalidOperationException: The request message was already sent.` The call site catches
+(`AccPullClashesCommand.cs:178`), so the issue is **dropped** while the log says
+`ACC 429 — retrying in 1s`. Bulk-escalating clashes to ACC Issues is exactly the workload that
+provokes 429s. `PullIssuesAsync` already builds its request inside its loop (`:255`) — copy that.
+
+**Files to touch**
+- `StingTools/V6/AccIssueSync.cs` — move the `HttpRequestMessage` (and its `StringContent`)
+  construction inside the `for (int attempt ...)` loop. Dispose each attempt's request.
+- `StingTools.Acc.Tests/` — tests.
+
+**Done means** four real attempts happen against a persistent 429, and a 429-then-success sequence
+returns the created issue id.
+
+**Prove it** — loopback tests that count requests server-side:
+
+```bash
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo --filter "FullyQualifiedName~Retry"
+```
+
+Required cases:
+- listener always 429 → the client makes **4** requests (assert the server-side count is 4, not
+  that "it didn't throw" — counting is what proves the retry ran) and no
+  `InvalidOperationException` escapes.
+- listener 429, 429, then 201 with `{"id":"abc"}` → returns `"abc"`.
+
+Keep the back-off delays short in tests (inject the delay or use a test-only override) so the suite
+does not sleep 15 seconds. **Do not** change production back-off timings to suit the test.
+
+**Sabotage to run and report:** move the request construction back outside the loop, confirm both
+cases fail, restore.
+
+---
+
+### A3 — Stop `ACCPublish` claiming it published to ACC, and make the real uploader dispatchable
+
+**Why.** `ACCPublish` builds a local ZIP and tells the user to upload it by hand
+(`PlatformLinkCommands.cs:1230`). The UI is honest; the KUT workflow is not —
+`StingTools/Data/WORKFLOW_KUT_CoordinationCycle.json` step 6 reads *"Publish coordination data to
+ACC"*. An operator running the fortnightly cycle will believe the drop reached the CDE. Meanwhile
+the real uploader, `AccModelUpload`, is reachable only from one BCC button and from no workflow.
+
+**Two parts. The first is mandatory; the second is the build.**
+
+**A3a — relabel (mandatory, trivial).** In `WORKFLOW_KUT_CoordinationCycle.json`, change step 6's
+`label` so it states what happens: that it packages the deliverables into a local ACC-ready bundle
+for upload, not that it publishes. Do not change the `commandTag`. Keep the wording plain — a KUT
+operator reads this string.
+
+**A3b — expose the real uploader as a command.** Add an `ACC_UploadModel` tag that runs
+`AccModelUpload.UploadAsync` with a file picker, mirroring the existing BCC button
+(`BIMCoordinationCenter.cs:5581`). Wire **all three** layers:
+- `case "ACC_UploadModel":` in `StingTools/UI/StingCommandHandler.cs`
+- `case "ACC_UploadModel":` in `WorkflowEngine.ResolveCommand`
+- a `<Button ... Tag="ACC_UploadModel" Click="Cmd_Click"/>` in `StingTools/UI/StingDockPanel.xaml`,
+  beside the existing ACC Pull / ACC Sync buttons (around `:3134`)
+
+**Do not add the upload to any KUT workflow.** A workflow step cannot answer "upload which file?",
+and inventing an answer (guessing the model path, or silently uploading the active document) is
+exactly the guessing this prompt forbids. Leave that decision to a human and say so in your report.
+
+**Done means** the step-6 label matches behaviour; `ACC_UploadModel` is reachable from a button and
+resolvable by a workflow; no workflow step was invented.
+
+**Prove it**
+
+```bash
+# all three layers carry the new tag (expect >= 1 hit per layer)
+grep -n '"ACC_UploadModel"' StingTools/UI/StingCommandHandler.cs
+grep -n '"ACC_UploadModel"' StingTools/Core/WorkflowEngine.cs
+grep -n 'Tag="ACC_UploadModel"' StingTools/UI/StingDockPanel.xaml
+
+# no KUT workflow still claims to publish to ACC
+grep -rn -i "publish.*coordination data to ACC" StingTools/Data/WORKFLOW_KUT_*.json
+```
+
+The last command must return **nothing**. Before trusting that silence, prove the pattern can match:
+run it against the pre-edit file (`git stash`-free: `git show HEAD:StingTools/Data/WORKFLOW_KUT_CoordinationCycle.json | grep -i "publish.*coordination data to ACC"`)
+and confirm it **does** match there. A grep you have not seen succeed is not evidence.
+
+Then re-run the workflow resolve check from A7 and confirm it is still 97/97 (or higher if you added
+steps — you should not have).
+
+---
+
+### A4 — Resolve `StingTools/Clash/AccIssuesClient.cs`
+
+**Why.** 45 lines, a real `SendAsync` at `:37`, **zero callers**, and an endpoint
+(`bim360/docs/v1/projects/{id}/issues/bulk`) that disagrees with the live client's
+`construction/issues/v1`. It is a second, orphaned, differently-shaped ACC path that will mislead
+the next reader into thinking BCF bulk upload is available.
+
+**Do: delete the file.** The live path is `AccIssueSync`. If you believe it should be wired instead,
+you would need a BCF-bulk endpoint confirmed against live ACC — which you cannot do offline — so
+deletion is the only honest offline action.
+
+**Done means** the type no longer exists and the build is still 0/0.
+
+**Prove it**
+
+```bash
+# verify the instrument FIRST on a type that IS used — must return 20+ hits
+grep -rn "AccIssueSync" --include="*.cs" . | grep -v /obj/ | grep -v /bin/ | wc -l
+# then the deleted type — must return 0
+grep -rn "AccIssuesClient\|PostBcfAsync" --include="*.cs" . | grep -v /obj/ | grep -v /bin/
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
+```
+
+---
+
+### A5 — Ship a Niagara connection example, gated against the reader
+
+**Why.** `NiagaraJsonClient.FetchPoints` is a real transport, but **no `niagara_connection.json`
+or `.example` exists anywhere in the repo** — not in `project-templates/KUT/_BIM_COORD/`, not in
+`docs/examples/KUT/`. The required shape lives only in a code comment
+(`NiagaraJsonClient.cs:11-13`). Fohlio ships an example; Niagara does not. Whoever enables this at
+Stage 3.1 (~M40) must read the source to learn the field names.
+
+**Files to touch**
+- NEW `docs/examples/KUT/niagara_connection.json.example`
+- `docs/examples/KUT/README.md` — add a row for it
+- a test gating the example against the reader (see below)
+
+**The keys `NiagaraConnection.Load` reads** (`NiagaraJsonClient.cs:49-53`) — use exactly these:
+`baseUrl`, `pointsPath`, `apiKey`, `username`, `password`.
+
+**Do not invent the station URL, the oBIX path, or any credential.** Use
+`REPLACE_WITH_STATION_BASE_URL`, `REPLACE_WITH_API_KEY` etc. Note in the `_comment` that
+`pointsPath` defaults to `/obix` and is station-specific, that it must be confirmed with the
+controls contractor, and that the real file is gitignored and never committed. Mirror the tone of
+`docs/examples/KUT/fohlio_connection.json.example`.
+
+**Done means** the example's keys are exactly the keys the loader reads, and a gate enforces that so
+the two cannot drift.
+
+**Prove it** — add the test to `StingTools.Boq.Tests` (which already links
+`NiagaraPointParser.cs` and already gates the shipped KUT Fohlio map the same way; copy the
+`<None Include ... Link="Data\...">` pattern at `StingTools.Boq.Tests.csproj:184-186` so the test
+reads the **real** example file rather than a copy that can drift):
+
+```bash
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo --filter "FullyQualifiedName~NiagaraConnectionExample"
+```
+
+The test must assert every key the example declares is one the loader reads, **and** that every key
+the loader reads appears in the example. Both directions — a one-directional check is an
+alternative-path escape that lets the example go stale.
+
+**Sabotage to run and report:** rename `pointsPath` to `pointPath` in the example, confirm the test
+fails, restore. Then delete `password` from the example and confirm it fails the other direction.
+
+---
+
+### A6 — Remove the Fohlio false green
+
+**Why.** `FohlioRestTransport.TestConnection()` (`FohlioLink.cs:190-195`) returns `true` whenever
+`BaseUrl` and `ApiKey` are merely non-empty — **no network call at all**. Its siblings
+`ListItems` / `GetItem` / `UpdateItem` honestly throw `NotImplementedException` (`:198-204`). It is
+harmless today only because nothing calls it; the first person to wire a "Test connection" button
+inherits a test that passes against a typo.
+
+**Do:** make `TestConnection()` throw `NotImplementedException` with the same shape as its siblings,
+naming the CSV path as the working route. This is the smallest change that removes the false green
+while preserving the documented future interface. **Do not** implement the REST transport — the BEP
+(`GUIDES/KUT_BEP_TEMPLATE.md:326`) declares the file route as the mitigation and
+`project-templates/KUT/README.md:148-150` says REST stays stubbed for this contract, so building it
+is out of scope and needs an API key you do not have.
+
+Also correct the two comments that describe a "Test connection" gate which does not exist
+(`FohlioLink.cs:19-21` and `:183`) — say the REST tier is unimplemented and the CSV path is the
+contracted route.
+
+**Done means** no method in the file returns a success value without doing the work it claims.
+
+**Prove it**
+
+```bash
+# no bare 'return true' remains in the REST stub region
+sed -n '185,210p' StingTools/ExLink/FohlioLink.cs
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
+# the five CSV commands are untouched and still dispatch on all three layers
+grep -c 'Tag="Fohlio_' StingTools/UI/StingDockPanel.xaml    # expect 5
+grep -c 'case "Fohlio_' StingTools/UI/StingCommandHandler.cs # expect 5
+grep -c 'case "Fohlio_' StingTools/Core/WorkflowEngine.cs    # expect 5
+```
+
+Then confirm the Fohlio suites still pass — you must not regress the working tier:
+
+```bash
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo --filter "FullyQualifiedName~Fohlio"
+```
+
+---
+
+### A7 — Re-prove every KUT workflow still resolves
+
+**Why.** A3 edits a workflow file and adds dispatch entries. A step whose `commandTag` does not
+appear in `ResolveCommand` parses fine and silently does nothing.
+
+**Done means** all 10 `WORKFLOW_KUT_*.json` files resolve 100% of their steps, and every step still
+uses the `commandTag` + `label` field names (not `command` / `name`, which parse and do nothing).
+
+**Prove it.** Write the checker as `tools/check_kut_workflow_tags.py` so it is reusable and
+CI-gateable, not a throwaway. It must:
+- extract `case "X":` labels from `WorkflowEngine.cs` **lines 1395–2244 only**, and assert that
+  window contains **exactly one** `switch` (if a future edit moves the method, the checker must fail
+  loudly rather than silently widen its view and report false passes),
+- self-test before reporting: a known-good tag (`Fohlio_Export`) must be found and a nonsense tag
+  (`Fohlio_ExportZZZ_NOT_A_REAL_TAG`) must not; abort if either check misbehaves,
+- report per-file resolve rate and exit non-zero on any unresolved tag or wrong field name.
+
+```bash
+python tools/check_kut_workflow_tags.py .
+```
+
+Expected baseline: **97/97 steps across 10 files (100%)**. If your A3 work changed the count, state
+the new count and why.
+
+**Sabotage to run and report:** add a step with `commandTag: "NotARealTag"` to one KUT workflow,
+confirm the checker exits non-zero, remove it. Then change a step's `commandTag` key to `command`
+and confirm the checker catches that too.
+
+---
+
+### A8 — Write the live-verification runbook (offline authoring of blocked work)
+
+**Why.** Section B cannot be executed without third parties, but it can be made ready. The KUT
+README already prescribes *"do one live pull during mobilisation"*
+(`project-templates/KUT/README.md:142-143`) without saying how.
+
+**Files to touch** — NEW `docs/KUT_LIVE_VERIFICATION_RUNBOOK.md`, plus a row in `docs/INDEX.md`
+(under "Audits, proposals and role model", which is where dated reports live).
+
+**Content.** For each of B1/B2/B3 below: who must supply what, the exact steps once it arrives, the
+observable proof that it worked, and what to do when it does not. Specifically for ACC:
+- the APS app type required (**Traditional Web App** — confidential, uses a Client Secret, matching
+  the Basic-auth token exchange the code already does),
+- the exact callback URL to register: `http://localhost:8910/callback`
+  (`AccOAuthFlow.cs:42`, `:50`) — the sign-in fails with a clear message if it is missing,
+- the four fields and where they go (`ClientId`, `ClientSecret`, `ProjectId` = the `b.<guid>` Issues
+  container, `CoordContainerId` if Model Coordination differs),
+- that `IssueTypeId` does **not** need hand-entry — `EnsureIssueTypeAsync` resolves and caches it,
+- the single highest-value check: one `ACC_PullClashes` against a model set known to contain
+  clashes, to confirm the `bim360/clash/v3` **tests** and **resources** sub-paths, which
+  `AccModelCoordSync.cs:40-42` flags as the only real residual,
+- that after A1 a wrong path now returns `Result.Failed` with a named reason instead of looking
+  clean — so the runbook should say what that message looks like.
+
+**Do not invent** a Client ID, container id, station URL, or any credential. Leave
+`REPLACE_WITH_...` markers.
+
+**Done means** a competent BIM manager could execute it without reading any source code.
+
+**Prove it**
+
+```bash
+python tools/check_docs_index.py
+```
+
+This is the gate `.github/workflows/docs-index.yml` runs; it must pass. Also confirm the new doc is
+listed:
+
+```bash
+grep -n "KUT_LIVE_VERIFICATION_RUNBOOK" docs/INDEX.md
+```
+
+---
+
+## 5. SECTION B — blocked on someone else. Do not attempt.
+
+These need a person or a credential you do not have. **Do not** fabricate a credential, mock a
+service and report it as verified, or mark any of these done. Your only task here is A8 — write the
+runbook so they are ready.
+
+| # | Blocked work | Who must act first | Why you cannot proceed |
+|---|---|---|---|
+| **B1** | One live ACC pull to confirm the `bim360/clash/v3` tests/resources sub-paths, and one live issue push | **Owner / Autodesk account holder** — must create an APS app and register the callback URL; **ACC project admin** — must supply the container ids | No APS Client ID or Secret exists. Without them `EnsureAuthAsync` cannot get a token, and the only genuine unknown in the ACC path stays unknown. This is **overdue**, not upcoming — mobilisation began the week of 25 August 2026. |
+| **B2** | One live Niagara station fetch | **Controls / commissioning contractor** — station base URL, the oBIX points path, and credentials | No station exists to reach, and `pointsPath` defaults to a station-specific guess (`/obix`). Not due until Stage 3.1 (~M40). |
+| **B3** | Confirm the Fohlio field mapping is agreed | **Interior Designer** — owns the Fohlio record | `KUT_PROJECT_DELIVERY_PLAYBOOK.md:708` makes "field mapping agreed with Fohlio" a mobilisation obligation. The shipped map is STING-authored; nothing in the repo evidences sign-off. This is a meeting, not a code task, and it is on the mobilisation critical path. |
+
+If you find yourself tempted to "verify" any of these with a mock, stop: a fabricated verification
+is worse than an open item, because it closes the item in everyone's mind.
+
+---
+
+## 6. What you must NOT do
+
+- Do not implement the Fohlio REST transport (out of contract scope; needs an API key).
+- Do not implement BACnet or OPC-UA readback (`TwinReadback.cs`). Stubbed by design, an FM add-on,
+  not promised by any KUT document.
+- Do not add an ACC upload step to any KUT workflow (A3b explains why).
+- Do not refactor the god-files (`StingCommandHandler.cs`, `BIMCoordinationCenter.cs`). Add your
+  cases; change nothing else in them. They are the most contended files in the tree.
+- Do not edit a generated KUT document. Edit its generator and regenerate.
+- Do not change `CLAUDE.md` headline counts as a side-effect; if you notice drift, note it in your
+  report.
+- Do not delete or rename any shared parameter or GUID.
+
+---
+
+## 7. Finishing
+
+Run the full gate set and paste real output for each — not a summary, the actual last lines:
+
+```bash
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo   # 0 errors, 0 warnings
+dotnet test  StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
+dotnet test  StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo     # baseline 1311 passing
+python tools/check_kut_workflow_tags.py .                                  # 97/97 across 10 files
+python tools/check_kut_documents.py                                        # 100 assertions, 5 docs
+```
+
+`check_kut_documents.py` must stay green even though you should not have touched a generated
+document — run it to prove you did not.
+
+Then commit on your branch and open a PR. In the PR body, state for each task:
+
+- **what changed**, with `file:line`;
+- **the command that proves it**, and its real output;
+- **the sabotage you ran** and confirmation that the gate failed under it;
+- **anything you left blank with a marker**, and why — list every `REPLACE_WITH_...` and
+  `TODO(KUT):` you introduced;
+- **anything you could not do**, and who must act.
+
+Report failures plainly. If a gate will not go green, say so with the output rather than narrowing
+the gate until it passes — a gate relaxed to pass is worse than a red one, because it reports
+health it has not checked. If you finish only part of Section A, finish the tasks you did complete
+properly and say explicitly which you left and why; scaling the work down is the user's call, not
+yours.


### PR DESCRIPTION
Research only. **No behaviour is changed** — a mixed research-and-repair branch makes both halves unreviewable, so the fixes this report names are deliberately not in it.

Adds [`docs/KUT_INTEGRATION_READINESS_2026-09.md`](docs/KUT_INTEGRATION_READINESS_2026-09.md), measured 2026-09-10 on `main` @ `d318dcbee`. Plugin builds **0 errors / 0 warnings** on this machine.

## Verdicts

| Integration | Verdict | Basis |
|---|---|---|
| **ACC** | **WIRED BUT UNPROVEN** | Four real HTTP clients (`AccIssueSync`, `AccOAuthFlow`, `AccModelCoordSync`, `AccModelUpload`), a complete 3-legged OAuth flow with CSRF state, dispatch complete on all three layers — and, by the code's own admission, never run against a live Autodesk tenant. Zero tests. |
| **Fohlio** | **WORKS** (CSV tier) | The contracted route. Five commands, real I/O both ways, `FOHLIO_REF_TXT` defined and *universally bound*, 72 passing tests, and a gate that links the **real** KUT map into its test output so data and gate cannot drift. |
| **Niagara** | **WIRED BUT UNPROVEN** | The file-mediated path the playbook actually promises is built and honest about empty results. The live oBIX client is a real transport that has never met a station and **ships no connection template anywhere**. BACnet/OPC-UA readback is a genuine no-op. |

**Nothing is ABSENT and nothing fabricates data.** The gap is proof, not construction.

## The five findings

1. **`ACCPublish` does not publish to ACC** — it writes a local ZIP and says so in the UI, but `WORKFLOW_KUT_CoordinationCycle.json` step 6 reads *"Publish coordination data to ACC"*. The real uploader exists and is in no workflow.
2. **`PushIssueAsync`'s 429 retry cannot execute.** Verified empirically, not inferred: reproduced against a local always-429 listener on .NET 8.0.23, the plugin's runtime. The request is built once outside the loop and re-sent, so attempt 2 throws `InvalidOperationException`. Issues are dropped while the log says `retrying in 1s`. `PullIssuesAsync` builds inside its loop and is correct — the asymmetry shows an oversight.
3. **A wrong ACC clash sub-path is indistinguishable from a clean model.** It fails soft and returns empty; the command reports that as *"clash-clean, or a clash test has not completed"* and returns `Succeeded`. A misconfigured container reads as a clean fortnightly cycle — the house failure mode, in the one place it costs coordination.
4. **`Clash/AccIssuesClient.cs` is dead** — 45 lines, zero callers, and an endpoint shape disagreeing with the live client's. Verified the grep on `AccIssueSync` (20+ hits) before trusting the silence.
5. **`FohlioRestTransport.TestConnection()` returns `true` with no network call** — harmless only because nothing calls it. A loaded gun for whoever wires the button.

## Workflows

All **97 steps across all 10** `WORKFLOW_KUT_*.json` resolve (100%), correct `commandTag`/`label` throughout. The checker self-tests on a known-good and a nonsense tag before reporting, and the extraction window was confirmed to contain exactly one `switch` — a false *pass* was the worst available outcome here, so it was ruled out explicitly.

## What this changes for the project

Mobilisation is **not** blocked: `WORKFLOW_KUT_Mobilisation.json` is five local steps touching none of the three. The Fohlio stream is ready now. Niagara is not due until ~M40.

The critical path is **one Autodesk credential** — an APS app the Owner must issue — plus one live pull to settle the clash sub-paths, exactly as `project-templates/KUT/README.md` already prescribes. `docs/INDEX.md` records mobilisation as having begun the week of 25 August, so that credential is **overdue, not upcoming**.

Findings 1–4 are all offline fixes needing nobody; only #3 is load-bearing.

## Documentation corrected

Four stale claims, each with both numbers shown and a statement of which is right:
- `CLAUDE.md` mentions only the BACnet/OPC-UA stubs, so Niagara reads as absent when two of its three paths are built.
- `StingTools.Boq.Tests` measures **1311 passing**, against 196 in the CLAUDE.md table — understated ~6.7×.
- There are **10** KUT workflows, not 9.
- The brief's repo-match counts could not be reproduced by file count, by including build artefacts, or by occurrence count. Recorded rather than quietly adjusted; it affects no verdict, since logic files were enumerated directly.

`tools/check_kut_documents.py` still passes — 100 assertions, 5 issued documents. No generated document was touched.

## Stage 2 is in this PR

[`docs/PROMPT_KUT_INTEGRATION_BUILD.md`](docs/PROMPT_KUT_INTEGRATION_BUILD.md) — a self-contained build prompt for an agent with none of this context. It is a **document, not repair**, so it does not mix research with fixes; the two read as a pair and reviewing them together is easier than apart.

Eight offline tasks ordered by what unblocks KUT soonest (A1, the empty-vs-failed distinction, is the only load-bearing one), and three third-party-blocked items quarantined in their own section with an explicit instruction not to mock them. Every task states the files, what done means, and the command whose output is the evidence.

Every proof command in it was run against this checkout first, so none are guesses — including verifying that the one "must return nothing" grep *does* match before the fix, so its later silence means something. `tools/check_docs_index.py` then caught the prompt itself being unindexed, which is exactly the gate behaviour the prompt tells the executing agent to rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
