### PR TITLE
W1: stamp the register's MAT_CODE onto the material

### DIFF
--- a/StingTools.Tags.Tests/MaterialCodeStampPlannerTests.cs
+++ b/StingTools.Tags.Tests/MaterialCodeStampPlannerTests.cs
@@ -1,0 +1,305 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialCodeStampPlannerTests.cs — the gate on W1.
+//
+//  The claim being gated: before this work, NOTHING resolved a MAT_CODE for a
+//  material created by CompoundTypeCreator or inherited from an older model, so
+//  RateProviders Pass C — the most specific rate lookup in the BOQ — could never
+//  fire. The corpus test below is written so that the pre-change world is a
+//  MEASURABLE state of the same code, not a story: run it against a register
+//  that is not consulted and every one of the 1,815 names resolves no code.
+//
+//  RED / GREEN, recorded 2026-09-10 on this machine:
+//
+//    Corpus_Resolves_The_Registers_Codes
+//      RED   (register lookup severed in the planner) 0 stamped / 1,815 no-row
+//      GREEN (shipped register)                   1,279 stamped /   536 no-row
+//
+//    A_Code_Already_There_Is_Never_Overwritten
+//      RED   (planner's existing-code branch removed) FLR-999 proposed -> FLR-028
+//      GREEN                                          no write proposed at all
+//
+//  The second is the one that matters more. The suite does not discriminate on
+//  a wrong write — 2,230 tests passed on this tree before any of this existed —
+//  so the overwrite rule needs its own assertion or it is not defended.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class MaterialCodeStampPlannerTests
+    {
+        // ── the shipped register and the shipped corpus, both read from source ──
+
+        private static DirectoryInfo RepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return dir;
+        }
+
+        private static MaterialRegistry _shipped;
+
+        private static MaterialRegistry Shipped()
+        {
+            if (_shipped == null)
+            {
+                string data = Path.Combine(RepoRoot().FullName, "StingTools", "Data");
+                _shipped = MaterialRegistry.Parse(
+                    File.ReadAllText(Path.Combine(data, "BLE_MATERIALS.csv")),
+                    File.ReadAllText(Path.Combine(data, "MEP_MATERIALS.csv")));
+            }
+            return _shipped;
+        }
+
+        /// <summary>The 1,815-name corpus harvested off a real model on 2026-09-08.
+        /// Column 0 is the material name; the other two columns belong to the PROD work.</summary>
+        private static List<string> Corpus()
+        {
+            string path = Path.Combine(RepoRoot().FullName, "StingTools.Tags.Tests",
+                                       "Fixtures", "material_names_20260908.csv");
+            Assert.True(File.Exists(path), "corpus fixture missing: " + path);
+            var names = new List<string>();
+            bool first = true;
+            foreach (string line in File.ReadAllLines(path))
+            {
+                if (first) { first = false; continue; }
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                string name = MaterialRegistry.SplitCsvLine(line).FirstOrDefault();
+                if (!string.IsNullOrWhiteSpace(name)) names.Add(name.Trim());
+            }
+            return names;
+        }
+
+        private static List<KeyValuePair<string, string>> Uncoded(IEnumerable<string> names)
+            => names.Select(n => new KeyValuePair<string, string>(n, "")).ToList();
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The corpus. RED is the same body against a register that says nothing.
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void With_No_Register_Consulted_Every_Material_Resolves_No_Code()
+        {
+            // This is the state of the world before W1, expressed as an assertion rather
+            // than as prose: nothing stamped, so nothing resolves, so Pass C cannot fire.
+            var corpus = Corpus();
+            var rows = MaterialCodeStampPlanner.PlanAll(Uncoded(corpus), MaterialRegistry.Empty);
+            var t = MaterialCodeStampPlanner.Tally(rows);
+
+            Assert.Equal(1815, t.Total);
+            Assert.Equal(0, t.Stamped);
+            Assert.Equal(1815, t.NoRegisterRow);
+            Assert.All(rows, r => Assert.Equal("", r.RegisterCode));
+        }
+
+        [Fact]
+        public void Corpus_Resolves_The_Registers_Codes()
+        {
+            var corpus = Corpus();
+            var rows = MaterialCodeStampPlanner.PlanAll(Uncoded(corpus), Shipped());
+            var t = MaterialCodeStampPlanner.Tally(rows);
+
+            Assert.Equal(1815, t.Total);
+
+            // 1,279 of the corpus names ARE register rows — the whole register appears in
+            // this model — and 536 are not. Pinned as numbers because the point of the
+            // work is that the second number is readable at all.
+            Assert.Equal(1279, t.Stamped);
+            Assert.Equal(536, t.NoRegisterRow);
+            Assert.Equal(0, t.AlreadyCoded);
+            Assert.Equal(536, t.RegisterSilent);
+
+            // Every stamped row carries a real code from the register, not a blank that
+            // happened to count. An empty string is the failure this whole area produces.
+            Assert.All(rows.Where(r => r.WillWrite), r =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(r.RegisterCode));
+                Assert.Equal(r.RegisterCode, Shipped().ByName(r.MaterialName)?.Code);
+            });
+        }
+
+        [Fact]
+        public void A_Named_Row_Resolves_The_Code_The_Register_Gives_It()
+        {
+            // FLR-028 is the row the whole chain is traced through in W4.
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+            Assert.NotNull(flr028);
+
+            var row = MaterialCodeStampPlanner.Plan(flr028.Name, "", reg);
+            Assert.Equal(MaterialCodeVerdict.Stamp, row.Verdict);
+            Assert.Equal("FLR-028", row.RegisterCode);
+            Assert.True(row.WillWrite);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. Never overwrite. The rule with no other defender.
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Code_Already_There_Is_Never_Overwritten()
+        {
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+
+            var row = MaterialCodeStampPlanner.Plan(flr028.Name, "FLR-999", reg);
+
+            Assert.Equal(MaterialCodeVerdict.AlreadyCoded, row.Verdict);
+            Assert.False(row.WillWrite);
+            Assert.Equal("FLR-999", row.ExistingCode);
+            Assert.True(row.CodeDisagrees);
+            Assert.Contains("FLR-028", row.Reason);   // the disagreement is SAID, not settled
+        }
+
+        [Fact]
+        public void An_Agreeing_Code_Is_Not_A_Disagreement()
+        {
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+            var row = MaterialCodeStampPlanner.Plan(flr028.Name, "flr-028", reg);
+
+            Assert.Equal(MaterialCodeVerdict.AlreadyCoded, row.Verdict);
+            Assert.False(row.CodeDisagrees);          // case, not conflict
+            Assert.False(row.WillWrite);
+        }
+
+        [Fact]
+        public void A_Coded_Material_The_Register_Does_Not_Know_Is_Left_Alone()
+        {
+            var row = MaterialCodeStampPlanner.Plan(
+                "SOMETHING THIS PROJECT INVENTED", "PRJ-001", Shipped());
+
+            Assert.Equal(MaterialCodeVerdict.AlreadyCoded, row.Verdict);
+            Assert.False(row.WillWrite);
+            Assert.False(row.CodeDisagrees);          // nothing to disagree WITH
+            Assert.Equal("", row.RegisterCode);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. The three counts are mutually exclusive, and the fourth is not one of them
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Three_Verdicts_Partition_The_Materials()
+        {
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+            var input = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>(flr028.Name, ""),          // Stamp
+                new KeyValuePair<string, string>(flr028.Name, "FLR-999"),   // AlreadyCoded
+                new KeyValuePair<string, string>("NOT A REGISTER NAME", ""),// NoRegisterRow
+                new KeyValuePair<string, string>("ALSO NOT ONE", "PRJ-9"),  // AlreadyCoded
+            };
+            var t = MaterialCodeStampPlanner.Tally(MaterialCodeStampPlanner.PlanAll(input, reg));
+
+            Assert.Equal(4, t.Total);
+            Assert.Equal(1, t.Stamped);
+            Assert.Equal(2, t.AlreadyCoded);
+            Assert.Equal(1, t.NoRegisterRow);
+            Assert.Equal(t.Total, t.Stamped + t.AlreadyCoded + t.NoRegisterRow);
+
+            // RegisterSilent crosses the verdicts on purpose: two of these four are not in
+            // the register, but only ONE of them is a NoRegisterRow, because the other
+            // already has a code and the headline counts describe the write decision.
+            Assert.Equal(2, t.RegisterSilent);
+            Assert.Equal(1, t.Disagreements);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  4. Exact means exact
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Revits_Clash_Suffix_Is_Not_Matched()
+        {
+            // Revit renames a colliding material to "NAME 2". That may be a copy of the
+            // register row or somebody's variant, and stamping a governed code onto it on
+            // the strength of a prefix is exactly the guess this design refuses.
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+
+            var row = MaterialCodeStampPlanner.Plan(flr028.Name + " 2", "", reg);
+            Assert.Equal(MaterialCodeVerdict.NoRegisterRow, row.Verdict);
+            Assert.False(row.WillWrite);
+        }
+
+        [Fact]
+        public void Name_Matching_Ignores_Case_And_Surrounding_Space()
+        {
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+
+            var row = MaterialCodeStampPlanner.Plan("  " + flr028.Name.ToLowerInvariant() + "  ", "", reg);
+            Assert.Equal(MaterialCodeVerdict.Stamp, row.Verdict);
+            Assert.Equal("FLR-028", row.RegisterCode);
+        }
+
+        [Fact]
+        public void A_Blank_Name_Is_Dropped_Rather_Than_Planned()
+        {
+            var input = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("", ""),
+                new KeyValuePair<string, string>("   ", "X"),
+                new KeyValuePair<string, string>(null, ""),
+            };
+            Assert.Empty(MaterialCodeStampPlanner.PlanAll(input, Shipped()));
+        }
+
+        [Fact]
+        public void A_Model_With_No_Materials_Says_So()
+        {
+            var rows = MaterialCodeStampPlanner.PlanAll(
+                new List<KeyValuePair<string, string>>(), Shipped());
+            Assert.Contains("no materials", MaterialCodeStampPlanner.Summary(rows));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  5. The CSV a human reads
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Plan_Csv_Carries_Every_Row_Including_The_Ones_Not_Written()
+        {
+            var reg = Shipped();
+            var flr028 = reg.ByCode("FLR-028");
+            var rows = MaterialCodeStampPlanner.PlanAll(new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>(flr028.Name, ""),
+                new KeyValuePair<string, string>("NOT A REGISTER NAME", ""),
+            }, reg);
+
+            var csv = MaterialCodeStampPlanner.ToCsv(rows);
+            Assert.Equal(3, csv.Count);                       // header + both rows
+            Assert.StartsWith("Material,ExistingCode,RegisterCode,Verdict,Reason", csv[0]);
+            Assert.Contains(csv, l => l.Contains("NoRegisterRow"));
+            Assert.Contains(csv, l => l.Contains("FLR-028"));
+        }
+
+        [Fact]
+        public void A_Name_With_A_Comma_Survives_The_Csv()
+        {
+            var row = MaterialCodeStampPlanner.Plan("Concrete, Cast-in-Place gray", "", Shipped());
+            string line = MaterialCodeStampPlanner.ToCsv(new[] { row })[1];
+            Assert.StartsWith("\"Concrete, Cast-in-Place gray\"", line);
+        }
+
+        [Fact]
+        public void The_Summary_Names_The_Vocabulary_Number()
+        {
+            var rows = MaterialCodeStampPlanner.PlanAll(Uncoded(Corpus()), Shipped());
+            string s = MaterialCodeStampPlanner.Summary(rows);
+            Assert.Contains("1279 will be stamped", s);
+            Assert.Contains("536 have no register row", s);
+            Assert.Contains("own vocabulary", s);
+        }
+    }
+}

