### PR TITLE
W2: resolve an element's MAT_CODE through its material — and the rate delta, measured

### DIFF
--- a/StingTools.Boq.Tests/MatCodeChainEndToEndTests.cs
+++ b/StingTools.Boq.Tests/MatCodeChainEndToEndTests.cs
@@ -1,0 +1,278 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MatCodeChainEndToEndTests.cs — W4. One row, register to rate.
+//
+//      register row FLR-028   ->  a material carrying MAT_CODE = FLR-028
+//                             ->  a floor type whose PRIMARY layer is that material
+//                             ->  the BOQ resolves MatCode = "FLR-028"
+//                             ->  CsvRateProvider Pass 3 matches
+//                             ->  Provenance "<rate file> MAT_CODE match"
+//
+//  THE ASSERTION IS THE PROVENANCE STRING, not the number. A rate that happens
+//  to be right for another reason is not this chain working — and on the shipped
+//  rate table every one of these categories has a Pass 4 category row, so a test
+//  that checked only the figure would pass on a category average and prove
+//  nothing. That is exactly the shape this codebase produces.
+//
+//  WHAT THIS WOULD HAVE CAUGHT. Every link here existed and was wired four
+//  phases ago; MAT_CODE was bound to Materials only, the BOQ read it off a wall,
+//  and Pass 3 has never once fired. Nothing failed. This test fails.
+//
+//  The rate table used is a SYNTHETIC one keyed on FLR-028, because the shipped
+//  cost_rates_5d.csv shares no key with the register — see
+//  MaterialCodeResolutionTests.The_Shipped_Rate_Table_Shares_No_Key_With_The_
+//  Register, which pins that and is why W2's measured rate delta is zero. The
+//  chain is proven here on the rate card a project would have to write; the
+//  reason it does not fire on shipped data is proven there. Both are true and
+//  they are different facts.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.BOQ.Rates;
+using StingTools.Core;
+using StingTools.Core.Materials;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Boq.Tests
+{
+    public class MatCodeChainEndToEndTests
+    {
+        private readonly ITestOutputHelper _out;
+        public MatCodeChainEndToEndTests(ITestOutputHelper output) => _out = output;
+
+        private const string RateFile = "project_rate_card.csv";
+
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        /// <summary>MAT_NAME and MAT_CODE for FLR-028, read from the SHIPPED register.
+        /// Not restated here: a copy that drifted from the file would pass while the
+        /// thing it describes was wrong.</summary>
+        private static (string name, string code) Flr028()
+        {
+            foreach (string f in new[] { "BLE_MATERIALS.csv", "MEP_MATERIALS.csv" })
+            {
+                var lines = File.ReadAllLines(Path.Combine(DataDir(), f));
+                int h = Array.FindIndex(lines, l => l.ToUpperInvariant().Contains("MAT_CODE"));
+                if (h < 0) continue;
+                var hdr = Split(lines[h]);
+                int ci = hdr.FindIndex(c => c.Trim().Equals("MAT_CODE", StringComparison.OrdinalIgnoreCase));
+                int ni = hdr.FindIndex(c => c.Trim().Equals("MAT_NAME", StringComparison.OrdinalIgnoreCase));
+                for (int i = h + 1; i < lines.Length; i++)
+                {
+                    var c = Split(lines[i]);
+                    if (c.Count > Math.Max(ci, ni)
+                        && c[ci].Trim().Equals("FLR-028", StringComparison.OrdinalIgnoreCase))
+                        return (c[ni].Trim(), c[ci].Trim());
+                }
+            }
+            Assert.Fail("FLR-028 is not in the shipped register");
+            return (null, null);
+        }
+
+        private static List<string> Split(string line)
+        {
+            var fields = new List<string>();
+            var cur = new System.Text.StringBuilder();
+            bool q = false;
+            foreach (char ch in line ?? "")
+            {
+                if (q) { if (ch == '"') q = false; else cur.Append(ch); }
+                else if (ch == '"' && cur.Length == 0) q = true;
+                else if (ch == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(ch);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+
+        /// <summary>A project rate card that keys BOTH the category and FLR-028, at
+        /// DIFFERENT rates. The difference is what makes the assertion meaningful: if
+        /// Pass 3 does not fire, Pass 4 answers with the other number.</summary>
+        private static Dictionary<string, (double rate, string unit)> RateCard()
+            => new Dictionary<string, (double rate, string unit)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Floors"]   = (444000, "m2"),   // Pass 4 — the category average
+                ["FLR-028"]  = (612500, "m2"),   // Pass 3 — this material specifically
+            };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  The chain
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void FLR_028_Walks_From_The_Register_To_A_Rate()
+        {
+            var (matName, code) = Flr028();
+            Assert.Equal("FLR-028", code);
+            Assert.False(string.IsNullOrWhiteSpace(matName));
+
+            // LINK 1 — the material carries the register's code. This is what W1's
+            // stamp writes and what Materials_StampCodes backfills; here it is the
+            // name→code map the resolver is handed.
+            var codeByMaterial = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [matName] = code,
+                ["Gypsum Wall Board"] = "WL-999",   // a skin, deliberately coded
+            };
+
+            // LINK 2 — a floor type whose PRIMARY layer is that material. The skin is
+            // listed first and is thinner, which is how a finish came to name a roof.
+            var layers = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = "Gypsum Wall Board", ThicknessMm = 12.5, IsStructure = false },
+                new MaterialLayer { Index = 1, MaterialName = matName,             ThicknessMm = 150,  IsStructure = true  },
+            };
+
+            // LINK 3 — what BOQCostManager now puts in RateRequest.MatCode. This is the
+            // same call both BOQ sites and CostStamp make.
+            var resolved = MaterialCodeResolution.Resolve(layers, codeByMaterial, null, "");
+            Assert.Equal("FLR-028", resolved.Code);
+            Assert.Equal(MatCodeSource.PrimaryLayerMaterial, resolved.Source);
+            Assert.Equal(matName, resolved.MaterialName);
+
+            // LINK 4 — the rate chain. Same code CsvRateProvider runs.
+            var m = CsvRateLookup.Resolve(RateCard(), RateFile,
+                        categoryName: "Floors", discipline: "A", prodCode: "",
+                        systemType: "", matCode: resolved.Code);
+
+            Assert.NotNull(m);
+
+            // THE ASSERTION. Not the number — the reason.
+            Assert.Equal(RateFile + " MAT_CODE match", m.Provenance);
+            Assert.Equal("FLR-028", m.MatchedKey);
+            Assert.Equal(RateResolutionLevel.Material, m.Level);
+            Assert.Equal(85, m.Confidence);
+            Assert.Equal(612500, m.UnitRate);
+            Assert.Equal("m2", m.Unit);
+
+            _out.WriteLine("FLR-028  " + matName);
+            _out.WriteLine("  -> " + resolved);
+            _out.WriteLine("  -> " + m.Provenance + " @ " + m.UnitRate + " UGX/" + m.Unit);
+        }
+
+        [Fact]
+        public void Without_The_Code_The_Same_Element_Prices_Off_The_Category_Average()
+        {
+            // The world before W2, in one assertion: MatCode empty, so Pass 3 is skipped
+            // and Pass 4 answers. Same element, same rate card, a DIFFERENT number and a
+            // different sentence — which is why the sentence is what gets asserted.
+            var m = CsvRateLookup.Resolve(RateCard(), RateFile,
+                        categoryName: "Floors", discipline: "A", prodCode: "",
+                        systemType: "", matCode: "");
+
+            Assert.NotNull(m);
+            Assert.Equal(RateFile + " category average (Floors)", m.Provenance);
+            Assert.Equal(RateResolutionLevel.Category, m.Level);
+            Assert.Equal(70, m.Confidence);
+            Assert.Equal(444000, m.UnitRate);
+        }
+
+        [Fact]
+        public void The_Skin_Never_Prices_The_Floor()
+        {
+            // The failure the chain must not have: the finish layer is coded WL-999 and
+            // listed first. If the resolver ever returns it, this floor prices as
+            // plasterboard and the provenance still reads "MAT_CODE match" — a confident
+            // wrong answer at confidence 85, which is worse than the empty one.
+            var (matName, _) = Flr028();
+            var card = RateCard();
+            card["WL-999"] = (35000, "m2");
+
+            var layers = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = "Gypsum Wall Board", ThicknessMm = 12.5, IsStructure = false },
+                new MaterialLayer { Index = 1, MaterialName = matName,             ThicknessMm = 150,  IsStructure = true  },
+            };
+            var codeByMaterial = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [matName] = "FLR-028",
+                ["Gypsum Wall Board"] = "WL-999",
+            };
+
+            var resolved = MaterialCodeResolution.Resolve(layers, codeByMaterial, "Gypsum Wall Board", "");
+            var m = CsvRateLookup.Resolve(card, RateFile, "Floors", "A", "", "", resolved.Code);
+
+            Assert.Equal("FLR-028", m.MatchedKey);
+            Assert.NotEqual(35000, m.UnitRate);
+        }
+
+        [Fact]
+        public void A_More_Specific_Pass_Still_Outranks_The_Material()
+        {
+            // Pass 3 sits BELOW the product passes on purpose. A DISC|PROD row must still
+            // win, or W2 would have quietly demoted the most specific key in the chain.
+            var card = RateCard();
+            card["A|FL"] = (700000, "m2");
+
+            var m = CsvRateLookup.Resolve(card, RateFile,
+                        categoryName: "Floors", discipline: "A", prodCode: "FL",
+                        systemType: "", matCode: "FLR-028");
+
+            Assert.Equal(RateFile + " product match (A|FL)", m.Provenance);
+            Assert.Equal(97, m.Confidence);
+            Assert.Equal(RateResolutionLevel.Product, m.Level);
+        }
+
+        [Fact]
+        public void A_Code_The_Rate_Card_Does_Not_Know_Falls_Through_Rather_Than_Guessing()
+        {
+            var m = CsvRateLookup.Resolve(RateCard(), RateFile,
+                        categoryName: "Floors", discipline: "A", prodCode: "",
+                        systemType: "", matCode: "FLR-999");
+
+            // Falls to the category average, and SAYS so. It does not invent a material
+            // rate, and it does not report a category rate as a material match.
+            Assert.Equal(RateFile + " category average (Floors)", m.Provenance);
+            Assert.Equal(RateResolutionLevel.Category, m.Level);
+        }
+
+        [Fact]
+        public void An_Empty_Rate_Card_Answers_Nothing_Rather_Than_Zero()
+        {
+            Assert.Null(CsvRateLookup.Resolve(
+                new Dictionary<string, (double, string)>(), RateFile, "Floors", "A", "", "", "FLR-028"));
+            Assert.Null(CsvRateLookup.Resolve(null, RateFile, "Floors", "A", "", "", "FLR-028"));
+        }
+
+        [Fact]
+        public void The_Pass_Order_Is_Specificity_Order()
+        {
+            // K-16b found category consulted first and RETURNING, which made the product
+            // pass dead and priced a fire door and a cupboard door alike. Asserted as an
+            // order rather than as five separate cases, so a reordering fails here.
+            var card = new Dictionary<string, (double rate, string unit)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["A|FL"] = (5, "m2"), ["FL"] = (4, "m2"), ["Floors|Podium"] = (3, "m2"),
+                ["FLR-028"] = (2, "m2"), ["Floors"] = (1, "m2"),
+            };
+            var expected = new[]
+            {
+                (RateResolutionLevel.Product,  97, 5.0),
+                (RateResolutionLevel.Product,  95, 4.0),
+                (RateResolutionLevel.System,   92, 3.0),
+                (RateResolutionLevel.Material, 85, 2.0),
+                (RateResolutionLevel.Category, 70, 1.0),
+            };
+
+            // Strip the winning key one at a time; the next-most-specific must answer.
+            foreach (var (level, conf, rate) in expected)
+            {
+                var m = CsvRateLookup.Resolve(card, RateFile, "Floors", "A", "FL", "Podium", "FLR-028");
+                Assert.Equal(level, m.Level);
+                Assert.Equal(conf, m.Confidence);
+                Assert.Equal(rate, m.UnitRate);
+                card.Remove(m.MatchedKey);
+            }
+            Assert.Empty(card);
+        }
+    }
+}

