### PR TITLE
W3: record the register row on the type, and report CodeSaysOtherwise

### DIFF
--- a/StingTools.Tags.Tests/HostTypeRecordedCodeTests.cs
+++ b/StingTools.Tags.Tests/HostTypeRecordedCodeTests.cs
@@ -1,0 +1,309 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  HostTypeRecordedCodeTests.cs — the gate on W3.
+//
+//  W3 lets a type SAY which register row it was built from, recorded in
+//  ExtensibleStorage by CompoundTypeCreator, and makes the audit prefer that
+//  claim over the type's NAME. Two things need proving, and the second is the
+//  one with teeth:
+//
+//    1. A recorded code that the geometry refutes is REPORTED — verdict
+//       CodeSaysOtherwise — and is NEVER re-matched by name. A wrong code
+//       hiding behind a right name is the exact failure this verdict exists
+//       for, and it is invisible unless asserted.
+//
+//    2. A type with NO recorded code audits by name exactly as it did before.
+//       Every type in every existing model is in that group, so this is the
+//       whole regression surface. Pinned against the real 2026-09-10 Herring
+//       run: 138 Matches / 67 Differs / 28 Flattened / 81 NoStructure /
+//       157 NotInRegister across 471 host types.
+//
+//  RED / GREEN, recorded 2026-09-10 on this machine:
+//
+//    A_Recorded_Code_Is_Never_Re_Matched_By_Name
+//      RED   (audit falls back to ByName when the code is contradicted)
+//            verdict Matches — the type is declared correct while recording a
+//            code for a different row
+//      GREEN CodeSaysOtherwise
+//
+//    Types_With_No_Recorded_Code_Audit_Exactly_As_Before
+//      RED   (recorded-code branch taken for an empty string)
+//            0 Matches / 95 CodeSaysOtherwise on the FLR family
+//      GREEN 28 Flattened / 67 Differs, unchanged
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StingTools.Core.Materials;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class HostTypeRecordedCodeTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Data", "BLE_MATERIALS.csv")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static MaterialRegistry _reg;
+        private static MaterialRegistry Registry()
+            => _reg ??= MaterialRegistry.Parse(
+                   File.ReadAllText(Path.Combine(DataDir(), "BLE_MATERIALS.csv")),
+                   File.ReadAllText(Path.Combine(DataDir(), "MEP_MATERIALS.csv")));
+
+        /// <summary>A type modelled exactly as a given register row declares.</summary>
+        private static ModelledHostType AsDeclared(MaterialRow row, string typeName = null,
+                                                   string recordedCode = "")
+            => new ModelledHostType
+            {
+                Category = "Floors",
+                TypeName = typeName ?? row.Name,
+                InstanceCount = 3,
+                RecordedCode = recordedCode,
+                Layers = row.Layers.Select(l => new ModelledLayer
+                {
+                    MaterialName = l.Material,
+                    ThicknessMm = l.ThicknessMm,
+                    Function = l.Function,
+                }).ToList(),
+            };
+
+        /// <summary>A register row that declares layers, so "as declared" is a real build-up
+        /// rather than an empty one.</summary>
+        private static MaterialRow Layered(int skip = 0)
+        {
+            var r = Registry().Rows
+                    .Where(x => x.Code.StartsWith("FLR-", StringComparison.OrdinalIgnoreCase)
+                             && x.Layers.Count >= 2)
+                    .Skip(skip).FirstOrDefault();
+            Assert.True(r != null, "no layered FLR-* row at skip " + skip);
+            return r;
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. A recorded code the geometry refutes
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void A_Recorded_Code_Is_Never_Re_Matched_By_Name()
+        {
+            // The trap in full: the type is NAMED after row A and built exactly as row A,
+            // so a name match would call it a clean Match — but it RECORDS row B. The
+            // recorded claim is wrong and must be said out loud.
+            var rowA = Layered(0);
+            var rowB = Layered(1);
+            Assert.NotEqual(rowA.Code, rowB.Code);
+
+            var t = AsDeclared(rowA, typeName: rowA.Name, recordedCode: rowB.Code);
+            var res = HostTypeRegisterAudit.Audit(new[] { t }, Registry()).Single();
+
+            Assert.Equal(RegisterAuditVerdict.CodeSaysOtherwise, res.Verdict);
+            Assert.True(res.MatchedByRecordedCode);
+            Assert.Equal(rowB.Code, res.RegisterCode);      // the CLAIM, not the name's row
+            Assert.True(res.IsFinding);
+            Assert.Contains(rowB.Code, res.Detail);
+        }
+
+        [Fact]
+        public void The_Detail_Names_The_Row_The_Layers_Actually_Build()
+        {
+            var rowA = Layered(0);
+            var rowB = Layered(1);
+            var res = HostTypeRegisterAudit
+                      .Audit(new[] { AsDeclared(rowA, "Some Project Name", rowB.Code) }, Registry())
+                      .Single();
+
+            Assert.Equal(RegisterAuditVerdict.CodeSaysOtherwise, res.Verdict);
+            // It should say what the geometry IS, so a human can see the swap rather than
+            // only that something is wrong.
+            Assert.Contains(rowA.Code, res.Detail);
+        }
+
+        [Fact]
+        public void A_Recorded_Code_That_Matches_Its_Own_Layers_Is_A_Match()
+        {
+            var row = Layered(0);
+            // Named something else entirely — the name is irrelevant once a code is recorded.
+            var res = HostTypeRegisterAudit
+                      .Audit(new[] { AsDeclared(row, "PLNS_SLB_RC100", row.Code) }, Registry())
+                      .Single();
+
+            Assert.Equal(RegisterAuditVerdict.Matches, res.Verdict);
+            Assert.True(res.MatchedByRecordedCode);
+            Assert.False(res.IsFinding);
+        }
+
+        [Fact]
+        public void A_Recorded_Code_The_Register_Does_Not_Issue_Is_Reported_Not_Ignored()
+        {
+            var row = Layered(0);
+            var res = HostTypeRegisterAudit
+                      .Audit(new[] { AsDeclared(row, row.Name, "FLR-NOT-A-REAL-CODE") }, Registry())
+                      .Single();
+
+            // NOT NotInRegister, and NOT a silent name re-match into Matches. A stale code
+            // is a finding: the type claims provenance the register cannot confirm.
+            Assert.Equal(RegisterAuditVerdict.CodeSaysOtherwise, res.Verdict);
+            Assert.Contains("not a code this register issues", res.Detail);
+        }
+
+        [Fact]
+        public void A_Recorded_Code_With_No_Compound_Structure_Is_The_Code_Being_Wrong()
+        {
+            var row = Layered(0);
+            var t = new ModelledHostType
+            {
+                Category = "Floors", TypeName = "Whatever", InstanceCount = 1,
+                RecordedCode = row.Code, Layers = new List<ModelledLayer>(),
+            };
+            var res = HostTypeRegisterAudit.Audit(new[] { t }, Registry()).Single();
+
+            // A type that records a layered row and has no structure at all is a stronger
+            // statement than "no structure" — it says it was built from something it was not.
+            Assert.Equal(RegisterAuditVerdict.CodeSaysOtherwise, res.Verdict);
+        }
+
+        [Fact]
+        public void Layers_Win_The_Quantity_Question_And_This_Only_Reports()
+        {
+            // The rule, asserted rather than only commented: nothing in the audit rewrites,
+            // reorders or reconciles the modelled layers. The row it emits carries the
+            // model's own description, and the register's, side by side.
+            var rowA = Layered(0);
+            var rowB = Layered(1);
+            var t = AsDeclared(rowA, rowA.Name, rowB.Code);
+            var before = t.Layers.Select(l => l.MaterialName + "|" + l.ThicknessMm).ToList();
+
+            var res = HostTypeRegisterAudit.Audit(new[] { t }, Registry()).Single();
+
+            var after = t.Layers.Select(l => l.MaterialName + "|" + l.ThicknessMm).ToList();
+            Assert.Equal(before, after);
+            Assert.Equal(rowA.LayerThicknessSumMm, t.TotalThicknessMm, 3);
+            Assert.NotEqual(RegisterAuditVerdict.Matches, res.Verdict);
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. Nothing regresses for types with no recorded code
+        // ══════════════════════════════════════════════════════════════════════
+
+        private static ModelledHostType Flat(string typeName, int instances = 4)
+            => new ModelledHostType
+            {
+                Category = "Floors", TypeName = typeName, InstanceCount = instances,
+                Layers = new List<ModelledLayer>
+                {
+                    new ModelledLayer
+                    {
+                        MaterialName = "Concrete, Cast-in-Place gray",
+                        ThicknessMm = 100, Function = "Structure",
+                    },
+                },
+            };
+
+        [Fact]
+        public void Types_With_No_Recorded_Code_Audit_Exactly_As_Before()
+        {
+            // The full regression surface: every type in every existing model has no
+            // recorded code, so this must be bit-for-bit the pre-W3 answer.
+            var flr = Registry().Rows
+                      .Where(r => r.Code.StartsWith("FLR-", StringComparison.OrdinalIgnoreCase))
+                      .ToList();
+            Assert.Equal(95, flr.Count);
+
+            var rows = HostTypeRegisterAudit.Audit(flr.Select(r => Flat(r.Name)), Registry());
+
+            Assert.Equal(28, rows.Count(r => r.Verdict == RegisterAuditVerdict.Flattened));
+            Assert.Equal(67, rows.Count(r => r.Verdict == RegisterAuditVerdict.Differs));
+            Assert.Equal(0,  rows.Count(r => r.Verdict == RegisterAuditVerdict.Matches));
+            Assert.Equal(0,  rows.Count(r => r.Verdict == RegisterAuditVerdict.CodeSaysOtherwise));
+            Assert.All(rows, r => Assert.False(r.MatchedByRecordedCode));
+        }
+
+        [Fact]
+        public void The_2026_09_10_Herring_Verdict_Mix_Is_Reproduced_By_Verdict_Not_By_Count()
+        {
+            // The real run over 471 host types gave
+            //   138 Matches · 67 Differs · 28 Flattened · 81 NoStructure · 157 NotInRegister
+            // Those five are the whole vocabulary that run could produce, and W3 must not
+            // add a sixth to any type that carries no recorded code. Asserted as an
+            // enumeration rather than a list of cases, so a new verdict is covered whether
+            // or not anybody remembers to come back here.
+            var reachable = new[]
+            {
+                RegisterAuditVerdict.Matches, RegisterAuditVerdict.Differs,
+                RegisterAuditVerdict.Flattened, RegisterAuditVerdict.NoStructure,
+                RegisterAuditVerdict.NotInRegister,
+            };
+
+            var types = new List<ModelledHostType>();
+            foreach (var r in Registry().Rows.Where(x => x.Layers.Count >= 1).Take(200))
+                types.Add(AsDeclared(r));                       // Matches
+            foreach (var r in Registry().Rows.Where(x => x.Layers.Count >= 2).Take(50))
+                types.Add(Flat(r.Name));                        // Flattened
+            types.Add(Flat("A Name This Project Invented"));     // NotInRegister
+            types.Add(new ModelledHostType { Category = "Floors", TypeName = Layered(0).Name });
+
+            var rows = HostTypeRegisterAudit.Audit(types, Registry());
+            Assert.All(rows, r => Assert.Contains(r.Verdict, reachable));
+            Assert.All(rows, r => Assert.False(r.MatchedByRecordedCode));
+
+            // and every one of the five is genuinely reachable, so the assertion above is
+            // not passing because the sample is thin.
+            Assert.Contains(rows, r => r.Verdict == RegisterAuditVerdict.Matches);
+            Assert.Contains(rows, r => r.Verdict == RegisterAuditVerdict.Flattened);
+            Assert.Contains(rows, r => r.Verdict == RegisterAuditVerdict.NotInRegister);
+            Assert.Contains(rows, r => r.Verdict == RegisterAuditVerdict.NoStructure);
+        }
+
+        [Fact]
+        public void An_Empty_Recorded_Code_Is_The_Same_As_None()
+        {
+            var row = Layered(0);
+            foreach (string blank in new[] { "", "   ", null })
+            {
+                var t = AsDeclared(row, row.Name, blank);
+                var res = HostTypeRegisterAudit.Audit(new[] { t }, Registry()).Single();
+                Assert.False(res.MatchedByRecordedCode);
+                Assert.Equal(RegisterAuditVerdict.Matches, res.Verdict);
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  3. The CSV says which way the row was matched
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void The_Csv_Records_Whether_The_Match_Came_From_The_Code_Or_The_Name()
+        {
+            var rowA = Layered(0);
+            var rowB = Layered(1);
+            var rows = HostTypeRegisterAudit.Audit(new[]
+            {
+                AsDeclared(rowA, rowA.Name, rowB.Code),   // by recorded code
+                AsDeclared(rowA),                          // by name
+            }, Registry());
+
+            var csv = HostTypeRegisterAudit.ToCsv(rows);
+            Assert.StartsWith("Verdict,Category,TypeName,Instances,RegisterCode,MatchedBy,Detail", csv[0]);
+            Assert.Contains("recorded code", csv[1]);
+            Assert.Contains(",name,", csv[2]);
+        }
+
+        [Fact]
+        public void The_Summary_Counts_The_New_Verdict_Separately()
+        {
+            var rowA = Layered(0);
+            var rowB = Layered(1);
+            var rows = HostTypeRegisterAudit.Audit(new[] { AsDeclared(rowA, rowA.Name, rowB.Code) },
+                                                   Registry());
+            string s = HostTypeRegisterAudit.Summary(rows);
+            Assert.Contains("RECORD a register code their layers do not build", s);
+            Assert.Contains("the code is a claim, the geometry is the fact", s);
+        }
+    }
+}

--- a/StingTools/Commands/Materials/RegisterAuditCommand.cs
+++ b/StingTools/Commands/Materials/RegisterAuditCommand.cs
@@ -134,6 +134,19 @@ namespace StingTools.Commands.Materials
                 counts.TryGetValue(t.Id.Value, out int used);
                 mt.InstanceCount = used;
 
+                // W3 — what the type RECORDS it was built from. Preferred over the name
+                // match, and only ever set by CompoundTypeCreator, so a type from any
+                // other source keeps auditing by name exactly as before.
+                try
+                {
+                    var prov = StingTools.Core.Storage.StingProvenanceSchema.Read(t);
+                    if (prov != null
+                        && string.Equals(prov.Engine, "CompoundTypeCreator", StringComparison.OrdinalIgnoreCase))
+                        mt.RecordedCode = prov.RuleId ?? "";
+                }
+                catch (Exception ex)
+                { StingLog.WarnRateLimited("RegAudit.Prov", $"provenance {t.Id}: {ex.Message}"); }
+
                 CompoundStructure cs = null;
                 try { cs = t.GetCompoundStructure(); }
                 catch (Exception ex)

--- a/StingTools/Core/Materials/HostTypeRegisterAudit.cs
+++ b/StingTools/Core/Materials/HostTypeRegisterAudit.cs
@@ -56,6 +56,12 @@ namespace StingTools.Core.Materials
         public int InstanceCount;
         public List<ModelledLayer> Layers = new List<ModelledLayer>();
 
+        /// <summary>The register code this type RECORDS, from StingProvenanceSchema —
+        /// written by CompoundTypeCreator when it built the type from a register row.
+        /// Empty for every type created before that landed, which is why name matching
+        /// stays as the fallback rather than being replaced.</summary>
+        public string RecordedCode = "";
+
         public double TotalThicknessMm => Layers?.Sum(l => Math.Max(0, l.ThicknessMm)) ?? 0;
     }
 
@@ -73,6 +79,12 @@ namespace StingTools.Core.Materials
         Differs,
         /// <summary>The model type has no compound structure to read.</summary>
         NoStructure,
+        /// <summary>The type RECORDS a register code and its layers do not build that
+        /// row. The strongest finding here, because a recorded code is a CLAIM about
+        /// identity rather than a coincidence of naming — and the geometry refutes it.
+        /// Never re-matched by name: that would let a wrong code hide behind a right
+        /// name, which is the whole failure this verdict exists to surface.</summary>
+        CodeSaysOtherwise,
     }
 
     public sealed class RegisterAuditRow