--- a/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
+++ b/StingTools.Tags.Tests/StingTools.Tags.Tests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="..\StingTools\Core\Materials\MaterialRegistry.cs" Link="Core\Materials\MaterialRegistry.cs" />
     <Compile Include="..\StingTools\Core\Materials\MaterialRegisterReconciliation.cs" Link="Core\Materials\MaterialRegisterReconciliation.cs" />
     <Compile Include="..\StingTools\Core\Materials\HostTypeRegisterAudit.cs" Link="Core\Materials\HostTypeRegisterAudit.cs" />
+    <Compile Include="..\StingTools\Core\Materials\MaterialCodeStampPlanner.cs" Link="Core\Materials\MaterialCodeStampPlanner.cs" />
     <!-- IM-15: config-driven revision scheme. Kept Revit-free so the P→C default and the
          per-appointment override are provable without a Revit host. -->
     <Compile Include="..\StingTools\Docs\Templates\RevisionScheme.cs" Link="Docs\Templates\RevisionScheme.cs" />

--- a/StingTools/Commands/Materials/StampMaterialCodesCommand.cs
+++ b/StingTools/Commands/Materials/StampMaterialCodesCommand.cs
@@ -1,0 +1,189 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  StampMaterialCodesCommand.cs — Materials_StampCodes.
+//
+//  Writes the governed register's MAT_CODE onto the materials that have none,
+//  matching by exact MAT_NAME. Sits beside Materials_RegisterAudit on the SETUP
+//  tab: the audit says what disagrees, this says what the register can name.
+//
+//  It exists because MAT_CODE is the key the BOQ's most specific rate lookup
+//  uses — RateProviders Pass C, confidence 80 — and only one of the two paths
+//  that mint materials ever wrote it. CompoundTypeCreator, which is what builds
+//  a project's host-type catalogue, read the register row and discarded the
+//  code; a model whose materials predate that work has none at all.
+//
+//  ── THE SHAPE, DELIBERATELY THE SAME AS Materials_SetClass ────────────────
+//  Plan CSV FIRST, then a TaskDialog that defaults to No. The plan is written
+//  whether or not the user says yes, so a decision to decline still leaves the
+//  three counts on disk. Nothing about this is reversible by accident: it only
+//  ever fills a blank.
+//
+//  The decision itself is in MaterialCodeStampPlanner — Revit-free, tested
+//  against the shipped 1,279-row register and the 1,815-name corpus. This file
+//  reads parameters and writes them and does no thinking of its own.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using StingTools.Core;
+using StingTools.Core.Materials;
+
+namespace StingTools.Commands.Materials
+{
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class StampMaterialCodesCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            try
+            {
+                var ctx = ParameterHelpers.GetContext(commandData);
+                if (ctx == null) { TaskDialog.Show("STING", "No document open."); return Result.Failed; }
+                Document doc = ctx.Doc;
+
+                var registry = RegisterAuditCommand.LoadRegistry(out string loadNote);
+                if (registry.Count == 0)
+                {
+                    // A register that loaded nothing must say so rather than report
+                    // "0 materials could be coded", which is the same sentence a healthy
+                    // run with nothing to do would produce.
+                    TaskDialog.Show("Stamp Material Codes",
+                        "The material register did not load, so there is nothing to stamp "
+                      + "from:\n\n" + loadNote);
+                    return Result.Failed;
+                }
+
+                var mats = new FilteredElementCollector(doc).OfClass(typeof(Material))
+                              .Cast<Material>().OrderBy(m => m.Name).ToList();
+                if (mats.Count == 0)
+                {
+                    TaskDialog.Show("Stamp Material Codes", "This model has no materials.");
+                    return Result.Succeeded;
+                }
+
+                // MAT_CODE is bound to Materials and to nothing else. If the binding is
+                // absent the read returns empty for every material and the plan would
+                // propose stamping the whole model — a write that then silently does
+                // nothing, because SetIfEmpty cannot find the parameter either. Say it.
+                bool bound = mats.Any(m => SafeHasMatCode(m));
+                if (!bound)
+                {
+                    TaskDialog.Show("Stamp Material Codes",
+                        "MAT_CODE is not bound to Materials in this model, so there is nowhere "
+                      + "to write the code.\n\nRun Load Shared Parameters first — MAT_CODE is "
+                      + "declared in MR_PARAMETERS.txt and binds to the Materials category.");
+                    return Result.Failed;
+                }
+
+                var byMat = new Dictionary<Material, MaterialCodeStampRow>();
+                var input = new List<KeyValuePair<string, string>>();
+                foreach (var m in mats)
+                    input.Add(new KeyValuePair<string, string>(
+                        m.Name, ParameterHelpers.GetString(m, "MAT_CODE") ?? ""));
+
+                var rows = MaterialCodeStampPlanner.PlanAll(input, registry);
+                for (int i = 0; i < mats.Count && i < rows.Count; i++) byMat[mats[i]] = rows[i];
+
+                string path = StingTools.Commands.Baseline.Standardise.Write(
+                                  doc, "material_code_plan", MaterialCodeStampPlanner.ToCsv(rows));
+
+                var todo = byMat.Where(kv => kv.Value.WillWrite).ToList();
+                var tally = MaterialCodeStampPlanner.Tally(rows);
+
+                var sb = new StringBuilder();
+                sb.AppendLine(MaterialCodeStampPlanner.Summary(rows));
+                if (!string.IsNullOrEmpty(loadNote)) { sb.AppendLine(loadNote); sb.AppendLine(); }
+                sb.AppendLine("MAT_CODE is what the BOQ's most specific rate lookup keys on. A "
+                            + "material without one is priced by category and name instead.");
+                foreach (var kv in todo.Take(12))
+                    sb.AppendLine("  " + kv.Value.MaterialName + "  →  " + kv.Value.RegisterCode);
+                if (todo.Count > 12) sb.AppendLine("  … and " + (todo.Count - 12) + " more, in the CSV");
+                if (tally.Disagreements > 0)
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(tally.Disagreements + " material(s) already carry a code the "
+                                + "register contradicts. They are in the CSV and this changes "
+                                + "none of them.");
+                }
+                if (path != null) { sb.AppendLine(); sb.AppendLine("Plan: " + path); }
+
+                if (todo.Count == 0)
+                {
+                    TaskDialog.Show("Stamp Material Codes", sb.ToString());
+                    StingLog.Info("Materials_StampCodes: nothing to stamp; " + tally.AlreadyCoded
+                                + " coded, " + tally.NoRegisterRow + " not in register -> " + path);
+                    return Result.Succeeded;
+                }
+
+                var td = new TaskDialog("Stamp Material Codes")
+                {
+                    MainInstruction = todo.Count + " material(s) will be given their register code",
+                    MainContent = sb.ToString() + Environment.NewLine + "Apply?",
+                    CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                    DefaultButton = TaskDialogResult.No,
+                };
+                if (td.Show() != TaskDialogResult.Yes) return Result.Cancelled;
+
+                int done = 0;
+                var failed = new List<string>();
+                using (var t = new Transaction(doc, "STING Stamp Material Codes"))
+                {
+                    t.Start();
+                    foreach (var kv in todo)
+                    {
+                        try
+                        {
+                            if (ParameterHelpers.SetIfEmpty(kv.Key, "MAT_CODE", kv.Value.RegisterCode))
+                                done++;
+                            else
+                                failed.Add(kv.Value.MaterialName + " — MAT_CODE not writable");
+                        }
+                        catch (Exception ex) { failed.Add(kv.Value.MaterialName + " — " + ex.Message); }
+                    }
+                    t.Commit();
+                }
+
+                var res = new StringBuilder("Stamped " + done + " of " + todo.Count + " material(s).");
+                res.AppendLine();
+                res.AppendLine(tally.AlreadyCoded + " already had a code and were not touched.");
+                res.AppendLine(tally.NoRegisterRow + " are not in the register — this project's own "
+                             + "vocabulary, and what the next register revision should absorb.");
+                if (failed.Count > 0)
+                {
+                    res.AppendLine();
+                    res.AppendLine("Not stamped:");
+                    foreach (string f in failed.Take(10)) res.AppendLine("  " + f);
+                }
+                TaskDialog.Show("Stamp Material Codes", res.ToString());
+                StingLog.Info("Materials_StampCodes: " + done + "/" + todo.Count + " stamped, "
+                            + tally.AlreadyCoded + " already coded, " + tally.NoRegisterRow
+                            + " not in register, " + failed.Count + " failed -> " + path);
+                return Result.Succeeded;
+            }
+            catch (OperationCanceledException) { return Result.Cancelled; }
+            catch (Exception ex)
+            {
+                StingLog.Error("Materials_StampCodes", ex);
+                message = ex.Message;
+                return Result.Failed;
+            }
+        }
+
+        /// <summary>Is MAT_CODE actually bound here? A guarded LookupParameter, because
+        /// an unbound parameter and an empty one read identically through GetString and
+        /// the difference decides whether this command can do anything at all.</summary>
+        private static bool SafeHasMatCode(Material m)
+        {
+            try { return m?.LookupParameter("MAT_CODE") != null; }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("StampCodes.Bind", "LookupParameter MAT_CODE: " + ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialCodeStampPlanner.cs
+++ b/StingTools/Core/Materials/MaterialCodeStampPlanner.cs
@@ -2,7 +2,7 @@
 //  MaterialCodeStampPlanner.cs — put the register's CODE on the material, so
 //  that something other than a name can answer "what is this?".
 //
-//  WHY. MAT_CODE is a declared shared parameter (MR_PARAMETERS.txt:879,
+//  WHY. MAT_CODE is a declared shared parameter (MR_PARAMETERS.txt:973,
 //  758ba3d0-ea41-51fc-8dbf-3bb444174385), bound to `Materials` and to nothing
 //  else, and the BOQ rate chain keys on it: RateProviders "Pass C", confidence
 //  80, between the PROD match (85) and the COBie type map (75). The register

--- a/StingTools/Core/Materials/MaterialCodeStampPlanner.cs
+++ b/StingTools/Core/Materials/MaterialCodeStampPlanner.cs
@@ -1,0 +1,218 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialCodeStampPlanner.cs — put the register's CODE on the material, so
+//  that something other than a name can answer "what is this?".
+//
+//  WHY. MAT_CODE is a declared shared parameter (MR_PARAMETERS.txt:879,
+//  758ba3d0-ea41-51fc-8dbf-3bb444174385), bound to `Materials` and to nothing
+//  else, and the BOQ rate chain keys on it: RateProviders "Pass C", confidence
+//  80, between the PROD match (85) and the COBie type map (75). The register
+//  that supplies the codes is 100% populated — 815 BLE + 464 MEP rows, every
+//  one carrying a unique MAT_CODE.
+//
+//  One writer exists: MaterialCommands.ApplySharedParamValues (:1121), reached
+//  only from CreateBLEMaterials / CreateMEPMaterials. The OTHER path that mints
+//  materials — CompoundTypeCreator, which is what builds a project's wall /
+//  floor / ceiling / roof catalogue — called ApplyMaterialProperties and not the
+//  shared-parameter writer, so every material it created was born without a
+//  code. And a model whose materials predate any of this has none either.
+//
+//  So this plans the backfill, and the decision is deliberately Revit-free: the
+//  hard part is not reading a parameter, it is deciding WHETHER to write, and
+//  that decision is provable against the shipped register without a host.
+//
+//  ── THE RULE ──────────────────────────────────────────────────────────────
+//  Match by exact MAT_NAME — trimmed and case-insensitive, which is what
+//  MaterialRegistry.ByName already means by exact. NOT fuzzy: Revit appends
+//  " 2" and " (1)" on a name clash, and a material called
+//  `CEMENT SCREED 50MM 2` may be a duplicate of the register row or may be
+//  somebody's variant. Guessing which would put a governed code on an
+//  ungoverned material, which is the failure this whole area is about.
+//
+//  NEVER OVERWRITE. A code already present belongs to whoever set it. Where it
+//  disagrees with the register the row says so and the plan still does not
+//  write — the register is a challenger, not an oracle, and a disagreement is a
+//  thing for a human to read, not for a tool to settle.
+//
+//  ── THE THIRD COUNT IS THE USEFUL ONE ─────────────────────────────────────
+//  Stamped and already-coded are bookkeeping. NoRegisterRow is the project's
+//  own vocabulary — the materials the governed register does not describe — and
+//  it is what the next register revision should absorb. Measured on the
+//  1,815-name corpus in Fixtures/material_names_20260908.csv: 1,279 of those
+//  names are register rows and 536 are not.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StingTools.Core.Materials
+{
+    /// <summary>What the planner decided to do about one material's MAT_CODE.</summary>
+    public enum MaterialCodeVerdict
+    {
+        /// <summary>No code today, and the register names this material. This one writes.</summary>
+        Stamp,
+        /// <summary>A code is already there. Never overwritten, register row or not.</summary>
+        AlreadyCoded,
+        /// <summary>No code today, and the register does not describe this material.
+        /// Not a failure — it is the project's own vocabulary, and the number worth
+        /// reading.</summary>
+        NoRegisterRow,
+    }
+
+    /// <summary>One row of a material_code_plan CSV.</summary>
+    public sealed class MaterialCodeStampRow
+    {
+        public string MaterialName = "";
+        /// <summary>MAT_CODE as it stands on the material now. Empty when unset.</summary>
+        public string ExistingCode = "";
+        /// <summary>What the register says, or "" when it says nothing.</summary>
+        public string RegisterCode = "";
+        public MaterialCodeVerdict Verdict;
+        public string Reason = "";
+
+        /// <summary>The one verdict that touches the model.</summary>
+        public bool WillWrite => Verdict == MaterialCodeVerdict.Stamp;
+
+        /// <summary>A code is present AND the register names a different one. Reported,
+        /// never reconciled — see the file header.</summary>
+        public bool CodeDisagrees =>
+            Verdict == MaterialCodeVerdict.AlreadyCoded
+            && RegisterCode.Length > 0
+            && !string.Equals(ExistingCode.Trim(), RegisterCode.Trim(),
+                              StringComparison.OrdinalIgnoreCase);
+
+        public override string ToString() => Verdict + ": " + MaterialName + " — " + Reason;
+    }
+
+    /// <summary>The three headline counts, plus the two a reader asks for next.</summary>
+    public sealed class MaterialCodeStampTally
+    {
+        public int Total;
+        public int Stamped;
+        public int AlreadyCoded;
+        public int NoRegisterRow;
+
+        /// <summary>Materials the register does not name AT ALL, whether or not they
+        /// already carry a code. <see cref="NoRegisterRow"/> counts only the ones that
+        /// also have no code, because the three headline verdicts are about the WRITE
+        /// decision and must not double-count. This is the vocabulary number.</summary>
+        public int RegisterSilent;
+
+        /// <summary>Already coded, and the register names a different code.</summary>
+        public int Disagreements;
+    }
+
+    public static class MaterialCodeStampPlanner
+    {
+        /// <summary>Decide one material. <paramref name="existingCode"/> is MAT_CODE as
+        /// read off the material — null and whitespace both mean "unset".</summary>
+        public static MaterialCodeStampRow Plan(
+            string materialName, string existingCode, MaterialRegistry registry)
+        {
+            var row = new MaterialCodeStampRow
+            {
+                MaterialName = (materialName ?? "").Trim(),
+                ExistingCode = (existingCode ?? "").Trim(),
+            };
+
+            var reg = registry?.ByName(row.MaterialName);
+            row.RegisterCode = (reg?.Code ?? "").Trim();
+
+            if (row.ExistingCode.Length > 0)
+            {
+                row.Verdict = MaterialCodeVerdict.AlreadyCoded;
+                if (row.RegisterCode.Length == 0)
+                    row.Reason = "already " + row.ExistingCode
+                               + "; the register does not name this material";
+                else if (string.Equals(row.ExistingCode, row.RegisterCode,
+                                       StringComparison.OrdinalIgnoreCase))
+                    row.Reason = "already " + row.ExistingCode + ", which is what the register says";
+                else
+                    row.Reason = "already " + row.ExistingCode + "; the register says "
+                               + row.RegisterCode + ". Reported, not changed — the register is a "
+                               + "challenger, not an oracle.";
+                return row;
+            }
+
+            if (row.RegisterCode.Length == 0)
+            {
+                row.Verdict = MaterialCodeVerdict.NoRegisterRow;
+                row.Reason = "no register row with this MAT_NAME — the project's own vocabulary";
+                return row;
+            }
+
+            row.Verdict = MaterialCodeVerdict.Stamp;
+            row.Reason = "register row " + row.RegisterCode + " (" + reg.Source
+                       + ") names this material exactly";
+            return row;
+        }
+
+        /// <summary>Plan a whole model's materials. Order is the caller's.</summary>
+        public static List<MaterialCodeStampRow> PlanAll(
+            IEnumerable<KeyValuePair<string, string>> nameAndExistingCode,
+            MaterialRegistry registry)
+        {
+            var outRows = new List<MaterialCodeStampRow>();
+            foreach (var kv in nameAndExistingCode
+                     ?? Enumerable.Empty<KeyValuePair<string, string>>())
+            {
+                if (string.IsNullOrWhiteSpace(kv.Key)) continue;
+                outRows.Add(Plan(kv.Key, kv.Value, registry));
+            }
+            return outRows;
+        }
+
+        public static MaterialCodeStampTally Tally(IEnumerable<MaterialCodeStampRow> rows)
+        {
+            var list = (rows ?? Enumerable.Empty<MaterialCodeStampRow>()).ToList();
+            return new MaterialCodeStampTally
+            {
+                Total          = list.Count,
+                Stamped        = list.Count(r => r.Verdict == MaterialCodeVerdict.Stamp),
+                AlreadyCoded   = list.Count(r => r.Verdict == MaterialCodeVerdict.AlreadyCoded),
+                NoRegisterRow  = list.Count(r => r.Verdict == MaterialCodeVerdict.NoRegisterRow),
+                RegisterSilent = list.Count(r => r.RegisterCode.Length == 0),
+                Disagreements  = list.Count(r => r.CodeDisagrees),
+            };
+        }
+
+        public static string Summary(IEnumerable<MaterialCodeStampRow> rows)
+        {
+            var list = (rows ?? Enumerable.Empty<MaterialCodeStampRow>()).ToList();
+            var t = Tally(list);
+            if (t.Total == 0) return "This model has no materials.";
+
+            var sb = new StringBuilder();
+            sb.AppendLine(t.Total + " material(s):");
+            sb.AppendLine("  " + t.Stamped + " will be stamped from the register");
+            sb.AppendLine("  " + t.AlreadyCoded + " already carry a MAT_CODE — never overwritten");
+            sb.AppendLine("  " + t.NoRegisterRow + " have no register row with that name");
+            if (t.Disagreements > 0)
+                sb.AppendLine("  (" + t.Disagreements + " of the coded ones disagree with the "
+                            + "register — listed in the CSV, changed by nothing)");
+            sb.AppendLine();
+            sb.AppendLine(t.RegisterSilent + " of this model's materials are not in the governed "
+                        + "register at all. That is the project's own vocabulary, and the number "
+                        + "the next register revision should absorb — not an error.");
+            return sb.ToString();
+        }
+
+        /// <summary>The plan CSV, in the shape Materials_SetClass writes.</summary>
+        public static List<string> ToCsv(IEnumerable<MaterialCodeStampRow> rows)
+        {
+            var outLines = new List<string> { "Material,ExistingCode,RegisterCode,Verdict,Reason" };
+            foreach (var r in rows ?? Enumerable.Empty<MaterialCodeStampRow>())
+                outLines.Add(string.Join(",", Csv(r.MaterialName), Csv(r.ExistingCode),
+                    Csv(r.RegisterCode), Csv(r.Verdict.ToString()), Csv(r.Reason)));
+            return outLines;
+        }
+
+        private static string Csv(string s)
+        {
+            s = s ?? "";
+            return s.IndexOfAny(new[] { ',', '"', '\n' }) >= 0
+                ? "\"" + s.Replace("\"", "\"\"") + "\"" : s;
+        }
+    }
+}

--- a/StingTools/Temp/FamilyCommands.cs
+++ b/StingTools/Temp/FamilyCommands.cs
@@ -127,6 +127,7 @@ namespace StingTools.Temp
         public enum ElementKind { Wall, Floor, Ceiling, Roof, Duct, Pipe, CableTray, Conduit }
 
         // CSV column indices (BLE_MATERIALS / MEP_MATERIALS)
+        private const int ColCode = 3;          // MAT_CODE — the register's key for this row
         private const int ColElementType = 4;   // MAT_ELEMENT_TYPE
         private const int ColCategory = 5;      // MAT_CATEGORY
         private const int ColName = 6;          // MAT_NAME
@@ -250,7 +251,28 @@ namespace StingTools.Temp
                                 // Apply material appearance properties from CSV
                                 Material newMat = doc.GetElement(newMatId) as Material;
                                 if (newMat != null)
+                                {
                                     MaterialPropertyHelper.ApplyMaterialProperties(newMat, cols);
+
+                                    // W1 — the register row that named this material also
+                                    // carries its CODE, and until now this path read the row
+                                    // and discarded it. MAT_CODE is what RateProviders Pass C
+                                    // keys on; a material born without one is invisible to the
+                                    // most specific rate lookup in the BOQ.
+                                    //
+                                    // SetIfEmpty, never Set: a code somebody already chose
+                                    // outranks the register, here as everywhere else.
+                                    //
+                                    // Only the PRIMARY material is stamped here. The layer
+                                    // materials minted below come from MAT_LAYER_n_MATERIAL,
+                                    // which names a material without naming its row — so they
+                                    // are left to Materials_StampCodes, which matches by name
+                                    // against the whole register rather than guessing from
+                                    // the row that happened to reference them.
+                                    string regCode = cols.Length > ColCode ? cols[ColCode].Trim() : "";
+                                    if (regCode.Length > 0)
+                                        ParameterHelpers.SetIfEmpty(newMat, "MAT_CODE", regCode);
+                                }
                             }
                         }
                         catch (Exception ex)

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -803,6 +803,9 @@ namespace StingTools.UI
                     // Read-only. Compares what the model BUILT against what the register
                     // DECLARES for the row the type is named after.
                     case "Materials_RegisterAudit": RunCommand<Commands.Materials.RegisterAuditCommand>(app); break;