--- a/StingTools.Boq.Tests/MaterialCodeResolutionTests.cs
+++ b/StingTools.Boq.Tests/MaterialCodeResolutionTests.cs
@@ -1,0 +1,321 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialCodeResolutionTests.cs — the gate on W2.
+//
+//  W2 changes what `RateRequest.MatCode` contains, which is what the BOQ's
+//  most specific rate lookup keys on. Two things therefore need proving, and
+//  they are different questions:
+//
+//    1. THE DECISION IS RIGHT. Layers in, code out, with the core layer
+//       answering and never the finish skin. Tested here against a plain layer
+//       list and a name→code map, no Revit.
+//
+//    2. WHAT IT ACTUALLY MOVES. Measured against the SHIPPED rate table, and
+//       the answer today is NOTHING — see The_Shipped_Rate_Table_Shares_No_Key.
+//       That test exists because a rate change nobody counted is the failure
+//       mode this codebase produces, and because "Pass 3 can now fire" and
+//       "Pass 3 now fires" are not the same sentence.
+//
+//  RED / GREEN, recorded 2026-09-10 on this machine:
+//
+//    A_Layered_Element_Answers_With_Its_CORE
+//      RED   (resolution reads the first layer instead of the selector)
+//            FLR-SKIN — the finish, which is the #873 defect exactly
+//      GREEN FLR-CORE
+//
+//    An_Element_With_No_Coded_Material_Stays_Empty
+//      RED   (empty falls through to the first material's code)  FLR-SKIN
+//      GREEN ""
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    public class MaterialCodeResolutionTests
+    {
+        private static Dictionary<string, string> Map(params (string name, string code)[] pairs)
+        {
+            var d = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (n, c) in pairs) d[n] = c;
+            return d;
+        }
+
+        /// <summary>A rendered masonry wall: thin gypsum skin listed FIRST, thick
+        /// structural brick core second. The shape that produced #873.</summary>
+        private static List<MaterialLayer> RenderedMasonryWall() => new List<MaterialLayer>
+        {
+            new MaterialLayer { Index = 0, MaterialName = "GYPSUM PLASTER 15MM", ThicknessMm = 15,  IsStructure = false },
+            new MaterialLayer { Index = 1, MaterialName = "CLAY BRICK 200MM",    ThicknessMm = 200, IsStructure = true  },
+            new MaterialLayer { Index = 2, MaterialName = "GYPSUM PLASTER 15MM", ThicknessMm = 15,  IsStructure = false },
+        };
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The core answers, not the skin
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Layered_Element_Answers_With_Its_CORE()
+        {
+            var r = MaterialCodeResolution.Resolve(
+                RenderedMasonryWall(),
+                Map(("GYPSUM PLASTER 15MM", "WL-SKIN"), ("CLAY BRICK 200MM", "WL-CORE")),
+                singleMaterialName: "GYPSUM PLASTER 15MM",
+                elementOwnCode: "");
+
+            Assert.Equal("WL-CORE", r.Code);
+            Assert.Equal(MatCodeSource.PrimaryLayerMaterial, r.Source);
+            Assert.Equal("CLAY BRICK 200MM", r.MaterialName);
+        }
+
+        [Fact]
+        public void A_Layered_Element_Whose_Core_Has_No_Code_Does_Not_Fall_Back_To_The_Skin()
+        {
+            // The whole point. Falling through here would hand back the finish
+            // material's code at confidence 85 — a confident wrong rate, which is
+            // worse than the empty one this replaces.
+            var r = MaterialCodeResolution.Resolve(
+                RenderedMasonryWall(),
+                Map(("GYPSUM PLASTER 15MM", "WL-SKIN")),   // core has NO code
+                singleMaterialName: "GYPSUM PLASTER 15MM",
+                elementOwnCode: "");
+
+            Assert.Equal("", r.Code);
+            Assert.False(r.Resolved);
+            Assert.Equal(MatCodeSource.None, r.Source);
+        }
+
+        [Fact]
+        public void The_Thickest_Structural_Layer_Wins_Over_A_Thicker_Non_Structural_One()
+        {
+            var layers = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = "SCREED",   ThicknessMm = 300, IsStructure = false },
+                new MaterialLayer { Index = 1, MaterialName = "CONCRETE", ThicknessMm = 100, IsStructure = true  },
+            };
+            var r = MaterialCodeResolution.Resolve(layers,
+                Map(("SCREED", "FLR-SCR"), ("CONCRETE", "FLR-RC")), null, "");
+
+            Assert.Equal("FLR-RC", r.Code);   // PrimaryMaterialSelector's rule, unchanged
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. Elements with no compound structure
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void An_Element_With_No_Layers_Uses_Its_Single_Material()
+        {
+            var r = MaterialCodeResolution.Resolve(
+                layers: null,
+                codeByMaterialName: Map(("COPPER PIPE 22MM", "PIPE-014")),
+                singleMaterialName: "COPPER PIPE 22MM",
+                elementOwnCode: "");
+
+            Assert.Equal("PIPE-014", r.Code);
+            Assert.Equal(MatCodeSource.SingleMaterial, r.Source);
+        }
+
+        [Fact]
+        public void An_Element_With_Nothing_At_All_Resolves_Empty()
+        {
+            var r = MaterialCodeResolution.Resolve(null, Map(), null, "");
+            Assert.Equal("", r.Code);
+            Assert.False(r.Resolved);
+            Assert.Equal(MatCodeSource.None, r.Source);
+        }
+
+        [Fact]
+        public void Layers_That_Name_No_Material_Are_The_Same_As_No_Layers()
+        {
+            var blank = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = "",   ThicknessMm = 100, IsStructure = true },
+                new MaterialLayer { Index = 1, MaterialName = null, ThicknessMm = 50,  IsStructure = false },
+            };
+            var r = MaterialCodeResolution.Resolve(blank,
+                Map(("STEEL DECK", "STR-009")), "STEEL DECK", "");
+
+            Assert.Equal("STR-009", r.Code);
+            Assert.Equal(MatCodeSource.SingleMaterial, r.Source);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. The element's own MAT_CODE — a fallback, not an invitation
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Elements_Own_Code_Is_The_Last_Resort_Not_The_First()
+        {
+            var r = MaterialCodeResolution.Resolve(
+                RenderedMasonryWall(),
+                Map(("CLAY BRICK 200MM", "WL-CORE")),
+                singleMaterialName: null,
+                elementOwnCode: "WL-STAMPED-ON-INSTANCE");
+
+            // The material wins. Binding MAT_CODE to host categories was considered
+            // and refused; this fallback exists so that day needs no second visit,
+            // not so an instance stamp can outrank the register row.
+            Assert.Equal("WL-CORE", r.Code);
+            Assert.Equal(MatCodeSource.PrimaryLayerMaterial, r.Source);
+        }
+
+        [Fact]
+        public void The_Elements_Own_Code_Answers_When_No_Material_Does()
+        {
+            var r = MaterialCodeResolution.Resolve(null, Map(), null, "  WL-042  ");
+            Assert.Equal("WL-042", r.Code);
+            Assert.Equal(MatCodeSource.ElementParameter, r.Source);
+        }
+
+        [Fact]
+        public void Whitespace_Is_Not_A_Code()
+        {
+            var r = MaterialCodeResolution.Resolve(null, Map(), null, "   ");
+            Assert.False(r.Resolved);
+            Assert.Equal(MatCodeSource.None, r.Source);
+        }
+
+        [Fact]
+        public void A_Map_Entry_That_Is_Blank_Is_Not_A_Code()
+        {
+            // A material bound to MAT_CODE but never stamped reads as "". That must be
+            // "no code", not a code of length zero that satisfies a null check upstream.
+            var r = MaterialCodeResolution.Resolve(
+                RenderedMasonryWall(), Map(("CLAY BRICK 200MM", "")), null, "");
+            Assert.False(r.Resolved);
+        }
+
+        [Fact]
+        public void Material_Names_Match_Case_Insensitively_And_Trimmed()
+        {
+            var layers = new List<MaterialLayer>
+            {
+                new MaterialLayer { Index = 0, MaterialName = "  clay brick 200mm  ", ThicknessMm = 200, IsStructure = true },
+            };
+            var r = MaterialCodeResolution.Resolve(layers, Map(("CLAY BRICK 200MM", "WL-CORE")), null, "");
+            Assert.Equal("WL-CORE", r.Code);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  4. WHAT THIS ACTUALLY MOVES — measured, not assumed
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static DirectoryInfo RepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "cost_rates_5d.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return dir;
+        }
+
+        private static string Data(string file)
+            => Path.Combine(RepoRoot().FullName, "StingTools", "Data", file);
+
+        /// <summary>Every MAT_CODE the governed register issues.</summary>
+        private static HashSet<string> RegisterCodes()
+        {
+            var codes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string f in new[] { "BLE_MATERIALS.csv", "MEP_MATERIALS.csv" })
+            {
+                var lines = File.ReadAllLines(Data(f));
+                int hdr = Array.FindIndex(lines, l => l.ToUpperInvariant().Contains("MAT_CODE"));
+                Assert.True(hdr >= 0, f + " has no MAT_CODE header");
+                var cols = Split(lines[hdr]);
+                int ci = cols.FindIndex(c => c.Trim().Equals("MAT_CODE", StringComparison.OrdinalIgnoreCase));
+                for (int i = hdr + 1; i < lines.Length; i++)
+                {
+                    if (string.IsNullOrWhiteSpace(lines[i]) || lines[i].TrimStart().StartsWith("#")) continue;
+                    var f2 = Split(lines[i]);
+                    if (f2.Count > ci && f2[ci].Trim().Length > 0) codes.Add(f2[ci].Trim());
+                }
+            }
+            return codes;
+        }
+
+        /// <summary>Every key LoadCsvRatesUncached would register from the shipped
+        /// 8-column rate table — DISC|PROD, Category and the MAT_CODE column.</summary>
+        private static HashSet<string> RateTableKeys()
+        {
+            var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var lines = File.ReadAllLines(Data("cost_rates_5d.csv"));
+            for (int i = 1; i < lines.Length; i++)
+            {
+                var c = Split(lines[i]);
+                if (c.Count < 8) continue;
+                if (c[1].Trim().Length > 0 && c[3].Trim().Length > 0) keys.Add(c[3].Trim() + "|" + c[1].Trim());
+                if (c[0].Trim().Length > 0) keys.Add(c[0].Trim());
+                if (c[2].Trim().Length > 0) keys.Add(c[2].Trim());
+            }
+            return keys;
+        }
+
+        private static List<string> Split(string line)
+        {
+            var fields = new List<string>();
+            var cur = new System.Text.StringBuilder();
+            bool q = false;
+            foreach (char ch in line ?? "")
+            {
+                if (q) { if (ch == '"') q = false; else cur.Append(ch); }
+                else if (ch == '"' && cur.Length == 0) q = true;
+                else if (ch == ',') { fields.Add(cur.ToString()); cur.Clear(); }
+                else cur.Append(ch);
+            }
+            fields.Add(cur.ToString());
+            return fields;
+        }
+
+        [Fact]
+        public void The_Shipped_Rate_Table_Shares_No_Key_With_The_Register()
+        {
+            // ── THE RATE DELTA W2 CAUSES, ON SHIPPED CORPORATE DATA: ZERO. ──
+            //
+            // The register issues 1,279 codes shaped FLR-028 / CLG-052 / WL-128.
+            // cost_rates_5d.csv has a column CALLED MAT_CODE holding 43 three-letter
+            // abbreviations — FLR, CLG, WAL, AHU — which are PROD-shaped, not register
+            // codes. The intersection is EMPTY, so Pass 3 still cannot match against
+            // the shipped table however well MatCode is now resolved.
+            //
+            // That is the same defect the brief found, one file over: a lookup wired
+            // end to end whose two halves speak different vocabularies. It is pinned
+            // here rather than fixed because changing 43 rate keys IS a cost change and
+            // needs its own evidence — and because the day somebody adds register codes
+            // to a rate card, this test must fail and make them count what moved.
+            var codes = RegisterCodes();
+            var keys = RateTableKeys();
+
+            Assert.Equal(1279, codes.Count);
+            var shared = codes.Where(keys.Contains).OrderBy(x => x).ToList();
+
+            Assert.True(shared.Count == 0,
+                "Register codes are now rate-table keys, so Pass 3 (MATERIAL, confidence 85) "
+              + "will fire where it never has. This is a RATE CHANGE. Count what moved, then "
+              + "update this test:\n  " + string.Join("\n  ", shared.Take(20)));
+        }
+
+        [Fact]
+        public void The_Rate_Tables_MAT_CODE_Column_Is_Prod_Shaped_Not_Register_Shaped()
+        {
+            // Stated as a fact about the data so the reason the delta is zero is
+            // readable, and so a later cleanup of either file is a visible event.
+            var lines = File.ReadAllLines(Data("cost_rates_5d.csv"));
+            var col = new List<string>();
+            for (int i = 1; i < lines.Length; i++)
+            {
+                var c = Split(lines[i]);
+                if (c.Count >= 8 && c[2].Trim().Length > 0) col.Add(c[2].Trim());
+            }
+            Assert.NotEmpty(col);
+
+            // Register codes all carry a hyphen-and-number tail. None of these do.
+            Assert.All(col, v => Assert.DoesNotContain("-", v));
+            Assert.All(RegisterCodes().Take(50), v => Assert.Contains("-", v));
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -43,6 +43,8 @@
     <Compile Include="..\StingTools\Core\Materials\MaterialKeyCanonicaliser.cs" Link="Materials\MaterialKeyCanonicaliser.cs" />
     <Compile Include="..\StingTools\Core\PrimaryMaterialSelector.cs" Link="Core\PrimaryMaterialSelector.cs" />
     <Compile Include="..\StingTools\Core\Materials\MaterialCodeResolution.cs" Link="Core\Materials\MaterialCodeResolution.cs" />
+    <Compile Include="..\StingTools\BOQ\Rates\RateResolutionLevel.cs" Link="BOQ\Rates\RateResolutionLevel.cs" />
+    <Compile Include="..\StingTools\BOQ\Rates\CsvRateLookup.cs" Link="BOQ\Rates\CsvRateLookup.cs" />
     <!-- RC-2 — Document-free unit canonicalisation (tonne↔kg). -->
     <!-- ROADMAP LIFE-3: the markup waterfall. Revit-free, but not previously
          compiled here, so the OH&amp;P base had no test. -->

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -41,6 +41,8 @@
     <Compile Include="..\StingTools\Core\Materials\SlabConcreteCalculator.cs" Link="Materials\SlabConcreteCalculator.cs" />
     <!-- RC-1 — Document-free material-key canonicaliser. -->
     <Compile Include="..\StingTools\Core\Materials\MaterialKeyCanonicaliser.cs" Link="Materials\MaterialKeyCanonicaliser.cs" />
+    <Compile Include="..\StingTools\Core\PrimaryMaterialSelector.cs" Link="Core\PrimaryMaterialSelector.cs" />
+    <Compile Include="..\StingTools\Core\Materials\MaterialCodeResolution.cs" Link="Core\Materials\MaterialCodeResolution.cs" />
     <!-- RC-2 — Document-free unit canonicalisation (tonne↔kg). -->
     <!-- ROADMAP LIFE-3: the markup waterfall. Revit-free, but not previously
          compiled here, so the OH&amp;P base had no test. -->

--- a/StingTools/BOQ/BOQCostManager.cs
+++ b/StingTools/BOQ/BOQCostManager.cs
@@ -1181,7 +1181,7 @@ namespace StingTools.BOQ
                 //
                 // MAT_CODE is Instance-bound and is correctly read from the instance.
                 ProdCode = ReadInstanceThenType(el, ParamRegistry.PROD),
-                MatCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "",
+                MatCode = Core.Materials.ElementMatCodeReader.ResolveCode(el),   // W2: through the material, not off the element
                 SystemType = ReadInstanceThenType(el, ParamRegistry.SYS),   // RC-2
                 Unit = csvRates != null && csvRates.TryGetValue(catName ?? "", out var hint) ? hint.unit : "",
                 CurrencyCode = "UGX",
@@ -2813,7 +2813,7 @@ namespace StingTools.BOQ
                         CategoryName = catName,
                         Discipline = DisciplineForCategory(catName),
                         ProdCode = ParameterHelpers.GetString(el, ParamRegistry.PROD) ?? "",
-                        MatCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "",
+                        MatCode = Core.Materials.ElementMatCodeReader.ResolveCode(el),   // W2: through the material, not off the element
                         Unit = csvRates != null && csvRates.TryGetValue(catName, out var hint) ? hint.unit : "",
                         CurrencyCode = "UGX",
                         AsOf = DateTime.UtcNow,

--- a/StingTools/BOQ/CostStamp.cs
+++ b/StingTools/BOQ/CostStamp.cs
@@ -149,7 +149,11 @@ namespace StingTools.BOQ
                 // QS is using per-element overrides at scale, they
                 // should drive cost via the BOQ_Refresh path (which
                 // doesn't use this cache) rather than tag-time write-back.
-                string matCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "";
+                // W2 — resolved THROUGH the element's primary material. MAT_CODE is
+                // bound to Materials and to nothing else, so the old read off `el`
+                // returned empty for every element and kept it out of the cache key
+                // as well as out of the rate request.
+                string matCode = Core.Materials.ElementMatCodeReader.ResolveCode(el);
                 string cacheKey = $"{catName}|{disc}|{prod}|{matCode}|{rule.Unit ?? "each"}";
                 double ugxPerUsd = TagConfig.GetConfigDouble("UGX_PER_USD", 3700.0);
 

--- a/StingTools/BOQ/MeasurementStandard/MeasurementStandards.cs
+++ b/StingTools/BOQ/MeasurementStandard/MeasurementStandards.cs
@@ -206,7 +206,10 @@ namespace StingTools.BOQ.MeasurementStandard
             // CESMM4 descriptions follow a strict feature ladder. Stub here
             // with first feature + material; project-override layer can
             // extend.
-            string material = ParameterHelpers.GetString(el, "MAT_CODE") ?? "";
+            // W2 — same wrong read as the rate chain had: MAT_CODE is bound to
+            // Materials, so this was empty for every element and every CESMM4
+            // description said "as drawn" with no material named.
+            string material = Core.Materials.ElementMatCodeReader.ResolveCode(el);
             string baseDesc = line?.Category ?? "item";
             return string.IsNullOrEmpty(material)
                 ? $"{baseDesc}; as drawn"

--- a/StingTools/BOQ/Rates/CsvRateLookup.cs
+++ b/StingTools/BOQ/Rates/CsvRateLookup.cs
@@ -1,0 +1,137 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  CsvRateLookup.cs — the CSV rate table's five passes, lifted out of the
+//  provider so they can be run without Revit.
+//
+//  WHY. `CsvRateProvider` is the provider that prices most of a model, and its
+//  pass ORDER is the thing that has gone wrong before — K-16b found category
+//  consulted first and returning, which made the PROD pass dead and priced a
+//  fire door and a cupboard door alike. None of that logic needs a Document; it
+//  needs a dictionary and five strings. It was untestable only because it sat
+//  in a file that imports the Revit API for other classes.
+//
+//  This is the compute half. `CsvRateProvider.Resolve` is now the present half:
+//  it unpacks a RateRequest, calls this, and packs a RateLookup. Same code, one
+//  copy — a second implementation for tests would prove nothing about the one
+//  that runs.
+//
+//  PASS ORDER IS SPECIFICITY ORDER, and confidence follows it:
+//
+//      DISC|PROD (97)  →  PROD (95)  →  CATEGORY|SYSTEM (92)
+//                      →  MAT_CODE (85)  →  CATEGORY (70)
+//
+//  A category rate is the LEAST specific answer available, not the most
+//  confident one.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.BOQ.Rates
+{
+    /// <summary>One resolved rate, before it is dressed as a <c>RateLookup</c>.</summary>
+    public sealed class CsvRateMatch
+    {
+        public double UnitRate;
+        public string Unit = "each";
+        public int Confidence;
+        public RateResolutionLevel Level;
+        /// <summary>The sentence the audit reads. Asserted by the end-to-end test,
+        /// because a rate that happens to be right for another reason is not this
+        /// working.</summary>
+        public string Provenance = "";
+        public string MatchedKey = "";
+    }
+
+    public static class CsvRateLookup
+    {
+        /// <summary>
+        /// The five passes, most specific first. Returns null when nothing matched —
+        /// which is a real answer, not an error, and must not become a default rate.
+        /// </summary>
+        public static CsvRateMatch Resolve(
+            IReadOnlyDictionary<string, (double rate, string unit)> rates,
+            string sourceFile,
+            string categoryName, string discipline, string prodCode,
+            string systemType, string matCode)
+        {
+            if (rates == null || rates.Count == 0) return null;
+            string src = sourceFile ?? "cost_rates_5d.csv";
+
+            // Pass 0 (D6) — DISCIPLINE + PRODUCT. The most specific key there is.
+            //
+            // PROD alone is not unique: Air Terminals carries a mechanical air terminal
+            // and a lightning air terminal, both GRL in ProdMap, at different rates.
+            // DISC (M vs E) separates them without inventing a PROD code or migrating
+            // ProdMap — which would have touched every tag in every existing model.
+            if (!string.IsNullOrEmpty(prodCode) && !string.IsNullOrEmpty(discipline)
+                && rates.TryGetValue(discipline + "|" + prodCode, out var byDiscProd))
+                return new CsvRateMatch
+                {
+                    UnitRate = byDiscProd.rate,
+                    Unit = byDiscProd.unit ?? "each",
+                    Confidence = 97,
+                    Level = RateResolutionLevel.Product,
+                    Provenance = src + " product match (" + discipline + "|" + prodCode + ")",
+                    MatchedKey = discipline + "|" + prodCode,
+                };
+
+            // Pass 1 — PRODUCT without discipline. Kept for rate cards that carry a
+            // globally-unique PROD code and no discipline column.
+            if (!string.IsNullOrEmpty(prodCode) && rates.TryGetValue(prodCode, out var byProd))
+                return new CsvRateMatch
+                {
+                    UnitRate = byProd.rate,
+                    Unit = byProd.unit ?? "each",
+                    Confidence = 95,
+                    Level = RateResolutionLevel.Product,
+                    Provenance = src + " PROD match (" + prodCode + ")",
+                    MatchedKey = prodCode,
+                };
+
+            // Pass 2 (RC-2) — CATEGORY|SYSTEM. Lets a project price otherwise-identical
+            // categories differently by ASS_SYSTEM_TYPE_TXT ("Pipes|MedicalGas").
+            if (!string.IsNullOrEmpty(categoryName) && !string.IsNullOrEmpty(systemType))
+            {
+                string sysKey = categoryName + "|" + systemType;
+                if (rates.TryGetValue(sysKey, out var bySys))
+                    return new CsvRateMatch
+                    {
+                        UnitRate = bySys.rate,
+                        Unit = bySys.unit ?? "each",
+                        Confidence = 92,
+                        Level = RateResolutionLevel.System,
+                        Provenance = src + " system match (" + systemType + ")",
+                        MatchedKey = sysKey,
+                    };
+            }
+
+            // Pass 3 — MATERIAL. Empty for every element ever costed until W2, because
+            // MAT_CODE was read off the element and is bound to Materials.
+            if (!string.IsNullOrEmpty(matCode) && rates.TryGetValue(matCode, out var byMat))
+                return new CsvRateMatch
+                {
+                    UnitRate = byMat.rate,
+                    Unit = byMat.unit ?? "each",
+                    Confidence = 85,
+                    Level = RateResolutionLevel.Material,
+                    Provenance = src + " MAT_CODE match",
+                    MatchedKey = matCode,
+                };
+
+            // Pass 4 — CATEGORY. An average across every product in the category.
+            // Legitimate as a fallback, dishonest as a default: flagged so the QS can
+            // see how many lines were priced this way (2.4).
+            if (!string.IsNullOrEmpty(categoryName) && rates.TryGetValue(categoryName, out var direct))
+                return new CsvRateMatch
+                {
+                    UnitRate = direct.rate,
+                    Unit = direct.unit ?? "each",
+                    Confidence = 70,
+                    Level = RateResolutionLevel.Category,
+                    Provenance = src + " category average (" + categoryName + ")",
+                    MatchedKey = categoryName,
+                };
+
+            return null;
+        }
+    }
+}

--- a/StingTools/BOQ/Rates/IRateProvider.cs
+++ b/StingTools/BOQ/Rates/IRateProvider.cs
@@ -70,20 +70,8 @@ namespace StingTools.BOQ.Rates
     /// the good one, and everything below it is an ASSUMPTION that must be visible.
     /// </para>
     /// </summary>
-    public enum RateResolutionLevel
-    {
-        /// <summary>No rate at all. The item is not priced.</summary>
-        None = 0,
-        /// <summary>Category average — every product in the category shares one rate.</summary>
-        Category = 1,
-        /// <summary>Material-level.</summary>
-        Material = 2,
-        /// <summary>Category refined by MEP system.</summary>
-        System = 3,
-        /// <summary>The actual product. The only level that prices a fire door
-        /// differently from a cupboard door.</summary>
-        Product = 4,
-    }
+    // RateResolutionLevel moved to RateResolutionLevel.cs so the CSV rate passes
+    // can be compiled without the Revit API. Same namespace; no call site changed.
 
     public class RateLookup
     {

--- a/StingTools/BOQ/Rates/RateProviders.cs
+++ b/StingTools/BOQ/Rates/RateProviders.cs
@@ -241,122 +241,28 @@ namespace StingTools.BOQ.Rates
 
         public RateLookup Resolve(RateRequest req)
         {
-            if (req == null || _rates.Count == 0) return null;
+            if (req == null) return null;
 
-            // K-16b — PASS ORDER IS SPECIFICITY ORDER. It was not.
-            //
-            // Category used to be consulted FIRST and RETURN, so Pass B never saw a
-            // PROD code on any element whose category had a row. cost_rates_5d.csv has
-            // a row for every common category, so PROD was effectively dead: every door
-            // in KNP26 priced at "Doors,DOR,...,1665000,each" — fire door and cupboard
-            // door alike — and nothing said the rate was a category average.
-            //
-            // A category rate is the LEAST specific answer available, not the most
-            // confident one. Ordering now runs most-specific first:
-            //
-            //     product  →  category|system  →  material  →  category
-            //
-            // Confidence follows specificity for the same reason.
-            //
-            // Every branch reports HOW it resolved (2.3), reusing G-27's vocabulary
-            // rather than inventing a third one.
+            // The five passes live in CsvRateLookup — Revit-free, so the pass ORDER
+            // (the thing K-16b found wrong) is assertable without a Document. This is
+            // the present half: unpack the request, call the compute half, pack the
+            // answer. No decision is taken here.
+            var m = CsvRateLookup.Resolve(_rates, _sourceFile,
+                        req.CategoryName, req.Discipline, req.ProdCode,
+                        req.SystemType, req.MatCode);
+            if (m == null) return null;
 
-            // Pass 0 (D6) — DISCIPLINE + PRODUCT. The most specific key there is.
-            //
-            // PROD alone is not unique: Air Terminals carries a mechanical air terminal
-            // and a lightning air terminal, both GRL in ProdMap, at different rates.
-            // DISC (M vs E) separates them without inventing a PROD code or migrating
-            // ProdMap — which would have touched every tag in every existing model.
-            if (!string.IsNullOrEmpty(req.ProdCode) && !string.IsNullOrEmpty(req.Discipline) &&
-                _rates.TryGetValue($"{req.Discipline}|{req.ProdCode}", out var byDiscProd))
+            return new RateLookup
             {
-                return new RateLookup
-                {
-                    UnitRate = byDiscProd.rate,
-                    CurrencyCode = "UGX",
-                    Unit = byDiscProd.unit ?? "each",
-                    SourceId = Id,
-                    Confidence = 97,
-                    ResolutionLevel = RateResolutionLevel.Product,
-                    Provenance = $"{_sourceFile} product match ({req.Discipline}|{req.ProdCode})",
-                    MatchedKey = $"{req.Discipline}|{req.ProdCode}"
-                };
-            }
-
-            // Pass 1 — PRODUCT without discipline. Kept for rate cards that carry a
-            // globally-unique PROD code and no discipline column.
-            if (!string.IsNullOrEmpty(req.ProdCode) &&
-                _rates.TryGetValue(req.ProdCode, out var byProd))
-            {
-                return new RateLookup
-                {
-                    UnitRate = byProd.rate,
-                    CurrencyCode = "UGX",
-                    Unit = byProd.unit ?? "each",
-                    SourceId = Id,
-                    Confidence = 95,
-                    ResolutionLevel = RateResolutionLevel.Product,
-                    Provenance = $"{_sourceFile} PROD match ({req.ProdCode})",
-                    MatchedKey = req.ProdCode
-                };
-            }
-
-            // Pass 2 (RC-2) — CATEGORY|SYSTEM. Lets a project price otherwise-identical
-            // categories differently by ASS_SYSTEM_TYPE_TXT ("Pipes|MedicalGas").
-            if (!string.IsNullOrEmpty(req.CategoryName) && !string.IsNullOrEmpty(req.SystemType))
-            {
-                string sysKey = $"{req.CategoryName}|{req.SystemType}";
-                if (_rates.TryGetValue(sysKey, out var bySys))
-                    return new RateLookup
-                    {
-                        UnitRate = bySys.rate,
-                        CurrencyCode = "UGX",
-                        Unit = bySys.unit ?? "each",
-                        SourceId = Id,
-                        Confidence = 92,
-                        ResolutionLevel = RateResolutionLevel.System,
-                        Provenance = $"{_sourceFile} system match ({req.SystemType})",
-                        MatchedKey = sysKey
-                    };
-            }
-
-            // Pass 3 — MATERIAL.
-            if (!string.IsNullOrEmpty(req.MatCode) &&
-                _rates.TryGetValue(req.MatCode, out var byMat))
-            {
-                return new RateLookup
-                {
-                    UnitRate = byMat.rate,
-                    CurrencyCode = "UGX",
-                    Unit = byMat.unit ?? "each",
-                    SourceId = Id,
-                    Confidence = 85,
-                    ResolutionLevel = RateResolutionLevel.Material,
-                    Provenance = $"{_sourceFile} MAT_CODE match",
-                    MatchedKey = req.MatCode
-                };
-            }
-
-            // Pass 4 — CATEGORY. An average across every product in the category.
-            // Legitimate as a fallback, dishonest as a default: flagged so the QS can
-            // see how many lines were priced this way (2.4).
-            if (!string.IsNullOrEmpty(req.CategoryName) &&
-                _rates.TryGetValue(req.CategoryName, out var direct))
-            {
-                return new RateLookup
-                {
-                    UnitRate = direct.rate,
-                    CurrencyCode = "UGX",
-                    Unit = direct.unit ?? "each",
-                    SourceId = Id,
-                    Confidence = 70,
-                    ResolutionLevel = RateResolutionLevel.Category,
-                    Provenance = $"{_sourceFile} category average ({req.CategoryName})",
-                    MatchedKey = req.CategoryName
-                };
-            }
-
-            return null;
+                UnitRate = m.UnitRate,
+                CurrencyCode = "UGX",
+                Unit = m.Unit,
+                SourceId = Id,
+                Confidence = m.Confidence,
+                ResolutionLevel = m.Level,
+                Provenance = m.Provenance,
+                MatchedKey = m.MatchedKey,
+            };
         }
     }
 

