### PR TITLE
W1: make the seven button-only commands reachable from a workflow

### DIFF
--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -1406,6 +1406,35 @@ namespace StingTools.Core
                 case "CreateBLEMaterials": return new Temp.CreateBLEMaterialsCommand();
                 case "CreateMEPMaterials": return new Temp.CreateMEPMaterialsCommand();
 
+                // ── Post-import material hygiene ─────────────────────────────
+                // These seven were BUTTON-ONLY for a month. A tag with no case here
+                // cannot appear in a preset AND is invisible to
+                // tools/check_workflow_wiring.ps1, which gates preset steps against
+                // this switch — so a chain silently stopped covering new work.
+                // ProjectKickoff imported the register and built types from it and
+                // then never stamped a code, set a class, or audited what it built.
+                // Class names taken from StingCommandHandler, not guessed.
+                case "Materials_StampCodes": return new Commands.Materials.StampMaterialCodesCommand();
+                case "Materials_SetClass": return new Commands.Baseline.SetMaterialClassCommand();
+                // Read-only. Compares what the model BUILT against what the register
+                // DECLARES for the row each type is named after.
+                case "Materials_RegisterAudit": return new Commands.Materials.RegisterAuditCommand();
+
+                // ── Baseline ─────────────────────────────────────────────────
+                // Reachable from a workflow, but NOT placed in any preset:
+                // Baseline_Apply and Baseline_RenameTypes are destructive and both
+                // ask first. A chained rename is what 2026-09-09 produced — 87 floor
+                // types proposed the identical name. Resolving them is what lets a
+                // human write a deliberate one-step workflow; shipping them inside
+                // the 26-step kickoff is a different act entirely.
+                case "Baseline_Audit": return new Commands.Baseline.BaselineAuditCommand();
+                case "Baseline_Apply": return new Commands.Baseline.BaselineApplyCommand();
+                case "Baseline_RenameTypes": return new Commands.Baseline.RenameTypesToStandardCommand();
+
+                // Read-only. Names the families no PROD rule covers, before an
+                // unruled code becomes a wrong rate.
+                case "Prod_CoverageAudit": return new Commands.Classification.ProdCoverageAuditCommand();
+
                 // Families
                 case "CreateWalls": return new Temp.CreateWallsCommand();
                 case "CreateFloors": return new Temp.CreateFloorsCommand();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 Phase-by-phase history of completed work on the StingTools plugin, Planscape Server, and Planscape Mobile. See [`../CLAUDE.md`](../CLAUDE.md) for current architecture and [`ROADMAP.md`](ROADMAP.md) for open gaps.
 
+#### Completed (Phase 270 — W1: the seven become reachable from a workflow)
+
+**Seven commands built this month were button-only.** `Materials_SetClass`,
+`Materials_StampCodes`, `Materials_RegisterAudit`, `Baseline_Audit`,
+`Baseline_Apply`, `Baseline_RenameTypes` and `Prod_CoverageAudit` had a
+`Cmd_Click` button and a `StingCommandHandler` case, and **no `ResolveCommand`
+case and no appearance in any of the 48 presets**. Re-measured on `origin/main`
+@ `4b4ca588b`: `presets=0 engine=0` for all seven, and `0` hits across all 277
+shipped JSON files, not only the `WORKFLOW_*.json` ones.
+
+Three consequences, and the third is why this is the load-bearing step:
+
+1. They cannot be chained, scripted, or run unattended.
+2. `ProjectKickoff` imports the register, builds host types from it, and then
+   **never stamps a code, sets a class, or audits what it just built** — which is
+   the state the 2026-09-10 register audit found: 138 Matches against 67 Differs,
+   28 Flattened and 81 with no compound structure at all.
+3. `tools/check_workflow_wiring.ps1` gates **preset steps against
+   `ResolveCommand`**. A command in neither is invisible to it, so a chain stops
+   covering new work without anything being said.
+
+All seven now resolve. Class names were taken from `StingCommandHandler`, not
+guessed.
+
+**`Baseline_Apply` and `Baseline_RenameTypes` resolve but go in no preset.** Both
+are destructive and both ask first; a chained rename is what 2026-09-09 produced,
+when 87 floor types proposed the identical name. Resolving them lets a human
+write a deliberate one-step workflow; putting them inside the 26-step kickoff is
+a different act, and W2 does not.
+
+**RED then GREEN, on the gate that actually guards this.**
+
+    A preset step on Materials_StampCodes
+      RED   with the case removed — Tier 2, naming the tag and the file:
+            "WORKFLOW_ZZProbe.json step 1 : 'Materials_StampCodes' has no case
+             in WorkflowEngine.ResolveCommand"
+      GREEN Tier 2 = 0
+
+`ResolveCommand` case labels **663 → 670**.
+
+**A figure that differs from the brief.** It predicted both the case-label count
+and the dispatchable-name count would move. Only the first did: **dispatchable
+names stayed at 2,362**, because that set is registry + `Cmd_Click` runners +
+handler cases, and all seven already had buttons. Adding a `ResolveCommand` case
+makes a tag *chainable*; it does not make it a new *name*. Worth knowing, because
+it is exactly why the wiring gate could not see the gap — which is what W3
+addresses.
+
+Build 0/0; Tags 972 and Boq 1,331 unchanged; path-discipline OK; recount
+`--check` agrees; 277 JSON files parse.
+
+**Not verified in Revit.** `deploy.bat` was not run. No workflow was executed
+against a live document, and `Materials_StampCodes` in particular has still never
+run against one.
+
 #### Completed (Phase 269 — the type creator stops reporting success after failing, and stops inventing what it was not given)
 
 `Baseline_RenameTypes` renamed 168 host types on a delivered model and logged