+                    // Writes MAT_CODE where a material has none, from the register row of
+                    // the same MAT_NAME. MAT_CODE is what RateProviders Pass C keys on.
+                    case "Materials_StampCodes": RunCommand<Commands.Materials.StampMaterialCodesCommand>(app); break;
                     // Read-only: writes a catalogue pack JSON, never the model.
                     case "Baseline_HarvestTypes": RunCommand<Commands.Baseline.BaselineHarvestTypesCommand>(app); break;
 

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1974,6 +1974,9 @@
                                 <Button Style="{StaticResource BlueBtn}" Content="Register audit (read-only)" Tag="Materials_RegisterAudit" Click="Cmd_Click"
                                         ToolTip="READ-ONLY. For every host type whose NAME is a row of BLE_MATERIALS.csv / MEP_MATERIALS.csv, compares the modelled compound structure against the layers, materials and thicknesses that register row declares, and writes the mismatches to CSV. Written after 87 floor types named after register rows turned out to be one 100mm layer of concrete each - the register was read for its NAME column and nothing else. Changes NOTHING: rebuilding a compound structure moves every element hosted on the type."
                                         HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
+                                <Button Style="{StaticResource OrangeBtn}" Content="Stamp material Codes (asks first)" Tag="Materials_StampCodes" Click="Cmd_Click"
+                                        ToolTip="Writes each material's MAT_CODE from the register row of the same MAT_NAME, where the material has none. MAT_CODE is the key the BOQ's most specific rate lookup uses - a material without one is priced by category and name instead, which is where vocabulary drift turns into a wrong rate. Matches on the EXACT name only, never overwrites a code somebody set, and writes the full plan to CSV before asking. Reports three counts: stamped, already coded, and NOT IN THE REGISTER - the third is this project's own vocabulary and the number the next register revision should absorb."
+                                        HorizontalAlignment="Stretch" Margin="0,4,0,0"/>
                             </StackPanel>
                         </Border>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@ Phase-by-phase history of completed work on the StingTools plugin, Planscape Ser
 
 **`MAT_CODE` is the key `RateProviders` Pass C looks up, and one of the two paths
 that mint materials never wrote it.** The parameter is declared
