### PR TITLE
W2: put the material hygiene steps into ProjectKickoff, at the seams [needs #936 + #938]

### DIFF
--- a/StingTools.Tags.Tests/ProjectKickoffStepsTests.cs
+++ b/StingTools.Tags.Tests/ProjectKickoffStepsTests.cs
@@ -1,0 +1,205 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  ProjectKickoffStepsTests.cs — the gate on W2.
+//
+//  W2 puts four steps into ProjectKickoff at the seams the 2026-09-10 register
+//  audit made visible. Two things need holding, and the second is a rule rather
+//  than a feature:
+//
+//    1. The four are THERE, in the right places, with the read-only pair marked
+//       optional. A read-only audit that can abort a 32-step TransactionGroup
+//       after a project's whole catalogue has been built is worse than no audit.
+//
+//    2. Baseline_RenameTypes and Baseline_Apply are in NO preset, ever. Both are
+//       destructive and both ask first, and a chained rename is what 2026-09-09
+//       produced — 87 floor types proposed the identical name PLNS_SLB_RC100.
+//       W1 made them RESOLVABLE, which is what a deliberate one-step workflow
+//       needs; that is the same edit that makes it possible to drop one into a
+//       26-step chain by accident. This test is the thing standing in the way.
+//
+//  It reads the engine's source rather than running it, for the reason
+//  check_workflow_wiring.ps1 gives: the test project cannot reference
+//  StingTools.csproj, which needs the Revit API.
+//
+//  RED / GREEN, recorded 2026-09-10 on this machine:
+//    Baseline_RenameTypes added to ProjectKickoff
+//      RED   "destructive command in a preset ... Baseline_RenameTypes"
+//      GREEN neither tag appears in any preset, built-in or JSON
+//    Materials_RegisterAudit's Optional = true removed
+//      RED   "read-only audit ... is not optional"
+//      GREEN both audits optional
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StingTools.Tags.Tests
+{
+    public class ProjectKickoffStepsTests
+    {
+        private readonly ITestOutputHelper _out;
+        public ProjectKickoffStepsTests(ITestOutputHelper output) => _out = output;
+
+        private static DirectoryInfo RepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "StingTools", "Core", "WorkflowEngine.cs")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate WorkflowEngine.cs from " + AppContext.BaseDirectory);
+            return dir;
+        }
+
+        private static string Engine() =>
+            File.ReadAllText(Path.Combine(RepoRoot().FullName, "StingTools", "Core", "WorkflowEngine.cs"));
+
+        /// <summary>The body of one built-in preset's step list.</summary>
+        private static string PresetBody(string src, string caseName)
+        {
+            int i = src.IndexOf("case \"" + caseName + "\":", StringComparison.Ordinal);
+            Assert.True(i > 0, "built-in preset not found: " + caseName);
+            int j = src.IndexOf("case \"", i + 10, StringComparison.Ordinal);
+            if (j < 0) j = src.Length;
+            return src.Substring(i, j - i);
+        }
+
+        private static List<string> Tags(string body) =>
+            Regex.Matches(body, "CommandTag = \"([A-Za-z_0-9]+)\"")
+                 .Select(m => m.Groups[1].Value).ToList();
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  1. The rule with teeth
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData("Baseline_RenameTypes")]
+        [InlineData("Baseline_Apply")]
+        public void A_Destructive_Command_Is_In_No_Preset(string tag)
+        {
+            // Built-in presets, in C#.
+            string src = Engine();
+            var inBuiltIn = Regex.Matches(src, "CommandTag = \"" + Regex.Escape(tag) + "\"")
+                                 .Select(m => m.Value).ToList();
+            Assert.True(inBuiltIn.Count == 0,
+                "destructive command in a built-in preset: " + tag + ". Both ask first, and a "
+              + "chained rename is what 2026-09-09 produced. W1 made it resolvable so a human "
+              + "can write a deliberate one-step workflow — not so it can ride inside kickoff.");
+
+            // Shipped JSON presets.
+            string data = Path.Combine(RepoRoot().FullName, "StingTools", "Data");
+            foreach (string f in Directory.GetFiles(data, "WORKFLOW_*.json"))
+                Assert.False(File.ReadAllText(f).Contains("\"" + tag + "\"", StringComparison.Ordinal),
+                    "destructive command in a preset: " + tag + " in " + Path.GetFileName(f));
+        }
+
+        // ══════════════════════════════════════════════════════════════════════
+        //  2. The four steps, where they belong
+        // ══════════════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Kickoff_Stamps_And_Classes_Materials_Right_After_Importing_Them()
+        {
+            var tags = Tags(PresetBody(Engine(), "ProjectKickoff"));
+
+            int mep = tags.IndexOf("CreateMEPMaterials");
+            int stamp = tags.IndexOf("Materials_StampCodes");
+            int cls = tags.IndexOf("Materials_SetClass");
+            int walls = tags.IndexOf("CreateWalls");
+
+            Assert.True(mep >= 0 && stamp >= 0 && cls >= 0 && walls >= 0,
+                "a step is missing: " + string.Join(", ", tags));
+
+            // Between importing the register and building types FROM it. Before the
+            // types, because a type built from an uncoded material is what the audit
+            // found 138 of.
+            Assert.Equal(mep + 1, stamp);
+            Assert.Equal(stamp + 1, cls);
+            Assert.True(cls < walls);
+        }
+
+        [Fact]
+        public void Kickoff_Audits_The_Types_It_Just_Built()
+        {
+            var tags = Tags(PresetBody(Engine(), "ProjectKickoff"));
+            int pipes = tags.IndexOf("CreatePipes");
+            int audit = tags.IndexOf("Materials_RegisterAudit");
+            Assert.True(pipes >= 0 && audit >= 0);
+            Assert.Equal(pipes + 1, audit);
+        }
+
+        [Fact]
+        public void Kickoff_Checks_Prod_Coverage_Before_Tagging_Not_After()
+        {
+            var tags = Tags(PresetBody(Engine(), "ProjectKickoff"));
+            int prod = tags.IndexOf("Prod_CoverageAudit");
+            int tag = tags.IndexOf("TagAndCombine");
+            Assert.True(prod >= 0 && tag >= 0);
+            Assert.True(prod < tag,
+                "an unruled family takes a PROD code by category fallback, and PROD is what "
+              + "the rate chain's most specific pass keys on. Naming them after tagging is "
+              + "naming them too late.");
+        }
+
+        [Fact]
+        public void The_Two_Read_Only_Audits_Are_Optional()
+        {
+            // They REPORT. Neither may abort a 32-step TransactionGroup that has already
+            // built a project's whole catalogue.
+            string body = PresetBody(Engine(), "ProjectKickoff");
+            foreach (string tag in new[] { "Materials_RegisterAudit", "Prod_CoverageAudit" })
+            {
+                var m = Regex.Match(body,
+                    "CommandTag = \"" + tag + "\"[^}]*?Optional = true", RegexOptions.Singleline);
+                Assert.True(m.Success, "read-only audit " + tag + " is not optional — it can "
+                                     + "abort the whole kickoff after the catalogue is built");
+            }
+        }
+
+        [Fact]
+        public void The_Two_Writing_Steps_Are_Gated_By_A_Condition_Not_By_A_Data_Hash()
+        {
+            // skipIfDataUnchanged compares a hash of the DEPLOYED data folder against a
+            // sidecar. It says nothing about this model's materials, so a project that
+            // gained 200 materials with the corporate CSVs untouched would SKIP the
+            // stamp and report success. The conditions ask the model.
+            string body = PresetBody(Engine(), "ProjectKickoff");
+
+            Assert.Matches("CommandTag = \"Materials_StampCodes\"[\\s\\S]*?Condition = \"has_uncoded_materials\"", body);
+            Assert.Matches("CommandTag = \"Materials_SetClass\"[\\s\\S]*?Condition = \"has_unclassed_materials\"", body);
+
+            foreach (string tag in new[] { "Materials_StampCodes", "Materials_SetClass" })
+            {
+                var m = Regex.Match(body,
+                    "CommandTag = \"" + tag + "\"[^}]*?SkipIfDataUnchanged", RegexOptions.Singleline);
+                Assert.False(m.Success, tag + " uses skipIfDataUnchanged, which compares the "
+                                      + "deployed data folder and not this model");
+            }
+        }
+
+        [Fact]
+        public void Kickoff_Grew_By_Exactly_Four_Steps()
+        {
+            var tags = Tags(PresetBody(Engine(), "ProjectKickoff"));
+            _out.WriteLine(string.Join("\n", tags.Select((t, n) => $"{n + 1,2} {t}")));
+
+            // 28 before W2 — NOT the 26 the brief said; counted from the source.
+            Assert.Equal(32, tags.Count);
+            Assert.Equal(4, tags.Count(t => t == "Materials_StampCodes" || t == "Materials_SetClass"
+                                         || t == "Materials_RegisterAudit" || t == "Prod_CoverageAudit"));
+            Assert.Equal(tags.Count, tags.Distinct().Count());   // no step added twice
+        }
+
+        [Fact]
+        public void Every_Kickoff_Step_Has_A_Label()
+        {
+            // A step with no label reports as a blank line in the progress dialog and in
+            // the run report, which is how a step nobody noticed gets added.
+            string body = PresetBody(Engine(), "ProjectKickoff");
+            int steps = Regex.Matches(body, "CommandTag = \"").Count;
+            int labels = Regex.Matches(body, "Label = \"").Count;
+            Assert.Equal(steps, labels);
+        }
+    }
+}