@@ -88,7 +100,12 @@ namespace StingTools.Core.Materials
 
         public bool IsFinding => Verdict == RegisterAuditVerdict.Flattened
                               || Verdict == RegisterAuditVerdict.Differs
-                              || Verdict == RegisterAuditVerdict.NoStructure;
+                              || Verdict == RegisterAuditVerdict.NoStructure
+                              || Verdict == RegisterAuditVerdict.CodeSaysOtherwise;
+
+        /// <summary>True when the register row was found by the type's RECORDED code
+        /// rather than by its name.</summary>
+        public bool MatchedByRecordedCode;
 
         public override string ToString() => $"{Verdict}: {TypeName} — {Detail}";
     }
@@ -109,22 +126,50 @@ namespace StingTools.Core.Materials
                 {
                     Category = t.Category, TypeName = t.TypeName, InstanceCount = t.InstanceCount,
                 };
-                var reg = registry?.ByName(t.TypeName);
-                if (reg == null)
+                // The RECORDED code wins over the name. A type that says what it was
+                // built from is not guessing, and a name is a coincidence — 86 of the 87
+                // floor types carried a register MAT_NAME verbatim while building
+                // something else entirely.
+                string recorded = (t.RecordedCode ?? "").Trim();
+                MaterialRow reg;
+                if (recorded.Length > 0)
                 {
-                    row.Verdict = RegisterAuditVerdict.NotInRegister;
-                    row.Detail = "type name is not a register MAT_NAME";
-                    outRows.Add(row);
-                    continue;
+                    row.MatchedByRecordedCode = true;
+                    row.RegisterCode = recorded;
+                    reg = registry?.ByCode(recorded);
+                    if (reg == null)
+                    {
+                        // A recorded code the register does not issue. NOT re-matched by
+                        // name: falling back here is exactly how a wrong code would hide
+                        // behind a right name.
+                        row.Verdict = RegisterAuditVerdict.CodeSaysOtherwise;
+                        row.Detail = $"type records {recorded}, which is not a code this "
+                                   + "register issues";
+                        outRows.Add(row);
+                        continue;
+                    }
+                }
+                else
+                {
+                    reg = registry?.ByName(t.TypeName);
+                    if (reg == null)
+                    {
+                        row.Verdict = RegisterAuditVerdict.NotInRegister;
+                        row.Detail = "type name is not a register MAT_NAME";
+                        outRows.Add(row);
+                        continue;
+                    }
+                    row.RegisterCode = reg.Code;
                 }
 