--- a/StingTools/BOQ/Rates/RateResolutionLevel.cs
+++ b/StingTools/BOQ/Rates/RateResolutionLevel.cs
@@ -1,0 +1,23 @@
+// RateResolutionLevel.cs — how specifically a rate resolved.
+//
+// Lives in its own file, and NOT in IRateProvider.cs, because that file imports
+// the Revit API for RateRequest.Element and would drag a Document into any test
+// project that wanted to assert a pass order. Same namespace as before, so no
+// call site changed when it moved.
+namespace StingTools.BOQ.Rates
+{
+    public enum RateResolutionLevel
+    {
+        /// <summary>No rate at all. The item is not priced.</summary>
+        None = 0,
+        /// <summary>Category average — every product in the category shares one rate.</summary>
+        Category = 1,
+        /// <summary>Material-level.</summary>
+        Material = 2,
+        /// <summary>Category refined by MEP system.</summary>
+        System = 3,
+        /// <summary>The actual product. The only level that prices a fire door
+        /// differently from a cupboard door.</summary>
+        Product = 4,
+    }
+}

--- a/StingTools/Core/Materials/ElementMatCodeReader.cs
+++ b/StingTools/Core/Materials/ElementMatCodeReader.cs
@@ -1,0 +1,222 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ElementMatCodeReader.cs — the ONE place that answers "what is this element's
+//  MAT_CODE?". Four call sites asked a wall for a parameter bound to materials;
+//  they now all come here.
+//
+//  This file reads Revit and decides nothing. The decision — which material
+//  answers, and in what order — is MaterialCodeResolution, which is Revit-free
+//  and tested against a plain layer list and a name→code map.
+//
+//  ── THE PER-DOCUMENT MAP ──────────────────────────────────────────────────
+//  MAT_CODE lives on Material elements, so answering per element would mean a
+//  parameter read per layer per element. Instead the document's materials are
+//  read ONCE into a name→code map.
+//
+//  It is memoised on (document, material count, 30 seconds) — the same stale
+//  window ComplianceScan uses. The count alone is NOT enough: stamping codes
+//  onto existing materials changes no count, so a count-only memo would keep
+//  serving a map with no codes in it straight after the command that wrote
+//  them, and the BOQ would price off category exactly as before with nothing
+//  said. A TTL bounds that to half a minute without needing a Revit hook that
+//  does not exist, and Invalidate() closes it exactly for callers that write.
+//
+//  The map also carries HOW MANY materials have a code, which is the number
+//  that says whether any of this can work at all. A model where that is 0 is
+//  not a model where Pass 3 "found nothing"; it is a model where nobody has run
+//  Materials_StampCodes, and the two are worth telling apart.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using StingTools.Core;
+
+namespace StingTools.Core.Materials
+{
+    public static class ElementMatCodeReader
+    {
+        private static readonly object _lock = new object();
+        private static string _docKey;
+        private static int _materialCount = -1;
+        private static DateTime _builtUtc = DateTime.MinValue;
+        private static Dictionary<string, string> _codeByName;
+
+        /// <summary>How long a built map is trusted. Same window ComplianceScan uses.</summary>
+        public static readonly TimeSpan StaleAfter = TimeSpan.FromSeconds(30);
+
+        /// <summary>Materials in the cached map that actually carry a MAT_CODE.</summary>
+        public static int CodedMaterialCount { get; private set; }
+
+        /// <summary>Drop the cached map. Call after writing MAT_CODE to materials.</summary>
+        public static void Invalidate()
+        {
+            lock (_lock)
+            {
+                _docKey = null; _materialCount = -1; _codeByName = null;
+                _builtUtc = DateTime.MinValue; CodedMaterialCount = 0;
+            }
+        }
+
+        /// <summary>
+        /// The element's MAT_CODE, resolved through its material. Never null; an
+        /// unresolved element answers <see cref="MatCodeResolution.Nothing"/>, whose
+        /// Code is "" — and empty must stay empty rather than become a guess.
+        /// </summary>
+        public static MatCodeResolution Resolve(Element el)
+        {
+            if (el == null) return MatCodeResolution.Nothing;
+            try
+            {
+                var doc = el.Document;
+                if (doc == null) return MatCodeResolution.Nothing;
+
+                return MaterialCodeResolution.Resolve(
+                    ReadLayers(el, doc),
+                    CodeByMaterialName(doc),
+                    ReadSingleMaterialName(el, doc),
+                    ParameterHelpers.GetString(el, "MAT_CODE") ?? "");
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("MatCode.Resolve", "Resolve " + el?.Id + ": " + ex.Message);
+                return MatCodeResolution.Nothing;
+            }
+        }
+
+        /// <summary>The code alone, for the call sites that only want the string.</summary>
+        public static string ResolveCode(Element el) => Resolve(el).Code;
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  Revit reads
+        // ══════════════════════════════════════════════════════════════════════
+
+        /// <summary>The element type's compound structure, flattened into the shape
+        /// PrimaryMaterialSelector takes. Empty for anything that is not a layered host.
+        /// Deliberately the same read MaterialProdOverrideRegistry does — one shape, so
+        /// the PROD suffix and the rate key cannot disagree about which layer is the core.</summary>
+        private static IReadOnlyList<MaterialLayer> ReadLayers(Element el, Document doc)
+        {
+            var layers = new List<MaterialLayer>();
+            try
+            {
+                if (!(doc.GetElement(el.GetTypeId()) is HostObjAttributes host)) return layers;
+                CompoundStructure cs = host.GetCompoundStructure();
+                if (cs == null) return layers;
+
+                var csLayers = cs.GetLayers();
+                for (int i = 0; i < csLayers.Count; i++)
+                {
+                    var cl = csLayers[i];
+                    string name = null;
+                    if (cl.MaterialId != null && cl.MaterialId.Value > 0)
+                        name = doc.GetElement(cl.MaterialId)?.Name;
+                    if (string.IsNullOrWhiteSpace(name)) continue;
+
+                    layers.Add(new MaterialLayer
+                    {
+                        Index = i,
+                        MaterialName = name,
+                        // Width is FEET. Millimetres because every other STING layer
+                        // reader uses them and the selector only compares layers to
+                        // each other.
+                        ThicknessMm = cl.Width * 304.8,
+                        IsStructure = cl.Function == MaterialFunctionAssignment.Structure,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("MatCode.Layers", "ReadLayers " + el?.Id + ": " + ex.Message);
+            }
+            return layers;
+        }
+
+        /// <summary>The element's own material, for things with no compound structure —
+        /// a FamilyInstance, a pipe. Explicit Material parameter first, then the first
+        /// material the element admits to.</summary>
+        private static string ReadSingleMaterialName(Element el, Document doc)
+        {
+            try
+            {
+#pragma warning disable CS0618
+                Parameter p = el.LookupParameter("Material")
+                              ?? el.get_Parameter(BuiltInParameter.MATERIAL_ID_PARAM);
+#pragma warning restore CS0618
+                if (p != null && p.StorageType == StorageType.ElementId)
+                {
+                    var mid = p.AsElementId();
+                    if (mid != null && mid.Value > 0) return doc.GetElement(mid)?.Name;
+                }
+
+                var mats = el.GetMaterialIds(false);
+                if (mats != null)
+                    foreach (var mid in mats)
+                        if (mid != null && mid.Value > 0) return doc.GetElement(mid)?.Name;
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("MatCode.Single", "ReadSingleMaterial " + el?.Id + ": " + ex.Message);
+            }
+            return null;
+        }
+
+        /// <summary>MAT_CODE per material name for the whole document, memoised.</summary>
+        internal static IReadOnlyDictionary<string, string> CodeByMaterialName(Document doc)
+        {
+            if (doc == null) return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            string key = doc.PathName ?? doc.Title ?? "";
+            int count;
+            try { count = new FilteredElementCollector(doc).OfClass(typeof(Material)).GetElementCount(); }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("MatCode.Count", "material count: " + ex.Message);
+                count = -1;
+            }
+
+            lock (_lock)
+            {
+                if (_codeByName != null && _docKey == key && _materialCount == count
+                    && DateTime.UtcNow - _builtUtc < StaleAfter)
+                    return _codeByName;
+            }
+
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            int coded = 0;
+            try
+            {
+                foreach (Material m in new FilteredElementCollector(doc)
+                                       .OfClass(typeof(Material)).Cast<Material>())
+                {
+                    string name = m?.Name;
+                    if (string.IsNullOrWhiteSpace(name)) continue;
+                    string code = (ParameterHelpers.GetString(m, "MAT_CODE") ?? "").Trim();
+                    if (code.Length == 0) continue;
+                    // First wins, like every other STING key map: two materials sharing a
+                    // name is a data question, and picking one silently is how a register
+                    // stops being governed.
+                    if (map.ContainsKey(name.Trim())) continue;
+                    map[name.Trim()] = code;
+                    coded++;
+                }
+            }
+            catch (Exception ex)
+            {
+                StingLog.Warn("ElementMatCodeReader.CodeByMaterialName: " + ex.Message);
+            }
+
+            lock (_lock)
+            {
+                _docKey = key; _materialCount = count; _codeByName = map;
+                _builtUtc = DateTime.UtcNow; CodedMaterialCount = coded;
+            }
+
+            // One line per rebuild, not per element. A zero here is the difference
+            // between "no material matched" and "no material has ever been coded".
+            StingLog.Info("MAT_CODE map: " + coded + " of " + (count < 0 ? map.Count : count)
+                        + " material(s) carry a code" + (coded == 0
+                          ? " — Pass 3 (MATERIAL) cannot fire; run Materials_StampCodes." : "."));
+            return map;
+        }
+    }
+}

--- a/StingTools/Core/Materials/MaterialCodeResolution.cs
+++ b/StingTools/Core/Materials/MaterialCodeResolution.cs
@@ -1,0 +1,150 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  MaterialCodeResolution.cs — an element's MAT_CODE, resolved THROUGH its
+//  material rather than asked of the element directly.
+//
+//  WHAT WAS WRONG. Four places built a rate request like this:
+//
+//      MatCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "",
+//
+//  where `el` is a wall, a floor, a pipe. MAT_CODE is bound to `Materials` and
+//  to nothing else — CATEGORY_BINDINGS.csv:4693, agreeing with
+//  PARAMETER_CATEGORIES.csv:510, FAMILY_PARAMETER_BINDINGS.csv:4022,
+//  BINDING_COVERAGE_MATRIX.csv:611 and PARAMETER_REGISTRY.json:9971. Asking a
+//  wall for it returns empty, every time, for every element ever costed. So
+//  CsvRateProvider "Pass 3 — MATERIAL" (RateProviders.cs:323, confidence 85)
+//  has never fired, and the rate chain has always fallen through to matching on
+//  category and name — which is the root of every vocabulary divergence this
+//  month has produced.
+//
+//  The binding is not wrong. The READ was in the wrong place. The code belongs
+//  on the material, because that is what the register row is ABOUT; putting it
+//  on thousands of instances would copy a fact they already have through their
+//  type, and would drift the moment a type changed.
+//
+//  ── THE DECISION, WHICH IS THE PART WORTH TESTING ─────────────────────────
+//  Layers in, code out. Deliberately Revit-free: reading a parameter is not
+//  where this goes wrong, choosing WHICH material answers is.
+//
+//    1. The PRIMARY layer material, chosen by PrimaryMaterialSelector — the
+//       thickest structural layer, falling back to the thickest of any
+//       function. One definition, the one #873 settled; a second would fork it.
+//    2. Only when the layers name no material at all: the element's single
+//       material, where Revit exposes one.
+//    3. Only then: the element's own MAT_CODE, for the day somebody binds it
+//       there. This is a fallback so that day needs no second visit — it is not
+//       an invitation to do it.
+//    4. Empty. AND EMPTY STAYS EMPTY. A guessed code is worse than no code:
+//       Pass 3 is the most specific lookup in the chain and it would carry the
+//       guess at confidence 85.
+//
+//  ── THE ONE SUBTLETY ──────────────────────────────────────────────────────
+//  When the layers DO name a primary material and that material has no code,
+//  this stops. It does NOT then try the element's first material. That fall-
+//  through would hand back the FINISH SKIN — a 230 mm rendered masonry wall
+//  answering "gypsum" — which is precisely the defect #873 was opened for. A
+//  layered element is answered by its core or by nothing.
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+
+namespace StingTools.Core.Materials
+{
+    /// <summary>Where a resolved MAT_CODE came from. Carried so a caller can say
+    /// WHY a rate matched, rather than only that it did.</summary>
+    public enum MatCodeSource
+    {
+        /// <summary>Nothing answered. Code is empty and must stay empty.</summary>
+        None,
+        /// <summary>The primary layer material of a compound element.</summary>
+        PrimaryLayerMaterial,
+        /// <summary>The element's single material — families, MEP, anything with no
+        /// compound structure.</summary>
+        SingleMaterial,
+        /// <summary>MAT_CODE read off the element itself. Only reachable if a future
+        /// change binds the parameter to a host category.</summary>
+        ElementParameter,
+    }
+
+    public sealed class MatCodeResolution
+    {
+        public string Code = "";
+        /// <summary>The material the code came from, or "" when it did not come from one.</summary>
+        public string MaterialName = "";
+        public MatCodeSource Source = MatCodeSource.None;
+
+        public bool Resolved => Code.Length > 0;
+
+        public static readonly MatCodeResolution Nothing = new MatCodeResolution();
+
+        public override string ToString()
+            => Resolved ? Code + " (" + Source + (MaterialName.Length > 0 ? " · " + MaterialName : "") + ")"
+                        : "no MAT_CODE";
+    }
+
+    public static class MaterialCodeResolution
+    {
+        /// <summary>
+        /// Resolve an element's MAT_CODE from what its materials say.
+        /// </summary>
+        /// <param name="layers">The element type's compound structure, flattened.
+        /// Null or empty for anything that is not a layered host.</param>
+        /// <param name="codeByMaterialName">MAT_CODE per material NAME, as read off the
+        /// document's Material elements. Case-insensitive by construction of the caller;
+        /// a name absent from it simply has no code.</param>
+        /// <param name="singleMaterialName">The element's own material, used only when
+        /// the layers name none. See the file header for why it is not a fall-through.</param>
+        /// <param name="elementOwnCode">MAT_CODE read off the element. Empty today.</param>
+        public static MatCodeResolution Resolve(
+            IReadOnlyList<MaterialLayer> layers,
+            IReadOnlyDictionary<string, string> codeByMaterialName,
+            string singleMaterialName,
+            string elementOwnCode)
+        {
+            string primary = PrimaryMaterialSelector.Select(layers);
+
+            if (!string.IsNullOrWhiteSpace(primary))
+            {
+                // The layers answered. Whatever comes back is the answer — including
+                // "no code", which does NOT reopen the question with a different
+                // material. See the file header.
+                string code = Lookup(codeByMaterialName, primary);
+                return code.Length > 0
+                    ? new MatCodeResolution
+                      {
+                          Code = code,
+                          MaterialName = primary.Trim(),
+                          Source = MatCodeSource.PrimaryLayerMaterial,
+                      }
+                    : FromElementParameter(elementOwnCode);
+            }
+
+            if (!string.IsNullOrWhiteSpace(singleMaterialName))
+            {
+                string code = Lookup(codeByMaterialName, singleMaterialName);
+                if (code.Length > 0)
+                    return new MatCodeResolution
+                    {
+                        Code = code,
+                        MaterialName = singleMaterialName.Trim(),
+                        Source = MatCodeSource.SingleMaterial,
+                    };
+            }
+
+            return FromElementParameter(elementOwnCode);
+        }
+
+        private static MatCodeResolution FromElementParameter(string elementOwnCode)
+        {
+            string own = (elementOwnCode ?? "").Trim();
+            return own.Length > 0
+                ? new MatCodeResolution { Code = own, Source = MatCodeSource.ElementParameter }
+                : MatCodeResolution.Nothing;
+        }
+
+        private static string Lookup(IReadOnlyDictionary<string, string> map, string name)
+        {
+            if (map == null || string.IsNullOrWhiteSpace(name)) return "";
+            return map.TryGetValue(name.Trim(), out string code) ? (code ?? "").Trim() : "";
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 266 — W2: an element's MAT_CODE, resolved through its material)
+
+**Four places asked a wall for a parameter bound to materials.**
+
+    MatCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "",
+
+`BOQCostManager:1184` and `:2816` (the rate request), `CostStamp:152` (the rate
+request *and* the shared rate-cache key) and
+`MeasurementStandards:209` (the CESMM4 description). `MAT_CODE` binds to
+`Materials` and to nothing else — `CATEGORY_BINDINGS.csv:4693`, agreeing with
+`PARAMETER_CATEGORIES.csv:510`, `FAMILY_PARAMETER_BINDINGS.csv:4022`,
+`BINDING_COVERAGE_MATRIX.csv:611` and `PARAMETER_REGISTRY.json:9971` — so every
+one of those reads returned empty for every element ever costed, and
+`CsvRateProvider` **"Pass 3 — MATERIAL"** (`RateProviders.cs:323`, confidence
+85) has never fired.
+
+All four now go through **one** resolver. The decision is Revit-free:
+`MaterialCodeResolution` takes a layer list and a name→code map and answers
+**primary layer material → its code**, falling back to the element's single
+material only when the layers name none, then to the element's own `MAT_CODE`
+for the day somebody binds it there. `PrimaryMaterialSelector` picks the layer —
+**not a second definition of "primary"**; the fork #873 closed stays closed.
+
+**The one subtlety, and it is the whole risk.** When the layers DO name a core
+material and that material has no code, resolution **stops**. It does not then
+try the element's first material — that fall-through hands back the FINISH SKIN,
+a 230 mm rendered masonry wall answering "gypsum", which is #873 exactly. A
+layered element is answered by its core or by nothing, and empty stays empty: a
+guess would ride at confidence 85, above the category match.
+
+---
+
+### WHAT THIS MOVES ON MONEY — measured on the Herring model, not assumed
+
+Computed from the model's own exported artefacts (`register_audit_20260910_
+202805.csv`, `type_rename_core_materials_20260909.csv`) against the shipped
+register and `cost_rates_5d.csv`. No Revit.
+
+| Category | types | instances | gain a MAT_CODE | coded instances | Pass 3 matches | old rate UGX | **delta** |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Floors   | 98 | 1 | **0** | 0 | 0 | 444,000 | **0** |
+| Roofs    | 96 | 11 | **88** | 0 | 0 | 555,000 | **0** |
+| Walls    | 96 | 61 | **49** | 48 | 0 | 315,000 | **0** |
+| Ceilings | 4 | 0 | **0** | 0 | 0 | 166,500 | **0** |
+| **Total**| **294** | **73** | **137** | **48** | **0** | | **0 UGX** |
+
+**137 host types gain a MAT_CODE. Zero rates change.** The reason is exact and
+is a second instance of the very defect this work was opened for:
+
+> **Not one of the register's 1,279 codes is a key in `cost_rates_5d.csv`.**
+> The register issues `FLR-028`, `CLG-052`, `WL-128`. The rate table has a column
+> **called** `MAT_CODE` holding 43 three-letter, PROD-shaped abbreviations —
+> `FLR`, `CLG`, `WAL`, `AHU`. The two files use one column name for two
+> vocabularies, and the intersection is empty.
+
+So Pass 3 *can* now fire and still *does* not. Those are different sentences and
+the difference is the point: before W2 the lookup was dead at the key; now it is
+dead at the table, which is a place a QS can fix by editing a rate card.
+
+**Floors gain nothing, and that is the 87-type finding again.** 90 of the 98
+floor types have the core material `Concrete, Cast-in-Place gray` — a Revit stock
+material, not a register `MAT_NAME` — so no code reaches them even after W1.
+
+**This is pinned, not fixed.** `The_Shipped_Rate_Table_Shares_No_Key_With_The_
+Register` asserts the empty intersection and fails loudly, naming the codes, the
+moment one appears. Changing 43 rate keys IS a cost change and needs its own
+evidence; what this guarantees is that nobody makes it by accident.
+
+**Two other behaviour changes, stated because they are not rate changes and
+would otherwise pass unremarked.** `CostStamp`'s shared rate cache is keyed on
+`{category}|{disc}|{prod}|{matCode}|{unit}`, so a previously-constant empty
+segment now varies — the cache partitions more finely and cannot merge two
+elements that differ only by material. And every CESMM4 description said
+"`{category}; as drawn`" with no material named; it will now name the code where
+one resolves.
+
+**One thing left alone, deliberately.** `UI/IfcMaterialPsetWriter.cs:69` carries
+a *second* `ReadPrimaryMaterialName` that skips the compound-structure step
+entirely and returns the first material — the #873 defect, still live, in a
+second place. Out of scope here; logged in `ROADMAP.md` rather than folded into
+a cost change.
+
+**RED then GREEN, by sabotage, both counts.**
+
+    A_Layered_Element_Answers_With_Its_CORE
+      RED   first layer instead of the selector    WL-SKIN  (4 of 13 fail)
+      GREEN                                        WL-CORE
+
+    A_Layered_Element_Whose_Core_Has_No_Code_Does_Not_Fall_Back_To_The_Skin
+      RED   fall-through restored                  WL-SKIN  (1 of 13 fails)
+      GREEN                                        ""
+
+    The_Shipped_Rate_Table_Shares_No_Key_With_The_Register
+      RED   one row keying FLR-028 added to cost_rates_5d.csv
+            fails, names FLR-028, demands the mover count what moved  (2 of 13)
+      GREEN 0 of 1,279
+
+**Not verified in Revit.** `deploy.bat` was not run. `ElementMatCodeReader` —
+the compound-structure read, the single-material read, the memoised name→code
+map and its 30-second stale window — is **entirely unexercised against a live
+document**. Every defect this area has produced has lived in the Revit-bound
+half, and this half is the Revit-bound half. Build 0/0; Boq 1,311 → 1,324; Tags
+919 unchanged.
+
 #### Completed (Phase 264 — one timber vocabulary, and the matcher swap that needed stems)
 
 **Four word-lists answered "is this timber", and they disagreed both ways on a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,68 @@ document**. Every defect this area has produced has lived in the Revit-bound
 half, and this half is the Revit-bound half. Build 0/0; Boq 1,311 → 1,324; Tags
 919 unchanged.
 
+#### Completed (Phase 268 — W4: FLR-028, register to rate, in one test)
+
+    register row FLR-028  ->  a material carrying MAT_CODE = FLR-028
+                          ->  a floor type whose PRIMARY layer is that material
+                          ->  the BOQ resolves MatCode = "FLR-028"
+                          ->  CsvRateProvider Pass 3 matches
+                          ->  Provenance "<rate file> MAT_CODE match"
+
+**The assertion is the provenance STRING, not the number.** The rate card in the
+test keys the category and `FLR-028` at *different* rates, so a chain that failed
+would still return a plausible figure from Pass 4. Proven load-bearing: a
+sabotage that leaves Pass 3's rate at 612,500 and only mislabels its provenance
+as a category average fails exactly one test — this one — on the string.
+
+**What it would have caught.** Every link existed and was wired four phases ago.
+`MAT_CODE` was bound to `Materials` only, the BOQ read it off a wall, and Pass 3
+has never once fired. Nothing failed. This test fails: sabotaged back to the
+pre-W2 read, `FLR_028_Walks_From_The_Register_To_A_Rate` reports `""` where
+`FLR-028` was expected, and `The_Skin_Never_Prices_The_Floor` reports `WL-999` —
+the plasterboard finish pricing the floor slab.
+
+**`CsvRateProvider` is now a compute/present split**, which is what made the
+above assertable at all. The five passes moved to `BOQ/Rates/CsvRateLookup.cs` —
+Revit-free, one copy, called by the provider — and `RateResolutionLevel` moved to
+its own file because `IRateProvider.cs` imports the Revit API for
+`RateRequest.Element` and would otherwise drag a `Document` into any test that
+wanted to assert a pass order. Same namespace; **no call site changed**. This is
+CLAUDE.md P1 #4 proven on a second feature after the Visibility Center, and on
+the provider that prices most of a model.
+
+`The_Pass_Order_Is_Specificity_Order` asserts the order by stripping the winning
+key one at a time and requiring the next-most-specific to answer — five levels,
+five confidences, in one loop, so a reordering fails here rather than being
+noticed on a tender. That order has been wrong before: K-16b found category
+consulted first and returning, which priced a fire door and a cupboard door
+alike.
+
+**The rate card is synthetic, and that is stated rather than hidden.** The
+shipped `cost_rates_5d.csv` shares no key with the register, so the chain is
+proven here on the rate card a project would have to write, while the reason it
+does not fire on shipped data is proven next door in
+`The_Shipped_Rate_Table_Shares_No_Key_With_The_Register`. Both are true; they are
+different facts, and neither is allowed to stand in for the other.
+
+**RED then GREEN, by sabotage, both counts.**
+
+    FLR_028_Walks_From_The_Register_To_A_Rate
+      RED   pre-W2 read restored (the element answers, and answers nothing)
+            expected "FLR-028", actual ""                      (2 of 7 fail)
+            and The_Skin_Never_Prices_The_Floor -> "WL-999"
+      GREEN "project_rate_card.csv MAT_CODE match" @ 612,500 UGX/m2
+
+    the provenance assertion itself
+      RED   Pass 3 keeps its rate and reports the category sentence
+            one test fails, on the string alone                (1 of 7)
+      GREEN "project_rate_card.csv MAT_CODE match"
+
+**Not verified in Revit.** `deploy.bat` was not run. The chain is proven over the
+Revit-free halves the plugin actually calls; the Revit-bound link between them —
+`ElementMatCodeReader` reading a compound structure and a material parameter — is
+still unexercised against a document. Build 0/0; Boq 1,311 → 1,331.
+
 #### Completed (Phase 264 — one timber vocabulary, and the matcher swap that needed stems)
 
 **Four word-lists answered "is this timber", and they disagreed both ways on a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,39 @@
 
 Open automation gaps, future-enhancement tables, and deep-review findings for the StingTools plugin. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`CHANGELOG.md`](CHANGELOG.md) for the history of closed items.
 
+## MAT_CODE as a rate key — what W2 left open (2026-09-10)
+
+**MC-1 — the register and the rate table use one column name for two
+vocabularies.** `cost_rates_5d.csv` has a column called `MAT_CODE` holding 43
+PROD-shaped abbreviations (`FLR`, `CLG`, `WAL`, `AHU`); the governed register
+issues 1,279 codes shaped `FLR-028`, `CLG-052`, `WL-128`. **The intersection is
+empty**, so `CsvRateProvider` Pass 3 (MATERIAL, confidence 85) still matches
+nothing even now that `RateRequest.MatCode` carries a real value. Closing it
+means deciding which vocabulary that column speaks and repricing accordingly —
+a cost change needing its own evidence, not a rename. Pinned by
+`MaterialCodeResolutionTests.The_Shipped_Rate_Table_Shares_No_Key_With_The_
+Register`, which fails and names the codes the moment one crosses over.
+
+**MC-2 — `UI/IfcMaterialPsetWriter.cs:69` carries a second
+`ReadPrimaryMaterialName`** that reads the explicit Material parameter then the
+first material, **skipping the compound structure entirely**. On a rendered
+masonry wall it returns the gypsum skin — the defect #873 closed, still live in
+this one place, and it is what gets written into `Pset_StingMaterial`. Should
+call the single definition (`MaterialProdOverrideRegistry` / the layer read in
+`ElementMatCodeReader`) rather than keep a third copy.
+
+**MC-3 — 90 of the Herring model's 98 floor types have the core material
+`Concrete, Cast-in-Place gray`**, a Revit stock material absent from the
+register, so no `MAT_CODE` reaches them however the backfill is run. This is the
+87-type flattening finding seen from the cost side: until those types carry the
+build-up the register declares, floors cannot be priced by material at all.
+
+**MC-4 — `ElementMatCodeReader`'s memo is bounded by a 30-second TTL, not by a
+change hook.** Stamping codes onto existing materials changes no material count,
+so the count alone cannot invalidate. `Invalidate()` exists; once W1 and W2 are
+both on `main`, `Materials_StampCodes` should call it after its transaction
+commits rather than rely on the window.
+
 ## Shared-parameter data hygiene (2026-09-07)
 
 | ID | Item | Detail |

--- a/docs/UNREACHABLE_COMMANDS_TRIAGE.md
+++ b/docs/UNREACHABLE_COMMANDS_TRIAGE.md
@@ -21,13 +21,13 @@ python tools/recount_unreachable_commands.py --check    # CI gate
 
 ## Counts — re-derived 2026-09-09
 
-- **Total IExternalCommand classes**: **1721**
-- **Reached by a dispatch layer**: **1690**
+- **Total IExternalCommand classes**: **1722**
+- **Reached by a dispatch layer**: **1691**
 - **Referenced only from non-dispatch code**: **0**
 - **Named nowhere outside their own file**: **9**
 - **Ambiguous — name declared twice**: **22** (under 11 names)
 
-The four buckets partition all 1721; the script fails if they stop adding up.
+The four buckets partition all 1722; the script fails if they stop adding up.
 
 *+1 on both totals since the 2026-09-08 (WF-7) derivation:*
 `Commands/Materials/RegisterAuditCommand` (`Materials_RegisterAudit`), which is


### PR DESCRIPTION
> **This PR changes what the BOQ rate chain looks up.** The delta is stated below with its numbers, measured on the Herring model. It is **zero**, and the reason is a finding in its own right.

## What

Four places asked a wall for a parameter bound to materials:

```csharp
MatCode = ParameterHelpers.GetString(el, "MAT_CODE") ?? "",
```

`BOQCostManager:1184` and `:2816` (the rate request), `CostStamp:152` (the rate request **and** the shared rate-cache key), `MeasurementStandards:209` (the CESMM4 description). `MAT_CODE` binds to `Materials` and to nothing else — `CATEGORY_BINDINGS.csv:4693`, agreeing with four other data files — so all four returned empty for every element ever costed, and `CsvRateProvider` **"Pass 3 — MATERIAL"** (`RateProviders.cs:323`, confidence 85) has never fired.

All four now go through **one** resolver. The decision is Revit-free — `MaterialCodeResolution` takes a layer list plus a name→code map:

1. **primary layer material** → its code (`PrimaryMaterialSelector` picks the layer — no second definition of "primary")
2. the element's **single material**, only when the layers name none
3. the element's **own** `MAT_CODE`, for the day somebody binds it there
4. **empty — and empty stays empty**

**The subtlety is the whole risk.** When the layers DO name a core and that core has no code, resolution **stops**. Falling through would hand back the FINISH SKIN — a 230 mm rendered masonry wall answering "gypsum" — which is #873 exactly. A guess would ride at confidence 85, above the category match.

---

## The rate delta, measured on the Herring model

From the model's own exported artefacts (`register_audit_20260910_202805.csv`, `type_rename_core_materials_20260909.csv`) against the shipped register and `cost_rates_5d.csv`. No Revit.

| Category | types | instances | gain a `MAT_CODE` | coded instances | Pass 3 matches | old rate UGX | **delta** |
|---|---:|---:|---:|---:|---:|---:|---:|
| Floors   | 98 | 1  | **0**  | 0  | 0 | 444,000 | **0** |
| Roofs    | 96 | 11 | **88** | 0  | 0 | 555,000 | **0** |
| Walls    | 96 | 61 | **49** | 48 | 0 | 315,000 | **0** |
| Ceilings | 4  | 0  | **0**  | 0  | 0 | 166,500 | **0** |
| **Total** | **294** | **73** | **137** | **48** | **0** | | **0 UGX** |

**137 host types gain a `MAT_CODE`. Zero rates change.** The reason is exact, and it is the same defect this work was opened for, one file over:

> **Not one of the register's 1,279 codes is a key in `cost_rates_5d.csv`.**
> The register issues `FLR-028`, `CLG-052`, `WL-128`. The rate table has a column **called** `MAT_CODE` holding 43 three-letter, PROD-shaped abbreviations — `FLR`, `CLG`, `WAL`, `AHU`. One column name, two vocabularies, empty intersection.

Pass 3 *can* now fire and still *does* not. Those are different sentences, and the difference is the deliverable: before W2 the lookup was dead at the key; now it is dead at the table, which is a place a QS can fix by editing a rate card.

**Floors gain nothing, and that is the 87-type finding again** — 90 of the 98 floor types have the core material `Concrete, Cast-in-Place gray`, a Revit stock material absent from the register.

**Pinned, not fixed.** `The_Shipped_Rate_Table_Shares_No_Key_With_The_Register` asserts the empty intersection and fails loudly, **naming the codes**, the moment one crosses over. Changing 43 rate keys IS a cost change and needs its own evidence; this guarantees nobody makes it by accident.

### Two other behaviour changes, stated so they don't pass unremarked

- `CostStamp`'s shared rate cache is keyed `{category}|{disc}|{prod}|{matCode}|{unit}`. A previously-constant empty segment now varies, so the cache **partitions more finely** and can no longer merge two elements differing only by material.
- Every CESMM4 description said `"{category}; as drawn"` with no material named. It will now name the code where one resolves.

## RED and GREEN — by sabotage, both counts

```
A_Layered_Element_Answers_With_Its_CORE
  RED    first layer instead of the selector      WL-SKIN   (4 of 13 fail)
  GREEN                                           WL-CORE

A_Layered_Element_Whose_Core_Has_No_Code_Does_Not_Fall_Back_To_The_Skin
  RED    fall-through restored                    WL-SKIN   (1 of 13 fails)
  GREEN                                           ""

The_Shipped_Rate_Table_Shares_No_Key_With_The_Register
  RED    one row keying FLR-028 added to the rate table — fails, names
         FLR-028, demands the mover count what moved   (2 of 13 fail)
  GREEN  0 of 1,279
```

| | before | after |
|---|---|---|
| `dotnet build` | 0 err / 0 warn | 0 err / 0 warn |
| `StingTools.Boq.Tests` | 1,311 | **1,324** |
| `StingTools.Tags.Tests` | 919 | 919 |

## Left alone deliberately, logged in ROADMAP

`UI/IfcMaterialPsetWriter.cs:69` carries a **second** `ReadPrimaryMaterialName` that skips the compound structure entirely and returns the first material — #873's defect, still live, in a second place, and it is what gets written into `Pset_StingMaterial`. Out of scope for a cost change. Logged as **MC-2**, with MC-1 (the vocabulary split), MC-3 (the concrete floors) and MC-4 (the memo's TTL).

## Not verified in Revit

`deploy.bat` was **not** run. `ElementMatCodeReader` — the compound-structure read, the single-material read, the memoised name→code map and its 30-second stale window — is **entirely unexercised against a live document**. Every defect this area has produced has lived in the Revit-bound half, and this is the Revit-bound half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