--- a/StingTools/Core/WorkflowEngine.cs
+++ b/StingTools/Core/WorkflowEngine.cs
@@ -2599,12 +2599,47 @@ namespace StingTools.Core
                             new WorkflowStep { CommandTag = "LoadParams", Label = "Load Shared Parameters (200+ params)" },
                             new WorkflowStep { CommandTag = "CreateBLEMaterials", Label = "Create BLE Materials (815)" },
                             new WorkflowStep { CommandTag = "CreateMEPMaterials", Label = "Create MEP Materials (464)" },
+
+                            // W2 -- the seam the register audit found. The two steps above
+                            // import 1,279 governed material rows; nothing then stamped the
+                            // MAT_CODE those rows carry or set a class, so the material a
+                            // type is built from could not be priced by material and could
+                            // not be answered by the carbon engine.
+                            //
+                            // NOT skipIfDataUnchanged: that compares a hash of the DEPLOYED
+                            // data folder against a sidecar (ComputeDataHash, :1321). It
+                            // says nothing about this model's materials, so a project that
+                            // gained 200 materials with the corporate CSVs untouched would
+                            // SKIP the stamp and report success. The conditions below ask
+                            // the model instead, and answer with a count.
+                            new WorkflowStep { CommandTag = "Materials_StampCodes",
+                                               Label = "Stamp material codes from the register",
+                                               Condition = "has_uncoded_materials" },
+                            new WorkflowStep { CommandTag = "Materials_SetClass",
+                                               Label = "Set material Class where the name says one",
+                                               Condition = "has_unclassed_materials" },
+
                             new WorkflowStep { CommandTag = "CreateWalls", Label = "Create Wall Types" },
                             new WorkflowStep { CommandTag = "CreateFloors", Label = "Create Floor Types" },
                             new WorkflowStep { CommandTag = "CreateCeilings", Label = "Create Ceiling Types" },
                             new WorkflowStep { CommandTag = "CreateRoofs", Label = "Create Roof Types" },
                             new WorkflowStep { CommandTag = "CreateDucts", Label = "Create Duct Types" },
                             new WorkflowStep { CommandTag = "CreatePipes", Label = "Create Pipe Types" },