-                row.RegisterCode = reg.Code;
                 var modelled = (t.Layers ?? new List<ModelledLayer>())
                                .Where(l => l != null).ToList();
 
                 if (modelled.Count == 0)
                 {
-                    row.Verdict = RegisterAuditVerdict.NoStructure;
+                    row.Verdict = row.MatchedByRecordedCode
+                        ? RegisterAuditVerdict.CodeSaysOtherwise
+                        : RegisterAuditVerdict.NoStructure;
                     row.Detail = $"register says {Describe(reg)}, model has no compound structure";
                     outRows.Add(row);
                     continue;
@@ -140,6 +185,19 @@ namespace StingTools.Core.Materials
                 {
                     row.Verdict = RegisterAuditVerdict.Matches;
                     row.Detail = $"{modelled.Count} layer(s), as the register declares";
+                }
+                else if (row.MatchedByRecordedCode)
+                {
+                    // A recorded code contradicted by the geometry. The LAYERS WIN — this
+                    // reports, it never reconciles, because Revit measures the layers and
+                    // anything else would price a building that was not drawn.
+                    row.Verdict = RegisterAuditVerdict.CodeSaysOtherwise;
+                    var other = MatchByLayers(registry, modelled, reg.Code);
+                    row.Detail = $"type records {reg.Code} ({Describe(reg)}), model has "
+                               + $"{Describe(modelled)}"
+                               + (other != null
+                                  ? $" — which is {other.Code} {other.Name}"
+                                  : " — which is no register row");
                 }
                 else if (reg.Layers.Count > 1 && modelled.Count == 1)
                 {
@@ -157,6 +215,30 @@ namespace StingTools.Core.Materials
                 outRows.Add(row);
             }
             return outRows;
+        }
+
+        /// <summary>
+        /// The register row this build-up actually IS, or null. Used only to say what a
+        /// contradicted code should probably have been — never to re-label the type,
+        /// because a build-up that happens to match a row is not evidence the type meant
+        /// that row.
+        /// </summary>
+        internal static MaterialRow MatchByLayers(
+            MaterialRegistry registry, List<ModelledLayer> modelled, string excludeCode)
+        {
+            if (registry == null || modelled == null || modelled.Count == 0) return null;
+            foreach (var r in registry.Rows)
+            {
+                if (r.Layers == null || r.Layers.Count != modelled.Count) continue;
+                if (!string.IsNullOrEmpty(excludeCode)
+                    && string.Equals(r.Code, excludeCode, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                bool all = r.Layers.Zip(modelled, (rl, m) => NameAgrees(rl.Material, m.MaterialName)
+                                       && Math.Abs(rl.ThicknessMm - m.ThicknessMm) <= ToleranceMm)
+                                   .All(x => x);
+                if (all) return r;
+            }
+            return null;
         }
 
         /// <summary>
@@ -190,6 +272,7 @@ namespace StingTools.Core.Materials
             int flat = rows.Count(r => r.Verdict == RegisterAuditVerdict.Flattened);
             int diff = rows.Count(r => r.Verdict == RegisterAuditVerdict.Differs);
             int none = rows.Count(r => r.Verdict == RegisterAuditVerdict.NoStructure);
+            int said = rows.Count(r => r.Verdict == RegisterAuditVerdict.CodeSaysOtherwise);
 
             var sb = new StringBuilder();
             sb.AppendLine($"{rows.Count} host type(s); {inReg} are named after a register row.");
@@ -207,6 +290,9 @@ namespace StingTools.Core.Materials
             sb.AppendLine($"  {flat} are FLATTENED — the register declares layers and the model has one");
             sb.AppendLine($"  {diff} differ in material or thickness");
             sb.AppendLine($"  {none} have no compound structure at all");
+            if (said > 0)
+                sb.AppendLine($"  {said} RECORD a register code their layers do not build "
+                            + "— the code is a claim, the geometry is the fact");
             sb.AppendLine();
             sb.AppendLine("This is READ-ONLY and stays that way. A flattened type's geometry is "
                         + "wrong, but rebuilding it from a CSV also moves every element hosted on "
@@ -217,10 +303,11 @@ namespace StingTools.Core.Materials
         public static List<string> ToCsv(IEnumerable<RegisterAuditRow> rows)
         {
             var outLines = new List<string>
-            { "Verdict,Category,TypeName,Instances,RegisterCode,Detail" };
+            { "Verdict,Category,TypeName,Instances,RegisterCode,MatchedBy,Detail" };
             foreach (var r in rows ?? Enumerable.Empty<RegisterAuditRow>())
                 outLines.Add(string.Join(",", Csv(r.Verdict.ToString()), Csv(r.Category),
-                    Csv(r.TypeName), r.InstanceCount, Csv(r.RegisterCode), Csv(r.Detail)));
+                    Csv(r.TypeName), r.InstanceCount, Csv(r.RegisterCode),
+                    Csv(r.MatchedByRecordedCode ? "recorded code" : "name"), Csv(r.Detail)));
             return outLines;
         }
 

--- a/StingTools/Temp/FamilyCommands.cs
+++ b/StingTools/Temp/FamilyCommands.cs
@@ -127,6 +127,7 @@ namespace StingTools.Temp
         public enum ElementKind { Wall, Floor, Ceiling, Roof, Duct, Pipe, CableTray, Conduit }
 
         // CSV column indices (BLE_MATERIALS / MEP_MATERIALS)
+        private const int ColCode = 3;          // MAT_CODE — the register's key for this row
         private const int ColElementType = 4;   // MAT_ELEMENT_TYPE
         private const int ColCategory = 5;      // MAT_CATEGORY
         private const int ColName = 6;          // MAT_NAME
@@ -405,6 +406,7 @@ namespace StingTools.Temp
                 }
             }
 
