### PR TITLE
W6: bridge kickoff to the BOQ chain with a PROD coverage audit [needs #936]

### DIFF
--- a/StingTools.Tags.Tests/BoqProdCoverageBridgeTests.cs
+++ b/StingTools.Tags.Tests/BoqProdCoverageBridgeTests.cs
@@ -1,0 +1,102 @@
+// ══════════════════════════════════════════════════════════════════════════
+//  BoqProdCoverageBridgeTests.cs — the gate on W6.
+//
+//  ProjectKickoff ends at CreateRevision; BOQ_FullRefresh starts at
+//  Cost_MigrateESEntities. Nothing joined them, and an unruled PROD code is a
+//  wrong rate — the rate chain's most specific pass keys on DISC|PROD, so a
+//  family no rule covers takes a code by category fallback and prices as the
+//  category average with nothing said.
+//
+//  W6 puts Prod_CoverageAudit ahead of BOQRefresh in both BOQ presets. The two
+//  things worth holding are the ORDER (after it, the audit names families whose
+//  rates are already in the sheet) and the OPTIONAL flag.
+//
+//  RED / GREEN, recorded 2026-09-10 on this machine:
+//    the step moved after BOQRefresh
+//      RED   "audits coverage AFTER the rates are already in the sheet"   (2 of 6)
+//      GREEN index 3, before BOQRefresh, in both presets
+//    optional removed
+//      RED   "is not optional"                                            (2 of 6)
+//      GREEN optional in both
+// ══════════════════════════════════════════════════════════════════════════
+using System;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace StingTools.Tags.Tests
+{
+    public class BoqProdCoverageBridgeTests
+    {
+        private static string DataDir()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "StingTools", "Data")))
+                dir = dir.Parent;
+            Assert.True(dir != null, "Could not locate StingTools/Data from " + AppContext.BaseDirectory);
+            return Path.Combine(dir.FullName, "StingTools", "Data");
+        }
+
+        private static JArray Steps(string preset)
+        {
+            string p = Path.Combine(DataDir(), preset);
+            Assert.True(File.Exists(p), "preset missing: " + preset);
+            var j = JObject.Parse(File.ReadAllText(p));
+            var steps = j["steps"] as JArray;
+            Assert.True(steps != null && steps.Count > 0, preset + " has no steps");
+            return steps;
+        }
+
+        public static TheoryData<string> BoqPresets => new TheoryData<string>
+        {
+            "WORKFLOW_BOQ_FullRefresh.json",
+            "WORKFLOW_BOQ_TenderPack.json",
+        };
+
+        [Theory]
+        [MemberData(nameof(BoqPresets))]
+        public void Prod_Coverage_Is_Audited_Before_The_Boq_Is_Rebuilt(string preset)
+        {
+            var tags = Steps(preset).Select(s => (string)s["commandTag"]).ToList();
+
+            int audit = tags.IndexOf("Prod_CoverageAudit");
+            int refresh = tags.IndexOf("BOQRefresh");
+
+            Assert.True(audit >= 0, preset + " does not audit PROD coverage at all");
+            Assert.True(refresh >= 0, preset + " has no BOQRefresh");
+            Assert.True(audit < refresh,
+                preset + " audits coverage AFTER the rates are already in the sheet. An "
+              + "unruled family takes a PROD code by category fallback and prices as the "
+              + "category average; naming it afterwards is naming it too late.");
+        }
+
+        [Theory]
+        [MemberData(nameof(BoqPresets))]
+        public void The_Audit_Is_Optional_Because_It_Only_Reports(string preset)
+        {
+            var step = Steps(preset).First(s => (string)s["commandTag"] == "Prod_CoverageAudit");
+            Assert.True((bool?)step["optional"] == true,
+                preset + ": Prod_CoverageAudit is not optional. It is read-only — it must not "
+              + "be able to halt a BOQ rebuild or a tender pack on its own.");
+        }
+
+        [Theory]
+        [MemberData(nameof(BoqPresets))]
+        public void The_Audit_Is_Added_Once_And_Changes_Nothing_Else(string preset)
+        {
+            var tags = Steps(preset).Select(s => (string)s["commandTag"]).ToList();
+
+            Assert.Equal(1, tags.Count(t => t == "Prod_CoverageAudit"));
+
+            // The rest of the chain is untouched and still in order — W6 is one
+            // insertion, not a re-plan of the BOQ workflow.
+            var rest = tags.Where(t => t != "Prod_CoverageAudit").ToList();
+            Assert.Equal("BOQRefresh", rest[rest.IndexOf("Cost_ValidateAll") + 1 == rest.Count
+                                            ? rest.Count - 1
+                                            : rest.IndexOf("BOQRefresh")]);
+            Assert.Contains("BOQSnapshotSave", rest);
+            Assert.True(rest.IndexOf("BOQRefresh") < rest.IndexOf("BOQSnapshotSave"));
+        }
+    }
+}