-(`MR_PARAMETERS.txt:879`, `758ba3d0-ea41-51fc-8dbf-3bb444174385`, TEXT), bound to
-`Materials` and to nothing else (`CATEGORY_BINDINGS.csv:4682`, and agreeing in
+(`MR_PARAMETERS.txt:973`, `758ba3d0-ea41-51fc-8dbf-3bb444174385`, TEXT), bound to
+`Materials` and to nothing else (`CATEGORY_BINDINGS.csv:4693`, and agreeing in
 `PARAMETER_CATEGORIES.csv:510`, `FAMILY_PARAMETER_BINDINGS.csv:4022`,
 `BINDING_COVERAGE_MATRIX.csv:611`, `PARAMETER_REGISTRY.json:9971`), and the
 register that supplies the codes is **100% populated — 815 BLE + 464 MEP rows,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 265 — W1: the register's CODE reaches the material)
+
+**`MAT_CODE` is the key `RateProviders` Pass C looks up, and one of the two paths
+that mint materials never wrote it.** The parameter is declared
+(`MR_PARAMETERS.txt:879`, `758ba3d0-ea41-51fc-8dbf-3bb444174385`, TEXT), bound to
+`Materials` and to nothing else (`CATEGORY_BINDINGS.csv:4682`, and agreeing in
+`PARAMETER_CATEGORIES.csv:510`, `FAMILY_PARAMETER_BINDINGS.csv:4022`,
+`BINDING_COVERAGE_MATRIX.csv:611`, `PARAMETER_REGISTRY.json:9971`), and the
+register that supplies the codes is **100% populated — 815 BLE + 464 MEP rows,
+1,279 unique codes, no blanks**.
+
+**Correction to the brief this work came from.** It reported *"anything writes it
+— nothing"*. That is wrong: `MaterialCommands.ApplySharedParamValues` (`:1121`)
+writes `MAT_CODE` onto every material `CreateBLEMaterials` /
+`CreateMEPMaterials` creates, through `LookupParameter(name).Set(value)` — which
+the brief's `SetString|SetIfEmpty` grep could not see. What was actually missing
+is narrower and still real:
+
+* `CompoundTypeCreator` — the path that builds a project's wall / floor /
+  ceiling / roof catalogue — called `ApplyMaterialProperties` and **not** the
+  shared-parameter writer, so every material it minted was born without a code.
+* `MaterialCommands.PopulateSharedParameters` (`:1269`) is a second, **uncalled**
+  copy of the same writer. Left alone here; noted so it is not mistaken for live
+  coverage.
+* Nothing at all backfilled a model whose materials predate any of it.
+
+**`CompoundTypeCreator` now stamps the row's own `MAT_CODE`** on the primary
+material it creates, via `SetIfEmpty` — never `Set`. Only the primary material:
+the layer materials minted alongside come from `MAT_LAYER_n_MATERIAL`, which
+names a material without naming its row, and stamping those from the referencing
+row would put a governed code on a material that row does not describe.
+
+**`Materials_StampCodes`** (SETUP tab, beside `Register audit (read-only)`)
+backfills the rest, in the shape `Materials_SetClass` uses — plan CSV written
+first, `TaskDialog` with `DefaultButton = No`. It matches on the **exact**
+`MAT_NAME` only. Revit renames a colliding material to `NAME 2`, and that may be
+a copy of the register row or somebody's variant; stamping a governed code on the
+strength of a prefix is the same guess the rename collision was made of.
+
+**Three counts, and the third is the one worth reading.** Measured over the
+1,815-name corpus in `Fixtures/material_names_20260908.csv`:
+
+    1,279  stamped        — the whole register appears in this model
+      536  no register row — the project's own vocabulary
+        0  already coded   — because nothing had ever written one
+
+536 is what the next register revision should absorb. It is reported separately
+from a `RegisterSilent` count that also includes already-coded materials the
+register cannot name, because the three headline verdicts describe the **write
+decision** and must partition, while the vocabulary question does not.
+
+**A code already there is never overwritten, and a disagreement is said rather
+than settled.** A material carrying `FLR-999` where the register says `FLR-028`
+is reported in the CSV, counted as a disagreement, and left exactly as it is. The
+register is a challenger, not an oracle — the same rule the material-class work
+settled on.
+
+**RED then GREEN, by sabotage, both counts recorded.**
+
+    Corpus_Resolves_The_Registers_Codes
+      RED    register lookup severed in the planner   0 stamped / 1,815 no-row
+             (7 of the 14 new tests fail)
+      GREEN  shipped register                     1,279 stamped /   536 no-row
+
+    A_Code_Already_There_Is_Never_Overwritten
+      RED    never-overwrite branch removed   verdict Stamp — FLR-999 → FLR-028
+      GREEN                                   verdict AlreadyCoded, no write
+
+The second matters more. **2,230 tests passed on this tree before any of this
+existed**, and a wrong write would not have moved one of them.
+
+**Not verified in Revit.** `deploy.bat` was not run and no Revit session
+exercised either the `CompoundTypeCreator` stamp or `Materials_StampCodes`. What
+is proven is the build (0 errors / 0 warnings), the Revit-free decision against
+the shipped register, and `check_workflow_wiring.ps1` Tier 4 = 0 for the new
+button. `check_dispatch_parity.ps1` fails on `Hvac_FanStaticReport`, which is
+pre-existing and untouched here.
+
 #### Completed (Phase 264 — one timber vocabulary, and the matcher swap that needed stems)
 
 **Four word-lists answered "is this timber", and they disagreed both ways on a


### PR DESCRIPTION
## What

`MAT_CODE` is what `RateProviders` **Pass C** keys on — confidence 80, between the PROD match (85) and the COBie type map (75). It is a declared shared parameter (`MR_PARAMETERS.txt:879`, `758ba3d0-ea41-51fc-8dbf-3bb444174385`), bound to **`Materials` and nothing else**, and the register that supplies it is **100% populated: 815 BLE + 464 MEP rows, 1,279 unique codes, no blanks**.

Two changes:

1. **`CompoundTypeCreator` now stamps the code it was already reading.** The path that builds a project's wall / floor / ceiling / roof catalogue read the register row and discarded `MAT_CODE`, so every material it minted was born without one. `SetIfEmpty`, never `Set`. **Primary material only** — the layer materials minted alongside come from `MAT_LAYER_n_MATERIAL`, which names a material without naming its row.
2. **`Materials_StampCodes`** (SETUP tab, beside `Register audit (read-only)`) backfills the rest, in the shape `Materials_SetClass` uses: plan CSV written **first**, then a `TaskDialog` with `DefaultButton = No`.

Matching is on the **exact** `MAT_NAME`. Revit renames a colliding material to `NAME 2`, which may be a copy of the register row or somebody's variant — stamping a governed code on the strength of a prefix is the guess this whole area is about.

## Correction to the brief

The brief said *"anything writes it — **nothing**"*. **That is wrong.** `MaterialCommands.ApplySharedParamValues` (`:1121`) writes `MAT_CODE` onto every material `CreateBLEMaterials` / `CreateMEPMaterials` creates, through `LookupParameter(name).Set(value)` — invisible to a `SetString|SetIfEmpty` grep. `PopulateSharedParameters` (`:1269`) is a second, **uncalled** copy.

What was actually missing is narrower and still real: the `CompoundTypeCreator` path, and any backfill at all.

**The load-bearing claim survives.** `MAT_CODE` binds to `Materials` only — agreeing across five independent data files — and both BOQ call sites read it off a wall or a floor. `req.MatCode` is empty for every costed element. W2 fixes that; this PR does not change any rate.

## Three counts, and the third is the point

Over the 1,815-name corpus in `Fixtures/material_names_20260908.csv`:

| | |
|---|---|
| **1,279** | stamped — the whole register appears in this model |
| **536** | no register row — the project's own vocabulary |
| **0** | already coded — because nothing had ever written one |

536 is what the next register revision should absorb. A code already present is **never overwritten**; where it disagrees with the register the row says so, is counted, and is left alone.

## RED and GREEN — by sabotage, both counts

```
Corpus_Resolves_The_Registers_Codes
  RED    register lookup severed in the planner    0 stamped / 1,815 no-row   (7 of 14 fail)
  GREEN  shipped register                      1,279 stamped /   536 no-row

A_Code_Already_There_Is_Never_Overwritten
  RED    never-overwrite branch removed    verdict Stamp — FLR-999 → FLR-028
  GREEN                                    verdict AlreadyCoded, no write
```

The second matters more: **2,230 tests passed on this tree before any of this existed**, and a wrong write would not have moved one of them.

| | before | after |
|---|---|---|
| `dotnet build` | 0 err / 0 warn | 0 err / 0 warn |
| `StingTools.Tags.Tests` | 919 | **933** |
| `StingTools.Boq.Tests` | 1,311 | 1,311 |
| `check_workflow_wiring.ps1` Tier 4 | 0 | **0** (1,681 buttons) |
| `check_path_discipline.ps1` | OK | OK |

## Not verified in Revit

`deploy.bat` was **not** run. No Revit session exercised the `CompoundTypeCreator` stamp or `Materials_StampCodes` — the binding check, the `SetIfEmpty` write and the plan-CSV path are unproven against a live document. `check_dispatch_parity.ps1` fails on `Hvac_FanStaticReport`, which is pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