+
+                            // W2 -- read-only, immediately after the host types are built,
+                            // which is the moment the 2026-09-10 audit found 28 Flattened,
+                            // 67 Differs and 81 with no compound structure at all. Catching
+                            // that at birth is the whole point: by the time elements are
+                            // hosted on those types, rebuilding one moves every element on
+                            // it.
+                            //
+                            // optional:true because it REPORTS. A read-only audit must never
+                            // abort a 28-step TransactionGroup that has already built a
+                            // project's entire catalogue.
+                            new WorkflowStep { CommandTag = "Materials_RegisterAudit",
+                                               Label = "Audit host types against the register (read-only)",
+                                               Optional = true },
+
                             new WorkflowStep { CommandTag = "BatchSchedules", Label = "Batch Create Schedules (168)" },
                             new WorkflowStep { CommandTag = "EvaluateFormulas", Label = "Evaluate Formulas (199)" },
                             new WorkflowStep { CommandTag = "CreateFilters", Label = "Create View Filters (28+)" },
@@ -2620,6 +2655,15 @@ namespace StingTools.Core
                             new WorkflowStep { CommandTag = "BatchFamilyParams", Label = "Batch Family Params (4,686)" },
                             new WorkflowStep { CommandTag = "AutoAssignTemplates", Label = "Auto-Assign Templates (5-layer)" },
                             new WorkflowStep { CommandTag = "AutoFixTemplate", Label = "Auto-Fix Template Health" },
