### PR TITLE
Request data:create, or every ACC upload 403s on its first call

### DIFF
--- a/.github/workflows/aps-scopes.yml
+++ b/.github/workflows/aps-scopes.yml
@@ -1,0 +1,59 @@
+name: APS Scope Gate
+
+# The OAuth scopes we REQUEST must cover the APS calls we actually MAKE.
+#
+# WHY THIS RUNS IN CI
+# A scope mismatch is invisible everywhere a mismatch is normally caught. It compiles,
+# it types, the sign-in succeeds, the token is stored and the connection panel goes
+# green. The failure arrives later, as a 403 on the one call that needed the missing
+# scope -- in practice the first time anyone tries it against a real tenant, with the
+# client's credential, during a scheduled verification.
+#
+# That is not hypothetical here. Until 2026-09-10 `AccOAuthFlow.DefaultScope`
+# requested `data:read data:write account:read`, while `AccModelUpload` POSTs to three
+# data/v1 endpoints that create resources (/storage, /items, /versions) and therefore
+# need `data:create`. Every upload would have 403'd on its first call, and the cheapest
+# place to discover that would have been the live ACC verification -- the one test a
+# project gets exactly one cheap attempt at.
+#
+# WHAT THE CHECKER PROVES (see its docstring)
+#   * the requirement is derived FROM SOURCE: it finds resource-creating POSTs in the
+#     ACC clients and requires data:create only when such a call exists. Delete the
+#     upload code and the requirement relaxes on its own;
+#   * it self-tests -- a creating POST is recognised and the same URL via GET is not --
+#     and aborts if its extractor stops discriminating, rather than reporting a pass it
+#     did not earn.
+#
+# WHAT IT CANNOT PROVE: that our endpoint -> scope mapping matches Autodesk's actual
+# requirements. That mapping is our declared understanding and can be wrong or go
+# stale. Only a live call settles it. A green run means we are consistent with what we
+# believe, not that what we believe is correct.
+
+on:
+  pull_request:
+    paths:
+      - 'StingTools/V6/Acc*.cs'
+      - 'tools/check_aps_scopes.py'
+      - '.github/workflows/aps-scopes.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'StingTools/V6/Acc*.cs'
+      - 'tools/check_aps_scopes.py'
+      - '.github/workflows/aps-scopes.yml'
+  workflow_dispatch:
+
+jobs:
+  scopes:
+    name: Requested scopes cover the calls made
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # stdlib only, deliberately -- the gate must run on a bare runner.
+      - name: Check APS scopes
+        run: python tools/check_aps_scopes.py .

--- a/StingTools/V6/AccOAuthFlow.cs
+++ b/StingTools/V6/AccOAuthFlow.cs
@@ -41,8 +41,20 @@ namespace StingTools.V6
         /// <summary>Default loopback callback port. Must match the URL registered in the APS app.</summary>
         public const int DefaultCallbackPort = 8910;
 
-        /// <summary>Default scopes — enough for ACC Issues + Model Coordination.</summary>
-        public const string DefaultScope = "data:read data:write account:read";
+        /// <summary>
+        /// Default scopes. Derived from what the clients actually call, not from habit:
+        ///   data:read    GET issues, issue-types, model sets, clash tests, topFolders
+        ///   data:write   POST an issue
+        ///   data:create  POST data/v1 projects/{id}/storage, /items and /versions —
+        ///                the three calls AccModelUpload makes. WITHOUT THIS, EVERY
+        ///                UPLOAD 403s ON THE FIRST CALL. It was missing until 2026-09-10,
+        ///                so no token minted before then can upload: a user who signed in
+        ///                earlier must sign in again, because scopes are fixed at consent
+        ///                and a refresh token cannot widen them.
+        ///   account:read hubs / projects lookup
+        /// The OSS signed-S3 PUT needs no scope — the pre-signed URL carries its own auth.
+        /// </summary>
+        public const string DefaultScope = "data:read data:write data:create account:read";
 
         private static readonly HttpClient _http = new HttpClient();
 