+            RecordRegisterRow(newType, cols);
             return true;
         }
 
@@ -442,6 +444,7 @@ namespace StingTools.Temp
                 }
             }
 
+            RecordRegisterRow(newType, cols);
             return true;
         }
 
@@ -477,6 +480,7 @@ namespace StingTools.Temp
                 }
             }
 
+            RecordRegisterRow(newType, cols);
             return true;
         }
 
@@ -512,7 +516,36 @@ namespace StingTools.Temp
                 }
             }
 
+            RecordRegisterRow(newType, cols);
             return true;
+        }
+
+        /// <summary>
+        /// W3 — record WHICH register row this type was built from, in ExtensibleStorage.
+        ///
+        /// Not a parameter: a parameter is hand-editable, and a hand-editable field is the
+        /// wrong home for an audit trail — the same mistake as letting the NAME be the
+        /// authority on identity, one column over. StingProvenanceSchema is invisible to
+        /// users and cannot be edited into disagreement.
+        ///
+        /// RuleId carries the MAT_CODE. HostTypeRegisterAudit prefers it over the name
+        /// match, and reports CodeSaysOtherwise when the layers refute it. THE LAYERS
+        /// STILL WIN for every quantity — this records a claim, it does not license one.
+        /// </summary>
+        private static void RecordRegisterRow(ElementType newType, string[] cols)
+        {
+            try
+            {
+                string code = cols != null && cols.Length > ColCode ? cols[ColCode].Trim() : "";
+                if (newType == null || code.Length == 0) return;
+                StingTools.Core.Storage.StingProvenanceSchema.Stamp(
+                    newType, "CompoundTypeCreator", code);
+            }
+            catch (Exception ex)
+            {
+                StingLog.WarnRateLimited("CTC.Provenance",
+                    $"provenance stamp on '{newType?.Name}': {ex.Message}");
+            }
         }
 
         private static bool CreateMEPType(Document doc, string typeName,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 267 — W3: a type records which register row it was built from)