--- a/StingTools/Data/WORKFLOW_BOQ_FullRefresh.json
+++ b/StingTools/Data/WORKFLOW_BOQ_FullRefresh.json
@@ -20,6 +20,11 @@
       "optional": false
     },
     {
+      "commandTag": "Prod_CoverageAudit",
+      "label": "Audit PROD rule coverage (read-only) — an unruled family is a wrong rate",
+      "optional": true
+    },
+    {
       "commandTag": "BOQRefresh",
       "label": "Rebuild BOQ from model",
       "optional": false,

--- a/StingTools/Data/WORKFLOW_BOQ_TenderPack.json
+++ b/StingTools/Data/WORKFLOW_BOQ_TenderPack.json
@@ -20,6 +20,11 @@
       "optional": false
     },
     {
+      "commandTag": "Prod_CoverageAudit",
+      "label": "Audit PROD rule coverage (read-only) — an unruled family is a wrong rate",
+      "optional": true
+    },
+    {
       "commandTag": "BOQRefresh",
       "label": "Final BOQ rebuild",
       "optional": false,


### PR DESCRIPTION
> **Draft: depends on #936 (W1).** These are JSON presets, which Tier 2 of the wiring gate scans — without W1's `ResolveCommand` case the gate fails, and I proved that rather than assumed it (below).

## What

`ProjectKickoff` ends at `CreateRevision`; `BOQ_FullRefresh` starts at `Cost_MigrateESEntities`. Nothing joined them, and **an unruled PROD code is a wrong rate**: the rate chain's most specific pass keys on `DISC|PROD`, so a family no rule covers takes a code by category fallback and prices as the category average with nothing said.

`Prod_CoverageAudit` now runs ahead of `BOQRefresh` in both presets, read-only and optional:

| preset | steps | inserted at |
|---|---|---|
| `WORKFLOW_BOQ_FullRefresh.json` | 7 → 8 | index 3, before `BOQRefresh` |
| `WORKFLOW_BOQ_TenderPack.json` | 8 → 9 | index 3, before `BOQRefresh` |

## One consequence worth stating rather than discovering

`BOQ_TenderPack` sets **`rollback_on_optional_failure: true`**, so an optional step that *fails* — as opposed to *skipping* — rolls the whole tender pack back. Adding any step to that preset inherits this. For a strict quality gate it is arguably the right behaviour (a tender should not ship when a check could not run), but it is a real change and is said here so it is not a surprise later.

## RED and GREEN — by sabotage, both counts

```
Prod_Coverage_Is_Audited_Before_The_Boq_Is_Rebuilt
  RED    step moved after BOQRefresh — "audits coverage AFTER the rates are
         already in the sheet"                                       (2 of 6)
  GREEN  index 3 in both, before BOQRefresh

The_Audit_Is_Optional_Because_It_Only_Reports
  RED    optional removed — "it must not be able to halt a BOQ rebuild or a
         tender pack on its own"                                     (2 of 6)
  GREEN  optional in both
```

## The dependency, proved rather than asserted

With `WorkflowEngine.cs` reverted to `origin/main` (i.e. W1 absent), on this branch's presets:

```
Workflow-wiring FAILED -- Tier 2: 2 unresolvable commandTag(s):
  WORKFLOW_BOQ_FullRefresh.json step 4 : 'Prod_CoverageAudit' has no case in WorkflowEngine.ResolveCommand
  WORKFLOW_BOQ_TenderPack.json step 4 : 'Prod_CoverageAudit' has no case in WorkflowEngine.ResolveCommand
```

With #936 merged in a scratch worktree: **Tier 2 = 0**, 670 case labels, 389 steps scanned, build 0/0, Tags 987, path-discipline OK, recount agrees, 277 JSON files parse.

On this branch alone: build 0/0, Tags 972 → **978**, Boq 1,331 unchanged.

## Not verified in Revit

`deploy.bat` was **not** run. Neither preset was executed against a live document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzLmu1kH7PQKwjgXpYmXNC