+                            // W2 -- read-only, BEFORE tagging. An unruled family takes a
+                            // PROD code by category fallback, and a PROD code is what the
+                            // rate chain's most specific pass keys on: an unruled family is
+                            // a wrong rate long before anybody looks at a BOQ. Naming them
+                            // here costs nothing and is the last cheap moment.
+                            new WorkflowStep { CommandTag = "Prod_CoverageAudit",
+                                               Label = "Audit PROD rule coverage (read-only)",
+                                               Optional = true },
+
                             new WorkflowStep { CommandTag = "TagAndCombine", Label = "Tag & Combine (full pipeline)" },
                             new WorkflowStep { CommandTag = "AutoCreateLegends", Label = "Auto-Create Legends" },
                             new WorkflowStep { CommandTag = "TagSheets", Label = "Tag Sheets (ISO 19650 doc codes)" },


### PR DESCRIPTION
> **Draft: depends on #936 (W1) and #938 (W5).** Without W1 the four tags resolve to nothing; without W5 the two conditions are unrecognised and the steps run ungated. Verified locally against a scratch merge of #936 — see below.

## What

`ProjectKickoff` imported 1,279 governed material rows and built host types from them, and then **never stamped a `MAT_CODE`, set a class, or audited what it had built**. That is the state the 2026-09-10 register audit found: 138 Matches, 67 Differs, 28 Flattened, 81 with no compound structure at all.

Four steps, **28 → 32**:

```
   3 CreateMEPMaterials
   4 Materials_StampCodes      condition has_uncoded_materials
   5 Materials_SetClass        condition has_unclassed_materials
   6 CreateWalls …
  11 CreatePipes
  12 Materials_RegisterAudit   optional  (read-only)
  …
  28 Prod_CoverageAudit        optional  (read-only)
  29 TagAndCombine
```

The two audits are `optional: true` because they **report**. Neither may abort a 32-step `TransactionGroup` that has already built a project's whole catalogue.

## `skipIfDataUnchanged` does not fit, having checked what it compares

The brief said to set it "where the engine's definition of unchanged actually applies — check what it compares before assuming it fits." It does not fit: `ComputeDataHash` (`:1321`) hashes the **deployed data folder** against a sidecar. It says nothing about this model's materials, so a project that gained 200 materials with the corporate CSVs untouched would **skip the stamp and report success**.

W5's conditions ask the model instead, and answer with a count.

## `Baseline_RenameTypes` and `Baseline_Apply` are in no preset

W1 made them **resolvable**, which is what a deliberate one-step workflow needs — and is the same edit that makes it possible to drop one into a 32-step chain by accident. `A_Destructive_Command_Is_In_No_Preset` now stands in the way, scanning the built-in presets in C# **and** every shipped `WORKFLOW_*.json`.

## RED and GREEN — by sabotage, both counts

```
A_Destructive_Command_Is_In_No_Preset
  RED    Baseline_RenameTypes chained into kickoff — named, with why   (2 of 9)
  GREEN  neither tag in any preset, built-in or JSON

The_Two_Read_Only_Audits_Are_Optional
  RED    Optional removed from Materials_RegisterAudit —
         "it can abort the whole kickoff after the catalogue is built" (1 of 9)
  GREEN  both optional
```

## Verified against a scratch merge of #936

Merging `origin/main` + W1 + W2 + W6 in a throwaway worktree:

| | result |
|---|---|
| `check_workflow_wiring.ps1` | **OK** — Tier 2 = 0, 670 case labels, 389 steps scanned |
| `dotnet build` | 0 err / 0 warn |
| `StingTools.Tags.Tests` | 987 |
| `check_path_discipline.ps1` | OK |
| `recount --check` | agrees |
| JSON parse | 277 files, 0 unparseable |

On this branch alone: build 0/0, Tags 972 → **981**, Boq 1,331 unchanged.

## A figure that differs from the brief

`ProjectKickoff` had **28** steps, not the 26 the brief states — counted from the source. `Kickoff_Grew_By_Exactly_Four_Steps` asserts 32 so a later addition has to be deliberate.

## Not verified in Revit

`deploy.bat` was **not** run and no workflow was executed against a live document. **`Materials_StampCodes` has never executed against a Revit document at all**, so step 4 of this chain is unproven — this PR does not present the chain as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