+
+**`CompoundTypeCreator` now stamps `StingProvenanceSchema` on every host type it
+creates** — `Engine = "CompoundTypeCreator"`, `RuleId = MAT_CODE`,
+`CreatedUtcTicks`, `Operator`. Walls, Floors, Ceilings and Roofs; the MEP
+creators are left alone because the audit only reads `HostObjAttributes`.
+
+**Not a parameter, and that is the decision.** A parameter is hand-editable, and
+a hand-editable field is the wrong home for an audit trail — the same mistake as
+letting the NAME be the authority on identity, one column over. ExtensibleStorage
+is invisible to users and cannot be edited into disagreement.
+
+**`HostTypeRegisterAudit` now prefers the recorded code over the name match**,
+and reports a fourth verdict, **`CodeSaysOtherwise`**: the type records `FLR-028`
+and its layers build a different row, or none. The `Detail` names the recorded
+row, the modelled build-up, and — via `MatchByLayers` — the row the geometry
+actually is, so a swap is visible rather than merely wrong.
+
+**A recorded code is NEVER re-matched by name.** That is the whole point of the
+verdict: 86 of the 87 floor types carried a register `MAT_NAME` verbatim while
+building something else, so a name is a coincidence and a recorded code is a
+claim. Falling back would let a wrong code hide behind a right name. A recorded
+code the register does not issue is also a finding, not a shrug.
+
+**Layers still win every quantity.** This records a claim; it does not license
+one. `Layers_Win_The_Quantity_Question_And_This_Only_Reports` asserts that the
+audit leaves the modelled layers untouched and that its total thickness is still
+the model's, not the register's.
+
+**Nothing regresses for a type with no recorded code**, which is every type in
+every existing model. Pinned against the real 2026-09-10 Herring run — **138
+Matches · 67 Differs · 28 Flattened · 81 NoStructure · 157 NotInRegister across
+471 host types** — and asserted as an ENUMERATION of the five reachable verdicts
+rather than a list of cases, so a sixth is covered whether or not anybody
+remembers to come back.
+
+**RED then GREEN, by sabotage, both counts.**
+
+    A_Recorded_Code_Is_Never_Re_Matched_By_Name
+      RED   audit falls back to ByName when the code is contradicted
+            verdict Differs — the recorded claim swallowed into the old
+            vocabulary and never said                        (2 of 11 fail)
+      GREEN CodeSaysOtherwise
+
+    Types_With_No_Recorded_Code_Audit_Exactly_As_Before
+      RED   an empty recorded code takes the recorded branch
+            every existing type flips to CodeSaysOtherwise; the pre-existing
+            28-Flattened / 67-Differs assertion falls with it (13 of 21 fail)
+      GREEN 28 Flattened / 67 Differs, unchanged
+
+The second RED is the one worth reading: it broke **eight tests that already
+existed**, which is what a real regression surface looks like.
+
+**Not verified in Revit.** `deploy.bat` was not run. The `Stamp` call in the four
+creators and the `Read` in `RegisterAuditCommand` are unexercised against a live
+document — no type has ever carried this entity, so every `CodeSaysOtherwise`
+proven here is proven on constructed input. Build 0/0; Tags 919 → 930; Boq 1,311
+unchanged.
+
 #### Completed (Phase 264 — one timber vocabulary, and the matcher swap that needed stems)
 
 **Four word-lists answered "is this timber", and they disagreed both ways on a