### PR DESCRIPTION
## What

Seven commands built this month were **button-only** — a `Cmd_Click` button and a `StingCommandHandler` case, and **no `ResolveCommand` case, and no appearance in any of the 48 presets**.

Re-measured on `origin/main` @ `4b4ca588b`, the brief's own command:

```
Materials_SetClass       presets=0 engine=0
Materials_StampCodes     presets=0 engine=0
Materials_RegisterAudit  presets=0 engine=0
Baseline_Apply           presets=0 engine=0
Baseline_RenameTypes     presets=0 engine=0
Baseline_Audit           presets=0 engine=0
Prod_CoverageAudit       presets=0 engine=0
```

Broadened to **all 277 shipped JSON files**, not only `WORKFLOW_*.json`: still 0 for all seven. **The diagnosis holds.**

Three consequences, and the third is why this is the load-bearing step:

1. They cannot be chained, scripted, or run unattended.
2. `ProjectKickoff` imports the register, builds host types from it, and then **never stamps a code, sets a class, or audits what it just built** — which is the state the 2026-09-10 register audit found: 138 Matches against 67 Differs, 28 Flattened, 81 with no compound structure at all.
3. `tools/check_workflow_wiring.ps1` gates **preset steps against `ResolveCommand`**. A command in neither is invisible to it, so a chain stops covering new work with nothing said.

Class names were taken from `StingCommandHandler`, not guessed.

## `Baseline_Apply` and `Baseline_RenameTypes` resolve, but go in no preset

Both are destructive and both ask first; a chained rename is what 2026-09-09 produced, when 87 floor types proposed the identical name. Resolving them lets a human write a deliberate one-step workflow — putting them inside the 26-step kickoff is a different act, and W2 does not do it.

## RED and GREEN — on the gate that actually guards this

```
a preset step on Materials_StampCodes
  RED    with the case removed — Tier 2, naming the tag and the file:
         "WORKFLOW_ZZProbe.json step 1 : 'Materials_StampCodes' has no case
          in WorkflowEngine.ResolveCommand"
  GREEN  Tier 2 = 0
```

The probe preset was deleted before commit; it exists in this PR only as the proof that Tier 2 discriminates, which is the mechanism W2 depends on.

## A figure that differs from the brief

The brief predicted **both** the case-label and the dispatchable-name counts would move. Only the first did:

| | before | after |
|---|---|---|
| `ResolveCommand` case labels | 663 | **670** |
| Dispatchable names | 2,362 | **2,362 — unchanged** |

Dispatchable names is registry + `Cmd_Click` runners + handler cases, and all seven already had buttons. A `ResolveCommand` case makes a tag **chainable**; it does not make it a new **name**. That is precisely why the wiring gate could not see this gap — which is what W3 addresses.

## CI gates, run locally

| | result |
|---|---|
| `dotnet build` | 0 err / 0 warn |
| `StingTools.Tags.Tests` | 972 (unchanged) |
| `StingTools.Boq.Tests` | 1,331 (unchanged) |
| `check_workflow_wiring.ps1` | OK, all tiers 0 |
| `check_path_discipline.ps1` | OK |
| `recount_unreachable_commands.py --check` | doc headline numbers agree |
| JSON parse over `Data/**/*.json` | 277 files, 0 unparseable |

## Not verified in Revit

`deploy.bat` was **not** run. No workflow was executed against a live document, and `Materials_StampCodes` in particular has still never run against one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