--- a/tools/check_aps_scopes.py
+++ b/tools/check_aps_scopes.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assert the OAuth scopes we REQUEST cover the APS calls we actually MAKE.
+
+WHY THIS EXISTS
+A scope mismatch is silent until the moment it matters. The sign-in succeeds, the
+token is stored, the connection panel goes green, and then the one call that needed
+the missing scope returns 403 -- typically the first time someone tries it against a
+real tenant, with the client's credential, in front of people.
+
+That is exactly what happened here. `AccOAuthFlow.DefaultScope` requested
+`data:read data:write account:read`, and `AccModelUpload` POSTs to three data/v1
+endpoints that create resources (`/storage`, `/items`, `/versions`). Those need
+`data:create`. Every upload would have 403'd on its first call. Nothing in the build,
+the tests or the type system could see it, because the scope is a string and the
+requirement lives in Autodesk's documentation.
+
+WHAT THIS PROVES
+The requirement is derived FROM THE SOURCE, not from a hand-maintained list: the
+checker looks for resource-creating POSTs in the ACC clients and, if it finds any,
+requires `data:create` in the requested scope set. Delete the upload code and the
+requirement relaxes on its own; drop the scope while the upload exists and this fails.
+
+WHAT IT CANNOT PROVE
+It cannot verify Autodesk's actual scope requirements -- that lives in APS
+documentation and can change without us knowing. The endpoint -> scope mapping below
+is our declared understanding, and a wrong entry here produces a confidently wrong
+result. It checks that our declared mapping is applied consistently; it does not
+check that the mapping is right. The only thing that proves that is a live call.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+
+OAUTH = ROOT / "StingTools" / "V6" / "AccOAuthFlow.cs"
+CLIENT_GLOB = "StingTools/V6/Acc*.cs"
+
+# Our declared endpoint -> scope mapping. See "WHAT IT CANNOT PROVE" above.
+# A data/v1 POST that mints a new resource requires data:create; reads require
+# data:read; modifying an existing resource requires data:write.
+CREATING_ENDPOINTS = ("/storage", "/items", "/versions")
+
+SCOPE_RE = re.compile(r'DefaultScope\s*=\s*"([^"]*)"')
+# A POST whose URL mentions one of the creating endpoints, on one line or split
+# across the argument list -- so match the call and look ahead a little.
+POST_RE = re.compile(r'HttpMethod\.Post\s*,\s*\$?"([^"]*)"')
+
+
+def fail(msg):
+    print("FAIL: " + msg)
+    sys.exit(1)
+
+
+def requested_scopes():
+    if not OAUTH.exists():
+        fail("%s not found -- cannot read the requested scopes." % OAUTH)
+    text = OAUTH.read_text(encoding="utf-8", errors="replace")
+    m = SCOPE_RE.search(text)
+    if not m:
+        fail("DefaultScope not found in %s -- the constant was renamed or removed, so "
+             "this checker can no longer see what is requested. Fix the checker rather "
+             "than deleting it." % OAUTH)
+    return set(m.group(1).split()), m.group(1)
+
+
+def creating_calls():
+    """(file, endpoint) for every POST to a resource-creating data/v1 endpoint."""
+    hits = []
+    for path in sorted(ROOT.glob(CLIENT_GLOB)):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for m in POST_RE.finditer(text):
+            url = m.group(1)
+            for ep in CREATING_ENDPOINTS:
+                if url.rstrip("/").endswith(ep) and "DataBase" in url:
+                    hits.append((path.name, url))
+                    break
+    return hits
+
+
+def selftest():
+    """Prove the extractor discriminates before trusting anything it says."""
+    print("GATE SELF-TEST")
+    probe_yes = 'await SendAsync(HttpMethod.Post, $"{DataBase}/projects/{p}/storage",'
+    probe_no = 'await SendAsync(HttpMethod.Get, $"{DataBase}/projects/{p}/storage",'
+    found_yes = bool(POST_RE.search(probe_yes))
+    found_no = bool(POST_RE.search(probe_no))
+    print("  a creating POST is recognised            : %s  (expect True)" % found_yes)
+    print("  the same URL via GET is not              : %s  (expect False)" % found_no)
+    if not found_yes or found_no:
+        fail("the extractor does not discriminate -- its findings below mean nothing.")
+    print("  extractor discriminates correctly")
+    print()
+
+
+def main():
+    selftest()
+
+    scopes, raw = requested_scopes()
+    print("Requested scopes: %s" % raw)
+
+    hits = creating_calls()
+    print("Resource-creating POSTs found in %s: %d" % (CLIENT_GLOB, len(hits)))
+    for fn, url in hits:
+        print("   %-22s %s" % (fn, url))
+    print()
+
+    if not hits:
+        print("No resource-creating call found, so data:create is not required.")
+        print("OK.")
+        return 0
+
+    if "data:create" not in scopes:
+        fail("%d resource-creating POST(s) exist (above) but the requested scope set is "
+             "'%s' -- it does not include data:create. Every one of those calls will "
+             "return 403 against a real tenant. Add data:create to "
+             "AccOAuthFlow.DefaultScope.\n\n"
+             "  Note: scopes are fixed at consent. Anyone who signed in before the fix "
+             "holds a refresh token that cannot widen them, and must sign in again."
+             % (len(hits), raw))
+
+    print("OK: data:create is requested, and %d call(s) need it." % len(hits))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
One-line behaviour change, plus the gate that would have caught it. **Branched from `main`, not stacked on #927/#932** — both files predate that work, so this merges independently.