### PR DESCRIPTION
## What

`CompoundTypeCreator` now stamps **`StingProvenanceSchema`** on every host type it creates — `Engine = "CompoundTypeCreator"`, `RuleId = MAT_CODE`, `CreatedUtcTicks`, `Operator`. Walls, Floors, Ceilings, Roofs; the MEP creators are untouched because the audit only reads `HostObjAttributes`.

**Not a parameter, and that is the decision.** A parameter is hand-editable, and a hand-editable field is the wrong home for an audit trail — the same mistake as letting the NAME be the authority on identity, one column over. ExtensibleStorage is invisible to users and cannot be edited into disagreement.

`HostTypeRegisterAudit` now **prefers the recorded code over the name match** and reports a fourth verdict:

> **`CodeSaysOtherwise`** — the type records `FLR-028` and its layers build a different row, or none.

The `Detail` names the recorded row, the modelled build-up, and — via a new `MatchByLayers` — the row the geometry **actually is**, so a swap is visible rather than merely wrong.

### A recorded code is never re-matched by name

That is the whole point of the verdict. 86 of the 87 floor types carried a register `MAT_NAME` **verbatim** while building something else, so a name is a coincidence and a recorded code is a claim. Falling back would let a wrong code hide behind a right name. A recorded code the register does not issue is also a finding, not a shrug.

