### PR TITLE
KUT: finish the defect class — a failed read is never an empty one

### DIFF
--- a/.github/workflows/kut-workflow-tags.yml
+++ b/.github/workflows/kut-workflow-tags.yml
@@ -1,0 +1,65 @@
+name: KUT Workflow Tag Gate
+
+# Every step of every shipped KUT workflow must resolve to a real command.
+#
+# WHY THIS RUNS IN CI
+# A workflow step whose `commandTag` is not a `case` label in
+# WorkflowEngine.ResolveCommand parses perfectly, runs, and does NOTHING. So does a
+# step that spells its keys `command` / `name` instead of `commandTag` / `label`.
+# Neither produces an error, a warning or a log line: the run reports success having
+# skipped the step. On KUT those ten workflows are the fortnightly coordination
+# rhythm and the deliverable gates, so a silently-skipped step is a coordination
+# cycle nobody performed and a gate nobody ran.
+#
+# tools/check_kut_workflow_tags.py was written to catch exactly that, and it works —
+# but until this file, nothing ran it. A checker nobody runs rots: the first edit
+# that moves ResolveCommand or renames a tag would go unnoticed for as long as it
+# took someone to remember the script existed. That is the same failure shape as
+# issue #553, where two test projects stopped compiling and reported nothing for two
+# and a half months.
+#
+# WHAT THE CHECKER PROVES (see its docstring for the detail)
+#   * its own extraction window still holds exactly one `switch (tag)` reaching
+#     `default: return null;` — it aborts rather than silently widening or clipping;
+#   * it discriminates: a known-good tag is found and a nonsense tag is not, asserted
+#     before any resolve rate is reported;
+#   * every step uses `commandTag` + `label`;
+#   * every tag resolves. Baseline: 97/97 across 10 files.
+#
+# WHAT IT CANNOT PROVE: that a resolving command does the right thing, or anything
+# about a real Revit model. A green run means no step is silently dead.
+#
+# NO PYTHON DEPENDENCIES. The checker is stdlib-only so it runs on a bare runner —
+# the same constraint kut-document-gate.yml works under. Keep it that way.
+
+on:
+  push:
+    paths:
+      - 'StingTools/Data/WORKFLOW_KUT_*.json'
+      - 'StingTools/Core/WorkflowEngine.cs'
+      - 'tools/check_kut_workflow_tags.py'
+      - '.github/workflows/kut-workflow-tags.yml'
+  pull_request:
+    paths:
+      - 'StingTools/Data/WORKFLOW_KUT_*.json'
+      - 'StingTools/Core/WorkflowEngine.cs'
+      - 'tools/check_kut_workflow_tags.py'
+      - '.github/workflows/kut-workflow-tags.yml'
+  workflow_dispatch:
+
+jobs:
+  kut-workflow-tags:
+    name: Every KUT workflow step resolves to a real command
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Gate the KUT workflow command tags
+        run: python tools/check_kut_workflow_tags.py .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ dated, reproducible source) instead of carrying exact numbers that re-rot within
   |---|---|---|
   | Sustainability | 365 | ✅ 438 cases, 0 failing |
   | Tags | 158 | ✅ 241 cases, **2 failing** (#554) |
-  | Boq | 121 | ✅ 196 cases, 0 failing |
+  | Boq | **956** | ✅ **1,335 cases, 0 failing** (re-measured 2026-09-10; the 121/196 was a month-stale count) |
   | Cost | 63 | ✅ 90 cases, 0 failing |
   | Clash | 56 | ✅ 64 cases, **1 failing** (#596) |
   | Routing | 41 | ✅ 45 cases, **1 failing** (#597) |
@@ -137,6 +137,11 @@ dated, reproducible source) instead of carrying exact numbers that re-rot within
   | Licensing | 14 | ✅ 14 cases, 0 failing |
   | SitePhotos | 8 | ⚠ needs a built plugin DLL first (fails loudly if absent, not silently); with it: 14 cases, **11 failing** — these assert the site-photo behaviour PR #550 delivers and #550 is not merged |
   | Connectivity | 0 | empty project |
+  | **Acc** (new 2026-09-10) | **60** | ✅ **67 cases, 0 failing** — the ACC surface had zero coverage until then |
+
+  Only the **Boq** and **Acc** rows were re-measured on 2026-09-10 (declared via the same
+  `[Fact]`/`[Theory]` census `.github/workflows/stingtools-unit-tests.yml` runs; cases via
+  `dotnet test`). Every other row is still the 2026-08-06 figure and should be assumed stale.
 
   Declared methods and *executed cases* are different metrics and get conflated: one `[Theory]`
   with `InlineData` expands into many cases, which is why the totals above do not match.
@@ -769,7 +774,12 @@ A dropdown on the **SELECT** tab that shows/hides elements by **category** and b
 
 1. `healthcare_rds.docx` template ships only as a README authoring guide
 2. MGS family stubs ship parameter specs only — real `.rfa` files come from manufacturers
-3. `TwinReadback` BACnet / OPC-UA transports are abstract stubs
+3. `TwinReadback` BACnet / OPC-UA transports are abstract stubs. That is true of
+   `Core/Twin/TwinReadback.cs:39,46` and is the whole of what it says — it is **not** the
+   Niagara story: the file-mediated path the KUT playbook actually promises
+   (`Commands/Twin/NiagaraCommands.cs` — export a point list, reconcile against a station
+   export) and a real oBIX/JSON HTTP client (`Core/Twin/NiagaraJsonClient.cs`) are both
+   built. Two of the three paths exist; only BACnet/OPC-UA is a shell.
 4. `RAD_QE_NAME_TXT` sign-off remains mandatory before radiation calculators are treated as authoritative
 5. EF migration not run yet — `dotnet ef migrations add HealthcarePack` is required
 6. No dedicated Healthcare tab in the dock panel — commands dispatch via `WorkflowEngine.ResolveCommand` and `StingCommandHandler` button tags

--- a/StingTools.Acc.Tests/AccCommandOutcomeTests.cs
+++ b/StingTools.Acc.Tests/AccCommandOutcomeTests.cs
@@ -1,0 +1,144 @@
+// The last mile: given an AccFetchResult, what does the command do and what does the
+// operator read?
+//
+// That decision is the entire point of the outcome split — a workflow step must FAIL
+// rather than pass — and until this file it lived inside two Revit-bound commands that no
+// test project can link. It was verified by reading. This covers it.
+//
+// The table is driven by Enum.GetValues<AccFetchStatus>(), not by a hand-listed set, so a
+// status member added later is covered without anyone remembering to add a case. A
+// hand-listed table is a copy of the enum that drifts silently, which is the same shape as
+// the defect being fixed.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using StingTools.V6;
+using Xunit;
+
+namespace StingTools.Acc.Tests
+{
+    public class AccCommandOutcomeTests
+    {
+        /// <summary>Words that must never appear in a FAILURE message. Each one turns
+        /// "our request was wrong" into "ACC lost the data" in a coordinator's head, and
+        /// each has a real consequence: "clash-clean" passes a coordination gate,
+        /// "not found" reads as issues deleted from the container.</summary>
+        private static readonly string[] Forbidden = { "clash-clean", "no clashes", "not found" };
+
+        private static AccFetchStatus[] AllStatuses()
+        {
+            var all = Enum.GetValues<AccFetchStatus>();
+            // A vacuous pass would be the worst outcome here: an empty enumeration makes
+            // every [Theory] below trivially true.
+            Assert.True(all.Length >= 5,
+                $"expected at least the five documented statuses, found {all.Length}. " +
+                "The enumeration is broken, so nothing below proves anything.");
+            return all;
+        }
+
+        [Fact]
+        public void EveryStatus_HasAVerdict()
+        {
+            // Verdict is an exhaustive switch expression with no discard arm, so an
+            // unhandled member throws here rather than silently taking a default meaning.
+            foreach (var status in AllStatuses())
+            {
+                var verdict = AccCommandOutcome.Verdict(status);
+                Assert.True(Enum.IsDefined(verdict), $"{status} produced an undefined verdict.");
+            }
+        }
+
+        [Fact]
+        public void EveryStatus_HasARemedy()
+        {
+            foreach (var status in AllStatuses())
+                Assert.False(string.IsNullOrWhiteSpace(AccCommandOutcome.Remedy(status)),
+                    $"{status} has no remedy text — an operator would be told what failed and not what to do.");
+        }
+
+        [Fact]
+        public void OnlyOkAndEmptyOk_Succeed()
+        {
+            var succeeding = AllStatuses()
+                .Where(s => AccCommandOutcome.Verdict(s) != AccCommandVerdict.Failed)
+                .ToList();
+
+            Assert.Equal(
+                new[] { AccFetchStatus.Ok, AccFetchStatus.EmptyOk }.OrderBy(s => s).ToList(),
+                succeeding.OrderBy(s => s).ToList());
+        }
+
+        [Fact]
+        public void Ok_Proceeds_And_EmptyOk_SucceedsWithoutProceeding()
+        {
+            // The legitimate empty case must stay legitimate. An empty container, a
+            // clash-clean model set and a station with nothing commissioned are real
+            // states; turning them into errors would be a worse bug than the original.
+            Assert.Equal(AccCommandVerdict.Proceed, AccCommandOutcome.Verdict(AccFetchStatus.Ok));
+            Assert.Equal(AccCommandVerdict.SucceededEmpty, AccCommandOutcome.Verdict(AccFetchStatus.EmptyOk));
+            Assert.False(AccCommandOutcome.IsFailure(AccFetchStatus.Ok));
+            Assert.False(AccCommandOutcome.IsFailure(AccFetchStatus.EmptyOk));
+        }
+
+        [Fact]
+        public void EveryFailingStatus_ProducesAMessageThatCannotReadAsAnEmptyResult()
+        {
+            var failing = AllStatuses().Where(AccCommandOutcome.IsFailure).ToList();
+            Assert.NotEmpty(failing);
+
+            foreach (var status in failing)
+            {
+                string msg = AccCommandOutcome.FailureMessage(
+                    "the ACC issue list", status, 404, detail: null,
+                    containerId: "b.11111111-2222-3333-4444-555555555555");
+
+                Assert.False(string.IsNullOrWhiteSpace(msg));
+                foreach (var word in Forbidden)
+                    Assert.DoesNotContain(word, msg, StringComparison.OrdinalIgnoreCase);
+
+                // It must say nothing was checked, name the failure kind, and name the
+                // container — the three facts that stop a failed read being acted on.
+                Assert.Contains("NOTHING WAS CHECKED", msg, StringComparison.Ordinal);
+                Assert.Contains(status.ToString(), msg, StringComparison.Ordinal);
+                Assert.Contains("b.11111111-2222-3333-4444-555555555555", msg, StringComparison.Ordinal);
+            }
+        }
+
+        [Fact]
+        public void FailureMessage_PrefersTheSuppliedDetail_OverTheGenericDescription()
+        {
+            string msg = AccCommandOutcome.FailureMessage("the ACC issue list",
+                AccFetchStatus.TransportFailed, 500,
+                detail: "the issue list failed at page 2 (offset 100) after 1 page(s) succeeded",
+                containerId: "b.container");
+
+            Assert.Contains("page 2", msg, StringComparison.Ordinal);
+            Assert.Contains("1 page(s) succeeded", msg, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void FailureMessage_RefusesASucceedingStatus()
+        {
+            // Calling the failure path for a success would print "NOTHING WAS CHECKED"
+            // over a perfectly good read — the mirror image of the original defect.
+            foreach (var ok in new[] { AccFetchStatus.Ok, AccFetchStatus.EmptyOk })
+                Assert.Throws<ArgumentException>(() =>
+                    AccCommandOutcome.FailureMessage("x", ok, 200, null, "b.container"));
+        }
+
+        [Fact]
+        public void Describe_NeverUsesTheForbiddenWords_ForAnyFailingStatus()
+        {
+            // AccFetchOutcome.Describe feeds FailureMessage when no detail is supplied,
+            // so it is bound by the same rule. "404 Not Found" is the HTTP reason phrase
+            // and is exactly the phrasing that invites the wrong conclusion.
+            foreach (var status in AllStatuses().Where(AccCommandOutcome.IsFailure))
+            {
+                string text = AccFetchOutcome.Describe(status, 404);
+                foreach (var word in Forbidden)
+                    Assert.DoesNotContain(word, text, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/StingTools.Acc.Tests/AccIssuePullLoopbackTests.cs
+++ b/StingTools.Acc.Tests/AccIssuePullLoopbackTests.cs
@@ -1,0 +1,238 @@
+// AccIssueSync.PullIssuesAsync, driven over a real loopback listener.
+//
+// The defect: three exits — auth failure, a mid-pagination HTTP error, and success — all
+// returned a bare List<AccIssue> the caller could not tell apart.
+// AccSyncIssueStatusCommand reconciled the escalation sidecar against that list and
+// reported every tracked clash whose issue was absent as NOT_FOUND / keep. So an expired
+// token made every escalated clash look deleted from ACC, and a page-2 failure produced a
+// PARTIAL reconciliation presented as a complete one — after which the sidecar was
+// written, permanently un-tracking whatever happened to be on page 1.
+//
+// Every assertion below asserts the STATUS, not just emptiness. Emptiness is the bug:
+// an empty list is what a successful read of an empty container also returns.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using StingTools.Acc.Tests.TestHelpers;
+using StingTools.V6;
+using Xunit;
+
+namespace StingTools.Acc.Tests
+{
+    public class AccIssuePullLoopbackTests : IDisposable
+    {
+        private const string Container = "b.11111111-2222-3333-4444-555555555555";
+
+        public AccIssuePullLoopbackTests() => AccIssueSync.DelayHook = _ => Task.CompletedTask;
+
+        public void Dispose()
+        {
+            AccIssueSync.OverrideHostForTests(null);
+            AccIssueSync.DelayHook = t => Task.Delay(t);
+        }
+
+        /// <summary>A fresh token, so EnsureAuthAsync short-circuits and no test reaches the
+        /// real Autodesk token endpoint or writes %APPDATA%\Planscape\acc_credentials.json.</summary>
+        private static AccCredentials FreshCreds() => new AccCredentials
+        {
+            ClientId = "test-client",
+            ClientSecret = "test-secret",
+            RefreshToken = "test-refresh",
+            ProjectId = Container,
+            AccessToken = "test-access-token",
+            AccessTokenExpiry = DateTime.UtcNow.AddHours(1),
+            IssueTypeId = "issue-type-clash",
+        };
+
+        /// <summary>Credentials with no usable token, so EnsureAuthAsync must attempt a
+        /// refresh — which the listener rejects.</summary>
+        private static AccCredentials StaleCreds() => new AccCredentials
+        {
+            ClientId = "test-client",
+            ClientSecret = "test-secret",
+            RefreshToken = "expired-refresh",
+            ProjectId = Container,
+            AccessToken = "",
+            AccessTokenExpiry = DateTime.UtcNow.AddHours(-1),
+        };
+
+        private static string Page(int count, string idPrefix) =>
+            "{\"results\":[" + string.Join(",", Enumerable.Range(0, count)
+                .Select(i => $"{{\"id\":\"{idPrefix}{i}\",\"title\":\"Clash {idPrefix}{i}\",\"status\":\"open\"}}"))
+            + "]}";
+
+        // ── The auth case: "every escalated clash looks deleted" ────────────────
+
+        [Fact]
+        public async Task AuthFailure_IsAuthFailed_NotAnEmptySuccess()
+        {
+            // The token endpoint rejects the refresh, so no issue is read at all.
+            using var server = LoopbackServer.Always(401, "{\"error\":\"invalid_grant\"}");
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(StaleCreds());
+
+            Assert.Equal(AccFetchStatus.AuthFailed, result.Status);
+            Assert.False(result.Succeeded);
+            Assert.NotEqual(AccFetchStatus.EmptyOk, result.Status);   // this is the bug shape
+            Assert.Empty(result.Value);
+            Assert.False(string.IsNullOrWhiteSpace(result.Detail));
+            // And the command must refuse rather than reconcile against nothing.
+            Assert.Equal(AccCommandVerdict.Failed, AccCommandOutcome.Verdict(result.Status));
+        }
+
+        [Fact]
+        public async Task Http401OnTheIssueList_IsAuthFailed()
+        {
+            using var server = LoopbackServer.Always(401, "{\"developerMessage\":\"token invalid\"}");
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.Equal(AccFetchStatus.AuthFailed, result.Status);
+            Assert.False(result.Succeeded);
+            Assert.Empty(result.Value);
+        }
+
+        // ── The partial case: a subset presented as the whole ──────────────────
+
+        [Fact]
+        public async Task FullPageThenServerError_IsAFailure_AndTheDetailNamesThePageCount()
+        {
+            using var server = new LoopbackServer((index, _) => index == 0
+                ? new CannedResponse(200, Page(2, "p1-"))     // a FULL page -> pagination continues
+                : new CannedResponse(500, "{\"error\":\"boom\"}"));
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(AccFetchStatus.TransportFailed, result.Status);
+            Assert.NotEqual(AccFetchStatus.Ok, result.Status);
+            Assert.NotEqual(AccFetchStatus.EmptyOk, result.Status);
+
+            // Attribution, not just the verdict: the detail must say how far it got, so a
+            // partial set cannot be mistaken for the whole container.
+            Assert.Contains("page 2", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("1 page(s) succeeded", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("INCOMPLETE", result.Detail, StringComparison.Ordinal);
+
+            // The rows read so far are carried for diagnostics — and they are a SUBSET.
+            Assert.Equal(2, result.Value.Count);
+            Assert.Equal(2, server.RequestCount);
+
+            // The consumer must refuse: this is what stops the sidecar being written.
+            Assert.Equal(AccCommandVerdict.Failed, AccCommandOutcome.Verdict(result.Status));
+            string msg = AccCommandOutcome.FailureMessage("the ACC issue list", result.Status,
+                result.HttpStatus, result.Detail, Container);
+            Assert.DoesNotContain("not found", msg, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task FullPageThenTransportDown_IsTransportFailed_WithNoHttpStatus()
+        {
+            // Page 1 succeeds, then the port closes. Attribution matters: HttpStatus 0
+            // means no response arrived, which a downstream shape check could not have
+            // inferred. #927 learned this the hard way.
+            LoopbackServer server = null;
+            server = new LoopbackServer((index, _) =>
+            {
+                if (index == 0) return new CannedResponse(200, Page(2, "p1-"));
+                server.Dispose();                                  // kill the listener mid-run
+                return new CannedResponse(200, Page(2, "p2-"));
+            });
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(AccFetchStatus.TransportFailed, result.Status);
+            Assert.Equal(0, result.HttpStatus);
+            Assert.Contains("did not complete", result.Detail, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task Http200_WithNoResultsArray_IsTransportFailed_NotAnEmptyContainer()
+        {
+            // What a changed construction/issues/v1 payload looks like.
+            using var server = LoopbackServer.Always(200, "{\"data\":{\"items\":[]}}");
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.Equal(AccFetchStatus.TransportFailed, result.Status);
+            Assert.NotEqual(AccFetchStatus.EmptyOk, result.Status);
+            Assert.False(result.Succeeded);
+        }
+
+        [Fact]
+        public async Task PageCapReachedWithoutAShortPage_IsAFailure()
+        {
+            // Every page full means there is more than we read. Returning that as Ok would
+            // be a truncated set presented as complete.
+            using var server = LoopbackServer.Always(200, Page(2, "x-"));
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2, maxPages: 3);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("INCOMPLETE", result.Detail, StringComparison.Ordinal);
+            Assert.Equal(6, result.Value.Count);
+            Assert.Equal(3, server.RequestCount);
+        }
+
+        // ── The success cases, so "everything fails" would not pass either ─────
+
+        [Fact]
+        public async Task TwoFullPagesThenAShortPage_IsOk_WithTheSummedCount()
+        {
+            using var server = new LoopbackServer((index, _) => index switch
+            {
+                0 => new CannedResponse(200, Page(2, "a-")),
+                1 => new CannedResponse(200, Page(2, "b-")),
+                _ => new CannedResponse(200, Page(1, "c-")),      // short page ends pagination
+            });
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.Equal(AccFetchStatus.Ok, result.Status);
+            Assert.True(result.Succeeded);
+            Assert.Equal(5, result.Value.Count);                  // assert on non-empty data
+            Assert.Equal(3, server.RequestCount);
+            Assert.Equal("a-0", result.Value[0].Id);
+            Assert.Equal("c-0", result.Value[4].Id);
+            Assert.Equal(AccCommandVerdict.Proceed, AccCommandOutcome.Verdict(result.Status));
+        }
+
+        [Fact]
+        public async Task AContainerWithNoIssues_IsEmptyOk_AndStillSucceeds()
+        {
+            // The legitimate empty case. Over-correcting this into an error would make a
+            // genuinely clean container unreportable, which is worse than the original bug.
+            using var server = LoopbackServer.Always(200, "{\"results\":[]}");
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.Equal(AccFetchStatus.EmptyOk, result.Status);
+            Assert.True(result.Succeeded);
+            Assert.Empty(result.Value);
+            Assert.Equal(AccCommandVerdict.SucceededEmpty, AccCommandOutcome.Verdict(result.Status));
+        }
+
+        [Fact]
+        public async Task RateLimitedOnEveryAttempt_IsAFailure_NotAShortRead()
+        {
+            using var server = LoopbackServer.Always(429, "{\"detail\":\"rate limited\"}");
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccIssueSync.PullIssuesAsync(FreshCreds(), pageSize: 2);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal(4, server.RequestCount);                 // the per-page retry ran
+            Assert.Contains("rate-limited", result.Detail, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/StingTools.Acc.Tests/AccUploadTests.cs
+++ b/StingTools.Acc.Tests/AccUploadTests.cs
@@ -1,0 +1,232 @@
+// A5 — the bundle record that makes a non-interactive upload a file CHOICE, not a guess.
+// A6 — an upload failure that names which KIND of failure it was.
+//
+// PR #927 wired ACC_UploadModel behind a file picker and refused to put it in the
+// fortnightly Coordination Cycle, because a workflow step cannot answer "upload which
+// file?" and guessing would put an unintended file into an issued CDE container. That
+// question is answerable now: ACCPublish records the ZIP it built. The rule that keeps it
+// a choice rather than a guess is that a record naming a file which is NO LONGER THERE is
+// not a bundle — and that rule is what the first half of this file pins.
+//
+// The second half pins A6: before it, UploadResult carried only bool Ok and a string, so a
+// 403 from Autodesk, a wrong folder and a network drop were one undifferentiated failure.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using StingTools.Acc.Tests.TestHelpers;
+using StingTools.V6;
+using Xunit;
+
+namespace StingTools.Acc.Tests
+{
+    public class AccBundleRecordTests : IDisposable
+    {
+        private readonly string _dir;
+        private readonly string _record;
+        private readonly string _zip;
+
+        public AccBundleRecordTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "sting-accbundle-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _record = Path.Combine(_dir, AccBundleRecord.FileName);
+            _zip = Path.Combine(_dir, "KUT_ACC_Publish_S3.zip");
+        }
+
+        public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+        private void WriteZip(int bytes = 2048) => File.WriteAllBytes(_zip, new byte[bytes]);
+
+        [Fact]
+        public void RoundTrips_TheBundleItRecorded()
+        {
+            WriteZip();
+            var rec = AccBundleRecord.ForFile(_zip, "S3", deliverableCount: 7);
+            Assert.NotNull(rec);
+            Assert.True(AccBundleRecord.TryWrite(_record, rec, out string err), err);
+
+            var back = AccBundleRecord.ReadExisting(_record);
+            Assert.NotNull(back);
+            Assert.Equal(_zip, back.Path);
+            Assert.Equal("S3", back.Suitability);
+            Assert.Equal(7, back.DeliverableCount);
+            Assert.Equal(2048, back.SizeBytes);
+            Assert.Contains("KUT_ACC_Publish_S3.zip", back.Describe(), StringComparison.Ordinal);
+            Assert.Contains("7 deliverable", back.Describe(), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void ReadExisting_RefusesARecordWhoseFileIsGone()
+        {
+            // THE rule. A record pointing at a deleted ZIP is not a file to upload:
+            // acting on it either fails at the last moment or matches whatever has since
+            // taken that path. Read() still returns the record so the caller can say WHY.
+            WriteZip();
+            var rec = AccBundleRecord.ForFile(_zip, "S3", 7);
+            Assert.True(AccBundleRecord.TryWrite(_record, rec, out _));
+
+            File.Delete(_zip);
+
+            Assert.Null(AccBundleRecord.ReadExisting(_record));
+            Assert.NotNull(AccBundleRecord.Read(_record));
+            Assert.Equal(_zip, AccBundleRecord.Read(_record).Path);
+        }
+
+        [Fact]
+        public void NoRecord_IsNull_NotAnEmptyRecord()
+        {
+            Assert.Null(AccBundleRecord.Read(_record));
+            Assert.Null(AccBundleRecord.ReadExisting(_record));
+            Assert.Null(AccBundleRecord.Read(null));
+            Assert.Null(AccBundleRecord.ReadExisting(null));
+        }
+
+        [Fact]
+        public void ForFile_RefusesAZipThatWasNeverWritten()
+        {
+            // There is no such thing as a record of a file that does not exist. Writing one
+            // would create a "bundle" that the uploader would then refuse — a confusing
+            // report of a problem that started here.
+            Assert.Null(AccBundleRecord.ForFile(_zip, "S3", 7));
+            Assert.Null(AccBundleRecord.ForFile(null, "S3", 7));
+            Assert.Null(AccBundleRecord.ForFile("", "S3", 7));
+        }
+
+        [Fact]
+        public void AGarbageRecordFile_ReadsAsNoRecord_NotAsAThrow()
+        {
+            File.WriteAllText(_record, "not json at all {{{");
+            Assert.Null(AccBundleRecord.Read(_record));
+            Assert.Null(AccBundleRecord.ReadExisting(_record));
+        }
+
+        [Fact]
+        public void ARecordWithNoPath_IsNoRecord()
+        {
+            File.WriteAllText(_record, "{\"suitability\":\"S3\",\"deliverableCount\":3}");
+            Assert.Null(AccBundleRecord.Read(_record));
+        }
+    }
+
+    public class AccModelUploadTests : IDisposable
+    {
+        private readonly string _dir;
+        private readonly string _file;
+
+        public AccModelUploadTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "sting-accupload-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _file = Path.Combine(_dir, "bundle.zip");
+            File.WriteAllBytes(_file, new byte[64]);
+        }
+
+        public void Dispose()
+        {
+            AccModelUpload.OverrideHostForTests(null);
+            try { Directory.Delete(_dir, true); } catch { }
+        }
+
+        private static AccCredentials FreshCreds() => new AccCredentials
+        {
+            ClientId = "test-client",
+            ClientSecret = "test-secret",
+            RefreshToken = "test-refresh",
+            ProjectId = "b.11111111-2222-3333-4444-555555555555",
+            AccessToken = "test-access-token",
+            AccessTokenExpiry = DateTime.UtcNow.AddHours(1),
+            // Set, so the run goes straight to storage creation rather than resolving folders.
+            FolderUrn = "urn:adsk.wipprod:fs.folder:co.TESTFOLDER",
+        };
+
+        [Fact]
+        public async Task Http403OnStorageCreation_IsAnAuthKindFailure_NotABareNotOk()
+        {
+            using var server = LoopbackServer.Always(403, "{\"detail\":\"forbidden\"}");
+            AccModelUpload.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccModelUpload.UploadAsync(FreshCreds(), _file);
+
+            Assert.False(result.Ok);
+            Assert.Equal(AccFetchStatus.AuthFailed, result.Status);      // the point of A6
+            Assert.Equal(403, result.HttpStatus);
+            Assert.Contains("403", result.Message, StringComparison.Ordinal);
+            // And the remedy is the one every other ACC path gives for an auth failure.
+            Assert.Equal(AccCommandOutcome.Remedy(AccFetchStatus.AuthFailed), result.Remedy);
+            Assert.Contains("Sign in", result.Remedy, StringComparison.OrdinalIgnoreCase);
+            Assert.True(server.RequestCount >= 1, "the client must actually have made the request");
+        }
+
+        [Fact]
+        public async Task Http404OnStorageCreation_IsNotFoundKind()
+        {
+            using var server = LoopbackServer.Always(404, "{\"detail\":\"no such project\"}");
+            AccModelUpload.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccModelUpload.UploadAsync(FreshCreds(), _file);
+
+            Assert.False(result.Ok);
+            Assert.Equal(AccFetchStatus.NotFound, result.Status);
+            Assert.Equal(404, result.HttpStatus);
+            Assert.NotEqual(AccFetchStatus.AuthFailed, result.Status);   // kinds are distinguished
+        }
+
+        [Fact]
+        public async Task Http500OnStorageCreation_IsTransportKind()
+        {
+            using var server = LoopbackServer.Always(500, "{\"detail\":\"boom\"}");
+            AccModelUpload.OverrideHostForTests(server.BaseUrl);
+
+            var result = await AccModelUpload.UploadAsync(FreshCreds(), _file);
+
+            Assert.False(result.Ok);
+            Assert.Equal(AccFetchStatus.TransportFailed, result.Status);
+            Assert.Equal(500, result.HttpStatus);
+        }
+
+        [Fact]
+        public async Task LocalFailures_AreAttributedWithNoHttpStatus()
+        {
+            // No HTTP exchange happened, so claiming one would be a fabricated attribution.
+            var noFile = await AccModelUpload.UploadAsync(FreshCreds(), Path.Combine(_dir, "missing.zip"));
+            Assert.False(noFile.Ok);
+            Assert.Equal(0, noFile.HttpStatus);
+            Assert.Equal(AccFetchStatus.TransportFailed, noFile.Status);
+
+            var noCreds = await AccModelUpload.UploadAsync(null, _file);
+            Assert.False(noCreds.Ok);
+            Assert.Equal(0, noCreds.HttpStatus);
+        }
+
+        [Fact]
+        public async Task NotAuthenticated_IsAuthFailed()
+        {
+            // A stale token whose refresh the listener rejects.
+            using var server = LoopbackServer.Always(401, "{\"error\":\"invalid_grant\"}");
+            AccModelUpload.OverrideHostForTests(server.BaseUrl);
+            AccIssueSync.OverrideHostForTests(server.BaseUrl);
+            try
+            {
+                var creds = FreshCreds();
+                creds.AccessToken = "";
+                creds.AccessTokenExpiry = DateTime.UtcNow.AddHours(-1);
+
+                var result = await AccModelUpload.UploadAsync(creds, _file);
+
+                Assert.False(result.Ok);
+                Assert.Equal(AccFetchStatus.AuthFailed, result.Status);
+                Assert.Contains("Sign in", result.Message, StringComparison.OrdinalIgnoreCase);
+            }
+            finally { AccIssueSync.OverrideHostForTests(null); }
+        }
+
+        [Fact]
+        public void ASuccessfulResult_CarriesOkStatus_AndNoRemedy()
+        {
+            var ok = new AccModelUpload.UploadResult { Ok = true, Message = "Uploaded.", ItemUrn = "urn:x" };
+            Assert.Equal(AccFetchStatus.Ok, ok.Status);
+            Assert.Equal("", ok.Remedy);
+        }
+    }
+}

--- a/StingTools.Acc.Tests/StingTools.Acc.Tests.csproj
+++ b/StingTools.Acc.Tests/StingTools.Acc.Tests.csproj
@@ -31,11 +31,22 @@
          (HTTP status + parsed count -> Ok / EmptyOk / AuthFailed / NotFound /
          TransportFailed) is testable on its own. -->
     <Compile Include="..\StingTools\V6\AccFetchOutcome.cs" Link="V6\AccFetchOutcome.cs" />
+    <!-- The command DECISION, extracted out of the Revit-bound commands so the branch that
+         makes the whole outcome split matter (Result.Failed instead of Succeeded) is
+         covered by a test rather than by reading. -->
+    <Compile Include="..\StingTools\V6\AccCommandOutcome.cs" Link="V6\AccCommandOutcome.cs" />
     <!-- The real clients. A pure-function test alone would be an alternative-path escape:
          it would not catch the CLIENT mapping a 404 to an empty list, which is the actual
          defect. So the real transports are linked and driven over a loopback listener. -->
     <Compile Include="..\StingTools\V6\AccModelCoordSync.cs" Link="V6\AccModelCoordSync.cs" />
     <Compile Include="..\StingTools\V6\AccIssueSync.cs" Link="V6\AccIssueSync.cs" />
+    <!-- A5: the record ACCPublish writes so ACC_UploadLastBundle can upload the bundle it
+         built without a human picking a file. The "is the file still there?" rule is the
+         difference between a file choice and a guess, so it is tested. -->
+    <Compile Include="..\StingTools\V6\AccBundleRecord.cs" Link="V6\AccBundleRecord.cs" />
+    <!-- A6: the uploader, so a 403 on storage creation can be proved to surface as an
+         auth-kind failure rather than a bare Ok=false. -->
+    <Compile Include="..\StingTools\V6\AccModelUpload.cs" Link="V6\AccModelUpload.cs" />
     <!-- TestHelpers/StingLogShim.cs is picked up by the SDK's default Compile glob;
          StingTools/Core/StingLog.cs cannot be linked (it drags in StingTools.Core.Drawing). -->
   </ItemGroup>

--- a/StingTools.Boq.Tests/NiagaraLiveReadTests.cs
+++ b/StingTools.Boq.Tests/NiagaraLiveReadTests.cs
@@ -1,0 +1,251 @@
+// The Niagara live-read path, end to end, over a real loopback listener.
+//
+// The defect this closes, in four compounding steps:
+//   1. NiagaraPointParser.Parse correctly set Error on an unparseable body.
+//   2. NiagaraJsonClient.ParsePoints logged that failure and returned r.Points ANYWAY,
+//      discarding the flag.
+//   3. That empty dictionary is not null, so CommissioningSource.Resolve took the LIVE
+//      branch and reported "live (captured ...)".
+//   4. Persist then wrote the empty result over last_station_points.json - destroying the
+//      last good snapshot, which is the fallback that exists for an unreachable station.
+//
+// KUT_ValuationFromBms turns those points into a commissioning valuation percentage that
+// the cost module carries toward payment certification. A fabricated 0% presented as live,
+// with the recovery cache deleted, is the most consequential defect in these integrations.
+//
+// The worst input is {"error":"unauthorized"}: it PARSES, yields zero points, and sets no
+// error at all, so nothing anywhere said anything was wrong.
+//
+// A test over NiagaraPointParser alone would have passed against every version of this
+// bug - the parser was already right. So these drive the real client and the real
+// resolver, and the cache assertion is a FILE-CONTENT comparison, not "Resolve returned
+// Cached", because only the bytes prove the snapshot survived.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using StingTools.Acc.Tests.TestHelpers;
+using StingTools.Core.Twin;
+using Xunit;
+
+namespace StingTools.Boq.Tests
+{
+    public class NiagaraLiveReadTests : IDisposable
+    {
+        private readonly string _dir;
+        private readonly string _snapshot;
+
+        public NiagaraLiveReadTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "sting-niagara-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _snapshot = Path.Combine(_dir, "last_station_points.json");
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); } catch { }
+        }
+
+        private static NiagaraConnection ConnTo(LoopbackServer server) => new NiagaraConnection
+        {
+            BaseUrl = server.BaseUrl,
+            PointsPath = "/obix/points",
+            ApiKey = "test-key",
+        };
+
+        /// <summary>A real, non-empty snapshot on disk — the fallback an outage depends on.</summary>
+        private void WriteGoodSnapshot()
+        {
+            using var server = LoopbackServer.Always(200,
+                "[{\"id\":\"AHU-1\",\"status\":\"ok\",\"present_value\":21.4}," +
+                "{\"id\":\"FCU-2\",\"status\":\"ok\",\"present_value\":19.1}]");
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.Equal(CommissioningSourceKind.Live, snap.Source);
+            Assert.Equal(2, snap.Points.Count);                       // assert on non-empty data
+            Assert.True(File.Exists(_snapshot), "the good read must have written a snapshot");
+        }
+
+        // ── The three failure bodies. None may end as Live. ────────────────────
+
+        [Theory]
+        [InlineData("not json at all {{{", "unparseable")]
+        [InlineData("{\"error\":\"unauthorized\"}", "JSON error envelope")]
+        [InlineData("<html><body>502 Bad Gateway</body></html>", "HTML error page")]
+        [InlineData("\"just a string\"", "bare scalar")]
+        [InlineData("[{\"deviceRef\":\"AHU-1\",\"present_value\":21.4}]", "entries present, none understood")]
+        public void AFailedLiveRead_FallsBackToCache_AndIsNeverLive(string body, string why)
+        {
+            WriteGoodSnapshot();
+            string before = File.ReadAllText(_snapshot);
+
+            using var server = LoopbackServer.Always(200, body);
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.NotEqual(CommissioningSourceKind.Live, snap.Source);
+            Assert.Equal(CommissioningSourceKind.Cached, snap.Source);
+            Assert.Equal(2, snap.Points.Count);                       // the CACHED points, not zero
+            Assert.Contains("CACHED", snap.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("live (captured", snap.Detail, StringComparison.Ordinal);
+
+            // The assertion that catches the data loss: the file itself, byte for byte.
+            Assert.Equal(before, File.ReadAllText(_snapshot));
+        }
+
+        [Theory]
+        [InlineData("not json at all {{{")]
+        [InlineData("{\"error\":\"unauthorized\"}")]
+        [InlineData("<html><body>502 Bad Gateway</body></html>")]
+        [InlineData("\"just a string\"")]
+        public void AFailedLiveRead_WithNoCache_IsNone_NotLive(string body)
+        {
+            Assert.False(File.Exists(_snapshot));
+
+            using var server = LoopbackServer.Always(200, body);
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.Equal(CommissioningSourceKind.None, snap.Source);
+            Assert.Empty(snap.Points);
+            Assert.Equal("no BMS data", snap.Detail);
+            // A failed read must not create a snapshot either — an empty one would look
+            // like a fallback and LoadCache would reject it, so it is worse than none.
+            Assert.False(File.Exists(_snapshot),
+                "a failed read must not write a snapshot: an empty one is a file, not a fallback");
+        }
+
+        [Fact]
+        public void TheJsonErrorEnvelope_SetsNoParserError_AndIsStillRejected()
+        {
+            // Named specifically because this is the input that used to slip through with
+            // nothing anywhere reporting a problem: it parses, and Error stays null.
+            var r = NiagaraPointParser.Parse("{\"error\":\"unauthorized\"}");
+
+            Assert.Null(r.Error);            // still not a parse ERROR - that is correct
+            Assert.False(r.Failed);
+            Assert.False(r.RecognisedShape); // ...but it is not a points feed
+            Assert.True(r.Unusable);
+            Assert.Empty(r.Points);
+
+            Assert.Null(NiagaraJsonClient.ParsePoints("{\"error\":\"unauthorized\"}"));
+        }
+
+        [Fact]
+        public void HttpErrorFromTheStation_FallsBackToCache_AndKeepsTheSnapshot()
+        {
+            WriteGoodSnapshot();
+            string before = File.ReadAllText(_snapshot);
+
+            using var server = LoopbackServer.Always(401, "{\"error\":\"unauthorized\"}");
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.Equal(CommissioningSourceKind.Cached, snap.Source);
+            Assert.Equal(before, File.ReadAllText(_snapshot));
+        }
+
+        [Fact]
+        public void StationUnreachable_FallsBackToCache_AndKeepsTheSnapshot()
+        {
+            WriteGoodSnapshot();
+            string before = File.ReadAllText(_snapshot);
+
+            NiagaraConnection dead;
+            using (var probe = LoopbackServer.Always(200, "[]")) { dead = ConnTo(probe); }
+            // probe disposed -> nothing is listening on that port
+
+            var snap = CommissioningSource.Resolve(_snapshot, dead);
+
+            Assert.Equal(CommissioningSourceKind.Cached, snap.Source);
+            Assert.Equal(before, File.ReadAllText(_snapshot));
+        }
+
+        // ── The legitimate cases. Over-correcting these would be the worse bug. ─
+
+        [Fact]
+        public void AValidFeedWithZeroPoints_IsStillLive()
+        {
+            // A station with nothing commissioned yet is a real, expected state in early
+            // Stage 3. Turning it into an error would make a clean station unreportable.
+            using var server = LoopbackServer.Always(200, "{\"points\":[]}");
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.Equal(CommissioningSourceKind.Live, snap.Source);
+            Assert.Empty(snap.Points);
+            Assert.Contains("live (captured", snap.Detail, StringComparison.Ordinal);
+        }
+
+        [Theory]
+        [InlineData("[]")]
+        [InlineData("{\"points\":[]}")]
+        [InlineData("{}")]
+        public void EmptyFeedShapes_AreRecognised_NotRejected(string body)
+        {
+            var r = NiagaraPointParser.Parse(body);
+            Assert.True(r.RecognisedShape, $"'{body}' is an empty station, not an unrecognised body");
+            Assert.False(r.Unusable);
+            Assert.Equal(0, r.CandidateEntries);
+            Assert.NotNull(NiagaraJsonClient.ParsePoints(body));
+        }
+
+        [Fact]
+        public void AZeroPointLiveRead_DoesNotDestroyAGoodSnapshot()
+        {
+            // Live and empty is legitimate; wiping the fallback on the way past is not.
+            // LoadCache rejects a zero-point snapshot, so writing one does not update the
+            // cache — it removes it.
+            WriteGoodSnapshot();
+            string before = File.ReadAllText(_snapshot);
+
+            using (var server = LoopbackServer.Always(200, "{\"points\":[]}"))
+            {
+                var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+                Assert.Equal(CommissioningSourceKind.Live, snap.Source);   // still reported honestly
+                Assert.Empty(snap.Points);
+            }
+
+            Assert.Equal(before, File.ReadAllText(_snapshot));
+
+            // And the fallback still works on the next outage.
+            NiagaraConnection dead;
+            using (var probe = LoopbackServer.Always(200, "[]")) { dead = ConnTo(probe); }
+            var after = CommissioningSource.Resolve(_snapshot, dead);
+            Assert.Equal(CommissioningSourceKind.Cached, after.Source);
+            Assert.Equal(2, after.Points.Count);
+        }
+
+        [Fact]
+        public void AGoodLiveRead_UpdatesTheSnapshot()
+        {
+            // The mirror of the guard: a real read with real points must still persist,
+            // or "never overwrite" would have quietly frozen the cache forever.
+            WriteGoodSnapshot();
+            string before = File.ReadAllText(_snapshot);
+
+            using var server = LoopbackServer.Always(200,
+                "[{\"id\":\"AHU-1\",\"status\":\"ok\",\"present_value\":22.0}," +
+                "{\"id\":\"FCU-2\",\"status\":\"ok\",\"present_value\":19.1}," +
+                "{\"id\":\"VAV-3\",\"status\":\"ok\",\"present_value\":18.0}]");
+            var snap = CommissioningSource.Resolve(_snapshot, ConnTo(server));
+
+            Assert.Equal(CommissioningSourceKind.Live, snap.Source);
+            Assert.Equal(3, snap.Points.Count);
+            Assert.NotEqual(before, File.ReadAllText(_snapshot));
+            Assert.Contains("VAV-3", File.ReadAllText(_snapshot), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AGoodFeed_StillParsesAndReportsItsPoints()
+        {
+            // So "reject everything" would not pass this suite either.
+            var pts = NiagaraJsonClient.ParsePoints(
+                "[{\"id\":\"AHU-1\",\"status\":\"ok\",\"present_value\":21.4}," +
+                "{\"id\":\"DEAD-2\",\"status\":\"ok\"}]");
+
+            Assert.NotNull(pts);
+            Assert.Equal(2, pts.Count);
+            Assert.True(pts["AHU-1"].HasValue);
+            Assert.False(pts["DEAD-2"].HasValue);   // configured but not reporting
+        }
+    }
+}

--- a/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
+++ b/StingTools.Boq.Tests/StingTools.Boq.Tests.csproj
@@ -113,8 +113,24 @@
          station, this only does the maths. -->
     <Compile Include="..\StingTools\Core\Twin\BmsValuation.cs" Link="Twin\BmsValuation.cs" />
     <!-- The oBIX/JSON shape handling under the certification decision. Extracted from
-         NiagaraJsonClient.cs, which logs through StingLog and so cannot be linked here. -->
+         NiagaraJsonClient.cs so it could be linked before this project carried a StingLog
+         shim; both are linked now. -->
     <Compile Include="..\StingTools\Core\Twin\NiagaraPointParser.cs" Link="Twin\NiagaraPointParser.cs" />
+    <!-- The rest of the Niagara live path. Both log through StingLog, so they ride the
+         TestHelpers/StingLogShim.cs no-op in the same namespace - the pattern
+         StingTools.Visibility.Tests and StingTools.Acc.Tests already use, because
+         StingTools/Core/StingLog.cs itself cannot be linked (it drags in
+         StingTools.Core.Drawing).
+
+         These are linked because the defect was NOT in the parser: the parser correctly
+         reported the failure, NiagaraJsonClient.ParsePoints threw the flag away, and
+         CommissioningSource then reported Live and overwrote the cached snapshot. A test
+         over the parser alone would have passed against every version of that bug. -->
+    <Compile Include="..\StingTools\Core\Twin\NiagaraJsonClient.cs" Link="Twin\NiagaraJsonClient.cs" />
+    <Compile Include="..\StingTools\Core\Twin\CommissioningSource.cs" Link="Twin\CommissioningSource.cs" />
+    <!-- One copy of the loopback listener, shared with StingTools.Acc.Tests rather than
+         duplicated. A second copy would drift, and this one is already proven. -->
+    <Compile Include="..\StingTools.Acc.Tests\TestHelpers\LoopbackServer.cs" Link="TestHelpers\LoopbackServer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StingTools.Boq.Tests/TestHelpers/StingLogShim.cs
+++ b/StingTools.Boq.Tests/TestHelpers/StingLogShim.cs
@@ -1,0 +1,17 @@
+// Test-only no-op StingLog. NiagaraJsonClient and CommissioningSource log via
+// StingTools.Core.StingLog; we supply a minimal identically-shaped type in the same
+// namespace so the tests compile without pulling in the full net8.0-windows StingTools
+// assembly (StingTools/Core/StingLog.cs itself drags in StingTools.Core.Drawing).
+//
+// Same shape as StingTools.Visibility.Tests/TestHelpers/StingLogShim.cs.
+using System;
+
+namespace StingTools.Core
+{
+    internal static class StingLog
+    {
+        public static void Info(string msg) { /* no-op in tests */ }
+        public static void Warn(string msg) { /* no-op in tests */ }
+        public static void Error(string msg, Exception ex = null) { /* no-op in tests */ }
+    }
+}

--- a/StingTools/BIMManager/PlatformLinkCommands.cs
+++ b/StingTools/BIMManager/PlatformLinkCommands.cs
@@ -1201,6 +1201,27 @@ namespace StingTools.BIMManager
                 BIMManagerEngine.AutoRegisterExport(doc, zipPath, "CM",
                     $"ACC publish package — {suitability} — {deliverables.Count} deliverables");
 
+                // Record WHICH bundle this was, so ACC_UploadLastBundle can upload it
+                // without a human picking a file. This command still only builds a local
+                // ZIP — nothing here uploads anything — but the file choice a later step
+                // would otherwise have to guess is now written down.
+                // Best-effort: a failure to record must never fail the publish.
+                try
+                {
+                    string recDir = StingPaths.MetaFile(doc, "_BIM_COORD", "acc");
+                    Directory.CreateDirectory(recDir);
+                    string recPath = Path.Combine(recDir, V6.AccBundleRecord.FileName);
+                    var rec = V6.AccBundleRecord.ForFile(zipPath, suitability, deliverables.Count);
+                    if (rec == null)
+                        StingLog.Warn("ACC publish: could not record the bundle for later upload " +
+                                      "(the ZIP was not found on disk).");
+                    else if (!V6.AccBundleRecord.TryWrite(recPath, rec, out string recErr))
+                        StingLog.Warn("ACC publish: could not record the bundle for later upload: " + recErr);
+                    else
+                        StingLog.Info("ACC publish: recorded bundle at " + recPath);
+                }
+                catch (Exception ex) { StingLog.Warn("ACC publish: bundle record: " + ex.Message); }
+
                 // Record transmittal
                 string txPath = BIMManagerEngine.GetBIMManagerFilePath(doc, "transmittals.json");
                 var transmittals = BIMManagerEngine.LoadJsonArray(txPath);

--- a/StingTools/Clash/AccPullClashesCommand.cs
+++ b/StingTools/Clash/AccPullClashesCommand.cs
@@ -172,38 +172,14 @@ namespace StingTools.Core.Clash
             return Result.Succeeded;
         }
 
-        /// <summary>Message for a read that did NOT succeed. It names the failure kind, the
-        /// container that was used, and what to check — deliberately never the words
-        /// "clash-clean" or "no clashes", because a failure that reads as an empty result is
-        /// how a coordination gate passes without having checked anything.</summary>
+        /// <summary>Message for a read that did NOT succeed. Delegates to
+        /// <see cref="AccCommandOutcome.FailureMessage"/> so this command and
+        /// AccSyncIssueStatusCommand cannot describe the same failure differently, and so
+        /// the wording is covered by a test — it lives in a Revit-free file precisely
+        /// because this one cannot be linked into a test project.</summary>
         internal static string FailureMessage(string what, AccFetchStatus status, int httpStatus,
             string detail, string containerId)
-        {
-            var sb = new StringBuilder();
-            sb.AppendLine($"Could not read {what} from ACC. NOTHING WAS CHECKED — this is not a clean result.");
-            sb.AppendLine();
-            sb.AppendLine($"Failure: {status}");
-            sb.AppendLine($"Reason:  {(string.IsNullOrEmpty(detail) ? AccFetchOutcome.Describe(status, httpStatus) : detail)}");
-            sb.AppendLine($"Container id used: {(string.IsNullOrEmpty(containerId) ? "(none)" : containerId)}");
-            sb.AppendLine();
-            switch (status)
-            {
-                case AccFetchStatus.AuthFailed:
-                    sb.AppendLine("Sign in to Autodesk again (BIM Coordination Center → Platforms → ACC), " +
-                                  "then confirm the app's Client ID/Secret and that the account can see this project.");
-                    break;
-                case AccFetchStatus.NotFound:
-                    sb.AppendLine("Check the container id. ProjectId is the Issues container; set " +
-                                  "CoordContainerId when the Model Coordination container differs. If both are " +
-                                  "correct, the clash-service sub-path has changed and needs confirming against APS.");
-                    break;
-                default:
-                    sb.AppendLine("Check network access to developer.api.autodesk.com and retry. If the payload " +
-                                  "shape has changed, the clash-service sub-path needs confirming against APS.");
-                    break;
-            }
-            return sb.ToString();
-        }
+            => AccCommandOutcome.FailureMessage(what, status, httpStatus, detail, containerId);
 
         // Idempotent push: skip clashes already issued (by stable signature), record the
         // returned ACC issue id in the sidecar so re-runs don't create duplicate issues.

--- a/StingTools/Clash/AccSyncIssueStatusCommand.cs
+++ b/StingTools/Clash/AccSyncIssueStatusCommand.cs
@@ -55,9 +55,26 @@ namespace StingTools.Core.Clash
                 return Result.Succeeded;
             }
 
-            List<AccIssue> issues;
-            try { issues = AccIssueSync.PullIssuesAsync(creds).GetAwaiter().GetResult(); }
+            AccFetchResult<List<AccIssue>> pull;
+            try { pull = AccIssueSync.PullIssuesAsync(creds).GetAwaiter().GetResult(); }
             catch (Exception ex) { StingLog.Error("ACC SyncIssueStatus pull", ex); TaskDialog.Show("ACC", "Issue pull failed: " + ex.Message); return Result.Failed; }
+
+            // The load-bearing branch. Reconciling against a failed or PARTIAL read marks
+            // every unseen escalation NOT_FOUND, which reads as "ACC deleted our issues",
+            // and then writes the sidecar — so an expired token silently un-tracked nothing
+            // while a page-2 failure un-tracked a subset and called it a full sync.
+            // Nothing below this point may run unless the whole list was read.
+            if (!pull.Succeeded)
+            {
+                TaskDialog.Show("ACC — Sync Issue Status",
+                    AccCommandOutcome.FailureMessage("the ACC issue list", pull.Status, pull.HttpStatus,
+                        pull.Detail, creds.ProjectId) +
+                    "\nThe escalation record was left untouched — nothing was un-tracked.");
+                StingLog.Warn($"ACC_SyncIssueStatus FAILED ({pull.Status}) reading issues on container " +
+                              $"'{creds.ProjectId}': {pull.Detail}");
+                return Result.Failed;
+            }
+            var issues = pull.Value;
 
             var statusById = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var i in issues)

--- a/StingTools/Clash/AccUploadModelCommand.cs
+++ b/StingTools/Clash/AccUploadModelCommand.cs
@@ -4,18 +4,28 @@
 // upload it by hand. That is honest, but it left the actual uploader — AccModelUpload,
 // which does the full APS Data Management dance (storage object -> signed-S3 PUT ->
 // item/version) — reachable from exactly one button inside the BIM Coordination Center
-// and from no command tag at all. This exposes it on the dock panel and to
-// WorkflowEngine.ResolveCommand, mirroring BIMCoordinationCenter.BuildAccDetail's
-// "Upload Model to ACC" button.
+// and from no command tag at all.
 //
-// Deliberately NOT added to any KUT workflow. A workflow step cannot answer "upload
-// which file?", and guessing (the model path, or silently the active document) would
-// put an unintended file in an issued CDE container. The file choice stays with a human.
+// Two tags, one implementation:
+//
+//   ACC_UploadModel       picks a file. The manual case, unchanged.
+//   ACC_UploadLastBundle  uploads the bundle ACCPublish last produced, with no picker.
+//
+// The second is only possible because ACCPublish now writes _BIM_COORD/acc/last_bundle.json
+// naming the ZIP it built. That is a file choice, not a guess: PR #927 refused to wire an
+// automatic upload precisely because "which file?" had no answer, and inventing one would
+// put an unintended file into an issued CDE container.
+//
+// NEITHER TAG IS IN ANY KUT WORKFLOW, and that is deliberate. Wiring the capability is
+// offline work; deciding that a fortnightly cycle should push into an issued container is
+// the Information Manager's call, and it should not be made before one live round-trip has
+// been proved (docs/KUT_LIVE_VERIFICATION_RUNBOOK.md, B1).
 //
 // Read-only with respect to the Revit model (no Transaction). Network I/O only.
 // Credentials come from %APPDATA%\Planscape\acc_credentials.json (AccIssueSync).
 
 using System;
+using System.IO;
 using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
@@ -24,17 +34,27 @@ using StingTools.V6;
 
 namespace StingTools.Core.Clash
 {
-    [Transaction(TransactionMode.ReadOnly)]
-    [Regeneration(RegenerationOption.Manual)]
-    public class AccUploadModelCommand : IExternalCommand
+    /// <summary>Shared shell for both upload tags. The only difference is where the file
+    /// comes from, so the credential check, the failure reporting and the logging are
+    /// written once and cannot drift between the two.</summary>
+    public abstract class AccUploadCommandBase : IExternalCommand
     {
+        /// <summary>The file to upload, or null to cancel. Implementations report their own
+        /// reason for cancelling.</summary>
+        protected abstract string ResolveFile(Document doc, out string cancelReason);
+
+        protected abstract string DialogTitle { get; }
+
         public Result Execute(ExternalCommandData cmd, ref string msg, ElementSet els)
         {
+            var ctx = ParameterHelpers.GetContext(cmd);
+            Document doc = ctx?.Doc;
+
             var creds = AccIssueSync.LoadCredentials();
             if (string.IsNullOrEmpty(creds.ClientId) || string.IsNullOrEmpty(creds.RefreshToken) ||
                 string.IsNullOrEmpty(creds.ProjectId))
             {
-                TaskDialog.Show("ACC — Upload Model",
+                TaskDialog.Show(DialogTitle,
                     "ACC credentials are not configured.\n\n" +
                     "Create %APPDATA%\\Planscape\\acc_credentials.json with at least:\n" +
                     "  ClientId, ClientSecret, RefreshToken, ProjectId\n\n" +
@@ -43,43 +63,138 @@ namespace StingTools.Core.Clash
                 return Result.Cancelled;
             }
 
-            var dlg = new Microsoft.Win32.OpenFileDialog
+            string file = ResolveFile(doc, out string cancelReason);
+            if (string.IsNullOrEmpty(file))
             {
-                Title = "Pick a model / deliverable to upload to ACC",
-                Filter = "Model & doc files (*.glb;*.ifc;*.nwc;*.nwd;*.rvt;*.pdf;*.dwg)|*.glb;*.ifc;*.nwc;*.nwd;*.rvt;*.pdf;*.dwg|All files (*.*)|*.*",
-            };
-            if (dlg.ShowDialog() != true) return Result.Cancelled;
+                if (!string.IsNullOrEmpty(cancelReason)) TaskDialog.Show(DialogTitle, cancelReason);
+                return Result.Cancelled;
+            }
 
             AccModelUpload.UploadResult result;
             try
             {
-                result = AccModelUpload.UploadAsync(creds, dlg.FileName).GetAwaiter().GetResult();
+                result = AccModelUpload.UploadAsync(creds, file).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
-                StingLog.Error("ACC_UploadModel", ex);
-                TaskDialog.Show("ACC — Upload Model", "Upload failed: " + ex.Message);
+                StingLog.Error("ACC upload", ex);
+                TaskDialog.Show(DialogTitle, "Upload failed: " + ex.Message);
                 return Result.Failed;
             }
 
             if (result == null || !result.Ok)
             {
                 // A failed upload must not read as a completed one — the operator would
-                // believe the deliverable reached the CDE container.
+                // believe the deliverable reached the CDE container. The failure KIND comes
+                // from the same AccFetchStatus vocabulary every other ACC path reports, so
+                // an auth problem reads as an auth problem rather than as "it didn't work".
+                var status = result?.Status ?? AccFetchStatus.TransportFailed;
                 string why = result?.Message ?? "the upload returned no result";
-                TaskDialog.Show("ACC — Upload Model",
-                    "The file was NOT uploaded to ACC.\n\n" +
-                    "Reason: " + why + "\n\n" +
+                TaskDialog.Show(DialogTitle,
+                    $"The file was NOT uploaded to ACC.\n\n" +
+                    $"File:    {Path.GetFileName(file)}\n" +
+                    $"Failure: {status}\n" +
+                    $"Reason:  {why}\n" +
                     $"Project (container) used: {creds.ProjectId}\n" +
-                    $"Folder URN: {(string.IsNullOrWhiteSpace(creds.FolderUrn) ? "(auto-resolved 'Project Files')" : creds.FolderUrn)}");
-                StingLog.Warn($"ACC_UploadModel FAILED for '{dlg.FileName}': {why}");
+                    $"Folder URN: {(string.IsNullOrWhiteSpace(creds.FolderUrn) ? "(auto-resolved 'Project Files')" : creds.FolderUrn)}\n\n" +
+                    AccCommandOutcome.Remedy(status));
+                StingLog.Warn($"ACC upload FAILED ({status}, HTTP {result?.HttpStatus ?? 0}) for '{file}': {why}");
                 return Result.Failed;
             }
 
-            TaskDialog.Show("ACC — Upload Model",
+            TaskDialog.Show(DialogTitle,
                 result.Message + (string.IsNullOrWhiteSpace(result.ItemUrn) ? "" : "\n\nItem: " + result.ItemUrn));
-            StingLog.Info($"ACC_UploadModel: uploaded '{dlg.FileName}' -> {result.ItemUrn}");
+            StingLog.Info($"ACC upload: uploaded '{file}' -> {result.ItemUrn}");
             return Result.Succeeded;
+        }
+
+        /// <summary>Where ACCPublish records the bundle it built. One place, so the writer
+        /// and the reader cannot disagree.</summary>
+        internal static string BundleRecordPath(Document doc)
+        {
+            try
+            {
+                string dir = StingPaths.MetaFile(doc, "_BIM_COORD", "acc");
+                return Path.Combine(dir, AccBundleRecord.FileName);
+            }
+            catch (Exception ex) { StingLog.Warn("ACC bundle record path: " + ex.Message); return null; }
+        }
+    }
+
+    /// <summary>ACC_UploadModel — pick any file and upload it. The manual case.</summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class AccUploadModelCommand : AccUploadCommandBase
+    {
+        protected override string DialogTitle => "ACC — Upload Model";
+
+        protected override string ResolveFile(Document doc, out string cancelReason)
+        {
+            cancelReason = null;
+            var dlg = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Pick a model / deliverable to upload to ACC",
+                Filter = "Model & doc files (*.zip;*.glb;*.ifc;*.nwc;*.nwd;*.rvt;*.pdf;*.dwg)|*.zip;*.glb;*.ifc;*.nwc;*.nwd;*.rvt;*.pdf;*.dwg|All files (*.*)|*.*",
+            };
+            // If ACCPublish has built a bundle, start the picker in its folder — a nudge,
+            // not a default, so nothing is uploaded that the operator did not choose.
+            var rec = AccBundleRecord.ReadExisting(BundleRecordPath(doc));
+            if (rec != null)
+            {
+                try { dlg.InitialDirectory = Path.GetDirectoryName(rec.Path); } catch { }
+                try { dlg.FileName = Path.GetFileName(rec.Path); } catch { }
+            }
+            return dlg.ShowDialog() == true ? dlg.FileName : null;
+        }
+    }
+
+    /// <summary>ACC_UploadLastBundle — upload the bundle ACCPublish last produced, with no
+    /// file picker. Non-interactive, so it can run from a project-authored workflow.</summary>
+    [Transaction(TransactionMode.ReadOnly)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class AccUploadLastBundleCommand : AccUploadCommandBase
+    {
+        protected override string DialogTitle => "ACC — Upload Last Bundle";
+
+        protected override string ResolveFile(Document doc, out string cancelReason)
+        {
+            string recordPath = BundleRecordPath(doc);
+            // ReadExisting, not Read: a record naming a ZIP that has since been deleted or
+            // cleaned out is not a file to upload. Reporting "no bundle" is right; uploading
+            // whatever now sits at that path would be exactly the guess this avoids.
+            var rec = AccBundleRecord.ReadExisting(recordPath);
+            if (rec == null)
+            {
+                var stale = AccBundleRecord.Read(recordPath);
+                cancelReason = stale == null
+                    ? "No ACC bundle has been built for this project yet.\n\n" +
+                      "Run ACC Publish first — it packages the deliverables into a local " +
+                      "ACC-ready ZIP and records which one it built. This command then uploads " +
+                      "that bundle without asking you to pick a file."
+                    : "The recorded ACC bundle is no longer on disk:\n\n" +
+                      $"  {stale.Path}\n\n" +
+                      "Nothing was uploaded. Re-run ACC Publish to build a fresh bundle — " +
+                      "uploading whatever now sits at that path would be a guess.";
+                return null;
+            }
+
+            cancelReason = null;
+            var confirm = new TaskDialog(DialogTitle)
+            {
+                MainInstruction = "Upload the last ACC bundle?",
+                MainContent = $"This uploads the bundle ACC Publish built:\n\n  {rec.Describe()}\n\n" +
+                              $"Destination container: (from acc_credentials.json)\n\n" +
+                              "It goes into the real CDE. Nothing else is uploaded.",
+                CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No,
+                DefaultButton = TaskDialogResult.No,
+                AllowCancellation = true,
+            };
+            if (confirm.Show() != TaskDialogResult.Yes)
+            {
+                cancelReason = null;
+                return null;
+            }
+            return rec.Path;
         }
     }
 }

--- a/StingTools/Core/Twin/CommissioningSource.cs
+++ b/StingTools/Core/Twin/CommissioningSource.cs
@@ -68,6 +68,11 @@ namespace StingTools.Core.Twin
             // 1. Try live.
             if (conn != null && !string.IsNullOrEmpty(conn.BaseUrl))
             {
+                // FetchPoints returns null for EVERY unsuccessful read: a transport error,
+                // a body that is not JSON, a JSON error envelope, or a feed whose entries
+                // were all unreadable. A malformed feed used to arrive here as a non-null
+                // EMPTY dictionary, which took this branch, reported Live, and then wrote
+                // the empty result over the cached snapshot.
                 var live = NiagaraJsonClient.FetchPoints(conn);
                 if (live != null)
                 {
@@ -101,9 +106,23 @@ namespace StingTools.Core.Twin
             [JsonProperty("hasValue")] public bool HasValue { get; set; }
         }
 
+        /// <summary>Write the snapshot that a later outage will fall back to.
+        ///
+        /// Never trades a usable snapshot for an unusable one. <see cref="LoadCache"/>
+        /// rejects a snapshot holding zero points, so writing an empty read over a good one
+        /// does not "update" the cache — it DELETES the fallback that exists precisely for
+        /// the station being unreachable, turning a recoverable outage into data loss.
+        /// A genuinely empty live read is still reported as Live with zero points; it just
+        /// does not get to destroy the last good read on its way past.</summary>
         private static void Persist(string path, Dictionary<string, NiagaraPoint> pts, DateTime capturedUtc)
         {
             if (string.IsNullOrEmpty(path) || pts == null) return;
+            if (pts.Count == 0 && HasUsableSnapshot(path))
+            {
+                StingLog.Warn("CommissioningSource: the live read returned zero points; keeping the " +
+                              "existing snapshot rather than overwriting the last good read.");
+                return;
+            }
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
@@ -114,6 +133,11 @@ namespace StingTools.Core.Twin
             }
             catch (Exception ex) { StingLog.Warn($"CommissioningSource persist: {ex.Message}"); }
         }
+
+        /// <summary>Whether a snapshot exists that LoadCache would actually use. Asked
+        /// before overwriting, so "there is a file" is never mistaken for "there is a
+        /// fallback" — a zero-point snapshot is a file and not a fallback.</summary>
+        private static bool HasUsableSnapshot(string path) => LoadCache(path) != null;
 
         private static CommissioningSnapshot LoadCache(string path)
         {

--- a/StingTools/Core/Twin/NiagaraJsonClient.cs
+++ b/StingTools/Core/Twin/NiagaraJsonClient.cs
@@ -64,16 +64,44 @@ namespace StingTools.Core.Twin
         /// <summary>Parse a Niagara/oBIX points feed into deviceId → point. The shape
         /// handling lives in <see cref="NiagaraPointParser"/>, which carries no logging so
         /// it can be linked into the Revit-free test projects; this wrapper adds the
-        /// logging and keeps the dictionary-returning signature its callers use.</summary>
+        /// logging and keeps the dictionary-returning signature its callers use.
+        ///
+        /// Returns NULL when the body cannot be trusted as a points feed — the same signal
+        /// <see cref="FetchPoints"/> already uses for a transport failure, so a caller
+        /// cannot mistake it for a successful empty read.
+        ///
+        /// This used to return <c>r.Points</c> unconditionally: it LOGGED the parse failure
+        /// and then handed back the empty dictionary anyway. That empty dictionary is not
+        /// null, so CommissioningSource took the live branch, reported "live (captured …)",
+        /// and wrote the empty result over the cached snapshot — a fabricated 0%
+        /// commissioned presented as a live reading, with the recovery cache destroyed.
+        /// KUT_ValuationFromBms carries that percentage toward payment certification.</summary>
         public static Dictionary<string, NiagaraPoint> ParsePoints(string json)
         {
             var r = NiagaraPointParser.Parse(json);
-            if (r.Failed) StingLog.Warn($"Niagara parse: {r.Error}");
+            if (r.Failed)
+            {
+                StingLog.Warn($"Niagara parse: {r.Error} — treating as a FAILED read, not an empty station.");
+                return null;
+            }
+            if (!r.RecognisedShape)
+            {
+                // A JSON error envelope, or a bare scalar. Valid JSON, not a points feed.
+                StingLog.Warn("Niagara parse: the body was valid JSON but not a points feed " +
+                              "(no array, no points wrapper, no id-keyed point objects) — treating as a FAILED read.");
+                return null;
+            }
             // A feed whose id field we do not read yields an EMPTY dictionary, which reads
             // downstream as "no asset is commissioned" — the same as a station with nothing
             // on it. Say which one it was.
             if (r.SkippedNoId > 0)
                 StingLog.Warn($"Niagara parse: {r.SkippedNoId} entr(ies) carried no deviceId/id/name and were skipped.");
+            if (r.Unusable)
+            {
+                StingLog.Warn($"Niagara parse: {r.CandidateEntries} entr(ies) were present and none was understood " +
+                              "— treating as a FAILED read rather than an empty station.");
+                return null;
+            }
             return r.Points;
         }
 

--- a/StingTools/Core/Twin/NiagaraPointParser.cs
+++ b/StingTools/Core/Twin/NiagaraPointParser.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace StingTools.Core.Twin
@@ -34,7 +35,13 @@ namespace StingTools.Core.Twin
     /// <summary>What a parse understood, and what it did not. <see cref="Error"/> is
     /// non-null only when the payload was not JSON at all; a shape we simply did not
     /// recognise yields zero points and no error, because "the feed parsed but held
-    /// nothing we know how to read" is a different fact from "the feed is corrupt".</summary>
+    /// nothing we know how to read" is a different fact from "the feed is corrupt".
+    ///
+    /// Both of those are different again from "a points feed with nothing on it", and
+    /// until <see cref="RecognisedShape"/> existed they were the SAME VALUE downstream:
+    /// a JSON error envelope such as <c>{"error":"unauthorized"}</c> parses, yields zero
+    /// points and sets no error, so a rejected station read arrived at the commissioning
+    /// valuation as a successful live reading in which nothing is commissioned.</summary>
     public sealed class NiagaraPointParseResult
     {
         public Dictionary<string, NiagaraPoint> Points =
@@ -48,7 +55,32 @@ namespace StingTools.Core.Twin
         /// an EMPTY result that is otherwise indistinguishable from an empty station.</summary>
         public int SkippedNoId;
 
+        /// <summary>True when the payload was a shape this parser recognises AS A POINTS
+        /// FEED: a bare array, <c>{ "points": [...] }</c>, an object whose values are point
+        /// objects, or an empty object. FALSE for a JSON error envelope, and false for a
+        /// bare string / number / bool.
+        ///
+        /// An empty array or an empty object IS recognised — a station with nothing
+        /// commissioned yet is a real and expected state early in Stage 3, and turning it
+        /// into an error would make a legitimately empty station unreportable.</summary>
+        public bool RecognisedShape;
+
+        /// <summary>How many entries looked like point candidates (array elements that are
+        /// objects, or object properties whose value is an object). Zero on a genuinely
+        /// empty feed; non-zero with zero <see cref="Points"/> means entries were present
+        /// and NONE of them was understood.</summary>
+        public int CandidateEntries;
+
         public bool Failed => Error != null;
+
+        /// <summary>True when this body cannot be trusted as a points feed, and so must not
+        /// reach a consumer as a successful empty read. Three ways:
+        ///   - it was not JSON at all (an HTML error page),
+        ///   - it was JSON but not a points-feed shape (an error envelope),
+        ///   - it WAS a feed, entries were present, and not one of them was understood
+        ///     (a station naming its id field something we do not read).
+        /// A feed with zero candidate entries is NOT unusable: that is the empty station.</summary>
+        public bool Unusable => Failed || !RecognisedShape || (CandidateEntries > 0 && Points.Count == 0);
     }
 
     public static class NiagaraPointParser
@@ -66,14 +98,29 @@ namespace StingTools.Core.Twin
                 JArray arr = tok as JArray ?? (tok as JObject)?["points"] as JArray;
                 if (arr != null)
                 {
-                    foreach (var t in arr) Add(r, t as JObject);
+                    // A bare array or a {points:[...]} wrapper IS a feed, empty or not.
+                    r.RecognisedShape = true;
+                    foreach (var t in arr)
+                    {
+                        if (t is JObject) r.CandidateEntries++;
+                        Add(r, t as JObject);
+                    }
                 }
                 else if (tok is JObject obj)
                 {
-                    foreach (var pr in obj.Properties()) Add(r, pr.Value as JObject, pr.Name);
+                    // An object keyed by point id. Every value should be a point object.
+                    // An error envelope ({"error":"unauthorized"}) has scalar values only,
+                    // and is NOT a points feed - that is the case that used to arrive
+                    // downstream as "live, nothing commissioned".
+                    var props = obj.Properties().ToList();
+                    r.CandidateEntries = props.Count(pr => pr.Value is JObject);
+                    r.RecognisedShape = props.Count == 0 || r.CandidateEntries > 0;
+                    foreach (var pr in props) Add(r, pr.Value as JObject, pr.Name);
                 }
                 // Anything else (a bare string, number or bool) is valid JSON that holds no
-                // points. Zero points, no error — the caller reports "no live data".
+                // points. Deliberately NOT an Error - Error means "not JSON at all" - but
+                // RecognisedShape stays false, so the caller treats it as a failed read
+                // rather than as an empty station.
             }
             catch (Exception ex)
             {

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -350,7 +350,7 @@ namespace StingTools.Core
             "Niagara_ExportPoints", "Niagara_Reconcile", "Owner_KpiDashboard", "KUT_KpiDashboard",
             "KUT_ValuationFromBms", "KUT_LifecycleReconcile", "KUT_PushLifecycleGapsToAcc",
             "ACC_PullClashes", "ACC_SyncIssueStatus", "AccPullClashes", "AccSyncIssueStatus",
-            "ACC_UploadModel",
+            "ACC_UploadModel", "ACC_UploadLastBundle",
             "Lite_ComCheck",
             "ReviewComments_Import", "ReviewComments_Dashboard", "ReviewComments_Export", "ValidateTemplate",
             "CreateFilters", "CreateWorksets", "ViewTemplates", "AutoAssignTemplates", "AutoFixTemplate",
@@ -1993,6 +1993,7 @@ namespace StingTools.Core
                 // Resolvable so a PROJECT-authored workflow can use it; deliberately not
                 // in any shipped KUT workflow, because a step cannot answer "which file?".
                 case "ACC_UploadModel":         return new Core.Clash.AccUploadModelCommand();
+                case "ACC_UploadLastBundle":    return new Core.Clash.AccUploadLastBundleCommand();
                 case "BatchSystemPush":         return new Tags.BatchSystemPushCommand();
                 case "ExportSheetRegister":     return new Docs.ExportSheetRegisterCommand();
                 case "COBieHandoverExport":     return new Docs.COBieHandoverExportCommand();

--- a/StingTools/UI/StingCommandHandler.cs
+++ b/StingTools/UI/StingCommandHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -2877,6 +2877,10 @@ namespace StingTools.UI
                     // The REAL upload (APS Data Management), as distinct from ACCPublish,
                     // which only builds a local ACC-ready bundle for manual upload.
                     case "ACC_UploadModel":     RunCommand<Core.Clash.AccUploadModelCommand>(app); break;
+                    // Non-interactive twin: uploads the bundle ACCPublish recorded, so no
+                    // file picker is needed. Deliberately in no KUT workflow (see the
+                    // command's header) - the capability is wired, the decision is not made.
+                    case "ACC_UploadLastBundle": RunCommand<Core.Clash.AccUploadLastBundleCommand>(app); break;
                     case "CDEPackage": RunCommand<BIMManager.CDEPackageCommand>(app); break;
                     case "ValidateCDEHandover":
                     {

--- a/StingTools/UI/StingDockPanel.xaml
+++ b/StingTools/UI/StingDockPanel.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="StingTools.UI.StingDockPanel"
+﻿<Page x:Class="StingTools.UI.StingDockPanel"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       Title="STING Tools"
@@ -3137,6 +3137,8 @@
                                             ToolTip="Reconcile ACC Issue status back onto the escalation sidecar, so a closed ACC issue lets a recurring clash re-raise. Needs %APPDATA%\Planscape\acc_credentials.json."/>
                                     <Button Style="{StaticResource ActionBtn}" Content="ACC Upload" Tag="ACC_UploadModel" Click="Cmd_Click"
                                             ToolTip="Pick a file and upload it to ACC Docs for real (APS Data Management). This is the actual upload — 'ACC Publish' only builds a local ACC-ready bundle you would upload by hand. Needs %APPDATA%\Planscape\acc_credentials.json and an APS app with data:read/write/create."/>
+                                    <Button Style="{StaticResource ActionBtn}" Content="ACC Upload Bundle" Tag="ACC_UploadLastBundle" Click="Cmd_Click"
+                                            ToolTip="Upload the bundle ACC Publish last built, with no file picker. Needs an ACC Publish run first; it uploads that exact ZIP and nothing else, and asks for confirmation because it writes into the real CDE."/>
                                 </WrapPanel>
                             </StackPanel>
                         </Border>

--- a/StingTools/V6/AccBundleRecord.cs
+++ b/StingTools/V6/AccBundleRecord.cs
@@ -1,0 +1,111 @@
+// Licensed to Planscape under the STING Tools plug-in LICENSE. See LICENSE.
+//
+// StingTools/V6/AccBundleRecord.cs
+//
+// What ACCPublish just produced, written down so a later step can upload it.
+//
+// PR #927 added ACC_UploadModel behind a file picker and deliberately refused to put
+// it in the fortnightly Coordination Cycle: a workflow step cannot answer "upload
+// which file?", and guessing the model path — or silently uploading the active
+// document — would put an unintended file into an issued CDE container.
+//
+// That question is answerable now. ACCPublish already builds a ZIP at a deterministic
+// path and registers it in the export register; this records that path where the
+// uploader can read it. "Upload the bundle step 6 just produced" is a file choice, not
+// a guess.
+//
+// Revit-free and log-free: linked into StingTools.Acc.Tests, and it builds no project
+// paths of its own — the caller holds the Document and resolves through StingPaths, the
+// same contract CommissioningSource works under.
+
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace StingTools.V6
+{
+    /// <summary>The last ACC-ready bundle ACCPublish produced.</summary>
+    public sealed class AccBundleRecord
+    {
+        /// <summary>Absolute path to the ZIP.</summary>
+        [JsonProperty("path")] public string Path { get; set; } = string.Empty;
+        [JsonProperty("createdUtc")] public DateTime CreatedUtc { get; set; }
+        [JsonProperty("suitability")] public string Suitability { get; set; } = string.Empty;
+        [JsonProperty("deliverableCount")] public int DeliverableCount { get; set; }
+        [JsonProperty("sizeBytes")] public long SizeBytes { get; set; }
+
+        /// <summary>One line for a dialog: what would be uploaded, and how old it is.</summary>
+        public string Describe() =>
+            $"{System.IO.Path.GetFileName(Path)}  ({Suitability}, {DeliverableCount} deliverable(s), " +
+            $"{SizeBytes / 1024.0 / 1024.0:F1} MB, built {CreatedUtc:yyyy-MM-dd HH:mm}Z)";
+
+        /// <summary>Write the record. Failures are returned, not thrown: recording the
+        /// bundle is a convenience, and it must never fail the publish that produced it.</summary>
+        public static bool TryWrite(string recordPath, AccBundleRecord rec, out string error)
+        {
+            error = null;
+            if (string.IsNullOrEmpty(recordPath) || rec == null || string.IsNullOrEmpty(rec.Path))
+            {
+                error = "no record path or no bundle path";
+                return false;
+            }
+            try
+            {
+                string dir = System.IO.Path.GetDirectoryName(recordPath);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                File.WriteAllText(recordPath, JsonConvert.SerializeObject(rec, Formatting.Indented));
+                return true;
+            }
+            catch (Exception ex) { error = ex.Message; return false; }
+        }
+
+        /// <summary>Read the record as written. Null when absent or unreadable.</summary>
+        public static AccBundleRecord Read(string recordPath)
+        {
+            if (string.IsNullOrEmpty(recordPath)) return null;
+            try
+            {
+                if (!File.Exists(recordPath)) return null;
+                var rec = JsonConvert.DeserializeObject<AccBundleRecord>(File.ReadAllText(recordPath));
+                return string.IsNullOrEmpty(rec?.Path) ? null : rec;
+            }
+            catch (Exception) { return null; }
+        }
+
+        /// <summary>The recorded bundle IF THE FILE IS STILL THERE. Null otherwise.
+        ///
+        /// This is the difference between a file choice and a guess. A record pointing at a
+        /// ZIP somebody has since deleted, moved or cleaned out is not a file to upload —
+        /// acting on it either fails at the last moment or, worse, matches something else
+        /// that has taken the path. A caller must never treat Read() as "there is a bundle".</summary>
+        public static AccBundleRecord ReadExisting(string recordPath)
+        {
+            var rec = Read(recordPath);
+            if (rec == null) return null;
+            try { return File.Exists(rec.Path) ? rec : null; }
+            catch (Exception) { return null; }
+        }
+
+        /// <summary>Build a record for a bundle that exists on disk. Null when it does not —
+        /// there is no such thing as a record of a file that was never written.</summary>
+        public static AccBundleRecord ForFile(string zipPath, string suitability, int deliverableCount)
+        {
+            if (string.IsNullOrEmpty(zipPath)) return null;
+            long size = 0;
+            try { if (!File.Exists(zipPath)) return null; size = new FileInfo(zipPath).Length; }
+            catch (Exception) { return null; }
+            return new AccBundleRecord
+            {
+                Path = zipPath,
+                CreatedUtc = DateTime.UtcNow,
+                Suitability = suitability ?? string.Empty,
+                DeliverableCount = deliverableCount,
+                SizeBytes = size,
+            };
+        }
+
+        /// <summary>The record file name, so the writer and the reader cannot disagree on it.</summary>
+        public const string FileName = "last_bundle.json";
+    }
+}

--- a/StingTools/V6/AccCommandOutcome.cs
+++ b/StingTools/V6/AccCommandOutcome.cs
@@ -1,0 +1,115 @@
+// Licensed to Planscape under the STING Tools plug-in LICENSE. See LICENSE.
+//
+// StingTools/V6/AccCommandOutcome.cs
+//
+// The last mile of the "a failure is not an empty result" fix: given an
+// AccFetchResult, what does the operator see and does the command succeed?
+//
+// That decision used to live inside AccPullClashesCommand, which imports the
+// Revit API and can therefore be linked into no test project. The whole point
+// of the outcome split is that a workflow step FAILS instead of passing, and
+// that branch was verified by reading only - the same class of gap the exercise
+// is about. So the decision lives here: Revit-free and log-free, linked into
+// StingTools.Acc.Tests, with the Revit commands keeping only their shell.
+//
+// One function, two callers (AccPullClashesCommand + AccSyncIssueStatusCommand),
+// so the two cannot drift into describing the same failure differently.
+
+using System;
+
+namespace StingTools.V6
+{
+    /// <summary>What a command should do about a completed ACC read. Stands in for
+    /// Autodesk.Revit.UI.Result, which cannot be named from a Revit-free file.</summary>
+    public enum AccCommandVerdict
+    {
+        /// <summary>The read succeeded and returned data - carry on.</summary>
+        Proceed = 0,
+        /// <summary>The read succeeded and there was genuinely nothing. Report it plainly
+        /// and return Result.Succeeded: an empty container, a clash-clean model set and a
+        /// station with nothing commissioned are all real, expected states.</summary>
+        SucceededEmpty = 1,
+        /// <summary>The read did not succeed. Return Result.Failed so a workflow step
+        /// cannot record work it never did.</summary>
+        Failed = 2,
+    }
+
+    public static class AccCommandOutcome
+    {
+        /// <summary>Map a fetch status to what the command should do.
+        ///
+        /// The discard arm THROWS rather than defaulting. A permissive `_ => Failed`
+        /// would compile, pass every test, and silently decide the behaviour of a status
+        /// nobody thought about - which is how a new member ends up with an unconsidered
+        /// meaning. Throwing means AccCommandOutcomeTests, which enumerates
+        /// Enum.GetValues, goes red the moment a member is added without a decision.
+        /// (An arm-less switch expression would do the same, but warns CS8524 about
+        /// out-of-range casts, and this build is 0-warning.)</summary>
+        public static AccCommandVerdict Verdict(AccFetchStatus status) => status switch
+        {
+            AccFetchStatus.Ok => AccCommandVerdict.Proceed,
+            AccFetchStatus.EmptyOk => AccCommandVerdict.SucceededEmpty,
+            AccFetchStatus.AuthFailed => AccCommandVerdict.Failed,
+            AccFetchStatus.NotFound => AccCommandVerdict.Failed,
+            AccFetchStatus.TransportFailed => AccCommandVerdict.Failed,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status,
+                "Unhandled AccFetchStatus: every status needs an explicit command verdict. " +
+                "Add one here rather than letting it take a default meaning."),
+        };
+
+        /// <summary>True when the command must stop and report a failure.</summary>
+        public static bool IsFailure(AccFetchStatus status) => Verdict(status) == AccCommandVerdict.Failed;
+
+        /// <summary>The operator-facing message for a read that did NOT succeed.
+        ///
+        /// It names the failure kind, the reason and the container that was used, and it
+        /// opens by saying nothing was checked. What it must NEVER do is read like an
+        /// empty result: the words "clash-clean", "no clashes" and "not found" are absent
+        /// by construction and asserted absent by test, because each of them turns a
+        /// failed read into a coordinator's belief that ACC lost the data.</summary>
+        public static string FailureMessage(string what, AccFetchStatus status, int httpStatus,
+            string detail, string containerId)
+        {
+            if (!IsFailure(status))
+                throw new ArgumentException(
+                    $"FailureMessage called for {status}, which is not a failure. " +
+                    "A succeeding read must be reported by its own branch, not by this one.",
+                    nameof(status));
+
+            string reason = string.IsNullOrWhiteSpace(detail)
+                ? AccFetchOutcome.Describe(status, httpStatus)
+                : detail;
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"Could not read {what} from ACC. NOTHING WAS CHECKED — this is not a clean result.");
+            sb.AppendLine();
+            sb.AppendLine($"Failure: {status}");
+            sb.AppendLine($"Reason:  {reason}");
+            sb.AppendLine($"Container id used: {(string.IsNullOrEmpty(containerId) ? "(none)" : containerId)}");
+            sb.AppendLine();
+            sb.AppendLine(Remedy(status));
+            return sb.ToString();
+        }
+
+        /// <summary>What to do about each failure kind. Separate from the message so a test
+        /// can assert every failure kind has advice, not just a label.</summary>
+        public static string Remedy(AccFetchStatus status) => status switch
+        {
+            AccFetchStatus.AuthFailed =>
+                "Sign in to Autodesk again (BIM Coordination Center → Platforms → ACC), then confirm " +
+                "the app's Client ID/Secret and that the account can see this project.",
+            AccFetchStatus.NotFound =>
+                "Check the container id. ProjectId is the Issues container; set CoordContainerId when " +
+                "the Model Coordination container differs. If both are correct, the service sub-path " +
+                "has changed and needs confirming against APS.",
+            AccFetchStatus.TransportFailed =>
+                "Check network access to developer.api.autodesk.com and retry. If the payload shape " +
+                "has changed, the service sub-path needs confirming against APS.",
+            AccFetchStatus.Ok => "No action — the request succeeded.",
+            AccFetchStatus.EmptyOk => "No action — the request succeeded and there was nothing to return.",
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status,
+                "Unhandled AccFetchStatus: every status needs remedy text, or an operator is " +
+                "told what failed and not what to do."),
+        };
+    }
+}

--- a/StingTools/V6/AccFetchOutcome.cs
+++ b/StingTools/V6/AccFetchOutcome.cs
@@ -139,7 +139,11 @@ namespace StingTools.V6
             AccFetchStatus.Ok => "request succeeded",
             AccFetchStatus.EmptyOk => "request succeeded and returned nothing",
             AccFetchStatus.AuthFailed => $"Autodesk rejected the token (HTTP {httpStatus}) - the sign-in or refresh token is not valid for this container",
-            AccFetchStatus.NotFound => $"Autodesk returned HTTP {httpStatus} Not Found - the container id, model set or clash-service sub-path is wrong",
+            // Deliberately NOT the phrase "404 Not Found". That reason phrase invites the
+            // exact misreading this whole split exists to prevent - a coordinator seeing
+            // "not found" concludes ACC lost the data, rather than that our request was
+            // wrong. AccCommandOutcomeTests asserts the words are absent.
+            AccFetchStatus.NotFound => $"Autodesk returned HTTP {httpStatus} - the container id, model set or service sub-path is wrong",
             _ => httpStatus > 0
                 ? $"the request failed (HTTP {httpStatus}) or returned a payload this client does not recognise"
                 : "the request did not complete (network error, or an unreadable payload)",

--- a/StingTools/V6/AccIssueSync.cs
+++ b/StingTools/V6/AccIssueSync.cs
@@ -262,33 +262,94 @@ namespace StingTools.V6
 
         /// <summary>Pull the full issue set from ACC, following pagination (offset
         /// loop) so large projects aren't truncated at the first page. 429s retried
-        /// per page with back-off; stops at the first short page or maxPages cap.</summary>
-        public static async Task<List<AccIssue>> PullIssuesAsync(AccCredentials creds, int pageSize = 100, int maxPages = 200)
+        /// per page with back-off; stops at the first short page or maxPages cap.
+        ///
+        /// Returns an <see cref="AccFetchResult{T}"/>, not a bare list, because the three
+        /// old exits — auth failure, a mid-pagination HTTP error, and success — all
+        /// returned a <c>List&lt;AccIssue&gt;</c> that the caller could not tell apart.
+        /// AccSyncIssueStatusCommand then read "issue absent from the list" as
+        /// "ACC deleted our issue", so an expired token made every escalated clash look
+        /// deleted, and a page-2 failure produced a PARTIAL reconciliation presented as a
+        /// complete one — after which the escalation sidecar was written.
+        ///
+        /// A PARTIAL read is a FAILURE. Only a run that read every page it needed is
+        /// Ok/EmptyOk; the rows gathered before the break are still returned in Value for
+        /// diagnostics, and Detail names how many pages succeeded.</summary>
+        public static async Task<AccFetchResult<List<AccIssue>>> PullIssuesAsync(
+            AccCredentials creds, int pageSize = 100, int maxPages = 200)
         {
             var list = new List<AccIssue>();
-            if (!await EnsureAuthAsync(creds).ConfigureAwait(false)) return list;
+            if (!await EnsureAuthAsync(creds).ConfigureAwait(false))
+            {
+                StingLog.Warn("AccIssueSync.PullIssues: no access token (refresh rejected or absent).");
+                return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.AuthFailed, list, 0,
+                    "no ACC access token could be obtained — the refresh token in acc_credentials.json " +
+                    "was rejected or is absent, so no issue was read at all");
+            }
 
             int offset = 0;
+            int pagesRead = 0;
             for (int page = 0; page < maxPages; page++)
             {
                 JObject j = null;
+                int lastStatus = 0;
                 for (int attempt = 0; attempt < 4 && j == null; attempt++)
                 {
-                    var req = new HttpRequestMessage(HttpMethod.Get,
-                        $"{IssuesUrl}/containers/{creds.ProjectId}/issues?limit={pageSize}&offset={offset}");
-                    req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
-                    var resp = await _http.SendAsync(req).ConfigureAwait(false);
-                    if ((int)resp.StatusCode == 429) { await Task.Delay(TimeSpan.FromSeconds(1 << attempt)).ConfigureAwait(false); continue; }
-                    if (!resp.IsSuccessStatusCode)
+                    try
                     {
-                        StingLog.Warn($"AccIssueSync.PullIssues {(int)resp.StatusCode} at offset {offset}");
-                        return list;
+                        using var req = new HttpRequestMessage(HttpMethod.Get,
+                            $"{IssuesUrl}/containers/{creds.ProjectId}/issues?limit={pageSize}&offset={offset}");
+                        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", creds.AccessToken);
+                        using var resp = await _http.SendAsync(req).ConfigureAwait(false);
+                        lastStatus = (int)resp.StatusCode;
+                        if (lastStatus == 429) { await DelayHook(TimeSpan.FromSeconds(1 << attempt)).ConfigureAwait(false); continue; }
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            StingLog.Warn($"AccIssueSync.PullIssues {lastStatus} at offset {offset}");
+                            var st = AccFetchOutcome.Classify(lastStatus, -1);
+                            return AccFetchResult<List<AccIssue>>.Failure(st, list, lastStatus,
+                                $"the issue list failed at page {pagesRead + 1} (offset {offset}) after " +
+                                $"{pagesRead} page(s) succeeded — {AccFetchOutcome.Describe(st, lastStatus)}. " +
+                                $"The {list.Count} issue(s) already read are an INCOMPLETE set and must not be " +
+                                "reconciled against.");
+                        }
+                        string body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        try { j = JObject.Parse(body); }
+                        catch (Exception ex)
+                        {
+                            StingLog.Warn("AccIssueSync.PullIssues parse: " + ex.Message);
+                            return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.TransportFailed, list, lastStatus,
+                                $"page {pagesRead + 1} of the issue list was not valid JSON ({ex.Message}) after " +
+                                $"{pagesRead} page(s) succeeded");
+                        }
                     }
-                    j = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+                    catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is IOException)
+                    {
+                        // A network failure part-way through pagination is the shape that
+                        // produced a partial reconciliation. It is a failure, not a short read.
+                        StingLog.Warn("AccIssueSync.PullIssues transport: " + ex.Message);
+                        return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.TransportFailed, list, 0,
+                            $"the issue list request did not complete at page {pagesRead + 1} after " +
+                            $"{pagesRead} page(s) succeeded: {ex.Message}");
+                    }
                 }
-                if (j == null) break;
+                if (j == null)
+                {
+                    // Four consecutive 429s. Whatever we have is a partial set.
+                    return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.TransportFailed, list, lastStatus,
+                        $"Autodesk rate-limited page {pagesRead + 1} of the issue list on all 4 attempts " +
+                        $"(HTTP {lastStatus}) after {pagesRead} page(s) succeeded");
+                }
 
-                var results = j["results"] as JArray ?? new JArray();
+                var results = j["results"] as JArray;
+                if (results == null)
+                {
+                    // 200 with an unrecognised payload — a schema/sub-path change, never
+                    // "this container has no issues".
+                    return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.TransportFailed, list, lastStatus,
+                        $"page {pagesRead + 1} of the issue list carried no 'results' array — the " +
+                        "construction/issues/v1 payload shape has changed");
+                }
                 foreach (var t in results)
                 {
                     list.Add(new AccIssue
@@ -302,10 +363,16 @@ namespace StingTools.V6
                         LocationDescription = (string)t["location_description"] ?? string.Empty,
                     });
                 }
-                if (results.Count < pageSize) break;   // last page
+                pagesRead++;
+                if (results.Count < pageSize) return AccFetchResult<List<AccIssue>>.Success(list, list.Count == 0);
                 offset += pageSize;
             }
-            return list;
+
+            // Ran out of maxPages without ever seeing a short page: there is more than we
+            // read, so this is also an incomplete set.
+            return AccFetchResult<List<AccIssue>>.Failure(AccFetchStatus.TransportFailed, list, 200,
+                $"stopped at the {maxPages}-page cap with {pagesRead} page(s) read and no final short " +
+                "page — the container holds more issues than this read covered, so the set is INCOMPLETE");
         }
 
         /// <summary>True when an ACC issue status represents a closed/resolved state.</summary>

--- a/StingTools/V6/AccModelUpload.cs
+++ b/StingTools/V6/AccModelUpload.cs
@@ -32,18 +32,45 @@ namespace StingTools.V6
     /// </summary>
     public static class AccModelUpload
     {
-        private const string DataBase    = "https://developer.api.autodesk.com/data/v1";
-        private const string ProjectBase = "https://developer.api.autodesk.com/project/v1";
-        private const string OssBase     = "https://developer.api.autodesk.com/oss/v2";
+        internal const string DefaultHost = "https://developer.api.autodesk.com";
+        private static string _host = DefaultHost;
+
+        /// <summary>Test seam: point the client at a loopback listener. Production never
+        /// calls this. Pass null to restore the real APS host.</summary>
+        internal static void OverrideHostForTests(string host)
+            => _host = string.IsNullOrEmpty(host) ? DefaultHost : host.TrimEnd('/');
+
+        private static string DataBase    => _host + "/data/v1";
+        private static string ProjectBase => _host + "/project/v1";
+        private static string OssBase     => _host + "/oss/v2";
         private const string JsonApi     = "application/vnd.api+json";
 
         private static readonly HttpClient _http = new HttpClient();
 
+        /// <summary>The outcome of an upload.
+        ///
+        /// <see cref="Ok"/> and <see cref="Message"/> are unchanged - the BIM Coordination
+        /// Center card reads them - but a bare bool could not tell an auth failure from a
+        /// wrong folder from a network drop, which is the same under-attribution the rest
+        /// of the ACC surface has now shed. <see cref="Status"/> and
+        /// <see cref="HttpStatus"/> reuse AccFetchStatus rather than inventing a parallel
+        /// vocabulary, so one remedy table serves every ACC path.</summary>
         public sealed class UploadResult
         {
             public bool Ok { get; set; }
             public string Message { get; set; } = "";
             public string ItemUrn { get; set; } = "";
+
+            /// <summary>Which KIND of failure. Ok on success; never EmptyOk - an upload
+            /// either happened or did not, there is no empty case.</summary>
+            public AccFetchStatus Status { get; set; } = AccFetchStatus.Ok;
+
+            /// <summary>HTTP status when one was received; 0 when the request never completed
+            /// or the failure was local (no file, no credentials).</summary>
+            public int HttpStatus { get; set; }
+
+            /// <summary>What to do about it, shared with every other ACC failure.</summary>
+            public string Remedy => Ok ? "" : AccCommandOutcome.Remedy(Status);
         }
 
         /// <summary>DM endpoints want the account/project id in 'b.{guid}' form.</summary>
@@ -66,7 +93,12 @@ namespace StingTools.V6
                     return Fail("Set the Issues Project ID (the ACC project) first.");
 
                 if (!await AccIssueSync.EnsureAuthAsync(creds).ConfigureAwait(false))
-                    return Fail("Not authenticated — Sign in with Autodesk (or Test/Refresh) first.");
+                    return new UploadResult
+                    {
+                        Ok = false,
+                        Message = "Not authenticated — Sign in with Autodesk (or Test/Refresh) first.",
+                        Status = AccFetchStatus.AuthFailed,
+                    };
 
                 string projectId = EnsureB(creds.ProjectId);
                 string fileName = Path.GetFileName(filePath);
@@ -96,7 +128,7 @@ namespace StingTools.V6
                 };
                 var storageResp = await SendAsync(HttpMethod.Post, $"{DataBase}/projects/{projectId}/storage",
                     creds.AccessToken, storageBody, JsonApi, ct).ConfigureAwait(false);
-                if (!storageResp.ok) return Fail($"Create storage failed (HTTP {storageResp.status}). {Trim(storageResp.body)}");
+                if (!storageResp.ok) return Fail($"Create storage failed (HTTP {storageResp.status}). {Trim(storageResp.body)}", storageResp.status);
                 string objectId = JObject.Parse(storageResp.body)["data"]?["id"]?.Value<string>() ?? "";
                 if (string.IsNullOrEmpty(objectId)) return Fail("Storage response had no object id.");
 
@@ -110,7 +142,7 @@ namespace StingTools.V6
 
                 // 3. Upload the bytes to OSS (single- or multi-part, signed S3).
                 var up = await UploadFileAsync(creds.AccessToken, bucketKey, objectKey, filePath, ct).ConfigureAwait(false);
-                if (!up.ok) return Fail(up.err);
+                if (!up.ok) return Fail(up.err, up.status);
 
                 // 4. Create the item + first version pointing at the storage object.
                 var itemBody = new JObject
@@ -159,7 +191,7 @@ namespace StingTools.V6
                     StingLog.Info($"AccModelUpload: new version of '{fileName}' → {ver.urn}");
                     return new UploadResult { Ok = true, ItemUrn = ver.urn, Message = $"Uploaded a new version of '{fileName}' to ACC." };
                 }
-                if (!itemResp.ok) return Fail($"Create item failed (HTTP {itemResp.status}). {Trim(itemResp.body)}");
+                if (!itemResp.ok) return Fail($"Create item failed (HTTP {itemResp.status}). {Trim(itemResp.body)}", itemResp.status);
 
                 string itemUrn = JObject.Parse(itemResp.body)["data"]?["id"]?.Value<string>() ?? "";
                 StingLog.Info($"AccModelUpload: uploaded '{fileName}' → {itemUrn}");
@@ -182,7 +214,7 @@ namespace StingTools.V6
         /// part (one part buffered at a time to bound memory). Finalises with the
         /// uploadKey either way.
         /// </summary>
-        private static async Task<(bool ok, string err)> UploadFileAsync(
+        private static async Task<(bool ok, string err, int status)> UploadFileAsync(
             string accessToken, string bucketKey, string objectKey, string filePath, CancellationToken ct)
         {
             long size = new FileInfo(filePath).Length;
@@ -191,13 +223,13 @@ namespace StingTools.V6
             string signUrl = $"{OssBase}/buckets/{bucketKey}/objects/{Uri.EscapeDataString(objectKey)}/signeds3upload?minutesExpiration=60"
                              + (numParts > 1 ? $"&parts={numParts}" : "");
             var signResp = await SendAsync(HttpMethod.Get, signUrl, accessToken, null, null, ct).ConfigureAwait(false);
-            if (!signResp.ok) return (false, $"Signed-upload request failed (HTTP {signResp.status}). {Trim(signResp.body)}");
+            if (!signResp.ok) return (false, $"Signed-upload request failed (HTTP {signResp.status}). {Trim(signResp.body)}", signResp.status);
 
             var signJson = JObject.Parse(signResp.body);
             string uploadKey = signJson["uploadKey"]?.Value<string>() ?? "";
             var urls = signJson["urls"] as JArray;
             if (string.IsNullOrEmpty(uploadKey) || urls == null || urls.Count == 0)
-                return (false, "Signed-upload response missing uploadKey/urls.");
+                return (false, "Signed-upload response missing uploadKey/urls.", 0);
 
             if (numParts == 1)
             {
@@ -205,7 +237,7 @@ namespace StingTools.V6
                 using var fs = File.OpenRead(filePath);
                 using var put = new HttpRequestMessage(HttpMethod.Put, urls[0].Value<string>()) { Content = new StreamContent(fs) };
                 var putResp = await _http.SendAsync(put, ct).ConfigureAwait(false);
-                if (!putResp.IsSuccessStatusCode) return (false, $"S3 upload failed (HTTP {(int)putResp.StatusCode}).");
+                if (!putResp.IsSuccessStatusCode) return (false, $"S3 upload failed (HTTP {(int)putResp.StatusCode}).", (int)putResp.StatusCode);
             }
             else
             {
@@ -224,15 +256,15 @@ namespace StingTools.V6
                     }
                     using var put = new HttpRequestMessage(HttpMethod.Put, urls[i].Value<string>()) { Content = new ByteArrayContent(buffer, 0, read) };
                     var putResp = await _http.SendAsync(put, ct).ConfigureAwait(false);
-                    if (!putResp.IsSuccessStatusCode) return (false, $"S3 upload part {i + 1}/{urls.Count} failed (HTTP {(int)putResp.StatusCode}).");
+                    if (!putResp.IsSuccessStatusCode) return (false, $"S3 upload part {i + 1}/{urls.Count} failed (HTTP {(int)putResp.StatusCode}).", (int)putResp.StatusCode);
                 }
             }
 
             var finResp = await SendAsync(HttpMethod.Post,
                 $"{OssBase}/buckets/{bucketKey}/objects/{Uri.EscapeDataString(objectKey)}/signeds3upload",
                 accessToken, new JObject { ["uploadKey"] = uploadKey }, "application/json", ct).ConfigureAwait(false);
-            if (!finResp.ok) return (false, $"Finalise upload failed (HTTP {finResp.status}). {Trim(finResp.body)}");
-            return (true, "");
+            if (!finResp.ok) return (false, $"Finalise upload failed (HTTP {finResp.status}). {Trim(finResp.body)}", finResp.status);
+            return (true, "", 200);
         }
 
         /// <summary>Add a new version to an existing item (the 409 path), pointing at the just-uploaded storage object.</summary>
@@ -327,6 +359,21 @@ namespace StingTools.V6
         }
 
         private static string Trim(string s) => string.IsNullOrEmpty(s) ? "" : (s.Length > 300 ? s.Substring(0, 300) : s);
-        private static UploadResult Fail(string msg) => new UploadResult { Ok = false, Message = msg };
+        /// <summary>A failure with no HTTP exchange behind it (no file, no credentials,
+        /// an unparseable id). TransportFailed is the honest classification: something went
+        /// wrong and Autodesk never said anything about it.</summary>
+        private static UploadResult Fail(string msg) =>
+            new UploadResult { Ok = false, Message = msg, Status = AccFetchStatus.TransportFailed, HttpStatus = 0 };
+
+        /// <summary>A failure Autodesk answered. Classified with the SAME mapping the read
+        /// paths use, so a 403 on storage creation reads as an auth problem here exactly as
+        /// it would on a clash pull.</summary>
+        private static UploadResult Fail(string msg, int httpStatus) => new UploadResult
+        {
+            Ok = false,
+            Message = msg,
+            Status = AccFetchOutcome.Classify(httpStatus, -1),
+            HttpStatus = httpStatus,
+        };
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,86 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 266 — the two read paths #927 did not reach)
+
+Phase 265 gave ACC reads an outcome (`Ok` / `EmptyOk` / `AuthFailed` / `NotFound` /
+`TransportFailed`) and applied it to Model Coordination clashes. **The same defect was
+still live in two other read paths, and one was worse than the one that was fixed.**
+
+**A failed ACC issue read read as "the issues are gone".**
+`AccIssueSync.PullIssuesAsync` returned a bare `List<AccIssue>` from three exits — auth
+failure, a mid-pagination HTTP error, and success. `AccSyncIssueStatusCommand` reconciled
+the escalation sidecar against that list and reported every tracked clash whose issue was
+absent as `NOT_FOUND / keep`. So an expired token made **every escalated clash look deleted
+from ACC**, and a page-2 failure produced a **partial reconciliation presented as a
+complete one** — after which the sidecar was written, permanently un-tracking whatever
+happened to be on page 1.
+
+It now returns `AccFetchResult<List<AccIssue>>`. **A partial read is a failure**: only a run
+that saw a final short page is `Ok`/`EmptyOk`, and the `Detail` names how many pages
+succeeded before it broke. The command refuses to reconcile, returns `Result.Failed`, and
+says so — *"The escalation record was left untouched — nothing was un-tracked."*
+
+**A malformed Niagara feed read as "live, nothing commissioned" — and deleted the
+fallback.** Four steps compounded. `NiagaraPointParser.Parse` correctly flagged an
+unparseable body; `NiagaraJsonClient.ParsePoints` logged that and **returned the empty
+points anyway**, discarding the flag; the empty dictionary is not null, so
+`CommissioningSource.Resolve` took the *live* branch and reported `live (captured …)`; and
+`Persist` then wrote that empty result over `last_station_points.json`, **destroying the
+last good snapshot — the fallback that exists precisely for an unreachable station**.
+`KUT_ValuationFromBms` turns those points into a commissioning percentage the cost module
+carries toward payment certification.
+
+The worst input was `{"error":"unauthorized"}`: it *parses*, yields zero points and sets no
+error at all, so nothing anywhere reported a problem. The parser now separates "not a
+points feed I recognise" from "a points feed with nothing on it" — a JSON error envelope,
+an HTML error page, a bare scalar, and a feed whose entries all lack a readable id are each
+unusable; `[]`, `{"points":[]}` and `{}` remain a legitimately empty station. `ParsePoints`
+returns null for every unusable body, and `Persist` refuses to overwrite a usable snapshot
+with an empty read — `LoadCache` rejects a zero-point snapshot, so writing one does not
+update the cache, it removes it.
+
+**Not over-corrected.** A station with nothing commissioned yet still reports
+`live (captured …)` with zero points, an empty ACC container is still `EmptyOk`, and a
+clash-clean model set still passes. The bug was failures masquerading as empty, never
+emptiness itself.
+
+**The last mile is now tested.** The branch that decides `Result.Failed` lived inside two
+Revit-bound commands that no test project can link, so it was verified by reading — the same
+gap the whole exercise is about. `V6/AccCommandOutcome.cs` holds that decision, Revit-free,
+and both commands call it, so they cannot describe the same failure differently. Its table
+is driven by `Enum.GetValues<AccFetchStatus>()`, and its switches **throw** on an unhandled
+member rather than defaulting, so a status added without a decision goes red immediately.
+The phrase "404 Not Found" was dropped from the failure text: it is the HTTP reason phrase
+and it invites exactly the misreading — a test asserts "clash-clean", "no clashes" and
+"not found" cannot appear in any failure message.
+
+**Four smaller closures.**
+
+- `tools/check_kut_workflow_tags.py` now runs in CI (`.github/workflows/kut-workflow-tags.yml`).
+  Its extraction window also stopped being a hard-coded line range: adding one `case` to
+  `ResolveCommand` pushed `default: return null;` past the end and the checker refused to
+  run — correct, but on a perfectly fine change, and a gate that cries wolf gets switched
+  off. It now locates the method by signature and brace-matches to its end, keeping all
+  three assertions. 97/97 across 10 files.
+- `ACCPublish` records the ZIP it built (`_BIM_COORD/acc/last_bundle.json`), so
+  `ACC_UploadLastBundle` can upload it with no file picker. A record naming a file that is
+  no longer on disk is **not** a bundle — that rule is what keeps this a file *choice*
+  rather than the guess #927 refused to make. **Still in no KUT workflow**, deliberately.
+- `AccModelUpload.UploadResult` carries an `AccFetchStatus` and HTTP status beside
+  `Ok`/`Message`, so a 403 on storage creation reads as an auth problem rather than as
+  "it didn't work".
+- `docs/KUT_LIVE_VERIFICATION_RUNBOOK.md` updated: its expected-output sections described
+  failures that no longer look like that.
+
+`CLAUDE.md` corrections, each re-measured in the session that changed it: the Boq test row
+(121 declared / 196 cases → **956 / 1,335**), a new Acc row (**60 / 67** — that surface had
+none), and the healthcare Niagara caveat, which was true of `TwinReadback` and read as
+"Niagara is absent" when two of its three paths are built.
+
+Build 0 errors / 0 warnings. `StingTools.Acc.Tests` 67 passing (was 38);
+`StingTools.Boq.Tests` 1,335 passing (was 1,316).
+
 #### Completed (Phase 265 — the ACC coordination gate that could pass without checking)
 
 **On a wrong container id, the KUT fortnightly coordination cycle reported a

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -169,6 +169,10 @@ proven coordination cycle ·
 2026-09-10) — the build that closes what the readiness report found, ordered by what unblocks KUT
 soonest. Eight offline tasks, each with the command that proves it and the sabotage that must break
 it; three third-party-blocked items are quarantined in their own section ·
+[`PROMPT_KUT_INTEGRATION_BUILD_2.md`](PROMPT_KUT_INTEGRATION_BUILD_2.md) (work prompt, written
+2026-09-10) — the second build pass, after PR #927. Finishes the defect class #927 half-closed:
+a failed ACC issue read still reads as "the issues are gone", and a malformed Niagara feed still
+reads as "live, nothing commissioned" while overwriting the cached fallback. Seven offline tasks ·
 [`KUT_LIVE_VERIFICATION_RUNBOOK.md`](KUT_LIVE_VERIFICATION_RUNBOOK.md) (written 2026-09-10) — how to
 prove ACC, Niagara and Fohlio against the real tenant / station / designer, for the three items no
 developer can close alone. Per item: who must act first, what they must supply, the steps, the

--- a/docs/KUT_LIVE_VERIFICATION_RUNBOOK.md
+++ b/docs/KUT_LIVE_VERIFICATION_RUNBOOK.md
@@ -124,10 +124,14 @@ Could not read clashes for model set '<name>' from ACC.
 NOTHING WAS CHECKED — this is not a clean result.
 
 Failure: NotFound
-Reason:  Autodesk returned HTTP 404 Not Found — the container id, model set or
-         clash-service sub-path is wrong
+Reason:  Autodesk returned HTTP 404 — the container id, model set or service
+         sub-path is wrong
 Container id used: b.<the id it actually used>
 ```
+
+The words "not found" were deliberately removed from that message: a coordinator reading
+"404 Not Found" concludes ACC lost the data, when what it means is that our request was
+wrong. A test asserts the phrase cannot come back.
 
 Read the **Failure** line and act on it:
 
@@ -137,18 +141,48 @@ Read the **Failure** line and act on it:
 | `NotFound` | Wrong container id, wrong model set, or a changed clash sub-path | Check `ProjectId` / `CoordContainerId` against what the ACC administrator gave you. **If both are confirmed correct, this is the residual** — the `bim360/clash/v3` sub-paths need re-confirming against current APS documentation. Record the exact URL from `StingTools_<date>.log` and file it |
 | `TransportFailed` | Network failure, or a 200 whose payload shape this client does not recognise | Check reachability of `developer.api.autodesk.com`. A 200 with an unrecognised payload also means a schema change — same action as `NotFound` |
 
+**`ACC_SyncIssueStatus` now fails the same way.** Before 2026-09-10 it reconciled the
+escalation record against whatever `PullIssuesAsync` returned — and that returned a bare list
+for an auth failure, for a partial read, and for success alike. An expired token therefore made
+every escalated clash report `NOT_FOUND / keep`, which reads as "ACC deleted our issues"; a
+failure part-way through pagination un-tracked whatever happened to be on page 1 and called it
+a complete sync. Both now show the same NOTHING WAS CHECKED dialog, return `Result.Failed`, and
+say plainly:
+
+```
+The escalation record was left untouched — nothing was un-tracked.
+```
+
+A partial read is treated as a failure, and its Reason names how far it got — e.g.
+*"the issue list failed at page 2 (offset 100) after 1 page(s) succeeded"*. If you see that,
+re-run it; do not act on the rows it did return.
+
 A dialog that says *"Either the model set is clash-clean, or a clash test has not completed in ACC
 yet"* now appears **only** after a request that genuinely succeeded. Before the fix it also appeared
 after a 404, and the step still returned success — a coordination cycle that passed without having
 checked anything.
 
+**An upload failure now names its kind too.** `ACC_UploadModel` / `ACC_UploadLastBundle`
+report `Failure: AuthFailed` / `NotFound` / `TransportFailed` with the HTTP status and the same
+remedy text as the read paths, instead of a bare "it didn't work". A 403 on storage creation is
+the one to expect if the APS app is missing `data:create`.
+
 **Two operational facts worth knowing before scheduling this.** `ACC_PullClashes` opens a model-set
 picker, so the Coordination Cycle **cannot run unattended**. And step 6 of that cycle, `ACCPublish`,
 builds a **local** ACC-ready bundle for manual upload — it is labelled accordingly and does not
-publish to the CDE. The real uploader is the separate `ACC_UploadModel` command (dock panel → BIM
-tab → **ACC Upload**), which asks which file to upload; it is deliberately in no workflow, because a
-workflow step cannot answer that question and guessing would put an unintended file in an issued
-container.
+publish to the CDE. The real uploader is separate, and there are now two ways in:
+
+- **ACC Upload** (`ACC_UploadModel`) — pick any file.
+- **ACC Upload Bundle** (`ACC_UploadLastBundle`) — upload the bundle `ACCPublish` last built,
+  with no file picker. `ACCPublish` records which ZIP it produced in
+  `<project>/_BIM_COORD/acc/last_bundle.json`, so this is a file *choice*, not a guess. If that
+  ZIP has since been deleted the command says so and uploads nothing, rather than uploading
+  whatever now sits at that path. It asks for confirmation, naming the bundle, because it writes
+  into the real CDE.
+
+**Neither is in any KUT workflow**, and that is a decision, not an oversight: whether the
+fortnightly cycle should push into an issued container is the Information Manager's call, and it
+should not be made before B1 below has proved one live round-trip.
 
 ---
 
@@ -219,10 +253,30 @@ absence of `live (captured …)` is a definite negative, not an ambiguity.
 
 ### When it does not work
 
-The client returns **null** on a transport failure and an **empty dictionary** for a station that
-answered with nothing, and the two are reported differently. A feed whose id field is named something
-unexpected is counted as `SkippedNoId` rather than passing as an empty station — so "the station is
-empty" and "we could not read the station" cannot be confused.
+The client returns **null** for every unsuccessful read and an **empty dictionary** only for a
+station that genuinely answered with nothing, and the two are reported differently.
+
+That distinction was **not** reliable before 2026-09-10, and this is the failure mode to know
+about. The parser correctly flagged an unparseable body — and the client then returned the empty
+result anyway, so a station returning garbage was reported as `live (captured …)` with nothing
+commissioned, **and the empty result was written over the cached snapshot**, destroying the very
+fallback that exists for an unreachable station. The worst input was a JSON error envelope such as
+`{"error":"unauthorized"}`: it parses, yields zero points, and set no error at all.
+
+All four now fall through to the cache and end as `Cached` (or `None` when there is no snapshot),
+never `Live`:
+
+| Body from the station | Why it is not a reading |
+|---|---|
+| Not JSON at all | The station returned something else — often an HTML error page |
+| `{"error":"..."}` | Valid JSON, but an error envelope, not a points feed |
+| A bare string / number | Valid JSON, not a points feed |
+| Entries present, none with a readable id | The station names its id field something this client does not read — check `pointsPath` and the feed's field names with the contractor |
+
+A station that genuinely has **no points yet** still reports `live (captured …)` with zero
+points — that is a real, expected state in early Stage 3 and is deliberately not an error. It
+also no longer overwrites a non-empty cached snapshot, because a zero-point snapshot is a file
+and not a fallback.
 
 Most likely causes, in order: wrong `pointsPath`; wrong auth pair (`apiKey` set *and* `username`
 set — use one); station not reachable from the machine. This transport **has never been run against a

--- a/docs/PROMPT_KUT_INTEGRATION_BUILD_2.md
+++ b/docs/PROMPT_KUT_INTEGRATION_BUILD_2.md
@@ -1,0 +1,500 @@
+# Work prompt 2 — finish the KUT integration work (Fohlio · Niagara · ACC)
+
+**For an agent executing autonomously with no further input.** You cannot ask questions. Everything
+you need is here. Where something is genuinely unknowable, the task says to leave it blank with a
+marker and report it — never to guess.
+
+This is the **second** build pass. The first (PR #927, branch `claude/kut-integration-build`) fixed
+the ACC clash-read path and is good work — verified by re-running its gates and by five independent
+sabotages, all caught. **Read `docs/KUT_INTEGRATION_READINESS_2026-09.md` and
+`docs/PROMPT_KUT_INTEGRATION_BUILD.md` first**; they carry the `file:line` evidence and the
+conventions this pass continues.
+
+---
+
+## 0. Non-negotiable rules
+
+**Worktree.** Several agents share `C:\Dev\STINGTOOLS`. **Do not work in it.** Create your own
+worktree and do everything there:
+
+```bash
+git worktree add C:/Dev/wt-kut-build2 -b claude/kut-integration-build-2 origin/main
+cd C:/Dev/wt-kut-build2
+```
+
+Branch from `origin/main`, never from another unmerged branch. If you are already in an isolated
+worktree provided by the harness, use that one rather than creating a second.
+
+**If PR #927 is not yet merged into `main`**, its work is a prerequisite for most of this pass —
+`AccFetchResult<T>` and `StingTools.Acc.Tests` come from it. Check first:
+
+```bash
+git log --oneline origin/main | head -5
+ls StingTools/V6/AccFetchOutcome.cs
+```
+
+If `AccFetchOutcome.cs` is absent from `origin/main`, branch from
+`origin/claude/kut-integration-build` instead and say so in your report. Do not re-implement it.
+
+**Never run `deploy.bat`.** It rewrites the live Revit add-in manifest to point at whichever
+checkout ran it, which silently hijacks the add-in slot from every other agent and from the user.
+`build.bat` is safe. `dotnet build` is safe. **Do not open Revit.**
+
+**Never force-push.** Not with `--force`, not with `--force-with-lease`. If a push is rejected,
+rebase or merge and push again.
+
+**Never commit secrets.** No API key, client secret, refresh token, station password or credential
+of any kind enters the repo — not in code, not in a test, not in an example file, not in a commit
+message. Example files carry `REPLACE_WITH_...` placeholders only.
+
+**Never invent data.** If a mapping, code, URL, container id, parameter name or credential is
+unknown, leave it blank with a `REPLACE_WITH_...` or `TODO(KUT):` marker and say so in your final
+report. A guessed value that reaches an issued container has to be renumbered afterwards, and the
+number is already in transmittals. Guessing is worse than leaving a hole, because a wrong value
+looks supplied.
+
+**Never delete a deprecated shared parameter or its GUID.** Parameters are append-only here.
+
+---
+
+## 1. Standing project constraints
+
+- **The tooling is never named in any KUT-issued document** — no product name, command name,
+  parameter prefix (`ASS_`, `COM_`, `PRJ_`, …), file path, or `.py` / `.json` extension.
+  `KUT_BIM_MANAGER_PLAYBOOK_INTERNAL_STINGTOOLS.docx` is the sole exception and is never shared.
+  Internal `docs/` files (including this one) may name anything.
+- **Never hand-edit a generated document.** Edit the generator under `tools/` and regenerate.
+  `tools/check_kut_documents.py` (100 assertions, 5 documents) must stay green.
+- **Speckle / "Speck-Link" is private.** Never name it as a dependency or a CDE in anything issued.
+- **Documents carry no AI attribution.** PR bodies may.
+- **Close Microsoft Word** before any git operation touching a `.docx`.
+- End commit messages with `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`; end PR bodies
+  with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+
+---
+
+## 2. The defect class you are finishing
+
+PR #927 introduced `StingTools/V6/AccFetchOutcome.cs` — `AccFetchStatus` (`Ok` / `EmptyOk` /
+`AuthFailed` / `NotFound` / `TransportFailed`) and `AccFetchResult<T>` with a single `Succeeded`
+predicate. It applied that discipline to **one** read path: ACC Model Coordination clashes.
+
+**The same defect is still live in two other read paths**, and one of them is worse than the one
+that was fixed. In both, a read that FAILED is returned as a collection that looks like a read that
+SUCCEEDED and found nothing.
+
+This is the house failure mode. `CLAUDE.md` describes it: *"an empty list standing in for an
+error."* Your job is to finish applying the fix, not to invent a new mechanism — **`AccFetchResult<T>`
+already exists; use it.**
+
+Where things live:
+
+```
+StingTools/V6/AccFetchOutcome.cs              the outcome type (from #927) — reuse, do not re-invent
+StingTools/V6/AccIssueSync.cs                 PullIssuesAsync  <-- TASK A1
+StingTools/Clash/AccSyncIssueStatusCommand.cs its consumer     <-- TASK A1
+StingTools/Core/Twin/NiagaraJsonClient.cs     ParsePoints / FetchPoints  <-- TASK A2
+StingTools/Core/Twin/NiagaraPointParser.cs    the pure parser (already 43 tests)
+StingTools/Core/Twin/CommissioningSource.cs   live->cached->none resolver <-- TASK A2
+StingTools/Clash/AccPullClashesCommand.cs     fixed in #927; its branch is untested <-- TASK A3
+StingTools.Acc.Tests/                          from #927 — extend it
+StingTools.Boq.Tests/                          already links NiagaraPointParser.cs
+```
+
+**Two established patterns you must reuse rather than reinvent:**
+
+- **Linking Revit-free sources into tests:**
+  `<Compile Include="..\StingTools\...\X.cs" Link="X.cs" />`.
+- **Linking a source that calls `StingLog`:** `StingTools/Core/StingLog.cs` cannot be linked (it
+  drags in `StingTools.Core.Drawing`). Use the test-only no-op shim in the same namespace —
+  `StingTools.Acc.Tests/TestHelpers/StingLogShim.cs` (also in `StingTools.Visibility.Tests`). This
+  is how `CommissioningSource.cs` and `NiagaraJsonClient.cs` become testable.
+
+**Dispatch is three layers** — `StingCommandHandler.cs` case, `WorkflowEngine.ResolveCommand` case
+(`WorkflowEngine.cs` lines ~1395–2244, exactly one `switch`), and a `Tag="..." Click="Cmd_Click"`
+button in `StingDockPanel.xaml`. One-layer audits have twice produced large false-positive figures
+here.
+
+---
+
+## 3. How to work
+
+**Build the gate before the feature, and break your own gate once.**
+
+The #927 agent's A1 gate was wrong on its first run and **only deliberate sabotage found it**: it
+swallowed an `HttpRequestException` as `EmptyOk` and 37/37 still passed, because a downstream
+payload-shape check turned the bogus success into `TransportFailed` by another route — satisfying
+the assertion without the transport failure ever being attributed. That is an **alternative-path
+escape**, and it is the reason this rule is not optional.
+
+For every gate:
+
+1. Write the gate first.
+2. Run it. If it passes before the fix exists, **the gate is wrong**. Fix the gate.
+3. Write the fix. The gate must now pass.
+4. **Sabotage deliberately** — re-break the exact thing the gate exists to catch — and confirm it
+   **fails**. Restore.
+5. Report, per gate: the command, the pass result, the sabotage used, and that it failed.
+
+Watch for both gate faults: **circular expectations** (asserting what the code does rather than what
+is required) and **alternative-path escapes** (checking one route when the code has two). Where a
+result can be reached by more than one route, **assert the attribution, not just the verdict** —
+#927 did this by asserting `HttpStatus == 0` for a transport-down case, which only passes if the
+failure was attributed to the transport rather than inferred downstream. Copy that technique.
+
+**Assert on non-empty data.** A test that passes against an empty result set proves nothing.
+
+---
+
+## 4. SECTION A — work you can complete offline
+
+Ordered by what reaches KUT soonest. **A1 before A2** even though A2 is the more severe defect:
+ACC coordination is running fortnightly *now* (mobilisation began the week of 25 August 2026), while
+the Niagara path is not due until Stage 3.1 (~M40). Do not reorder.
+
+---
+
+### A1 — A failed ACC issue read must not read as "the issues are gone"
+
+**The defect.** `AccIssueSync.PullIssuesAsync` (`AccIssueSync.cs:266`) returns a bare
+`List<AccIssue>`:
+
+- `:269` — auth failure → `return list` (**empty**)
+- `:285` — HTTP error part-way through pagination → `return list` (**partial**)
+- `:308` — success → `return list`
+
+All three are indistinguishable to the caller. `AccSyncIssueStatusCommand` then builds `statusById`
+from that list and reports every tracked clash whose issue is absent as `NOT_FOUND` with action
+`keep`. So:
+
+- **auth failure** → *every* escalated clash reports `NOT_FOUND`, which reads to a coordinator as
+  "ACC deleted our issues", not "the read failed";
+- **partial pagination failure** → the issues on the pages that did arrive are reconciled and
+  un-tracked, while the rest report `NOT_FOUND` — a partial reconciliation presented as a complete
+  one, and the sidecar is then **written** (`AccSyncIssueStatusCommand.cs:87`).
+
+**Files to touch**
+- `StingTools/V6/AccIssueSync.cs` — `PullIssuesAsync` returns `AccFetchResult<List<AccIssue>>`.
+  Classify with the existing `AccFetchOutcome`. A partial read **is a failure**, not a success:
+  if any page fails, the outcome must not be `Ok`/`EmptyOk`, and the `Detail` must say how many
+  pages succeeded before it broke.
+- `StingTools/Clash/AccSyncIssueStatusCommand.cs` — branch on `Succeeded`. On any failure: say what
+  failed, name the container, return **`Result.Failed`**, and **do not write the sidecar**. Reuse
+  the message shape `AccPullClashesCommand.FailureMessage` already establishes — it says
+  *"NOTHING WAS CHECKED — this is not a clean result"* and never the words "not found".
+- Any other caller of `PullIssuesAsync` (search for it; fix them all).
+- `StingTools.Acc.Tests/` — tests.
+
+**Done means**
+- No caller can distinguish-by-accident: a failed or partial read cannot produce a reconciliation.
+- The sidecar is never mutated on a read that did not fully succeed.
+- `Result.Failed` on failure, so a workflow step cannot record a reconciliation it never did.
+
+**Prove it**
+
+```bash
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
+```
+
+Required cases, using the loopback server already in
+`StingTools.Acc.Tests/TestHelpers/LoopbackServer.cs`:
+- auth failure → not `Succeeded`; the returned list is empty **and** the status is `AuthFailed`
+  (assert the status, not just emptiness — emptiness alone is the bug);
+- page 1 returns a full page, page 2 returns 500 → **not** `Succeeded`, and `Detail` names the page
+  count. Assert the partial rows are *not* presented as a complete set;
+- two full pages then a short page → `Ok`, with the **summed** count asserted non-zero;
+- a container with genuinely zero issues → `EmptyOk`.
+
+**Sabotage to run and report:** (a) make the pagination-failure branch return `Ok`; confirm failure.
+(b) make the auth-failure branch return `EmptyOk`; confirm failure.
+
+---
+
+### A2 — A malformed Niagara feed must not read as "live, nothing commissioned"
+
+**The defect, and why it is the worst one left.** Three steps compound:
+
+1. `NiagaraPointParser.Parse` correctly sets `Error` on unparseable JSON and returns **empty**
+   `Points` (`NiagaraPointParser.cs:80`).
+2. `NiagaraJsonClient.ParsePoints` (`:68-78`) logs that failure — **and then returns `r.Points`
+   anyway (`:77`), discarding the `Failed` flag.**
+3. `FetchPoints` (`:82`) returns that empty dictionary. It is **not null**, so
+   `CommissioningSource.Resolve` (`CommissioningSource.cs:69-77`) takes the live branch, sets
+   `Source = Live`, and reports `"live (captured …)"`.
+
+The result: a station that returns garbage — or an HTML error page, or a JSON error envelope like
+`{"error":"unauthorized"}`, which parses as an object, yields zero points and **sets no error at
+all** — is reported as a **successful live reading in which nothing is commissioned**.
+
+And it is worse than a wrong number, because step 4 is:
+
+4. `CommissioningSource.Persist` (`:75`, `:104-116`) **writes that empty result over
+   `last_station_points.json`** — destroying the last good snapshot, which is the fallback that
+   exists precisely for a station being unreachable.
+
+`KUT_ValuationFromBms` consumes this to produce a commissioning valuation percentage, which the
+cost module carries toward payment certification. A fabricated 0% presented as live, with the
+recovery cache deleted, is the most consequential defect remaining in these three integrations.
+
+**Files to touch**
+- `StingTools/Core/Twin/NiagaraPointParser.cs` — the parser must be able to say *"this body was
+  not a points feed I recognise"* separately from *"this was a points feed with no points"*. Today
+  a JSON object of arbitrary keys silently produces zero points and no error (`:73` iterates
+  `obj.Properties()` and adds nothing). Add a recognition signal — e.g. how many candidate entries
+  were seen — so an error envelope is distinguishable from an empty station. **Do not** make a
+  bare string/number/bool an error; the existing comment (`:75`) explains that choice and it is
+  correct.
+- `StingTools/Core/Twin/NiagaraJsonClient.cs` — `ParsePoints`/`FetchPoints` must not discard the
+  failure. Return a result that carries it (mirror `AccFetchResult<T>`, or return `null` on a
+  failed parse as the transport path already does — either is acceptable, but the caller must be
+  unable to mistake it for a successful empty read).
+- `StingTools/Core/Twin/CommissioningSource.cs` — two rules:
+  - a failed live read must fall through to the cache exactly as an unreachable station does, and
+    end as `Cached` or `None`, never `Live`;
+  - **`Persist` must never overwrite an existing snapshot with the result of a read that did not
+    succeed.** Overwriting a good cache with an empty one turns a recoverable outage into data loss.
+- NEW or extended test coverage — `CommissioningSource.cs` and `NiagaraJsonClient.cs` are Revit-free
+  but call `StingLog`; link them with the `StingLogShim` pattern named in §2.
+
+**Done means**
+- A malformed body, an HTML error page, and a JSON error envelope each end as a **failure**, not as
+  `Live` with zero points.
+- A genuinely empty station still ends as a successful empty live read (do not over-correct —
+  a station with nothing commissioned yet is a real and expected state early in Stage 3).
+- The cached snapshot survives every failure mode.
+
+**Prove it**
+
+```bash
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo --filter "FullyQualifiedName~Niagara"
+```
+
+Required cases:
+- unparseable body → failure; `CommissioningSource` returns `Cached` when a snapshot exists and
+  `None` when it does not — **never** `Live`;
+- `{"error":"unauthorized"}` → failure, **not** an empty live read. This is the case that sets no
+  error today; assert it specifically;
+- HTML (`<html>…`) body → failure;
+- a valid feed with zero points → still `Live` and `EmptyOk`-equivalent (the legitimate empty case);
+- **cache preservation:** write a good snapshot, then run a failed live read, then assert the
+  snapshot file is **byte-identical** to what it was. This is the assertion that catches the data
+  loss, and it must be a file-content comparison, not just "Resolve returned Cached".
+
+**Sabotage to run and report:** (a) restore the `return r.Points` discard in `ParsePoints`; confirm
+failures. (b) make `Persist` write unconditionally again; confirm the cache-preservation test fails.
+
+---
+
+### A3 — Test the last mile: the command branches that decide `Result.Failed`
+
+**Why.** The whole point of #927's fix, and of A1 above, is that a workflow step **fails** instead
+of passing. That decision lives in `AccPullClashesCommand` and `AccSyncIssueStatusCommand`, which
+are Revit-bound and therefore linked into no test project. Today the branch that makes the fix
+matter is verified by reading only. That is the same class of gap the whole exercise is about.
+
+**Files to touch**
+- Extract the pure decision — *given an `AccFetchResult`, what does the user see and what does the
+  command return?* — into a Revit-free, log-free helper (the `AccFetchOutcome` precedent). The
+  command keeps the Revit shell and calls the helper.
+- `StingTools.Acc.Tests/` — tests over the helper.
+
+**Done means** a table-driven test asserts, for **every** `AccFetchStatus` value, the resulting
+`Result` and that the message does not contain the words `clash-clean`, `no clashes`, or `not found`
+for any non-succeeding status.
+
+Enumerate with `Enum.GetValues<AccFetchStatus>()` rather than listing cases, so a future status
+member is covered without anyone remembering to add it. **Assert the enumeration is non-empty**, or
+the test passes vacuously.
+
+**Prove it**
+
+```bash
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo --filter "FullyQualifiedName~Outcome"
+```
+
+**Sabotage to run and report:** add a new `AccFetchStatus` member and do **not** handle it in the
+helper; confirm the enumeration test fails rather than silently ignoring it. Remove it afterwards.
+
+---
+
+### A4 — Gate the workflow-tag checker in CI
+
+**Why.** `tools/check_kut_workflow_tags.py` (from #927) is well built — it self-tests on a
+known-good and a nonsense tag, asserts its extraction window holds exactly one `switch`, and
+confirms it is the *right* switch. Verified: exit 1 when sabotaged, 0 when clean. **But nothing
+runs it.** A checker nobody runs rots, and this one guards the KUT presets a live project depends on.
+
+**Files to touch** — NEW `.github/workflows/kut-workflow-tags.yml`.
+
+Model it on `.github/workflows/kut-document-gate.yml`. Trigger on changes to
+`StingTools/Data/WORKFLOW_KUT_*.json`, `StingTools/Core/WorkflowEngine.cs`, and the checker itself.
+Python 3.11, stdlib only (the checker has no dependencies — keep it that way).
+
+**Done means** the gate runs on PRs touching those paths and fails the build on an unresolved tag.
+
+**Prove it**
+
+```bash
+python tools/check_kut_workflow_tags.py .        # exit 0
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/kut-workflow-tags.yml')); print('workflow YAML parses')"
+```
+
+Then prove the wiring end-to-end locally by running exactly the command the workflow runs, with a
+sabotaged tag in place, and confirming a non-zero exit. Paste both exit codes.
+
+---
+
+### A5 — Decide the ACC upload chaining, now that it is decidable
+
+**Context.** #927 deliberately left this open, correctly: it added `ACC_UploadModel` (file picker,
+all three dispatch layers) but did **not** put it in the fortnightly Coordination Cycle, because a
+workflow step cannot answer *"upload which file?"* and guessing would put an unintended file in an
+issued CDE container.
+
+**It is now answerable.** `ACCPublish` already builds a ZIP at a deterministic path and registers
+it: `PlatformLinkCommands.cs:1196` computes `zipPath` and `:1201` calls
+`BIMManagerEngine.AutoRegisterExport(doc, zipPath, "CM", …)`. So *"upload the bundle step 6 just
+produced"* is a file choice that is not a guess.
+
+**Do this, and only this:**
+- Make `ACCPublish` record the bundle it produced somewhere a later step can read — the existing
+  export register is the natural home; a small sidecar under `_BIM_COORD/acc/` is acceptable. Do
+  not change what `ACCPublish` itself does.
+- Give `ACC_UploadModel` a non-interactive mode that uploads *that recorded bundle* when it exists,
+  keeping the file picker for the manual case.
+- **Do not add the step to `WORKFLOW_KUT_CoordinationCycle.json`.** Wiring the capability is offline
+  work; putting an automatic upload into an issued CDE container is a decision for the Information
+  Manager, and it should not happen before B1 (below) has proved one live round-trip. Say in your
+  report that the capability is ready and the step is deliberately not added.
+
+**Done means** the upload can run without a human picking a file, and no workflow uploads anything yet.
+
+**Prove it**
+
+```bash
+grep -n "AutoRegisterExport\|zipPath" StingTools/BIMManager/PlatformLinkCommands.cs | head
+grep -rn "ACC_UploadModel" StingTools/UI/StingCommandHandler.cs StingTools/Core/WorkflowEngine.cs StingTools/UI/StingDockPanel.xaml
+grep -c "ACC_UploadModel" StingTools/Data/WORKFLOW_KUT_CoordinationCycle.json   # must be 0
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
+```
+
+Before trusting that `0`, prove the grep can match — run it against a string you know is in the file
+(`grep -c ACCPublish` on the same file must be ≥ 1). A grep you have not seen succeed is not evidence.
+
+---
+
+### A6 — Make `AccModelUpload` report failures like everything else now does
+
+**Why.** `AccModelUpload.UploadResult` (`AccModelUpload.cs:42-45`) carries only `bool Ok` and a
+`string Message`. Every other ACC path now carries a status kind, an HTTP status and a `Detail`. A
+caller cannot tell an auth failure from a 404 folder from a network drop, which is the same
+under-attribution — milder, because `Ok=false` at least does not read as success.
+
+**Do:** align it with `AccFetchResult<T>` / `AccFetchStatus` — reuse, do not parallel-invent. Keep
+`Ok` if callers depend on it (`BIMCoordinationCenter.cs` ~`:5581` reads `r.Ok`/`r.Message`); adding
+the kind alongside is enough. Update callers to surface the kind.
+
+**Done means** an upload failure names which kind of failure it was.
+
+**Prove it**
+
+```bash
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
+grep -rn "UploadAsync" --include="*.cs" StingTools/ | grep -v /obj/
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
+```
+
+Add at least one loopback test: a 403 on storage creation must surface as an auth-kind failure, not
+a bare `Ok=false`.
+
+---
+
+### A7 — Correct the stale claims in `CLAUDE.md`
+
+**Why.** `CLAUDE.md` is the single onboarding surface; a wrong headline mis-informs every human and
+agent who starts there. These were measured on 2026-09-10 and confirmed still stale on the #927
+branch. **Correct only these**; do not restyle the file or re-measure anything you have not run.
+
+| Line / claim | Measured | Fix |
+|---|---|---|
+| Test table row `\| Boq \| 121 \| ✅ 196 cases, 0 failing \|` (~`:132`) | **1316 passing, 0 failing** | Update the row; keep the table's "declared vs executed" caveat |
+| Healthcare caveat 3 — *"`TwinReadback` BACnet / OPC-UA transports are abstract stubs"* | True of `TwinReadback.cs:39,46`, but it reads as "Niagara is absent" when the file-mediated path and a real oBIX HTTP client both exist | Keep the stub statement, add one sentence naming `NiagaraJsonClient` and `NiagaraCommands` |
+| Anywhere claiming 9 KUT workflows | There are **10** | Correct the count |
+
+**Also** add the two new test projects/counts if the file enumerates them, and note that
+`StingTools.Acc.Tests` now exists.
+
+**Done means** every number you touch is one you personally re-ran in this session.
+
+**Prove it** — paste the output you based each correction on:
+
+```bash
+dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo | tail -2
+dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo | tail -2
+ls -1 StingTools/Data/WORKFLOW_KUT_*.json | wc -l
+```
+
+---
+
+## 5. SECTION B — blocked on someone else. Do not attempt.
+
+Unchanged from the first pass, and **B1 is now the only thing standing between the pack and a proven
+coordination cycle.** Do not fabricate a credential, mock a service and call it verified, or mark any
+of these done. `docs/KUT_LIVE_VERIFICATION_RUNBOOK.md` (from #927) is the procedure; if your work
+changes what a failure looks like — A1 and A2 both will — **update that runbook's expected-output
+sections** so it still matches reality. That is offline work and it is in scope.
+
+| # | Blocked work | Who must act | Why you cannot proceed |
+|---|---|---|---|
+| **B1** | One live ACC pull + one live issue push | **Owner / Autodesk account holder** (APS app, Traditional Web App, callback `http://localhost:8910/callback`); **ACC project admin** (container ids) | No APS Client ID or Secret exists. **Overdue** — mobilisation began the week of 25 August 2026 and the fortnightly cycle depends on it. |
+| **B2** | One live Niagara station fetch | **Controls / commissioning contractor** — base URL, the station-specific oBIX points path, credentials | No station to reach. `/obix` is the oBIX lobby, not a points feed. Not due until Stage 3.1 (~M40). |
+| **B3** | Confirm the Fohlio field mapping is agreed | **Interior Designer** — owns the Fohlio record | `KUT_PROJECT_DELIVERY_PLAYBOOK.md:708` makes it a mobilisation obligation; the shipped map is authored on our side and nothing evidences sign-off. A meeting, not a code task, and on the mobilisation critical path. |
+
+---
+
+## 6. What you must NOT do
+
+- Do not re-implement `AccFetchResult<T>` / `AccFetchOutcome`. Reuse them.
+- Do not implement the Fohlio REST transport (out of contract scope — the BEP mitigates it with the
+  file route) or BACnet/OPC-UA readback (`TwinReadback.cs`, stubbed by design, not promised).
+- Do not add any upload step to a KUT workflow (A5 explains why).
+- Do not "fix" a genuinely empty result into an error. An empty station, an empty container and a
+  clash-clean model set are all real, expected states. The bug is failures *masquerading* as empty,
+  not emptiness itself. Over-correcting here would break the legitimate cases and is worse than the
+  original defect, because it would make a clean cycle unreportable.
+- Do not refactor the god-files (`StingCommandHandler.cs`, `BIMCoordinationCenter.cs`). Add your
+  cases; change nothing else in them.
+- Do not edit a generated KUT document. Edit its generator and regenerate.
+- Do not change `CLAUDE.md` beyond A7's three corrections.
+
+---
+
+## 7. Finishing
+
+Run the full gate set and paste real output — the actual last lines, not a summary:
+
+```bash
+dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo   # 0 errors, 0 warnings
+dotnet test  StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo     # baseline 38 passing
+dotnet test  StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo     # baseline 1316 passing
+python tools/check_kut_workflow_tags.py .                                  # 97/97 across 10 files
+python tools/check_kut_documents.py                                        # 100 assertions, 5 docs
+python tools/check_docs_index.py                                           # every docs/ file indexed
+```
+
+Both test baselines must **rise, not fall** — say by how much and why. `check_kut_documents.py` must
+stay green even though you should not have touched a generated document; run it to prove you did not.
+
+Then commit on your branch and open a PR stating, per task:
+
+- **what changed**, with `file:line`;
+- **the command that proves it**, and its real output;
+- **the sabotage you ran**, and confirmation the gate failed under it;
+- **every `REPLACE_WITH_...` / `TODO(KUT):`** you introduced, and why;
+- **what you could not do**, and who must act.
+
+Report failures plainly. If a gate will not go green, say so with the output rather than narrowing
+the gate until it passes — a gate relaxed to pass is worse than a red one, because it reports health
+it has not checked. If you finish only part of Section A, finish what you did completely and say
+explicitly which tasks you left and why. **A1 and A2 in full beat all seven half-done**; scaling the
+work down is the user's call, not yours.

--- a/tools/check_kut_workflow_tags.py
+++ b/tools/check_kut_workflow_tags.py
@@ -14,12 +14,13 @@ This is the house failure mode CLAUDE.md describes -- an absent side effect that
 exactly like a completed one -- in the place where it costs a delivery gate.
 
 WHAT IT CHECKS
-  1. The extraction window is sound. ``ResolveCommand`` lives at
-     WorkflowEngine.cs:1395-2244 and MUST contain exactly one ``switch``. If a future
-     edit moves or splits the method, the window would silently start scraping ``case``
-     labels from a neighbouring switch and report a HIGHER resolve rate than reality.
-     A checker that widens its own view rather than failing is worse than no checker,
-     so this aborts instead.
+  1. The extraction window is sound. ``ResolveCommand`` is located by its signature and
+     brace-matched to its end (string literals and comments are blanked first, so a brace
+     inside ``$"{x}"`` cannot end the method early), and the body MUST contain exactly one
+     ``switch (tag)`` reaching ``default: return null;``. If the dispatcher is restructured,
+     this aborts rather than scraping ``case`` labels from somewhere else and reporting a
+     HIGHER resolve rate than reality. A checker that widens its own view rather than
+     failing is worse than no checker.
   2. It discriminates. A known-good tag must be found and a nonsense tag must not.
      Every gate on this project was wrong on its first run; this one says so out loud
      before it reports anything.
@@ -39,10 +40,20 @@ import re
 import sys
 from pathlib import Path
 
-# ResolveCommand's body. Deliberately hard-coded and then VERIFIED (check 1 below)
-# rather than located by a regex that could drift onto another method.
-RESOLVE_START = 1395
-RESOLVE_END = 2244
+# ResolveCommand's body is LOCATED, not hard-coded.
+#
+# It used to be the literal line range 1395-2244, verified to hold exactly one switch.
+# That was safe but it cried wolf: adding a single `case` to ResolveCommand pushes its
+# closing `default: return null;` past the end of the window, and the checker then refused
+# to run - correctly, but on a change that was perfectly fine. A gate that goes red on
+# unrelated edits gets switched off, and this one now runs in CI
+# (.github/workflows/kut-workflow-tags.yml).
+#
+# So the window is derived: find the method by its SIGNATURE, brace-match to its end, and
+# then apply exactly the same three assertions to whatever that region turns out to be.
+# Anchoring on the signature is strictly stronger than a line range - a line range can
+# drift onto a neighbouring method, a signature cannot.
+RESOLVE_SIGNATURE = 'private static IExternalCommand ResolveCommand('
 
 WORKFLOW_GLOB = "StingTools/Data/WORKFLOW_KUT_*.json"
 ENGINE = "StingTools/Core/WorkflowEngine.cs"
@@ -61,40 +72,121 @@ def fail(msg: str) -> None:
     sys.exit(2)
 
 
-def extract_case_labels(engine_path: Path) -> set[str]:
-    lines = engine_path.read_text(encoding="utf-8", errors="replace").splitlines()
-    if len(lines) < RESOLVE_END:
-        fail(
-            f"{engine_path} has only {len(lines)} lines; the ResolveCommand window "
-            f"{RESOLVE_START}-{RESOLVE_END} no longer exists. The method has moved -- "
-            "re-locate it and update RESOLVE_START/RESOLVE_END rather than widening the window."
-        )
-    window = "\n".join(lines[RESOLVE_START - 1 : RESOLVE_END])
+def strip_strings_and_comments(text: str) -> str:
+    """Blank out string/char literals and comments, keeping length and newlines.
 
-    # Check 1: exactly one switch in the window.
+    Brace-matching a C# method has to ignore braces inside `$"{x}"` and inside a comment,
+    or the method's end is found in the wrong place - and a window that ends in the wrong
+    place is exactly the silent mis-measurement this gate exists to prevent.
+    """
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if c == "/" and nxt == "/":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if c == "/" and nxt == "*":
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            out.append("  ")
+            i += 2
+            continue
+        if c == "@" and nxt == '"':                       # verbatim string
+            out.append("  ")
+            i += 2
+            while i < n:
+                if text[i] == '"':
+                    if i + 1 < n and text[i + 1] == '"':   # "" escape
+                        out.append("  ")
+                        i += 2
+                        continue
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            continue
+        if c in ('"', "'"):                                # regular string / char literal
+            quote = c
+            out.append(" ")
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    out.append("  ")
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def locate_resolve_command(text: str) -> tuple[int, int]:
+    """Character offsets of ResolveCommand's body, found by signature + brace match."""
+    blank = strip_strings_and_comments(text)
+    hits = blank.count(RESOLVE_SIGNATURE)
+    if hits != 1:
+        fail(
+            f"expected exactly 1 declaration of '{RESOLVE_SIGNATURE}...', found {hits}. "
+            "Refusing to guess which one is the dispatcher."
+        )
+    start = blank.index(RESOLVE_SIGNATURE)
+    brace = blank.index("{", start)
+    depth = 0
+    for i in range(brace, len(blank)):
+        if blank[i] == "{":
+            depth += 1
+        elif blank[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return brace, i + 1
+    fail("ResolveCommand's opening brace is never closed -- the file is truncated or unbalanced.")
+
+
+def extract_case_labels(engine_path: Path) -> set[str]:
+    text = engine_path.read_text(encoding="utf-8", errors="replace")
+    lo, hi = locate_resolve_command(text)
+    window = text[lo:hi]
+    first_line = text.count("\n", 0, lo) + 1
+    last_line = text.count("\n", 0, hi) + 1
+    print(f"ResolveCommand located at {engine_path.name}:{first_line}-{last_line} "
+          f"(by signature + brace match, not a hard-coded range)")
+
+    # Check 1: exactly one switch in the located body.
     switches = SWITCH_RE.findall(window)
     if len(switches) != 1:
         fail(
-            f"the window {engine_path}:{RESOLVE_START}-{RESOLVE_END} contains "
-            f"{len(switches)} 'switch(' statements, expected exactly 1. Either "
-            "ResolveCommand has moved, or a second switch is now inside the window and "
-            "its case labels would inflate the resolvable set. Refusing to report a "
-            "resolve rate from a window I cannot vouch for."
+            f"ResolveCommand's body ({engine_path.name}:{first_line}-{last_line}) contains "
+            f"{len(switches)} 'switch(' statements, expected exactly 1. A second switch "
+            "inside it would inflate the resolvable set with case labels that are not "
+            "command tags. Refusing to report a resolve rate from a body I cannot vouch for."
         )
-    # Check 1b: it is the RIGHT switch, and the window still reaches its end. A window
-    # that has drifted off the bottom would clip real cases and under-report; one that
-    # has drifted off the top would scrape a neighbouring method. Both must be loud.
+    # Check 1b: it is the RIGHT switch, and the body really is the whole dispatcher.
+    # Kept from the hard-coded-window version: locating by signature makes drift onto a
+    # neighbouring method impossible, but these still catch a dispatcher that has been
+    # restructured into a shape this checker no longer measures correctly.
     if "switch (tag)" not in window and "switch(tag)" not in window:
         fail(
-            f"the single switch in {engine_path}:{RESOLVE_START}-{RESOLVE_END} is not "
-            "'switch (tag)'. The window is no longer looking at ResolveCommand."
+            f"the single switch in ResolveCommand ({engine_path.name}:{first_line}-{last_line}) "
+            "is not 'switch (tag)'. The dispatcher has been restructured; re-read it before "
+            "trusting any resolve rate."
         )
     if "default: return null;" not in window:
         fail(
-            f"the window {engine_path}:{RESOLVE_START}-{RESOLVE_END} does not reach "
-            "ResolveCommand's 'default: return null;'. It has drifted and would clip real "
-            "case labels, reporting tags as unresolvable that in fact resolve -- or worse, "
-            "the reverse after a later edit. Re-locate the method."
+            f"ResolveCommand's body ({engine_path.name}:{first_line}-{last_line}) has no "
+            "'default: return null;'. Either the method has been restructured, or the brace "
+            "match ended early -- either way the case labels below may be incomplete."
         )
     return set(CASE_RE.findall(window))
 
@@ -122,7 +214,7 @@ def main() -> int:
         fail(f"{engine} not found (run from the repo root, or pass the root as argv[1])")
 
     labels = extract_case_labels(engine)
-    print(f"ResolveCommand case labels in {ENGINE}:{RESOLVE_START}-{RESOLVE_END}: {len(labels)}\n")
+    print(f"ResolveCommand case labels: {len(labels)}\n")
     selftest(labels)
 
     files = sorted((root / "StingTools" / "Data").glob("WORKFLOW_KUT_*.json"))


### PR DESCRIPTION
> **Stacked on #927, which is still open.** `AccFetchOutcome.cs` and `StingTools.Acc.Tests` are
> prerequisites and are absent from `origin/main`, so per §0 of the prompt this branches from
> `origin/claude/kut-integration-build` and the PR base is that branch — so the diff shown here is
> only this pass's work. **Merge #927 first**; GitHub will re-target this to `main` automatically.
> The prompt-2 doc commit (`01210d409`) was cherry-picked across so the branch carries its own brief.

Closes A1–A7 of `docs/PROMPT_KUT_INTEGRATION_BUILD_2.md`. Section B is untouched — it is
third-party-blocked, and the runbook was updated instead so it still matches reality.

---

## A1 — a failed ACC issue read no longer reads as "the issues are gone"

**The defect.** `PullIssuesAsync` returned a bare `List<AccIssue>` from three exits — auth
failure, a mid-pagination HTTP error, and success. `AccSyncIssueStatusCommand` built
`statusById` from it and reported every tracked clash whose issue was absent as
`NOT_FOUND / keep`. So an expired token made **every escalated clash look deleted from ACC**,
and a page-2 failure produced a **partial reconciliation presented as a complete one** — after
which the sidecar was written, permanently un-tracking whatever was on page 1.

**What changed**

- `StingTools/V6/AccIssueSync.cs:277` — `PullIssuesAsync` returns
  `AccFetchResult<List<AccIssue>>`. Auth failure → `AuthFailed` (`:281`); a page HTTP error →
  classified, with the Detail naming pages-so-far (`:312`); a 200 with no `results` array →
  `TransportFailed` (`:349`); a network drop mid-pagination → `TransportFailed`, `HttpStatus 0`
  (`:334`); four 429s → failure (`:342`); the `maxPages` cap with no short page → failure
  (`:372`), because every page being full means there is more than we read. Only a final short
  page is `Ok`/`EmptyOk` (`:369`).
- `StingTools/Clash/AccSyncIssueStatusCommand.cs:63` — branches on `Succeeded`, returns
  `Result.Failed`, and says *"The escalation record was left untouched — nothing was
  un-tracked."* Nothing below that line runs.
- `StingTools/Clash/AccPullClashesCommand.cs:176` — its `FailureMessage` now delegates to the
  shared helper, so the two commands cannot describe the same failure differently.

`PullIssuesAsync` has exactly one production caller; `grep` confirms it (see A1 proof below).

**Command that proves it**

```
$ dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
Passed!  - Failed:     0, Passed:    67, Skipped:     0, Total:    67, Duration: 8 s - StingTools.Acc.Tests.dll (net8.0)
```

`AccIssuePullLoopbackTests` — every case asserts the **status**, not just emptiness, because
emptiness *is* the bug:

| Case | Asserted |
|---|---|
| refresh rejected | `AuthFailed`, not `EmptyOk`; empty value; `Verdict == Failed` |
| 401 on the issue list | `AuthFailed` |
| full page 1, then 500 | `TransportFailed`; Detail contains `page 2`, `1 page(s) succeeded`, `INCOMPLETE`; the 2 partial rows are carried but the verdict is `Failed`; server saw 2 requests |
| full page 1, then the port closes | `TransportFailed` **and `HttpStatus == 0`** — attribution, not just verdict (#927's technique) |
| 200 with no `results` array | `TransportFailed`, not `EmptyOk` |
| every page full to the cap | failure; Detail says `INCOMPLETE`; 6 rows, 3 requests |
| 2 full pages + a short page | `Ok`, **5 issues**, 3 requests, first id `a-0`, last `c-0` |
| container with no issues | `EmptyOk`, still `Succeeded` |
| 429 on every attempt | failure; server saw **4** requests |

**Sabotage run**

- (a) pagination-failure branch returns `Ok` → `Failed: 2, Passed: 53`
  (`FullPageThenServerError_…`, `Http401OnTheIssueList_…`).
- (b) auth-failure branch returns `EmptyOk` → `Failed: 1, Passed: 54`
  (`AuthFailure_IsAuthFailed_NotAnEmptySuccess`).

Both restored; `grep -rn SABOTAGE StingTools/` returns nothing.

---

## A2 — a malformed Niagara feed no longer reads as "live, nothing commissioned"

**The defect, in four compounding steps.** The parser flagged an unparseable body →
`ParsePoints` logged it and **returned `r.Points` anyway** → that empty dictionary is not null,
so `CommissioningSource.Resolve` took the *live* branch and reported `live (captured …)` →
`Persist` wrote the empty result over `last_station_points.json`, **destroying the last good
snapshot**, which is the fallback that exists for an unreachable station.
`KUT_ValuationFromBms` turns those points into a commissioning percentage the cost module
carries toward payment certification.

The worst input is `{"error":"unauthorized"}`: it *parses*, yields zero points and **sets no
error at all**, so nothing anywhere reported a problem.

**What changed**

- `StingTools/Core/Twin/NiagaraPointParser.cs:59` `RecognisedShape` + `:66`
  `CandidateEntries` + `:83` `Unusable`. A bare array, `{points:[…]}`, an id-keyed object and
  `{}` are recognised; an error envelope (scalar-valued properties) and a bare scalar are not.
  `Error` still means "not JSON at all" — a bare string/number/bool is deliberately **not** an
  error, per the existing comment. `Unusable` also covers "entries were present and not one was
  understood", which is precisely *not* the empty-station case (zero candidates).
- `StingTools/Core/Twin/NiagaraJsonClient.cs:78` — `ParsePoints` returns **null** for every
  unusable body, the same signal `FetchPoints` already used for a transport failure.
- `StingTools/Core/Twin/CommissioningSource.cs:117` — `Persist` refuses to overwrite a usable
  snapshot with a zero-point read, and `:141` `HasUsableSnapshot` asks `LoadCache`, so "there is
  a file" is never mistaken for "there is a fallback".

**Not over-corrected.** A station with nothing commissioned yet is still `Live` with zero
points — a real, expected state in early Stage 3.

**Command that proves it**

```
$ dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo --filter "FullyQualifiedName~Niagara"
Passed!  - Failed:     0, Passed:    67, Skipped:     0, Total:    67, Duration: 8 s - StingTools.Boq.Tests.dll (net8.0)
```

`NiagaraLiveReadTests` drives the **real client and the real resolver** over a loopback
listener — a test over the parser alone would have passed against every version of this bug,
because the parser was already right. Five bodies (unparseable, error envelope, HTML, bare
scalar, entries-with-no-readable-id) each assert `Cached` with a snapshot and `None` without,
never `Live`. The cache assertion is a **file-content comparison**:

```csharp
Assert.Equal(before, File.ReadAllText(_snapshot));
```

`TheJsonErrorEnvelope_SetsNoParserError_AndIsStillRejected` pins the nastiest case explicitly:
`Error` stays null, `RecognisedShape` is false, `ParsePoints` returns null.

The legitimate cases are pinned too: `{"points":[]}` is still `Live`; `[]`, `{"points":[]}` and
`{}` are all recognised; a zero-point live read does not destroy a good snapshot **and the
fallback still works on the next outage**; and a real read with real points still persists, so
"never overwrite" did not quietly freeze the cache forever.

**Sabotage run**

- (a) restore `return r.Points` in `ParsePoints` → **`Failed: 10, Passed: 57`** — all five
  failure bodies, with and without a cache, plus the error-envelope test.
- (b) `Persist` writes unconditionally again → `Failed: 1, Passed: 66`
  (`AZeroPointLiveRead_DoesNotDestroyAGoodSnapshot`).

Worth stating plainly: (b) fails only one test because the two guards are independent — with
`ParsePoints` correct, `Persist` is never reached on a failed read at all. That test is the only
thing holding the second guard, and it is the one that asserts the bytes.

---

## A3 — the branch that decides `Result.Failed` is now tested

**What changed.** NEW `StingTools/V6/AccCommandOutcome.cs` — Revit-free, log-free.
`Verdict` (`:48`) maps a status to `Proceed` / `SucceededEmpty` / `Failed`; `FailureMessage`
(`:70`) and `Remedy` (`:96`) produce the operator text. Both Revit commands call it, so they
cannot drift.

Two deliberate design points:

- The switches **throw** on an unhandled member (`:55`, `:110`) rather than defaulting. A
  permissive `_ => Failed` would compile, pass every test, and silently decide the behaviour of
  a status nobody thought about. (An arm-less switch expression does the same but warns CS8524
  on out-of-range casts, and this build is 0-warning.)
- `AccFetchOutcome.Describe` no longer says **"404 Not Found"** (`AccFetchOutcome.cs:144`).
  That reason phrase invites exactly the misreading A1 exists to prevent — a coordinator seeing
  "not found" concludes ACC lost the data.

**Command that proves it**

```
$ dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo --filter "FullyQualifiedName~Outcome"
Passed!  - Failed:     0, Passed:    28, Skipped:     0, Total:    28, Duration: 22 ms - StingTools.Acc.Tests.dll (net8.0)
```

(28, not 8: the `~Outcome` filter also matches #927's `AccFetchOutcomeTests` (20). The new
class is `AccCommandOutcomeTests`, 8 of them.)

The table is `Enum.GetValues<AccFetchStatus>()`, not a hand-listed set — a hand-listed table is
a copy of the enum that drifts. `AllStatuses()` asserts `Length >= 5` first, so an empty
enumeration cannot make every `[Theory]` vacuously true. Every failing status is asserted to
produce a message containing none of `clash-clean`, `no clashes`, `not found`, and containing
`NOTHING WAS CHECKED`, the status name and the container id. `FailureMessage` throws if handed
`Ok`/`EmptyOk` — printing "NOTHING WAS CHECKED" over a good read is the mirror-image defect.

**Sabotage run** — added `Throttled = 5` to `AccFetchStatus` and handled it nowhere:

```
Failed …AccCommandOutcomeTests.OnlyOkAndEmptyOk_Succeed
   System.ArgumentOutOfRangeException : Unhandled AccFetchStatus: every status needs an explicit command verdict…
Failed …AccCommandOutcomeTests.Describe_NeverUsesTheForbiddenWords_ForAnyFailingStatus   (same)
Failed …AccCommandOutcomeTests.EveryFailingStatus_ProducesAMessageThatCannotReadAsAnEmptyResult (same)
Failed …AccCommandOutcomeTests.EveryStatus_HasARemedy
   System.ArgumentOutOfRangeException : Unhandled AccFetchStatus: every status needs remedy text…
Failed …AccCommandOutcomeTests.EveryStatus_HasAVerdict   (same)
```

Five tests red. Member removed afterwards.

---

## A4 — the workflow-tag checker runs in CI

NEW `.github/workflows/kut-workflow-tags.yml`, modelled on `kut-document-gate.yml`: Python
3.11, stdlib only, triggered on `StingTools/Data/WORKFLOW_KUT_*.json`,
`StingTools/Core/WorkflowEngine.cs` and the checker itself.

```
$ python tools/check_kut_workflow_tags.py .          # EXIT=0
TOTAL                                            97     97/97 (100%)
Files checked: 10
OK: every step of every KUT workflow resolves to a real command.

$ python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/kut-workflow-tags.yml')); print('workflow YAML parses')"
workflow YAML parses
```

End-to-end, running **exactly** the command the workflow runs, with a sabotaged tag in place:

```
sabotaged GateAudit  ->  SABOTAGED EXIT=1
restored             ->  RESTORED  EXIT=0
```

### One thing I changed that the task did not ask for, and why

**The gate went red on my own A5 work, correctly, and that exposed a problem with putting it in
CI.** The checker hard-coded `WorkflowEngine.cs:1395-2244`. Adding one `case` to
`ResolveCommand` pushed `default: return null;` to line 2245, and the checker refused to run:

```
FAIL: the window …WorkflowEngine.cs:1395-2244 does not reach ResolveCommand's
'default: return null;'. It has drifted and would clip real case labels…
```

That is the right behaviour and it is why the checker was well built. But it means **every PR
touching `WorkflowEngine.cs` must bump two magic numbers**, and a CI gate that goes red on
unrelated edits gets switched off. So the window is now *derived*: locate `ResolveCommand` by
its **signature** and brace-match to its end, with string literals and comments blanked first.
All three assertions are unchanged and applied to whatever region that finds. Anchoring on a
signature is strictly stronger than a line range — a line range can drift onto a neighbouring
method; a signature cannot.

Re-sabotaged four ways after the change:

| Sabotage | Result |
|---|---|
| bogus `commandTag` in FFESync | `EXIT=1`, *"is not a case label in ResolveCommand — the step would be skipped silently"* |
| `commandTag` key renamed to `command` | `EXIT=1`, *"parses and silently does nothing"* |
| a second `switch (tag)` inside `ResolveCommand` | `EXIT=2`, *"contains 2 'switch(' statements, expected exactly 1"* |
| `default: return null;` → `default: break;` | `EXIT=2`, *"has no 'default: return null;' … the case labels below may be incomplete"* |

Restored → `EXIT=0`.

**Honest note on the string-stripping:** I checked whether it is load-bearing today, and it is
not — `ResolveCommand`'s body contains **0** interpolated-string braces, and brace-matching the
raw text finds the same range (1397–2247). It is defensive against a future `$"{…}"` in a case
body, not something this file currently exercises.

Label count moved 606 → **607**: the old hard-coded window was clipping one line. 97/97 either
way, which is why nothing depended on the absolute number.

---

## A5 — the ACC upload chaining, now that it is decidable

**What changed**

- NEW `StingTools/V6/AccBundleRecord.cs` — Revit-free, builds no project paths.
  `ReadExisting` (`:85`) returns the record **only if the ZIP is still on disk**; `Read` (`:66`)
  returns it regardless so a caller can say *why*. `ForFile` (`:97`) refuses to record a file
  that does not exist.
- `StingTools/BIMManager/PlatformLinkCommands.cs:1204` — `ACCPublish` writes
  `_BIM_COORD/acc/last_bundle.json` beside the existing `AutoRegisterExport` call. Best-effort
  and wrapped: recording the bundle must never fail the publish. **`ACCPublish` itself is
  otherwise unchanged.**
- `StingTools/Clash/AccUploadModelCommand.cs` — one shared base, two tags:
  `ACC_UploadModel` (picker, now starting in the bundle's folder as a nudge, not a default) and
  `ACC_UploadLastBundle` (no picker; confirms, naming the bundle, because it writes into the
  real CDE). A stale record uploads **nothing** and says the recorded ZIP is gone — uploading
  whatever now sits at that path would be exactly the guess this avoids.
- Wired on all three layers: `StingCommandHandler.cs:2883`, `WorkflowEngine.cs:1996`
  (+ `_allKnownCommandTags` `:353`), `StingDockPanel.xaml:3140`.

**Command that proves it**

```
$ grep -n "AutoRegisterExport\|zipPath" StingTools/BIMManager/PlatformLinkCommands.cs | head
1196:                string zipPath = packageDir + ".zip";
1198:                ZipFile.CreateFromDirectory(packageDir, zipPath, CompressionLevel.Optimal, false);
1201:                BIMManagerEngine.AutoRegisterExport(doc, zipPath, "CM",
1214:                    var rec = V6.AccBundleRecord.ForFile(zipPath, suitability, deliverables.Count);

$ grep -rn "ACC_UploadModel\|ACC_UploadLastBundle" StingTools/UI/StingCommandHandler.cs StingTools/Core/WorkflowEngine.cs StingTools/UI/StingDockPanel.xaml
StingCommandHandler.cs:2879  case "ACC_UploadModel":
StingCommandHandler.cs:2883  case "ACC_UploadLastBundle":
WorkflowEngine.cs:353        "ACC_UploadModel", "ACC_UploadLastBundle",
WorkflowEngine.cs:1995       case "ACC_UploadModel":
WorkflowEngine.cs:1996       case "ACC_UploadLastBundle":
StingDockPanel.xaml:3138     Tag="ACC_UploadModel"
StingDockPanel.xaml:3140     Tag="ACC_UploadLastBundle"
```

Instrument verified before trusting the 0:

```
$ grep -c "ACCPublish" StingTools/Data/WORKFLOW_KUT_CoordinationCycle.json          # 1  <- the grep works
$ grep -c "ACC_UploadModel\|ACC_UploadLastBundle" .../WORKFLOW_KUT_CoordinationCycle.json   # 0
$ grep -rn "ACC_Upload" StingTools/Data/WORKFLOW_KUT_*.json                          # (nothing, exit 1)
```

**The capability is ready and the step is deliberately not added.** Whether the fortnightly
cycle should push into an issued CDE container is the Information Manager's call, and it should
not be made before B1 has proved one live round-trip.

**Sabotage run** — `ReadExisting` stops checking the file exists →
`Failed: 1` (`ReadExisting_RefusesARecordWhoseFileIsGone`). Restored.

---

## A6 — an upload failure now names its kind

`UploadResult` (`AccModelUpload.cs:48`) gains `Status` (`AccFetchStatus`, reused not
re-invented), `HttpStatus`, and a `Remedy` that delegates to `AccCommandOutcome.Remedy`, so one
remedy table serves every ACC path. `Ok`/`Message` are unchanged for
`BIMCoordinationCenter.cs`. `Fail` gained an HTTP-aware overload (`:399`); the auth exit, the
storage-create exit, the item-create exit and every S3/signed-upload exit now carry their
status — `UploadFileAsync` threads it out rather than flattening it.

```
$ grep -rn "UploadAsync" --include="*.cs" StingTools/ | grep -v /obj/
StingTools/Clash/AccUploadModelCommand.cs:79      AccModelUpload.UploadAsync(creds, file)
StingTools/UI/BIMCoordinationCenter.cs:5581       V6.AccModelUpload.UploadAsync(c, dlg.FileName)
StingTools/V6/AccModelUpload.cs:58                public static async Task<UploadResult> UploadAsync(

$ dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
Passed!  - Failed: 0, Passed: 67, Skipped: 0, Total: 67
```

`AccModelUploadTests` drives the real uploader over a loopback listener: **403 on storage
creation → `AuthFailed`** (the required case) with `HttpStatus 403` and the shared "Sign in…"
remedy; 404 → `NotFound`; 500 → `TransportFailed`; local failures (no file, no credentials) →
`HttpStatus 0`, because claiming an HTTP status that never happened is a fabricated
attribution; a stale token → `AuthFailed`.

**Sabotage run** — `Fail(msg, httpStatus)` throws the kind away again →
`Failed: 3` (403/404/500 cases). Restored.

---

## A7 — the stale CLAUDE.md claims

Every number re-run in this session before it was written down.

```
$ dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo | tail -2
Passed!  - Failed:     0, Passed:  1335, Skipped:     0, Total:  1335, Duration: 8 s

$ dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo | tail -2
Passed!  - Failed:     0, Passed:    67, Skipped:     0, Total:    67, Duration: 8 s

$ ls -1 StingTools/Data/WORKFLOW_KUT_*.json | wc -l
10

$ grep -rhoE '^\s*\[(Fact|Theory)(\(|\])' StingTools.Boq.Tests --include=*.cs | wc -l   # 956
$ grep -rhoE '^\s*\[(Fact|Theory)(\(|\])' StingTools.Acc.Tests --include=*.cs | wc -l   # 60
```

- `CLAUDE.md:132` Boq row `121 | ✅ 196 cases` → **`956 | ✅ 1,335 cases`**. My first attempt
  updated only the Runs column and guessed the Declared count as 34 for Acc; I then ran the same
  `[Fact]`/`[Theory]` census the CI workflow uses and corrected both columns to the measured
  figures.
- `CLAUDE.md:140` new **Acc** row `60 | ✅ 67 cases`, plus a line saying only these two rows
  were re-measured and every other row is still the 2026-08-06 figure.
- `CLAUDE.md:772` healthcare caveat 3 — the `TwinReadback` stub statement is kept and a sentence
  added naming `Commands/Twin/NiagaraCommands.cs` and `Core/Twin/NiagaraJsonClient.cs`, so it no
  longer reads as "Niagara is absent" when two of three paths are built.

**The third correction had no target.** The prompt says to fix "anywhere claiming 9 KUT
workflows". A repo-wide sweep finds that string exactly once —
`docs/KUT_INTEGRATION_READINESS_2026-09.md:454` — where it is already recorded as the
*correction* ("this task's brief said 9; measured **10**"). Nothing asserts 9. Nothing changed.

Also updated **`docs/KUT_LIVE_VERIFICATION_RUNBOOK.md`** (in scope per §5), whose
expected-output sections described failures that no longer look like that: the clash dialog no
longer says "404 Not Found"; `ACC_SyncIssueStatus` now fails the same way and says the
escalation record was left untouched; upload failures name their kind; the two upload tags are
described; and the Niagara section gains a table of the four bodies that now fall through to
the cache, plus the fact that a genuinely empty station is still `Live`.

---

## Full gate set

```
$ dotnet build StingTools/StingTools.csproj -c Debug -clp:Summary --nologo
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:00:33.78

$ dotnet test StingTools.Acc.Tests/StingTools.Acc.Tests.csproj --nologo
Passed!  - Failed:     0, Passed:    67, Skipped:     0, Total:    67, Duration: 8 s

$ dotnet test StingTools.Boq.Tests/StingTools.Boq.Tests.csproj --nologo
Passed!  - Failed:     0, Passed:  1335, Skipped:     0, Total:  1335, Duration: 9 s

$ python tools/check_kut_workflow_tags.py .                       # EXIT=0
TOTAL  97  97/97 (100%)   Files checked: 10

$ python tools/check_kut_documents.py                             # EXIT=0
KUT document gate OK.
  Issued documents gated              : 5
  Assertions passed                   : 100
  Provenance + content stamps         : both match on all 5

$ python tools/check_docs_index.py                                # EXIT=0
Docs index gate OK.
```

**Both baselines rose.** `Acc.Tests` **38 → 67** (+29: 9 issue-pull loopback, 8 command-outcome,
6 bundle-record, 6 upload). `Boq.Tests` **1,316 → 1,335** (+19, all `NiagaraLiveReadTests` —
`[Theory]` cases expand, which is why 12 declared methods give 19 cases).
`check_kut_documents.py` is green and no generated document was touched.

CI-equivalent sweep, with the workflow's two named exclusions (#596, #597):

| Project | Result | | Project | Result |
|---|---|---|---|---|
| Acc | 67 | | Sustainability | 438 |
| Boq | 1335 | | Tags | 919 |
| Clash | 81 | | Templates | 37 |
| Connectivity | (empty — pre-existing) | | Visibility | 102 |
| Cost | 144 | | Licensing | 14 |
| Placement | 69 | | Routing | 44 |
| Scheduling | 38 | | SitePhotos | skipped (needs the plugin DLL) |

0 failing anywhere.

---

## Placeholders introduced

**None.** No `REPLACE_WITH_…` and no `TODO(KUT):` was added in this pass. The six from #927
(five in the Niagara example, one in the runbook) are unchanged. No secret, key, token or
password is in the diff.

---

## What I could not do, and who must act

Section B is untouched by design — no credential was fabricated and no service was mocked and
reported as verified.

| # | Blocked work | Who must act first |
|---|---|---|
| B1 | One live ACC pull to confirm the `bim360/clash/v3` tests/resources sub-paths, and one live issue push | **Owner / Autodesk account holder** (APS app — Traditional Web App — plus the callback `http://localhost:8910/callback`) and the **ACC project admin** (container ids). **Overdue** — mobilisation began the week of 25 August 2026 |
| B2 | One live Niagara station fetch | **Controls / commissioning contractor**: base URL, the station-specific oBIX points path, credentials. Not due until Stage 3.1 (~M40) |
| B3 | Confirm the Fohlio field mapping is agreed | **Interior Designer**. A meeting, not a code task, and on the mobilisation critical path |

One decision remains a human's: **whether `ACC_UploadLastBundle` belongs in the fortnightly
Coordination Cycle.** The capability is wired and non-interactive; the step is deliberately not
added, and should not be until B1 has proved one live round-trip.

## Things worth a reviewer's eye

- **The A2-b sabotage fails only one test**, because the two guards are independent — with
  `ParsePoints` correct, `Persist` is never reached on a failed read. That single test
  (`AZeroPointLiveRead_DoesNotDestroyAGoodSnapshot`) is all that holds the second guard.
- **`AccCommandOutcome.Verdict` throws on an unknown status.** That is deliberate (it is what
  makes the enumeration sabotage fail), but it is a runtime throw on a path a command calls.
  The status set is closed and compiled together, so an unhandled member cannot reach a user
  without going red here first — but it is a judgement call, not a free win.
- **`StingTools.Boq.Tests` now `<Compile Include>`s `LoopbackServer.cs` from
  `StingTools.Acc.Tests`.** One copy, two projects, no drift — but it couples the two test
  projects' directory layout. Deleting `StingTools.Acc.Tests` would break the Boq build,
  loudly.
- **Documentation drift noticed, not fixed:** `CLAUDE.md`'s Declared column is still the
  2026-08-06 census for every project except Boq and Acc. I said so in the file rather than
  re-measuring rows I had no reason to touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Djc5uVngh9ku5sCNGpLcp7