## The defect

`AccOAuthFlow.DefaultScope` requested `data:read data:write account:read` (`:45`). `AccModelUpload` POSTs to three `data/v1` endpoints that **create** resources — `projects/{id}/storage` (`:97`), `/items`, `/versions` — and those require **`data:create`**. There is exactly one `SignInAsync` call site (`BIMCoordinationCenter.cs:5516`) and it overrides nothing.

So no token this plugin has ever minted could upload. **The upload path added in #927 and extended in #932 cannot work as configured.**

## Why it matters more than a one-line fix usually does

Nothing catches this. It compiles, it types, sign-in succeeds, the token is stored, the ACC panel goes green. The 403 arrives only on the call that needed the scope — in practice the first attempt against a real tenant.

For KUT that first attempt is **B1**: the Owner's Autodesk credential, a scheduled verification slot, and the single cheap attempt a project gets at confirming the `bim360/clash/v3` sub-paths. Spending it on a scope typo costs a fortnight, and it is precisely the kind of failure that gets misread as "the API changed".

Landing it *before* the credential arrives is the whole point.

## The scope set is derived, not guessed

Taken from an inventory of every APS endpoint the four ACC clients call:

| Scope | Why |
|---|---|
| `data:read` | issues, issue-types, model sets, clash tests, topFolders |
| `data:write` | POST an issue |
| **`data:create`** | `/storage`, `/items`, `/versions` — the three creating POSTs |
| `account:read` | hubs / projects lookup |

The OSS signed-S3 `PUT` is deliberately excluded: the pre-signed URL carries its own auth.

## The gate

`tools/check_aps_scopes.py` derives the requirement **from source** rather than a hand-kept list — it finds resource-creating POSTs in the ACC clients and requires `data:create` only while such a call exists. Wired in CI via `.github/workflows/aps-scopes.yml`.

Sabotaged both directions:

- revert the scope while the POSTs exist → **exit 1** with a message naming all three calls;
- turn the POSTs into GETs → requirement relaxes on its own → **exit 0**, "not required".

It self-tests that its extractor still discriminates (a creating POST is recognised; the same URL via GET is not) and aborts rather than reporting a pass it did not earn.

**What it cannot prove**, stated plainly in its docstring and the workflow header: that our endpoint→scope mapping matches Autodesk's actual requirements. That mapping is our declared understanding and can be wrong or go stale. Only a live call settles it. A green run means we are consistent with what we believe, not that what we believe is correct.

## One consequence

Scopes are fixed at consent and a refresh token cannot widen them, so anyone holding a token minted before this must sign in again. **Nobody does yet** — the APS app does not exist — which is why this lands now rather than after.

Build: **0 errors, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)