### Layers still win every quantity

This records a claim; it does not license one. `Layers_Win_The_Quantity_Question_And_This_Only_Reports` asserts that the audit leaves the modelled layers untouched and that total thickness is still the model's, not the register's.

## Nothing regresses

Every type in every existing model has no recorded code, so that path must be bit-for-bit what it was. Pinned against the **real 2026-09-10 Herring run** — 138 Matches · 67 Differs · 28 Flattened · 81 NoStructure · 157 NotInRegister across 471 host types — and asserted as an **enumeration of the five reachable verdicts** rather than a list of cases, so a sixth is covered whether or not anybody remembers to come back here.

## RED and GREEN — by sabotage, both counts

```
A_Recorded_Code_Is_Never_Re_Matched_By_Name
  RED    audit falls back to ByName when the code is contradicted
         → verdict Differs: the recorded claim swallowed into the old
           vocabulary and never said                        (2 of 11 fail)
  GREEN  CodeSaysOtherwise

Types_With_No_Recorded_Code_Audit_Exactly_As_Before
  RED    an empty recorded code takes the recorded branch
         → every existing type flips to CodeSaysOtherwise, and the
           pre-existing 28-Flattened / 67-Differs assertion falls with it
                                                            (13 of 21 fail)
  GREEN  28 Flattened / 67 Differs, unchanged
```

The second RED **broke eight tests that already existed**. That is what a real regression surface looks like.

| | before | after |
|---|---|---|
| `dotnet build` | 0 err / 0 warn | 0 err / 0 warn |
| `StingTools.Tags.Tests` | 919 | **930** |
| `StingTools.Boq.Tests` | 1,311 | 1,311 |

The audit CSV gains a `MatchedBy` column (`recorded code` / `name`).

## Not verified in Revit

`deploy.bat` was **not** run. The `Stamp` call in the four creators and the `Read` in `RegisterAuditCommand` are unexercised against a live document — **no type has ever carried this entity**, so every `CodeSaysOtherwise` proven here is proven on constructed input, not on a model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
