### PR TITLE
fix(bonsai,core): repair silent pset writes + restore adapter status API

### DIFF
--- a/stingtools-bonsai/__init__.py
+++ b/stingtools-bonsai/__init__.py
@@ -53,16 +53,18 @@ for _cand in _REPO_ROOT_CANDIDATES:
 
 def register():
     """Blender entry point. Registers preferences + operator + panel classes."""
-    from . import prefs, ui, ops
+    from . import prefs, ui, ops, handlers
     prefs.register()
     ui.register()
     ops.register()
+    handlers.register()
     print("[STING] add-on registered")
 
 
 def unregister():
     """Blender exit point. Unregisters in reverse order."""
-    from . import prefs, ui, ops
+    from . import prefs, ui, ops, handlers
+    handlers.unregister()
     ops.unregister()
     ui.unregister()
     prefs.unregister()

--- a/stingtools-bonsai/ops/__init__.py
+++ b/stingtools-bonsai/ops/__init__.py
@@ -1,4 +1,4 @@
-"""STING operator registrations — Day-1 diagnostics + 16 MVP operators."""
+"""STING operator registrations — Day-1 diagnostics + 29 MVP operators."""
 
 from __future__ import annotations
 
@@ -12,6 +12,10 @@ from .select_ops import CLASSES as SELECT_CLASSES
 from .tagging_ops import CLASSES as TAGGING_CLASSES
 from .validation_ops import CLASSES as VALIDATION_CLASSES
 from .coord_ops import CLASSES as COORD_CLASSES
+from .export_ops import CLASSES as EXPORT_CLASSES
+from .spatial_ops import CLASSES as SPATIAL_CLASSES
+from .repair_ops import CLASSES as REPAIR_CLASSES
+from .mep_ops import CLASSES as MEP_CLASSES
 
 CLASSES = (
     StingAboutOperator,
@@ -21,6 +25,10 @@ CLASSES = (
     *TAGGING_CLASSES,
     *VALIDATION_CLASSES,
     *COORD_CLASSES,
+    *EXPORT_CLASSES,
+    *SPATIAL_CLASSES,
+    *REPAIR_CLASSES,
+    *MEP_CLASSES,
 )
 
 

--- a/stingtools-bonsai/ops/export_ops.py
+++ b/stingtools-bonsai/ops/export_ops.py
@@ -1,329 +1,304 @@
-"""Export operators — tag register CSV, compliance snapshot, BOQ, audit log."""
+"""Export operators — tag register CSV, BOQ CSV, compliance snapshot, audit log export."""
 
 from __future__ import annotations
 
 import csv
-import json
-import pathlib
 import hashlib
-import datetime
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
 
 import bpy
 
 
-def _bim_coord_dir(ifc_path: str) -> pathlib.Path:
-    """Return the _BIM_COORD directory next to the IFC file."""
-    p = pathlib.Path(ifc_path)
-    d = p.parent / "_BIM_COORD"
-    d.mkdir(exist_ok=True)
-    return d
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _get_ifc():
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        return _bridge.active_ifc()
+    except Exception:
+        return None
+
+
+def _bim_coord_dir(ifc_path: str) -> Path:
+    """Return <ifc_dir>/_BIM_COORD/, creating it if absent."""
+    p = Path(ifc_path).parent / "_BIM_COORD"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
 
 
 def _ts() -> str:
-    return datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 # ---------------------------------------------------------------------------
-# Tag register export
+# Tag Register CSV export
 # ---------------------------------------------------------------------------
 
 class StingExportTagRegisterOperator(bpy.types.Operator):
-    """Export all tagged IFC elements to a CSV tag register."""
+    """Export Pset_StingTags for every IfcElement to a CSV tag register."""
 
     bl_idname = "sting.export_tag_register"
     bl_label = "Export Tag Register"
-    bl_description = "Write all Pset_StingTags values to a CSV file in _BIM_COORD/"
+    bl_description = (
+        "Write a CSV of all IfcElement Pset_StingTags to "
+        "<ifc_dir>/_BIM_COORD/tag_register_<ts>.csv"
+    )
     bl_options = {"REGISTER"}
 
     def execute(self, context: bpy.types.Context) -> set[str]:
-        try:
-            from ..core.bonsai import bonsai as _bridge
-            ifc = _bridge.active_ifc()
-        except Exception as exc:
-            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
-            return {"CANCELLED"}
-
-        if ifc is None:
-            self.report({"ERROR"}, "No IFC file loaded — open a model in Bonsai first")
-            return {"CANCELLED"}
-
-        try:
-            ifc_path = ifc.path
-        except AttributeError:
-            self.report({"ERROR"}, "Cannot resolve IFC path")
-            return {"CANCELLED"}
-
-        pset_name = "Pset_StingTags"
-        fields = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence", "FullTag"]
-        rows = []
-
-        try:
-            import ifcopenshell  # provided by Bonsai
-            import ifcopenshell.util.element as ifc_util
-            for el in ifc.by_type("IfcElement"):
-                psets = ifc_util.get_psets(el)
-                stag = psets.get(pset_name, {})
-                if not stag:
-                    continue
-                rows.append({
-                    "GlobalId": el.GlobalId,
-                    "IfcClass": el.is_a(),
-                    "Name": el.Name or "",
-                    **{f: stag.get(f, "") for f in fields},
-                })
-        except Exception as exc:
-            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
-            return {"CANCELLED"}
-
-        out_path = _bim_coord_dir(ifc_path) / f"tag_register_{_ts()}.csv"
-        try:
-            with out_path.open("w", newline="", encoding="utf-8") as fh:
-                writer = csv.DictWriter(fh, fieldnames=["GlobalId", "IfcClass", "Name"] + fields)
-                writer.writeheader()
-                writer.writerows(rows)
-        except OSError as exc:
-            self.report({"ERROR"}, f"Cannot write CSV: {exc}")
-            return {"CANCELLED"}
-
-        self.report({"INFO"}, f"Tag register exported — {len(rows)} rows → {out_path.name}")
-        return {"FINISHED"}
-
-
-# ---------------------------------------------------------------------------
-# Compliance snapshot export
-# ---------------------------------------------------------------------------
-
-class StingExportComplianceSnapshotOperator(bpy.types.Operator):
-    """Export a JSON compliance snapshot and optionally push to Planscape."""
-
-    bl_idname = "sting.export_compliance_snapshot"
-    bl_label = "Export Compliance Snapshot"
-    bl_description = "Write tag-completeness JSON snapshot; optionally push to Planscape Server"
-    bl_options = {"REGISTER"}
-
-    def execute(self, context: bpy.types.Context) -> set[str]:
-        try:
-            from ..core.bonsai import bonsai as _bridge
-            ifc = _bridge.active_ifc()
-        except Exception as exc:
-            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
-            return {"CANCELLED"}
-
+        ifc = _get_ifc()
         if ifc is None:
             self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
 
         try:
-            ifc_path = ifc.path
-        except AttributeError:
-            self.report({"ERROR"}, "Cannot resolve IFC path")
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        pset_name = "Pset_StingTags"
-        required_fields = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence"]
+        ifc_path = getattr(ifc, "path", None) or ""
+        if not ifc_path:
+            self.report({"WARNING"}, "IFC path unknown — writing to Blender temp dir")
+            out_dir = Path(bpy.app.tempdir)
+        else:
+            out_dir = _bim_coord_dir(ifc_path)
 
-        total = complete = incomplete = untagged = 0
-        by_disc: dict[str, dict] = {}
+        out_path = out_dir / f"tag_register_{_ts()}.csv"
 
-        try:
-            import ifcopenshell
-            import ifcopenshell.util.element as ifc_util
+        fields = [
+            "GlobalId", "IfcClass", "Name",
+            "Discipline", "Location", "Zone", "Level",
+            "System", "Function", "Product", "Sequence", "FullTag",
+        ]
+
+        rows_written = 0
+        with out_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fields)
+            writer.writeheader()
             for el in ifc.by_type("IfcElement"):
                 psets = ifc_util.get_psets(el)
-                stag = psets.get(pset_name, {})
-                total += 1
-                if not stag:
-                    untagged += 1
-                    continue
-                disc = stag.get("Discipline", "XX")
-                filled = sum(1 for f in required_fields if stag.get(f, "XX") not in ("", "XX"))
-                if filled == len(required_fields):
-                    complete += 1
-                else:
-                    incomplete += 1
-                d = by_disc.setdefault(disc, {"total": 0, "complete": 0, "incomplete": 0})
-                d["total"] += 1
-                if filled == len(required_fields):
-                    d["complete"] += 1
-                else:
-                    d["incomplete"] += 1
-        except Exception as exc:
-            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
+                stag = psets.get("Pset_StingTags", {})
+                writer.writerow({
+                    "GlobalId":   getattr(el, "GlobalId", ""),
+                    "IfcClass":   el.is_a(),
+                    "Name":       getattr(el, "Name", "") or "",
+                    "Discipline": stag.get("Discipline", ""),
+                    "Location":   stag.get("Location", ""),
+                    "Zone":       stag.get("Zone", ""),
+                    "Level":      stag.get("Level", ""),
+                    "System":     stag.get("System", ""),
+                    "Function":   stag.get("Function", ""),
+                    "Product":    stag.get("Product", ""),
+                    "Sequence":   stag.get("Sequence", ""),
+                    "FullTag":    stag.get("FullTag", ""),
+                })
+                rows_written += 1
+
+        self.report({"INFO"}, f"Tag register exported: {rows_written} rows → {out_path.name}")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Bill of Quantities CSV export
+# ---------------------------------------------------------------------------
+
+class StingExportBOQOperator(bpy.types.Operator):
+    """Export a simple Bill of Quantities grouped by Discipline / System / IfcClass."""
+
+    bl_idname = "sting.export_boq"
+    bl_label = "Export BOQ"
+    bl_description = (
+        "Group IfcElements by (Discipline, System, IfcClass) and write a "
+        "count-based BOQ to <ifc_dir>/_BIM_COORD/boq_<ts>.csv"
+    )
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
+
+        try:
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        from collections import Counter
+        counts: Counter = Counter()
+
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            stag = psets.get("Pset_StingTags", {})
+            disc = stag.get("Discipline", "XX")
+            sys_ = stag.get("System", "XX")
+            ifc_class = el.is_a()
+            counts[(disc, sys_, ifc_class)] += 1
+
+        ifc_path = getattr(ifc, "path", None) or ""
+        out_dir = _bim_coord_dir(ifc_path) if ifc_path else Path(bpy.app.tempdir)
+        out_path = out_dir / f"boq_{_ts()}.csv"
+
+        with out_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["Discipline", "System", "IfcClass", "Quantity"])
+            for (disc, sys_, ifc_class), qty in sorted(counts.items()):
+                writer.writerow([disc, sys_, ifc_class, qty])
+
+        self.report({"INFO"}, f"BOQ exported: {sum(counts.values())} elements → {out_path.name}")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Compliance Snapshot JSON export
+# ---------------------------------------------------------------------------
+
+class StingExportComplianceSnapshotOperator(bpy.types.Operator):
+    """Snapshot tag completeness metrics to a JSON file and optionally push to Planscape."""
+
+    bl_idname = "sting.export_compliance_snapshot"
+    bl_label = "Export Compliance Snapshot"
+    bl_description = (
+        "Count complete / incomplete / untagged elements and write a JSON "
+        "snapshot to <ifc_dir>/_BIM_COORD/compliance_<ts>.json. "
+        "Pushes to Planscape when a token is configured in add-on prefs."
+    )
+    bl_options = {"REGISTER"}
+
+    _REQUIRED = ["Discipline", "Location", "Zone", "Level",
+                 "System", "Function", "Product", "Sequence"]
+    _SENTINEL = {"", "XX"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        total = complete = incomplete = untagged = 0
+        discipline_counts: dict[str, int] = {}
+
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            stag = psets.get("Pset_StingTags", {})
+            total += 1
+            disc = stag.get("Discipline", "XX")
+            if not stag or disc in self._SENTINEL:
+                untagged += 1
+                continue
+            missing = [f for f in self._REQUIRED if stag.get(f, "XX") in self._SENTINEL]
+            if missing:
+                incomplete += 1
+            else:
+                complete += 1
+                discipline_counts[disc] = discipline_counts.get(disc, 0) + 1
 
         pct = round(complete / total * 100, 1) if total else 0.0
         snapshot = {
-            "captured_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "timestamp": _ts(),
             "total": total,
             "complete": complete,
             "incomplete": incomplete,
             "untagged": untagged,
             "compliance_pct": pct,
-            "by_discipline": by_disc,
+            "by_discipline": discipline_counts,
         }
 
-        out_path = _bim_coord_dir(ifc_path) / f"compliance_{_ts()}.json"
-        try:
-            out_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
-        except OSError as exc:
-            self.report({"ERROR"}, f"Cannot write snapshot: {exc}")
-            return {"CANCELLED"}
+        ifc_path = getattr(ifc, "path", None) or ""
+        out_dir = _bim_coord_dir(ifc_path) if ifc_path else Path(bpy.app.tempdir)
+        out_path = out_dir / f"compliance_{_ts()}.json"
+        out_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
 
-        # Attempt Planscape push (non-fatal if offline)
+        # Optional Planscape push
         try:
             from .. import prefs as _p
             pr = _p.get_prefs(context)
-            token = pr.api_token or ""
-            project_id = pr.project_id or ""
-            if token and project_id:
+            if pr.api_token and pr.project_id:
                 from stingtools_core.planscape import PlanscapeClient  # type: ignore
-                client = PlanscapeClient(token=token)
-                client.push_compliance(project_id=project_id, snapshot=snapshot)
-                self.report({"INFO"}, f"Snapshot pushed to Planscape — {pct}% compliant")
-            else:
-                self.report({"INFO"}, f"Snapshot saved locally — {pct}% compliant ({out_path.name})")
+                client = PlanscapeClient(pr.api_token)
+                client.push_compliance_snapshot(pr.project_id, snapshot)
         except Exception:
-            self.report({"INFO"}, f"Snapshot saved locally (Planscape unavailable) — {pct}% compliant")
+            pass
 
+        self.report({"INFO"}, f"{pct}% compliant ({complete}/{total}) — saved to {out_path.name}")
         return {"FINISHED"}
 
 
 # ---------------------------------------------------------------------------
-# BOQ export
-# ---------------------------------------------------------------------------
-
-class StingExportBOQOperator(bpy.types.Operator):
-    """Export a Bill of Quantities CSV grouped by Discipline x System x IfcClass."""
-
-    bl_idname = "sting.export_boq"
-    bl_label = "Export BOQ"
-    bl_description = "Write a Bill of Quantities CSV to _BIM_COORD/"
-    bl_options = {"REGISTER"}
-
-    def execute(self, context: bpy.types.Context) -> set[str]:
-        try:
-            from ..core.bonsai import bonsai as _bridge
-            ifc = _bridge.active_ifc()
-        except Exception as exc:
-            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
-            return {"CANCELLED"}
-
-        if ifc is None:
-            self.report({"ERROR"}, "No IFC file loaded")
-            return {"CANCELLED"}
-
-        try:
-            ifc_path = ifc.path
-        except AttributeError:
-            self.report({"ERROR"}, "Cannot resolve IFC path")
-            return {"CANCELLED"}
-
-        pset_name = "Pset_StingTags"
-        groups: dict[tuple, int] = {}
-
-        try:
-            import ifcopenshell
-            import ifcopenshell.util.element as ifc_util
-            for el in ifc.by_type("IfcElement"):
-                psets = ifc_util.get_psets(el)
-                stag = psets.get(pset_name, {})
-                disc = stag.get("Discipline", "XX")
-                sys_ = stag.get("System", "XX")
-                ifc_class = el.is_a()
-                key = (disc, sys_, ifc_class)
-                groups[key] = groups.get(key, 0) + 1
-        except Exception as exc:
-            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
-            return {"CANCELLED"}
-
-        out_path = _bim_coord_dir(ifc_path) / f"boq_{_ts()}.csv"
-        try:
-            with out_path.open("w", newline="", encoding="utf-8") as fh:
-                writer = csv.writer(fh)
-                writer.writerow(["Discipline", "System", "IfcClass", "Quantity", "Unit"])
-                for (disc, sys_, cls_), qty in sorted(groups.items()):
-                    writer.writerow([disc, sys_, cls_, qty, "Nr"])
-        except OSError as exc:
-            self.report({"ERROR"}, f"Cannot write BOQ: {exc}")
-            return {"CANCELLED"}
-
-        total_items = sum(groups.values())
-        self.report({"INFO"}, f"BOQ exported — {total_items} items, {len(groups)} lines → {out_path.name}")
-        return {"FINISHED"}
-
-
-# ---------------------------------------------------------------------------
-# Audit log export / integrity check
+# Audit Log export
 # ---------------------------------------------------------------------------
 
 class StingAuditLogExportOperator(bpy.types.Operator):
-    """Verify and export the STING SHA-256-chained audit log."""
+    """Verify SHA-256 chain integrity and export the audit JSONL to a timestamped copy."""
 
     bl_idname = "sting.export_audit_log"
     bl_label = "Export Audit Log"
-    bl_description = "Verify SHA-256 chain integrity and copy audit log to a timestamped file"
+    bl_description = (
+        "Read <ifc_dir>/_BIM_COORD/sting_audit.jsonl, verify the SHA-256 "
+        "tamper-evidence chain, and copy to sting_audit_export_<ts>.jsonl"
+    )
     bl_options = {"REGISTER"}
 
     def execute(self, context: bpy.types.Context) -> set[str]:
-        try:
-            from ..core.bonsai import bonsai as _bridge
-            ifc = _bridge.active_ifc()
-        except Exception as exc:
-            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
-            return {"CANCELLED"}
-
+        ifc = _get_ifc()
         if ifc is None:
             self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
 
-        try:
-            ifc_path = ifc.path
-        except AttributeError:
-            self.report({"ERROR"}, "Cannot resolve IFC path")
+        ifc_path = getattr(ifc, "path", None) or ""
+        if not ifc_path:
+            self.report({"ERROR"}, "IFC path unknown — cannot locate audit log")
             return {"CANCELLED"}
 
-        src = _bim_coord_dir(ifc_path) / "sting_audit.jsonl"
-        if not src.exists():
-            self.report({"WARNING"}, "No audit log found at _BIM_COORD/sting_audit.jsonl")
+        bim_dir = _bim_coord_dir(ifc_path)
+        audit_path = bim_dir / "sting_audit.jsonl"
+
+        if not audit_path.exists():
+            self.report({"WARNING"}, "No audit log found — nothing to export")
             return {"CANCELLED"}
 
-        lines = src.read_text(encoding="utf-8").splitlines()
-        errors: list[str] = []
+        lines = audit_path.read_text(encoding="utf-8").splitlines()
+        tampered = 0
         prev_hash = ""
-        for i, line in enumerate(lines):
+        for line in lines:
+            if not line.strip():
+                continue
             try:
                 entry = json.loads(line)
+                stored_prev = entry.get("prev_hash", "")
+                if stored_prev != prev_hash:
+                    tampered += 1
+                prev_hash = hashlib.sha256(line.encode()).hexdigest()
             except json.JSONDecodeError:
-                errors.append(f"Line {i+1}: JSON parse error")
-                continue
-            stored_hash = entry.get("hash", "")
-            payload = json.dumps({k: v for k, v in entry.items() if k != "hash"}, sort_keys=True)
-            expected = hashlib.sha256((prev_hash + payload).encode()).hexdigest()
-            if stored_hash != expected:
-                errors.append(f"Line {i+1}: hash mismatch (chain broken)")
-            prev_hash = stored_hash
+                tampered += 1
 
-        out_path = _bim_coord_dir(ifc_path) / f"audit_export_{_ts()}.jsonl"
-        try:
-            import shutil
-            shutil.copy2(src, out_path)
-        except OSError as exc:
-            self.report({"ERROR"}, f"Cannot copy audit log: {exc}")
-            return {"CANCELLED"}
+        out_path = bim_dir / f"sting_audit_export_{_ts()}.jsonl"
+        import shutil
+        shutil.copy2(audit_path, out_path)
 
-        if errors:
-            self.report({"WARNING"}, f"Audit log has {len(errors)} chain error(s) — see system console")
-            for err in errors[:5]:
-                print(f"[STING AUDIT] {err}")
+        if tampered:
+            self.report({"WARNING"}, f"Exported {len(lines)} entries — {tampered} CHAIN VIOLATIONS detected")
         else:
-            self.report({"INFO"}, f"Audit log OK ({len(lines)} entries) → {out_path.name}")
-
+            self.report({"INFO"}, f"Audit log exported: {len(lines)} entries, chain OK → {out_path.name}")
         return {"FINISHED"}
 
 
 CLASSES = (
     StingExportTagRegisterOperator,
-    StingExportComplianceSnapshotOperator,
     StingExportBOQOperator,
+    StingExportComplianceSnapshotOperator,
     StingAuditLogExportOperator,
 )

--- a/stingtools-bonsai/ops/export_ops.py
+++ b/stingtools-bonsai/ops/export_ops.py
@@ -1,0 +1,329 @@
+"""Export operators — tag register CSV, compliance snapshot, BOQ, audit log."""
+
+from __future__ import annotations
+
+import csv
+import json
+import pathlib
+import hashlib
+import datetime
+
+import bpy
+
+
+def _bim_coord_dir(ifc_path: str) -> pathlib.Path:
+    """Return the _BIM_COORD directory next to the IFC file."""
+    p = pathlib.Path(ifc_path)
+    d = p.parent / "_BIM_COORD"
+    d.mkdir(exist_ok=True)
+    return d
+
+
+def _ts() -> str:
+    return datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+
+# ---------------------------------------------------------------------------
+# Tag register export
+# ---------------------------------------------------------------------------
+
+class StingExportTagRegisterOperator(bpy.types.Operator):
+    """Export all tagged IFC elements to a CSV tag register."""
+
+    bl_idname = "sting.export_tag_register"
+    bl_label = "Export Tag Register"
+    bl_description = "Write all Pset_StingTags values to a CSV file in _BIM_COORD/"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        try:
+            from ..core.bonsai import bonsai as _bridge
+            ifc = _bridge.active_ifc()
+        except Exception as exc:
+            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
+            return {"CANCELLED"}
+
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded — open a model in Bonsai first")
+            return {"CANCELLED"}
+
+        try:
+            ifc_path = ifc.path
+        except AttributeError:
+            self.report({"ERROR"}, "Cannot resolve IFC path")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        fields = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence", "FullTag"]
+        rows = []
+
+        try:
+            import ifcopenshell  # provided by Bonsai
+            import ifcopenshell.util.element as ifc_util
+            for el in ifc.by_type("IfcElement"):
+                psets = ifc_util.get_psets(el)
+                stag = psets.get(pset_name, {})
+                if not stag:
+                    continue
+                rows.append({
+                    "GlobalId": el.GlobalId,
+                    "IfcClass": el.is_a(),
+                    "Name": el.Name or "",
+                    **{f: stag.get(f, "") for f in fields},
+                })
+        except Exception as exc:
+            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
+            return {"CANCELLED"}
+
+        out_path = _bim_coord_dir(ifc_path) / f"tag_register_{_ts()}.csv"
+        try:
+            with out_path.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=["GlobalId", "IfcClass", "Name"] + fields)
+                writer.writeheader()
+                writer.writerows(rows)
+        except OSError as exc:
+            self.report({"ERROR"}, f"Cannot write CSV: {exc}")
+            return {"CANCELLED"}
+
+        self.report({"INFO"}, f"Tag register exported — {len(rows)} rows → {out_path.name}")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Compliance snapshot export
+# ---------------------------------------------------------------------------
+
+class StingExportComplianceSnapshotOperator(bpy.types.Operator):
+    """Export a JSON compliance snapshot and optionally push to Planscape."""
+
+    bl_idname = "sting.export_compliance_snapshot"
+    bl_label = "Export Compliance Snapshot"
+    bl_description = "Write tag-completeness JSON snapshot; optionally push to Planscape Server"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        try:
+            from ..core.bonsai import bonsai as _bridge
+            ifc = _bridge.active_ifc()
+        except Exception as exc:
+            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
+            return {"CANCELLED"}
+
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            ifc_path = ifc.path
+        except AttributeError:
+            self.report({"ERROR"}, "Cannot resolve IFC path")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        required_fields = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence"]
+
+        total = complete = incomplete = untagged = 0
+        by_disc: dict[str, dict] = {}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+            for el in ifc.by_type("IfcElement"):
+                psets = ifc_util.get_psets(el)
+                stag = psets.get(pset_name, {})
+                total += 1
+                if not stag:
+                    untagged += 1
+                    continue
+                disc = stag.get("Discipline", "XX")
+                filled = sum(1 for f in required_fields if stag.get(f, "XX") not in ("", "XX"))
+                if filled == len(required_fields):
+                    complete += 1
+                else:
+                    incomplete += 1
+                d = by_disc.setdefault(disc, {"total": 0, "complete": 0, "incomplete": 0})
+                d["total"] += 1
+                if filled == len(required_fields):
+                    d["complete"] += 1
+                else:
+                    d["incomplete"] += 1
+        except Exception as exc:
+            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
+            return {"CANCELLED"}
+
+        pct = round(complete / total * 100, 1) if total else 0.0
+        snapshot = {
+            "captured_at": datetime.datetime.utcnow().isoformat() + "Z",
+            "total": total,
+            "complete": complete,
+            "incomplete": incomplete,
+            "untagged": untagged,
+            "compliance_pct": pct,
+            "by_discipline": by_disc,
+        }
+
+        out_path = _bim_coord_dir(ifc_path) / f"compliance_{_ts()}.json"
+        try:
+            out_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+        except OSError as exc:
+            self.report({"ERROR"}, f"Cannot write snapshot: {exc}")
+            return {"CANCELLED"}
+
+        # Attempt Planscape push (non-fatal if offline)
+        try:
+            from .. import prefs as _p
+            pr = _p.get_prefs(context)
+            token = pr.api_token or ""
+            project_id = pr.project_id or ""
+            if token and project_id:
+                from stingtools_core.planscape import PlanscapeClient  # type: ignore
+                client = PlanscapeClient(token=token)
+                client.push_compliance(project_id=project_id, snapshot=snapshot)
+                self.report({"INFO"}, f"Snapshot pushed to Planscape — {pct}% compliant")
+            else:
+                self.report({"INFO"}, f"Snapshot saved locally — {pct}% compliant ({out_path.name})")
+        except Exception:
+            self.report({"INFO"}, f"Snapshot saved locally (Planscape unavailable) — {pct}% compliant")
+
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# BOQ export
+# ---------------------------------------------------------------------------
+
+class StingExportBOQOperator(bpy.types.Operator):
+    """Export a Bill of Quantities CSV grouped by Discipline x System x IfcClass."""
+
+    bl_idname = "sting.export_boq"
+    bl_label = "Export BOQ"
+    bl_description = "Write a Bill of Quantities CSV to _BIM_COORD/"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        try:
+            from ..core.bonsai import bonsai as _bridge
+            ifc = _bridge.active_ifc()
+        except Exception as exc:
+            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
+            return {"CANCELLED"}
+
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            ifc_path = ifc.path
+        except AttributeError:
+            self.report({"ERROR"}, "Cannot resolve IFC path")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        groups: dict[tuple, int] = {}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+            for el in ifc.by_type("IfcElement"):
+                psets = ifc_util.get_psets(el)
+                stag = psets.get(pset_name, {})
+                disc = stag.get("Discipline", "XX")
+                sys_ = stag.get("System", "XX")
+                ifc_class = el.is_a()
+                key = (disc, sys_, ifc_class)
+                groups[key] = groups.get(key, 0) + 1
+        except Exception as exc:
+            self.report({"ERROR"}, f"IFC traversal failed: {exc}")
+            return {"CANCELLED"}
+
+        out_path = _bim_coord_dir(ifc_path) / f"boq_{_ts()}.csv"
+        try:
+            with out_path.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.writer(fh)
+                writer.writerow(["Discipline", "System", "IfcClass", "Quantity", "Unit"])
+                for (disc, sys_, cls_), qty in sorted(groups.items()):
+                    writer.writerow([disc, sys_, cls_, qty, "Nr"])
+        except OSError as exc:
+            self.report({"ERROR"}, f"Cannot write BOQ: {exc}")
+            return {"CANCELLED"}
+
+        total_items = sum(groups.values())
+        self.report({"INFO"}, f"BOQ exported — {total_items} items, {len(groups)} lines → {out_path.name}")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Audit log export / integrity check
+# ---------------------------------------------------------------------------
+
+class StingAuditLogExportOperator(bpy.types.Operator):
+    """Verify and export the STING SHA-256-chained audit log."""
+
+    bl_idname = "sting.export_audit_log"
+    bl_label = "Export Audit Log"
+    bl_description = "Verify SHA-256 chain integrity and copy audit log to a timestamped file"
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        try:
+            from ..core.bonsai import bonsai as _bridge
+            ifc = _bridge.active_ifc()
+        except Exception as exc:
+            self.report({"ERROR"}, f"Cannot access IFC model: {exc}")
+            return {"CANCELLED"}
+
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            ifc_path = ifc.path
+        except AttributeError:
+            self.report({"ERROR"}, "Cannot resolve IFC path")
+            return {"CANCELLED"}
+
+        src = _bim_coord_dir(ifc_path) / "sting_audit.jsonl"
+        if not src.exists():
+            self.report({"WARNING"}, "No audit log found at _BIM_COORD/sting_audit.jsonl")
+            return {"CANCELLED"}
+
+        lines = src.read_text(encoding="utf-8").splitlines()
+        errors: list[str] = []
+        prev_hash = ""
+        for i, line in enumerate(lines):
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                errors.append(f"Line {i+1}: JSON parse error")
+                continue
+            stored_hash = entry.get("hash", "")
+            payload = json.dumps({k: v for k, v in entry.items() if k != "hash"}, sort_keys=True)
+            expected = hashlib.sha256((prev_hash + payload).encode()).hexdigest()
+            if stored_hash != expected:
+                errors.append(f"Line {i+1}: hash mismatch (chain broken)")
+            prev_hash = stored_hash
+
+        out_path = _bim_coord_dir(ifc_path) / f"audit_export_{_ts()}.jsonl"
+        try:
+            import shutil
+            shutil.copy2(src, out_path)
+        except OSError as exc:
+            self.report({"ERROR"}, f"Cannot copy audit log: {exc}")
+            return {"CANCELLED"}
+
+        if errors:
+            self.report({"WARNING"}, f"Audit log has {len(errors)} chain error(s) — see system console")
+            for err in errors[:5]:
+                print(f"[STING AUDIT] {err}")
+        else:
+            self.report({"INFO"}, f"Audit log OK ({len(lines)} entries) → {out_path.name}")
+
+        return {"FINISHED"}
+
+
+CLASSES = (
+    StingExportTagRegisterOperator,
+    StingExportComplianceSnapshotOperator,
+    StingExportBOQOperator,
+    StingAuditLogExportOperator,
+)

--- a/stingtools-bonsai/ops/mep_ops.py
+++ b/stingtools-bonsai/ops/mep_ops.py
@@ -1,0 +1,255 @@
+"""MEP engineering calculation operators — pipe flow, drainage units, conduit fill."""
+
+from __future__ import annotations
+
+import math
+
+import bpy
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _get_ifc():
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        return _bridge.active_ifc()
+    except Exception:
+        return None
+
+
+def _get_mep_pset(ifc, element) -> dict:
+    """Return Pset_StingMEP values for element (may be empty dict)."""
+    try:
+        import ifcopenshell.util.element as ifc_util
+        return ifc_util.get_psets(element).get("Pset_StingMEP", {})
+    except Exception:
+        return {}
+
+
+def _write_mep_pset(ifc, element, props: dict) -> None:
+    """Write properties into Pset_StingMEP via BonsaiBridge."""
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        _bridge.add_pset(ifc, element, "Pset_StingMEP", props)
+    except Exception as exc:
+        print(f"[STING] write_mep_pset failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Hazen-Williams pipe flow / sizing
+# ---------------------------------------------------------------------------
+
+class StingCalcPipeFlowOperator(bpy.types.Operator):
+    """Size pipe and calculate velocity using the Hazen-Williams formula."""
+
+    bl_idname = "sting.calc_pipe_flow"
+    bl_label = "Calc Pipe Flow (H-W)"
+    bl_description = (
+        "Apply Hazen-Williams formula to every IfcPipeSegment: select "
+        "the smallest standard DN that keeps velocity ≤ 3.0 m/s. "
+        "Writes PLM_SUP_VEL_MS, PLM_SUP_FLOW_LS, PLM_SUP_DN to Pset_StingMEP."
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    # Standard metric DN bore diameters in mm
+    _DN_SERIES = [15, 20, 25, 32, 40, 50, 65, 80, 100, 125, 150, 200, 250, 300]
+    _HW_C = 140        # Hazen-Williams C -- copper/plastic
+    _MAX_VEL = 3.0     # m/s maximum velocity
+    _SLOPE = 0.01      # assumed hydraulic gradient (m/m) for preliminary sizing
+
+    @classmethod
+    def _hw_velocity(cls, diameter_m: float, slope: float = None) -> float:
+        """Return velocity in m/s for a full-bore circular pipe."""
+        s = slope or cls._SLOPE
+        r = diameter_m / 4.0   # hydraulic radius for full circular pipe
+        return 0.8492 * cls._HW_C * (r ** 0.63) * (s ** 0.54)
+
+    @classmethod
+    def _select_dn(cls, flow_ls: float) -> tuple[int, float, float]:
+        """Return (DN_mm, velocity_m_s, flow_L_s) for the smallest passing DN."""
+        for dn in cls._DN_SERIES:
+            d_m = dn / 1000.0
+            area = math.pi * (d_m / 2.0) ** 2
+            v = cls._hw_velocity(d_m)
+            q = v * area * 1000.0   # L/s
+            if q >= flow_ls:
+                return dn, min(v, cls._MAX_VEL), q
+        dn = cls._DN_SERIES[-1]
+        d_m = dn / 1000.0
+        v = cls._hw_velocity(d_m)
+        return dn, v, v * math.pi * (d_m / 2.0) ** 2 * 1000.0
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        processed = 0
+        for el in ifc.by_type("IfcPipeSegment"):
+            mep = _get_mep_pset(ifc, el)
+            # Use existing flow if stamped, else default 0.5 L/s for a domestic branch
+            flow_ls = float(mep.get("PLM_SUP_FLOW_LS", 0.5) or 0.5)
+            dn, vel, actual_flow = self._select_dn(flow_ls)
+            _write_mep_pset(ifc, el, {
+                "PLM_SUP_DN": str(dn),
+                "PLM_SUP_VEL_MS": f"{vel:.3f}",
+                "PLM_SUP_FLOW_LS": f"{actual_flow:.3f}",
+            })
+            processed += 1
+
+        self.report({"INFO"}, f"Hazen-Williams sizing applied to {processed} pipe segment(s)")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# BS EN 12056-2 Drainage Unit assignment
+# ---------------------------------------------------------------------------
+
+class StingCalcDrainageUnitsOperator(bpy.types.Operator):
+    """Assign BS EN 12056-2 drainage unit (DU) values to sanitary terminals."""
+
+    bl_idname = "sting.calc_drainage_units"
+    bl_label = "Calc Drainage Units (DU)"
+    bl_description = (
+        "Look up BS EN 12056-2 / BS EN 806 DU per IfcSanitaryTerminal sub-type "
+        "and write PLM_DRN_DU to Pset_StingMEP on each element."
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    # BS EN 12056-2 Table 1 -- Discharge Unit values
+    _DU_TABLE = {
+        "WC": 2.0,
+        "WATERCLOSETWITHCISTERN": 2.0,
+        "WATERCLOSETWITHFLUSHOMETER": 2.0,
+        "WASHHANDBASIN": 0.5,
+        "BASIN": 0.5,
+        "SINK": 1.0,
+        "BATH": 3.0,
+        "SHOWER": 0.6,
+        "BIDET": 0.5,
+        "URINAL": 0.3,
+        "KITCHENSINK": 1.0,
+        "SHOWERBASE": 0.6,
+    }
+
+    def _resolve_du(self, el) -> float:
+        """Resolve DU from PredefinedType or Name heuristics."""
+        try:
+            pt = (el.PredefinedType or "").upper().replace(" ", "")
+        except AttributeError:
+            pt = ""
+        if pt in self._DU_TABLE:
+            return self._DU_TABLE[pt]
+        # Fallback: scan Name
+        name = (el.Name or "").upper()
+        for key, du in self._DU_TABLE.items():
+            if key in name:
+                return du
+        return 0.5  # conservative default
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        processed = 0
+        total_du = 0.0
+        for el in ifc.by_type("IfcSanitaryTerminal"):
+            du = self._resolve_du(el)
+            _write_mep_pset(ifc, el, {"PLM_DRN_DU": f"{du:.1f}"})
+            processed += 1
+            total_du += du
+
+        self.report(
+            {"INFO"},
+            f"Drainage units assigned to {processed} sanitary terminal(s) — total DU: {total_du:.1f}",
+        )
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# BS 7671 Conduit fill check
+# ---------------------------------------------------------------------------
+
+class StingCalcConduitFillOperator(bpy.types.Operator):
+    """Evaluate BS 7671 40% conduit fill for each IfcCableCarrierSegment."""
+
+    bl_idname = "sting.calc_conduit_fill"
+    bl_label = "Calc Conduit Fill"
+    bl_description = (
+        "Check BS 7671 40% fill rule for each IfcCableCarrierSegment. "
+        "Reads cable count + diameter from Pset_StingMEP; writes "
+        "ELC_FILL_PCT and ELC_FILL_STATUS (OK / OVERLOADED)."
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    _MAX_FILL_PCT = 40.0   # BS 7671 Appendix 5 maximum
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        processed = overloaded = 0
+        for el in ifc.by_type("IfcCableCarrierSegment"):
+            mep = _get_mep_pset(ifc, el)
+
+            # Conduit internal diameter (mm); default 25 mm if not set
+            conduit_d = float(mep.get("ELC_CONDUIT_DN_MM", 25) or 25)
+            conduit_area = math.pi * (conduit_d / 2.0) ** 2   # mm2
+
+            # Cable count and individual cable outer diameter (mm)
+            cable_count = int(float(mep.get("ELC_CABLE_COUNT", 1) or 1))
+            cable_d = float(mep.get("ELC_CABLE_OD_MM", 6) or 6)   # typical 6 mm2/1.5 mm2 T&E
+            cable_area_each = math.pi * (cable_d / 2.0) ** 2
+            total_cable_area = cable_count * cable_area_each
+
+            fill_pct = (total_cable_area / conduit_area * 100.0) if conduit_area > 0 else 0.0
+            status = "OK" if fill_pct <= self._MAX_FILL_PCT else "OVERLOADED"
+
+            _write_mep_pset(ifc, el, {
+                "ELC_FILL_PCT": f"{fill_pct:.1f}",
+                "ELC_FILL_STATUS": status,
+            })
+            processed += 1
+            if status == "OVERLOADED":
+                overloaded += 1
+
+        msg = f"Conduit fill checked on {processed} segment(s)"
+        if overloaded:
+            msg += f" — {overloaded} OVERLOADED (>40%)"
+            self.report({"WARNING"}, msg)
+        else:
+            self.report({"INFO"}, msg)
+
+        return {"FINISHED"}
+
+
+CLASSES = (
+    StingCalcPipeFlowOperator,
+    StingCalcDrainageUnitsOperator,
+    StingCalcConduitFillOperator,
+)

--- a/stingtools-bonsai/ops/mep_ops.py
+++ b/stingtools-bonsai/ops/mep_ops.py
@@ -19,7 +19,7 @@ def _get_ifc():
         return None
 
 
-def _get_mep_pset(ifc, element) -> dict:
+def _get_mep_pset(element) -> dict:
     """Return Pset_StingMEP values for element (may be empty dict)."""
     try:
         import ifcopenshell.util.element as ifc_util
@@ -28,13 +28,14 @@ def _get_mep_pset(ifc, element) -> dict:
         return {}
 
 
-def _write_mep_pset(ifc, element, props: dict) -> None:
-    """Write properties into Pset_StingMEP via BonsaiBridge."""
-    try:
-        from ..core.bonsai import bonsai as _bridge
-        _bridge.add_pset(ifc, element, "Pset_StingMEP", props)
-    except Exception as exc:
-        print(f"[STING] write_mep_pset failed: {exc}")
+def _write_mep_pset(element, props: dict) -> bool:
+    """Write props into Pset_StingMEP on element. Returns True on success.
+
+    BonsaiBridge.add_pset takes (element, pset_name, properties) and resolves the
+    active model itself — passing the model as a fourth argument raises TypeError.
+    """
+    from ..core.bonsai import bonsai as _bridge
+    return _bridge.add_pset(element, "Pset_StingMEP", props)
 
 
 # ---------------------------------------------------------------------------
@@ -95,11 +96,11 @@ class StingCalcPipeFlowOperator(bpy.types.Operator):
 
         processed = 0
         for el in ifc.by_type("IfcPipeSegment"):
-            mep = _get_mep_pset(ifc, el)
+            mep = _get_mep_pset(el)
             # Use existing flow if stamped, else default 0.5 L/s for a domestic branch
             flow_ls = float(mep.get("PLM_SUP_FLOW_LS", 0.5) or 0.5)
             dn, vel, actual_flow = self._select_dn(flow_ls)
-            _write_mep_pset(ifc, el, {
+            _write_mep_pset(el, {
                 "PLM_SUP_DN": str(dn),
                 "PLM_SUP_VEL_MS": f"{vel:.3f}",
                 "PLM_SUP_FLOW_LS": f"{actual_flow:.3f}",
@@ -172,7 +173,7 @@ class StingCalcDrainageUnitsOperator(bpy.types.Operator):
         total_du = 0.0
         for el in ifc.by_type("IfcSanitaryTerminal"):
             du = self._resolve_du(el)
-            _write_mep_pset(ifc, el, {"PLM_DRN_DU": f"{du:.1f}"})
+            _write_mep_pset(el, {"PLM_DRN_DU": f"{du:.1f}"})
             processed += 1
             total_du += du
 
@@ -215,7 +216,7 @@ class StingCalcConduitFillOperator(bpy.types.Operator):
 
         processed = overloaded = 0
         for el in ifc.by_type("IfcCableCarrierSegment"):
-            mep = _get_mep_pset(ifc, el)
+            mep = _get_mep_pset(el)
 
             # Conduit internal diameter (mm); default 25 mm if not set
             conduit_d = float(mep.get("ELC_CONDUIT_DN_MM", 25) or 25)
@@ -230,7 +231,7 @@ class StingCalcConduitFillOperator(bpy.types.Operator):
             fill_pct = (total_cable_area / conduit_area * 100.0) if conduit_area > 0 else 0.0
             status = "OK" if fill_pct <= self._MAX_FILL_PCT else "OVERLOADED"
 
-            _write_mep_pset(ifc, el, {
+            _write_mep_pset(el, {
                 "ELC_FILL_PCT": f"{fill_pct:.1f}",
                 "ELC_FILL_STATUS": status,
             })

--- a/stingtools-bonsai/ops/mep_ops.py
+++ b/stingtools-bonsai/ops/mep_ops.py
@@ -55,7 +55,7 @@ class StingCalcPipeFlowOperator(bpy.types.Operator):
 
     # Standard metric DN bore diameters in mm
     _DN_SERIES = [15, 20, 25, 32, 40, 50, 65, 80, 100, 125, 150, 200, 250, 300]
-    _HW_C = 140        # Hazen-Williams C -- copper/plastic
+    _HW_C = 140        # Hazen-Williams C — copper/plastic
     _MAX_VEL = 3.0     # m/s maximum velocity
     _SLOPE = 0.01      # assumed hydraulic gradient (m/m) for preliminary sizing
 
@@ -125,7 +125,7 @@ class StingCalcDrainageUnitsOperator(bpy.types.Operator):
     )
     bl_options = {"REGISTER", "UNDO"}
 
-    # BS EN 12056-2 Table 1 -- Discharge Unit values
+    # BS EN 12056-2 Table 1 — Discharge Unit values
     _DU_TABLE = {
         "WC": 2.0,
         "WATERCLOSETWITHCISTERN": 2.0,
@@ -219,11 +219,11 @@ class StingCalcConduitFillOperator(bpy.types.Operator):
 
             # Conduit internal diameter (mm); default 25 mm if not set
             conduit_d = float(mep.get("ELC_CONDUIT_DN_MM", 25) or 25)
-            conduit_area = math.pi * (conduit_d / 2.0) ** 2   # mm2
+            conduit_area = math.pi * (conduit_d / 2.0) ** 2   # mm²
 
             # Cable count and individual cable outer diameter (mm)
             cable_count = int(float(mep.get("ELC_CABLE_COUNT", 1) or 1))
-            cable_d = float(mep.get("ELC_CABLE_OD_MM", 6) or 6)   # typical 6 mm2/1.5 mm2 T&E
+            cable_d = float(mep.get("ELC_CABLE_OD_MM", 6) or 6)   # typical 6 mm²/1.5 mm² T&E
             cable_area_each = math.pi * (cable_d / 2.0) ** 2
             total_cable_area = cable_count * cable_area_each
 

--- a/stingtools-bonsai/ops/reload_substrate.py
+++ b/stingtools-bonsai/ops/reload_substrate.py
@@ -1,4 +1,4 @@
-"""Force-reload the STING enum + pset registry. Useful during dev."""
+"""Reload substrate operator — clears StingState caches."""
 
 from __future__ import annotations
 
@@ -6,22 +6,26 @@ import bpy
 
 
 class StingReloadSubstrateOperator(bpy.types.Operator):
-    """Reload the STING enum + pset XML from disk."""
+    """Clear and reload the STING substrate caches (enums, psets, tag grammar)."""
 
     bl_idname = "sting.reload_substrate"
     bl_label = "Reload Substrate"
-    bl_description = "Re-read shared/ifc/ from disk (after editing XML in another editor)"
+    bl_description = (
+        "Invalidate all cached enum/pset/tag-grammar data so the next "
+        "operation reloads from disk. Use after editing shared/ifc/ files."
+    )
     bl_options = {"REGISTER"}
 
     def execute(self, context: bpy.types.Context) -> set[str]:
-        # Drop cached registry references; they'll be rebuilt on next access
         try:
-            import stingtools_core
-            # The registries are constructed lazily by callers, so there's no
-            # global singleton to invalidate yet — but when a singleton lands
-            # in `core/state.py` this is where its `.invalidate()` is called.
-            self.report({"INFO"}, "STING substrate caches cleared")
+            import stingtools_core  # noqa: F401
         except ImportError as e:
             self.report({"ERROR"}, f"stingtools-core not available: {e}")
             return {"CANCELLED"}
+        try:
+            from ..core.state import StingState
+            StingState.get().invalidate()
+            self.report({"INFO"}, "STING substrate caches cleared")
+        except Exception as e:
+            self.report({"WARNING"}, f"Cache invalidation error: {e}")
         return {"FINISHED"}

--- a/stingtools-bonsai/ops/reload_substrate.py
+++ b/stingtools-bonsai/ops/reload_substrate.py
@@ -1,4 +1,4 @@
-"""Reload substrate operator — clears StingState caches."""
+"""Force-reload the STING enum + pset registry. Useful during dev."""
 
 from __future__ import annotations
 
@@ -6,19 +6,16 @@ import bpy
 
 
 class StingReloadSubstrateOperator(bpy.types.Operator):
-    """Clear and reload the STING substrate caches (enums, psets, tag grammar)."""
+    """Reload the STING enum + pset XML from disk."""
 
     bl_idname = "sting.reload_substrate"
     bl_label = "Reload Substrate"
-    bl_description = (
-        "Invalidate all cached enum/pset/tag-grammar data so the next "
-        "operation reloads from disk. Use after editing shared/ifc/ files."
-    )
+    bl_description = "Re-read shared/ifc/ from disk (after editing XML in another editor)"
     bl_options = {"REGISTER"}
 
     def execute(self, context: bpy.types.Context) -> set[str]:
         try:
-            import stingtools_core  # noqa: F401
+            import stingtools_core  # noqa: F401 — confirms package is importable
         except ImportError as e:
             self.report({"ERROR"}, f"stingtools-core not available: {e}")
             return {"CANCELLED"}

--- a/stingtools-bonsai/ops/repair_ops.py
+++ b/stingtools-bonsai/ops/repair_ops.py
@@ -13,12 +13,14 @@ def _get_ifc():
         return None
 
 
-def _write_stag(ifc, element, props: dict) -> None:
-    try:
-        from ..core.bonsai import bonsai as _bridge
-        _bridge.add_pset(ifc, element, "Pset_StingTags", props)
-    except Exception as exc:
-        print(f"[STING] write_stag failed: {exc}")
+def _write_stag(element, props: dict) -> bool:
+    """Write props into Pset_StingTags on element. Returns True on success.
+
+    BonsaiBridge.add_pset takes (element, pset_name, properties) and resolves the
+    active model itself — passing the model as a fourth argument raises TypeError.
+    """
+    from ..core.bonsai import bonsai as _bridge
+    return _bridge.add_pset(element, "Pset_StingTags", props)
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +77,7 @@ class StingRepairDuplicateSeqOperator(bpy.types.Operator):
                 if seq in seen:
                     # Duplicate — assign next available
                     max_seq += 1
-                    _write_stag(ifc, el, {"Sequence": f"{max_seq:04d}"})
+                    _write_stag(el, {"Sequence": f"{max_seq:04d}"})
                     repaired += 1
                 else:
                     seen[seq] = True
@@ -131,7 +133,7 @@ class StingRepairMissingPsetOperator(bpy.types.Operator):
         for el in ifc.by_type("IfcElement"):
             psets = ifc_util.get_psets(el)
             if "Pset_StingTags" not in psets:
-                _write_stag(ifc, el, self._DEFAULT.copy())
+                _write_stag(el, self._DEFAULT.copy())
                 created += 1
 
         self.report({"INFO"}, f"Created Pset_StingTags on {created} element(s)")
@@ -179,7 +181,7 @@ class StingClearStaleTagsOperator(bpy.types.Operator):
                 continue
             missing = [f for f in required if stag.get(f, "XX") in sentinel]
             if missing:
-                _write_stag(ifc, el, {"FullTag": ""})
+                _write_stag(el, {"FullTag": ""})
                 cleared += 1
 
         self.report({"INFO"}, f"Cleared stale FullTag on {cleared} element(s)")

--- a/stingtools-bonsai/ops/repair_ops.py
+++ b/stingtools-bonsai/ops/repair_ops.py
@@ -50,7 +50,7 @@ class StingRepairDuplicateSeqOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         pset_name = "Pset_StingTags"
-        # group_key -> list of (element, current_seq_int)
+        # group_key → list of (element, current_seq_int)
         groups: dict[tuple, list] = {}
 
         for el in ifc.by_type("IfcElement"):
@@ -73,7 +73,7 @@ class StingRepairDuplicateSeqOperator(bpy.types.Operator):
             max_seq = max(s for _, s in entries) if entries else 0
             for el, seq in entries:
                 if seq in seen:
-                    # Duplicate - assign next available
+                    # Duplicate — assign next available
                     max_seq += 1
                     _write_stag(ifc, el, {"Sequence": f"{max_seq:04d}"})
                     repaired += 1

--- a/stingtools-bonsai/ops/repair_ops.py
+++ b/stingtools-bonsai/ops/repair_ops.py
@@ -1,0 +1,193 @@
+"""Repair operators — duplicate SEQ fix, missing Pset creation, stale tag clear."""
+
+from __future__ import annotations
+
+import bpy
+
+
+def _get_ifc():
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        return _bridge.active_ifc()
+    except Exception:
+        return None
+
+
+def _write_stag(ifc, element, props: dict) -> None:
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        _bridge.add_pset(ifc, element, "Pset_StingTags", props)
+    except Exception as exc:
+        print(f"[STING] write_stag failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Repair duplicate Sequence numbers
+# ---------------------------------------------------------------------------
+
+class StingRepairDuplicateSeqOperator(bpy.types.Operator):
+    """Find elements sharing the same (Disc, Sys, Level, Seq) and reassign Sequence."""
+
+    bl_idname = "sting.repair_duplicate_seq"
+    bl_label = "Repair Duplicate Sequences"
+    bl_description = (
+        "Scan all elements for duplicate (Discipline, System, Level, Sequence) "
+        "tuples and assign new unique Sequence numbers to the duplicates"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        # group_key -> list of (element, current_seq_int)
+        groups: dict[tuple, list] = {}
+
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            stag = psets.get(pset_name, {})
+            disc = stag.get("Discipline", "XX")
+            sys_ = stag.get("System", "XX")
+            lvl = stag.get("Level", "XX")
+            seq_raw = stag.get("Sequence", "0")
+            try:
+                seq_int = int(seq_raw)
+            except (ValueError, TypeError):
+                seq_int = 0
+            key = (disc, sys_, lvl)
+            groups.setdefault(key, []).append((el, seq_int))
+
+        repaired = 0
+        for key, entries in groups.items():
+            seen: dict[int, bool] = {}
+            max_seq = max(s for _, s in entries) if entries else 0
+            for el, seq in entries:
+                if seq in seen:
+                    # Duplicate - assign next available
+                    max_seq += 1
+                    _write_stag(ifc, el, {"Sequence": f"{max_seq:04d}"})
+                    repaired += 1
+                else:
+                    seen[seq] = True
+
+        if repaired:
+            self.report({"INFO"}, f"Repaired {repaired} duplicate Sequence value(s)")
+        else:
+            self.report({"INFO"}, "No duplicate Sequence values found")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Repair missing Pset_StingTags
+# ---------------------------------------------------------------------------
+
+class StingRepairMissingPsetOperator(bpy.types.Operator):
+    """Create an empty Pset_StingTags (all XX) on elements that have none."""
+
+    bl_idname = "sting.repair_missing_pset"
+    bl_label = "Repair Missing Psets"
+    bl_description = (
+        "Create Pset_StingTags with placeholder XX values on elements "
+        "that have no STING property set at all"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    _DEFAULT = {
+        "Discipline": "XX",
+        "Location": "XX",
+        "Zone": "XX",
+        "Level": "XX",
+        "System": "XX",
+        "Function": "XX",
+        "Product": "XX",
+        "Sequence": "0000",
+        "FullTag": "",
+    }
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        created = 0
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            if "Pset_StingTags" not in psets:
+                _write_stag(ifc, el, self._DEFAULT.copy())
+                created += 1
+
+        self.report({"INFO"}, f"Created Pset_StingTags on {created} element(s)")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Clear stale (partially-completed) tags
+# ---------------------------------------------------------------------------
+
+class StingClearStaleTagsOperator(bpy.types.Operator):
+    """Reset FullTag to empty string on elements with partial/stale tags."""
+
+    bl_idname = "sting.clear_stale_tags"
+    bl_label = "Clear Stale Tags"
+    bl_description = (
+        "Find elements where FullTag is set but one or more required tokens "
+        "are still XX/empty, and reset FullTag to '' so they re-queue for tagging"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        required = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence"]
+        sentinel = {"", "XX"}
+        cleared = 0
+
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            stag = psets.get(pset_name, {})
+            full_tag = stag.get("FullTag", "")
+            if not full_tag:
+                continue
+            missing = [f for f in required if stag.get(f, "XX") in sentinel]
+            if missing:
+                _write_stag(ifc, el, {"FullTag": ""})
+                cleared += 1
+
+        self.report({"INFO"}, f"Cleared stale FullTag on {cleared} element(s)")
+        return {"FINISHED"}
+
+
+CLASSES = (
+    StingRepairDuplicateSeqOperator,
+    StingRepairMissingPsetOperator,
+    StingClearStaleTagsOperator,
+)

--- a/stingtools-bonsai/ops/spatial_ops.py
+++ b/stingtools-bonsai/ops/spatial_ops.py
@@ -1,4 +1,4 @@
-"""Spatial auto-detect operators — Location, Zone, Function, pre-tag audit."""
+"""Spatial auto-detection operators — Location, Zone, Function tokens + pre-tag audit."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ import bpy
 
 
 def _get_ifc():
-    """Return the active IFC model via BonsaiBridge, or None."""
     try:
         from ..core.bonsai import bonsai as _bridge
         return _bridge.active_ifc()
@@ -16,13 +15,12 @@ def _get_ifc():
         return None
 
 
-def _write_stag_prop(ifc, element, prop: str, value: str) -> None:
-    """Write a single Pset_StingTags property via ifcopenshell.api."""
+def _write_stag(ifc, element, props: dict) -> None:
     try:
         from ..core.bonsai import bonsai as _bridge
-        _bridge.add_pset(ifc, element, "Pset_StingTags", {prop: value})
+        _bridge.add_pset(ifc, element, "Pset_StingTags", props)
     except Exception as exc:
-        print(f"[STING] write_stag_prop failed ({prop}={value}): {exc}")
+        print(f"[STING] write_stag failed: {exc}")
 
 
 # ---------------------------------------------------------------------------
@@ -30,13 +28,13 @@ def _write_stag_prop(ifc, element, prop: str, value: str) -> None:
 # ---------------------------------------------------------------------------
 
 class StingAutoDetectLocationOperator(bpy.types.Operator):
-    """Derive Location code from the IFC spatial hierarchy (IfcBuilding)."""
+    """Derive Location token from IfcBuilding containment hierarchy."""
 
     bl_idname = "sting.auto_detect_location"
-    bl_label = "Auto-Detect Location"
+    bl_label = "Auto-detect Location"
     bl_description = (
-        "Walk IfcBuilding containment hierarchy and stamp the Location "
-        "token on every element using the building short-name or 'BLD1'"
+        "Walk IfcBuilding → IfcBuildingStorey → IfcSpace containment and "
+        "stamp Location (BLD1 / BLD2 / …) on every IfcElement"
     )
     bl_options = {"REGISTER", "UNDO"}
 
@@ -47,52 +45,46 @@ class StingAutoDetectLocationOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         try:
-            import ifcopenshell
             import ifcopenshell.util.element as ifc_util
         except ImportError as exc:
             self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        # Build building -> short-code map
-        building_code: dict[int, str] = {}
+        # Build building → code map (BLD1, BLD2, …)
         buildings = ifc.by_type("IfcBuilding")
-        for i, bld in enumerate(buildings, start=1):
-            name = (bld.Name or "").strip()
-            # Use first 4 alphanumeric chars of building name, else BLD<n>
-            code = "".join(c for c in name.upper() if c.isalnum())[:4] or f"BLD{i}"
-            building_code[bld.id()] = code
+        bld_code: dict[int, str] = {}
+        for idx, bld in enumerate(buildings, start=1):
+            bld_code[bld.id()] = f"BLD{idx}"
 
-        # Build element -> building mapping via IfcRelContainedInSpatialStructure
-        el_to_bld: dict[int, str] = {}
+        # Map element → building via IfcRelContainedInSpatialStructure
+        element_to_bld: dict[int, str] = {}
         for rel in ifc.by_type("IfcRelContainedInSpatialStructure"):
-            container = rel.RelatingStructure
-            # Walk up until IfcBuilding
-            node = container
+            spatial = rel.RelatingStructure
+            # Walk up to IfcBuilding
             code = None
-            for _ in range(10):
-                if node.is_a("IfcBuilding"):
-                    code = building_code.get(node.id(), "BLD1")
+            node = spatial
+            for _ in range(10):  # max 10 levels up
+                if node is None:
                     break
-                try:
-                    decomp = ifc.get_inverse(node, "Decomposes")
-                    if decomp:
-                        node = list(decomp)[0].RelatingObject
-                    else:
-                        break
-                except Exception:
+                if node.is_a("IfcBuilding") and node.id() in bld_code:
+                    code = bld_code[node.id()]
                     break
-            if code is None:
-                code = "BLD1"
-            for el in rel.RelatedElements or []:
-                el_to_bld[el.id()] = code
+                # Traverse Decomposes
+                decomp = getattr(node, "Decomposes", None) or []
+                if not decomp:
+                    break
+                node = decomp[0].RelatingObject if decomp else None
+            if code:
+                for el in (rel.RelatedElements or []):
+                    element_to_bld[el.id()] = code
 
         stamped = 0
         for el in ifc.by_type("IfcElement"):
-            loc_code = el_to_bld.get(el.id(), "BLD1")
-            _write_stag_prop(ifc, el, "Location", loc_code)
+            code = element_to_bld.get(el.id(), "BLD1")  # default BLD1
+            _write_stag(ifc, el, {"Location": code})
             stamped += 1
 
-        self.report({"INFO"}, f"Location stamped on {stamped} elements")
+        self.report({"INFO"}, f"Location stamped on {stamped} element(s)")
         return {"FINISHED"}
 
 
@@ -101,13 +93,13 @@ class StingAutoDetectLocationOperator(bpy.types.Operator):
 # ---------------------------------------------------------------------------
 
 class StingAutoDetectZoneOperator(bpy.types.Operator):
-    """Derive Zone code from IfcZone or IfcSpace membership."""
+    """Derive Zone token from IfcZone group assignments."""
 
     bl_idname = "sting.auto_detect_zone"
-    bl_label = "Auto-Detect Zone"
+    bl_label = "Auto-detect Zone"
     bl_description = (
-        "Map element containment through IfcSpace → IfcZone and stamp "
-        "Zone token (Z01 … Z99) on each element"
+        "Map IfcZone memberships to Z01/Z02/… codes and stamp Zone on every element. "
+        "Elements with no zone get ZZ."
     )
     bl_options = {"REGISTER", "UNDO"}
 
@@ -118,42 +110,37 @@ class StingAutoDetectZoneOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         try:
-            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
         except ImportError as exc:
             self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        # Build zone index: zone name -> short code Z01, Z02 ...
+        # Enumerate zones and assign codes
+        zones = ifc.by_type("IfcZone")
         zone_code: dict[int, str] = {}
-        for i, zone in enumerate(ifc.by_type("IfcZone"), start=1):
-            zone_code[zone.id()] = f"Z{i:02d}"
+        for idx, zone in enumerate(zones, start=1):
+            zone_code[zone.id()] = f"Z{idx:02d}"
 
-        # Build space -> zone mapping
-        space_to_zone: dict[int, str] = {}
-        for zone in ifc.by_type("IfcZone"):
-            code = zone_code[zone.id()]
-            for rel in ifc.get_inverse(zone):
-                if rel.is_a("IfcRelAssignsToGroup"):
-                    for obj in rel.RelatedObjects or []:
-                        if obj.is_a("IfcSpace"):
-                            space_to_zone[obj.id()] = code
-
-        # Build element -> zone via IfcRelContainedInSpatialStructure
-        el_to_zone: dict[int, str] = {}
-        for rel in ifc.by_type("IfcRelContainedInSpatialStructure"):
-            container = rel.RelatingStructure
-            if container.is_a("IfcSpace"):
-                code = space_to_zone.get(container.id(), "ZZ")
-                for el in rel.RelatedElements or []:
-                    el_to_zone[el.id()] = code
+        # Map elements → zone via IfcRelAssignsToGroup
+        element_to_zone: dict[int, str] = {}
+        for rel in ifc.by_type("IfcRelAssignsToGroup"):
+            group = rel.RelatingGroup
+            if not group.is_a("IfcZone"):
+                continue
+            code = zone_code.get(group.id())
+            if code is None:
+                continue
+            for obj in (rel.RelatedObjects or []):
+                if obj.is_a("IfcElement"):
+                    element_to_zone[obj.id()] = code
 
         stamped = 0
         for el in ifc.by_type("IfcElement"):
-            code = el_to_zone.get(el.id(), "ZZ")
-            _write_stag_prop(ifc, el, "Zone", code)
+            code = element_to_zone.get(el.id(), "ZZ")
+            _write_stag(ifc, el, {"Zone": code})
             stamped += 1
 
-        self.report({"INFO"}, f"Zone stamped on {stamped} elements")
+        self.report({"INFO"}, f"Zone stamped on {stamped} element(s) ({len(zones)} zone(s) found)")
         return {"FINISHED"}
 
 
@@ -161,56 +148,53 @@ class StingAutoDetectZoneOperator(bpy.types.Operator):
 # Auto-detect Function
 # ---------------------------------------------------------------------------
 
+# IFC class prefix → STING Function code mapping
+_CLASS_TO_FUNC: dict[str, str] = {
+    "IfcAirTerminal":            "SUP",
+    "IfcAirTerminalBox":         "SUP",
+    "IfcFan":                    "SUP",
+    "IfcDuctSegment":            "SUP",
+    "IfcDuctFitting":            "SUP",
+    "IfcDuctSilencer":           "SUP",
+    "IfcFilter":                 "RET",
+    "IfcSanitaryTerminal":       "SAN",
+    "IfcSanitaryTerminalType":   "SAN",
+    "IfcFlowTerminal":           "SAN",
+    "IfcPipeSegment":            "SUP",
+    "IfcPipeFitting":            "SUP",
+    "IfcValve":                  "SUP",
+    "IfcPump":                   "SUP",
+    "IfcElectricDistributionBoard": "PWR",
+    "IfcElectricMotor":          "PWR",
+    "IfcLamp":                   "LTG",
+    "IfcLightFixture":           "LTG",
+    "IfcOutlet":                 "PWR",
+    "IfcCableCarrierSegment":    "PWR",
+    "IfcCableSegment":           "PWR",
+    "IfcProtectiveDevice":       "PWR",
+    "IfcSwitchingDevice":        "PWR",
+    "IfcFireSuppressionTerminal": "FP",
+    "IfcAlarm":                  "FP",
+    "IfcSensor":                 "FP",
+    "IfcBoiler":                 "HTG",
+    "IfcChiller":                "CLG",
+    "IfcCoolingTower":           "CLG",
+    "IfcHeatExchanger":          "HTG",
+    "IfcUnitaryEquipment":       "SUP",
+}
+
+
 class StingAutoDetectFunctionOperator(bpy.types.Operator):
-    """Derive Function token from IFC class heuristics."""
+    """Derive Function token from IFC element class."""
 
     bl_idname = "sting.auto_detect_function"
-    bl_label = "Auto-Detect Function"
+    bl_label = "Auto-detect Function"
     bl_description = (
-        "Map IfcClass to a STING Function code (SUP, RET, SAN, PWR …) "
-        "using heuristic lookup and stamp Pset_StingTags.Function"
+        "Map each element's IFC class to a STING Function code "
+        "(SUP / RET / SAN / PWR / LTG / FP / HTG / CLG) and stamp the token. "
+        "Unknown classes get GEN."
     )
     bl_options = {"REGISTER", "UNDO"}
-
-    # IFC class prefix -> Function code heuristics
-    _CLASS_TO_FUNC = {
-        "IfcAirTerminal": "SUP",
-        "IfcAirTerminalBox": "SUP",
-        "IfcFan": "EXH",
-        "IfcUnitaryEquipment": "SUP",
-        "IfcCoil": "CLG",
-        "IfcBoiler": "HTG",
-        "IfcChiller": "CLG",
-        "IfcPump": "PMP",
-        "IfcValve": "ISO",
-        "IfcPipeSegment": "DCW",
-        "IfcPipeFitting": "DCW",
-        "IfcSanitaryTerminal": "SAN",
-        "IfcFlowTerminal": "SUP",
-        "IfcElectricAppliance": "PWR",
-        "IfcElectricDistributionBoard": "PWR",
-        "IfcLightFixture": "LGT",
-        "IfcOutlet": "PWR",
-        "IfcCableSegment": "PWR",
-        "IfcCableFitting": "PWR",
-        "IfcDoor": "ACC",
-        "IfcWindow": "ENV",
-        "IfcSlab": "STR",
-        "IfcBeam": "STR",
-        "IfcColumn": "STR",
-        "IfcWall": "ENV",
-        "IfcRoof": "ENV",
-        "IfcStair": "CIR",
-        "IfcFireSuppression": "FP",
-        "IfcAlarm": "DET",
-        "IfcSensor": "DET",
-    }
-
-    def _resolve_func(self, ifc_class: str) -> str:
-        for prefix, code in self._CLASS_TO_FUNC.items():
-            if ifc_class.startswith(prefix):
-                return code
-        return "GEN"
 
     def execute(self, context: bpy.types.Context) -> set[str]:
         ifc = _get_ifc()
@@ -219,18 +203,25 @@ class StingAutoDetectFunctionOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         try:
-            import ifcopenshell
+            import ifcopenshell  # noqa: F401
         except ImportError as exc:
             self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        stamped = 0
+        stamped = unrecognised = 0
         for el in ifc.by_type("IfcElement"):
-            func = self._resolve_func(el.is_a())
-            _write_stag_prop(ifc, el, "Function", func)
+            ifc_class = el.is_a()
+            func = _CLASS_TO_FUNC.get(ifc_class, "GEN")
+            if func == "GEN":
+                unrecognised += 1
+            _write_stag(ifc, el, {"Function": func})
             stamped += 1
 
-        self.report({"INFO"}, f"Function stamped on {stamped} elements")
+        self.report(
+            {"INFO"},
+            f"Function stamped on {stamped} element(s) "
+            f"({unrecognised} mapped to GEN — add to _CLASS_TO_FUNC to refine)",
+        )
         return {"FINISHED"}
 
 
@@ -239,15 +230,19 @@ class StingAutoDetectFunctionOperator(bpy.types.Operator):
 # ---------------------------------------------------------------------------
 
 class StingPreTagAuditOperator(bpy.types.Operator):
-    """READ-ONLY dry run — audit tag completeness without writing anything."""
+    """Dry-run audit showing tagging readiness without writing any data."""
 
     bl_idname = "sting.pre_tag_audit"
-    bl_label = "Pre-Tag Audit"
+    bl_label = "Pre-tag Audit"
     bl_description = (
-        "Dry-run audit: count tagged / untagged / incomplete elements "
-        "and store a summary in scene['sting_pretag_audit']. No writes."
+        "Read-only scan: count complete / incomplete / untagged elements "
+        "and cache the summary in scene properties for the SPATIAL panel strip."
     )
     bl_options = {"REGISTER"}
+
+    _REQUIRED = ["Discipline", "Location", "Zone", "Level",
+                 "System", "Function", "Product", "Sequence"]
+    _SENTINEL = {"", "XX"}
 
     def execute(self, context: bpy.types.Context) -> set[str]:
         ifc = _get_ifc()
@@ -256,38 +251,39 @@ class StingPreTagAuditOperator(bpy.types.Operator):
             return {"CANCELLED"}
 
         try:
-            import ifcopenshell
             import ifcopenshell.util.element as ifc_util
         except ImportError as exc:
             self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
             return {"CANCELLED"}
 
-        pset_name = "Pset_StingTags"
-        required = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence"]
-        sentinel = {"", "XX"}
-
         total = complete = incomplete = untagged = 0
-        issues: list[dict] = []
+        sample_issues: list[dict] = []
 
         for el in ifc.by_type("IfcElement"):
             psets = ifc_util.get_psets(el)
-            stag = psets.get(pset_name, {})
+            stag = psets.get("Pset_StingTags", {})
             total += 1
-            if not stag:
+            disc = stag.get("Discipline", "XX")
+            if not stag or disc in self._SENTINEL:
                 untagged += 1
-                continue
-            missing = [f for f in required if stag.get(f, "XX") in sentinel]
-            if not missing:
-                complete += 1
-            else:
-                incomplete += 1
-                if len(issues) < 50:
-                    issues.append({
-                        "id": el.GlobalId,
+                if len(sample_issues) < 5:
+                    sample_issues.append({
+                        "id": getattr(el, "GlobalId", ""),
                         "class": el.is_a(),
-                        "name": el.Name or "",
-                        "missing": missing,
+                        "issue": "untagged",
                     })
+                continue
+            missing = [f for f in self._REQUIRED if stag.get(f, "XX") in self._SENTINEL]
+            if missing:
+                incomplete += 1
+                if len(sample_issues) < 5:
+                    sample_issues.append({
+                        "id": getattr(el, "GlobalId", ""),
+                        "class": el.is_a(),
+                        "issue": f"missing: {', '.join(missing)}",
+                    })
+            else:
+                complete += 1
 
         pct = round(complete / total * 100, 1) if total else 0.0
         result = {
@@ -296,13 +292,14 @@ class StingPreTagAuditOperator(bpy.types.Operator):
             "incomplete": incomplete,
             "untagged": untagged,
             "compliance_pct": pct,
-            "sample_issues": issues,
+            "sample_issues": sample_issues,
         }
         context.scene["sting_pretag_audit"] = json.dumps(result)
 
         self.report(
             {"INFO"},
-            f"Pre-tag audit: {pct}% complete — {untagged} untagged, {incomplete} incomplete / {total} total",
+            f"Pre-tag audit: {pct}% ready ({complete}/{total} complete, "
+            f"{untagged} untagged, {incomplete} incomplete)",
         )
         return {"FINISHED"}
 

--- a/stingtools-bonsai/ops/spatial_ops.py
+++ b/stingtools-bonsai/ops/spatial_ops.py
@@ -6,6 +6,12 @@ import json
 
 import bpy
 
+# All token-inference logic lives in stingtools_core.hosts.inference — this
+# module is a thin Blender adapter. The Phase A6 boundary lint
+# (tools/ci/check_adapter_boundary.py) fails the build if inference rules are
+# re-implemented here.
+from stingtools_core.hosts import inference as _inf
+
 
 def _get_ifc():
     try:
@@ -15,12 +21,16 @@ def _get_ifc():
         return None
 
 
-def _write_stag(ifc, element, props: dict) -> None:
-    try:
-        from ..core.bonsai import bonsai as _bridge
-        _bridge.add_pset(ifc, element, "Pset_StingTags", props)
-    except Exception as exc:
-        print(f"[STING] write_stag failed: {exc}")
+def _write_stag(element, props: dict) -> bool:
+    """Write props into Pset_StingTags on element. Returns True on success.
+
+    BonsaiBridge.add_pset takes (element, pset_name, properties) — it resolves
+    the active model itself. Passing the model as a fourth argument raises
+    TypeError, which is exactly the bug that made every spatial operator report
+    success while writing nothing.
+    """
+    from ..core.bonsai import bonsai as _bridge
+    return _bridge.add_pset(element, "Pset_StingTags", props)
 
 
 # ---------------------------------------------------------------------------
@@ -44,47 +54,22 @@ class StingAutoDetectLocationOperator(bpy.types.Operator):
             self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
 
-        try:
-            import ifcopenshell.util.element as ifc_util
-        except ImportError as exc:
-            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
-            return {"CANCELLED"}
+        element_to_bld = _inf.building_codes_by_element(ifc)
 
-        # Build building → code map (BLD1, BLD2, …)
-        buildings = ifc.by_type("IfcBuilding")
-        bld_code: dict[int, str] = {}
-        for idx, bld in enumerate(buildings, start=1):
-            bld_code[bld.id()] = f"BLD{idx}"
-
-        # Map element → building via IfcRelContainedInSpatialStructure
-        element_to_bld: dict[int, str] = {}
-        for rel in ifc.by_type("IfcRelContainedInSpatialStructure"):
-            spatial = rel.RelatingStructure
-            # Walk up to IfcBuilding
-            code = None
-            node = spatial
-            for _ in range(10):  # max 10 levels up
-                if node is None:
-                    break
-                if node.is_a("IfcBuilding") and node.id() in bld_code:
-                    code = bld_code[node.id()]
-                    break
-                # Traverse Decomposes
-                decomp = getattr(node, "Decomposes", None) or []
-                if not decomp:
-                    break
-                node = decomp[0].RelatingObject if decomp else None
-            if code:
-                for el in (rel.RelatedElements or []):
-                    element_to_bld[el.id()] = code
-
-        stamped = 0
+        stamped = failed = 0
         for el in ifc.by_type("IfcElement"):
-            code = element_to_bld.get(el.id(), "BLD1")  # default BLD1
-            _write_stag(ifc, el, {"Location": code})
-            stamped += 1
+            code = element_to_bld.get(el.id(), _inf.LOCATION_FALLBACK)
+            if _write_stag(el, {"Location": code}):
+                stamped += 1
+            else:
+                failed += 1
 
-        self.report({"INFO"}, f"Location stamped on {stamped} element(s)")
+        if stamped == 0 and failed:
+            self.report({"ERROR"}, f"Location write failed on all {failed} element(s)")
+            return {"CANCELLED"}
+        msg = f"Location stamped on {stamped} element(s)"
+        self.report({"WARNING"} if failed else {"INFO"},
+                    msg + (f" — {failed} write(s) failed" if failed else ""))
         return {"FINISHED"}
 
 
@@ -109,80 +94,29 @@ class StingAutoDetectZoneOperator(bpy.types.Operator):
             self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
 
-        try:
-            import ifcopenshell.util.element as ifc_util
-        except ImportError as exc:
-            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
-            return {"CANCELLED"}
+        element_to_zone = _inf.zone_codes_by_element(ifc)
+        zone_count = len(set(element_to_zone.values()))
 
-        # Enumerate zones and assign codes
-        zones = ifc.by_type("IfcZone")
-        zone_code: dict[int, str] = {}
-        for idx, zone in enumerate(zones, start=1):
-            zone_code[zone.id()] = f"Z{idx:02d}"
-
-        # Map elements → zone via IfcRelAssignsToGroup
-        element_to_zone: dict[int, str] = {}
-        for rel in ifc.by_type("IfcRelAssignsToGroup"):
-            group = rel.RelatingGroup
-            if not group.is_a("IfcZone"):
-                continue
-            code = zone_code.get(group.id())
-            if code is None:
-                continue
-            for obj in (rel.RelatedObjects or []):
-                if obj.is_a("IfcElement"):
-                    element_to_zone[obj.id()] = code
-
-        stamped = 0
+        stamped = failed = 0
         for el in ifc.by_type("IfcElement"):
-            code = element_to_zone.get(el.id(), "ZZ")
-            _write_stag(ifc, el, {"Zone": code})
-            stamped += 1
+            code = element_to_zone.get(el.id(), _inf.ZONE_FALLBACK)
+            if _write_stag(el, {"Zone": code}):
+                stamped += 1
+            else:
+                failed += 1
 
-        self.report({"INFO"}, f"Zone stamped on {stamped} element(s) ({len(zones)} zone(s) found)")
+        if stamped == 0 and failed:
+            self.report({"ERROR"}, f"Zone write failed on all {failed} element(s)")
+            return {"CANCELLED"}
+        msg = f"Zone stamped on {stamped} element(s) ({zone_count} zone(s) found)"
+        self.report({"WARNING"} if failed else {"INFO"},
+                    msg + (f" — {failed} write(s) failed" if failed else ""))
         return {"FINISHED"}
 
 
 # ---------------------------------------------------------------------------
 # Auto-detect Function
 # ---------------------------------------------------------------------------
-
-# IFC class prefix → STING Function code mapping
-_CLASS_TO_FUNC: dict[str, str] = {
-    "IfcAirTerminal":            "SUP",
-    "IfcAirTerminalBox":         "SUP",
-    "IfcFan":                    "SUP",
-    "IfcDuctSegment":            "SUP",
-    "IfcDuctFitting":            "SUP",
-    "IfcDuctSilencer":           "SUP",
-    "IfcFilter":                 "RET",
-    "IfcSanitaryTerminal":       "SAN",
-    "IfcSanitaryTerminalType":   "SAN",
-    "IfcFlowTerminal":           "SAN",
-    "IfcPipeSegment":            "SUP",
-    "IfcPipeFitting":            "SUP",
-    "IfcValve":                  "SUP",
-    "IfcPump":                   "SUP",
-    "IfcElectricDistributionBoard": "PWR",
-    "IfcElectricMotor":          "PWR",
-    "IfcLamp":                   "LTG",
-    "IfcLightFixture":           "LTG",
-    "IfcOutlet":                 "PWR",
-    "IfcCableCarrierSegment":    "PWR",
-    "IfcCableSegment":           "PWR",
-    "IfcProtectiveDevice":       "PWR",
-    "IfcSwitchingDevice":        "PWR",
-    "IfcFireSuppressionTerminal": "FP",
-    "IfcAlarm":                  "FP",
-    "IfcSensor":                 "FP",
-    "IfcBoiler":                 "HTG",
-    "IfcChiller":                "CLG",
-    "IfcCoolingTower":           "CLG",
-    "IfcHeatExchanger":          "HTG",
-    "IfcUnitaryEquipment":       "SUP",
-}
-
 
 class StingAutoDetectFunctionOperator(bpy.types.Operator):
     """Derive Function token from IFC element class."""
@@ -202,26 +136,26 @@ class StingAutoDetectFunctionOperator(bpy.types.Operator):
             self.report({"ERROR"}, "No IFC file loaded")
             return {"CANCELLED"}
 
-        try:
-            import ifcopenshell  # noqa: F401
-        except ImportError as exc:
-            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
-            return {"CANCELLED"}
-
-        stamped = unrecognised = 0
+        stamped = failed = unrecognised = 0
         for el in ifc.by_type("IfcElement"):
-            ifc_class = el.is_a()
-            func = _CLASS_TO_FUNC.get(ifc_class, "GEN")
-            if func == "GEN":
+            func = _inf.infer_function(el)
+            if func == _inf.FUNCTION_FALLBACK:
                 unrecognised += 1
-            _write_stag(ifc, el, {"Function": func})
-            stamped += 1
+            if _write_stag(el, {"Function": func}):
+                stamped += 1
+            else:
+                failed += 1
 
-        self.report(
-            {"INFO"},
+        if stamped == 0 and failed:
+            self.report({"ERROR"}, f"Function write failed on all {failed} element(s)")
+            return {"CANCELLED"}
+        msg = (
             f"Function stamped on {stamped} element(s) "
-            f"({unrecognised} mapped to GEN — add to _CLASS_TO_FUNC to refine)",
+            f"({unrecognised} mapped to {_inf.FUNCTION_FALLBACK} — extend "
+            f"stingtools_core.hosts.inference.FUNCTION_BY_IFC_CLASS to refine)"
         )
+        self.report({"WARNING"} if failed else {"INFO"},
+                    msg + (f" — {failed} write(s) failed" if failed else ""))
         return {"FINISHED"}
 
 

--- a/stingtools-bonsai/ops/spatial_ops.py
+++ b/stingtools-bonsai/ops/spatial_ops.py
@@ -1,0 +1,315 @@
+"""Spatial auto-detect operators — Location, Zone, Function, pre-tag audit."""
+
+from __future__ import annotations
+
+import json
+
+import bpy
+
+
+def _get_ifc():
+    """Return the active IFC model via BonsaiBridge, or None."""
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        return _bridge.active_ifc()
+    except Exception:
+        return None
+
+
+def _write_stag_prop(ifc, element, prop: str, value: str) -> None:
+    """Write a single Pset_StingTags property via ifcopenshell.api."""
+    try:
+        from ..core.bonsai import bonsai as _bridge
+        _bridge.add_pset(ifc, element, "Pset_StingTags", {prop: value})
+    except Exception as exc:
+        print(f"[STING] write_stag_prop failed ({prop}={value}): {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect Location
+# ---------------------------------------------------------------------------
+
+class StingAutoDetectLocationOperator(bpy.types.Operator):
+    """Derive Location code from the IFC spatial hierarchy (IfcBuilding)."""
+
+    bl_idname = "sting.auto_detect_location"
+    bl_label = "Auto-Detect Location"
+    bl_description = (
+        "Walk IfcBuilding containment hierarchy and stamp the Location "
+        "token on every element using the building short-name or 'BLD1'"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        # Build building -> short-code map
+        building_code: dict[int, str] = {}
+        buildings = ifc.by_type("IfcBuilding")
+        for i, bld in enumerate(buildings, start=1):
+            name = (bld.Name or "").strip()
+            # Use first 4 alphanumeric chars of building name, else BLD<n>
+            code = "".join(c for c in name.upper() if c.isalnum())[:4] or f"BLD{i}"
+            building_code[bld.id()] = code
+
+        # Build element -> building mapping via IfcRelContainedInSpatialStructure
+        el_to_bld: dict[int, str] = {}
+        for rel in ifc.by_type("IfcRelContainedInSpatialStructure"):
+            container = rel.RelatingStructure
+            # Walk up until IfcBuilding
+            node = container
+            code = None
+            for _ in range(10):
+                if node.is_a("IfcBuilding"):
+                    code = building_code.get(node.id(), "BLD1")
+                    break
+                try:
+                    decomp = ifc.get_inverse(node, "Decomposes")
+                    if decomp:
+                        node = list(decomp)[0].RelatingObject
+                    else:
+                        break
+                except Exception:
+                    break
+            if code is None:
+                code = "BLD1"
+            for el in rel.RelatedElements or []:
+                el_to_bld[el.id()] = code
+
+        stamped = 0
+        for el in ifc.by_type("IfcElement"):
+            loc_code = el_to_bld.get(el.id(), "BLD1")
+            _write_stag_prop(ifc, el, "Location", loc_code)
+            stamped += 1
+
+        self.report({"INFO"}, f"Location stamped on {stamped} elements")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect Zone
+# ---------------------------------------------------------------------------
+
+class StingAutoDetectZoneOperator(bpy.types.Operator):
+    """Derive Zone code from IfcZone or IfcSpace membership."""
+
+    bl_idname = "sting.auto_detect_zone"
+    bl_label = "Auto-Detect Zone"
+    bl_description = (
+        "Map element containment through IfcSpace → IfcZone and stamp "
+        "Zone token (Z01 … Z99) on each element"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        # Build zone index: zone name -> short code Z01, Z02 ...
+        zone_code: dict[int, str] = {}
+        for i, zone in enumerate(ifc.by_type("IfcZone"), start=1):
+            zone_code[zone.id()] = f"Z{i:02d}"
+
+        # Build space -> zone mapping
+        space_to_zone: dict[int, str] = {}
+        for zone in ifc.by_type("IfcZone"):
+            code = zone_code[zone.id()]
+            for rel in ifc.get_inverse(zone):
+                if rel.is_a("IfcRelAssignsToGroup"):
+                    for obj in rel.RelatedObjects or []:
+                        if obj.is_a("IfcSpace"):
+                            space_to_zone[obj.id()] = code
+
+        # Build element -> zone via IfcRelContainedInSpatialStructure
+        el_to_zone: dict[int, str] = {}
+        for rel in ifc.by_type("IfcRelContainedInSpatialStructure"):
+            container = rel.RelatingStructure
+            if container.is_a("IfcSpace"):
+                code = space_to_zone.get(container.id(), "ZZ")
+                for el in rel.RelatedElements or []:
+                    el_to_zone[el.id()] = code
+
+        stamped = 0
+        for el in ifc.by_type("IfcElement"):
+            code = el_to_zone.get(el.id(), "ZZ")
+            _write_stag_prop(ifc, el, "Zone", code)
+            stamped += 1
+
+        self.report({"INFO"}, f"Zone stamped on {stamped} elements")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Auto-detect Function
+# ---------------------------------------------------------------------------
+
+class StingAutoDetectFunctionOperator(bpy.types.Operator):
+    """Derive Function token from IFC class heuristics."""
+
+    bl_idname = "sting.auto_detect_function"
+    bl_label = "Auto-Detect Function"
+    bl_description = (
+        "Map IfcClass to a STING Function code (SUP, RET, SAN, PWR …) "
+        "using heuristic lookup and stamp Pset_StingTags.Function"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    # IFC class prefix -> Function code heuristics
+    _CLASS_TO_FUNC = {
+        "IfcAirTerminal": "SUP",
+        "IfcAirTerminalBox": "SUP",
+        "IfcFan": "EXH",
+        "IfcUnitaryEquipment": "SUP",
+        "IfcCoil": "CLG",
+        "IfcBoiler": "HTG",
+        "IfcChiller": "CLG",
+        "IfcPump": "PMP",
+        "IfcValve": "ISO",
+        "IfcPipeSegment": "DCW",
+        "IfcPipeFitting": "DCW",
+        "IfcSanitaryTerminal": "SAN",
+        "IfcFlowTerminal": "SUP",
+        "IfcElectricAppliance": "PWR",
+        "IfcElectricDistributionBoard": "PWR",
+        "IfcLightFixture": "LGT",
+        "IfcOutlet": "PWR",
+        "IfcCableSegment": "PWR",
+        "IfcCableFitting": "PWR",
+        "IfcDoor": "ACC",
+        "IfcWindow": "ENV",
+        "IfcSlab": "STR",
+        "IfcBeam": "STR",
+        "IfcColumn": "STR",
+        "IfcWall": "ENV",
+        "IfcRoof": "ENV",
+        "IfcStair": "CIR",
+        "IfcFireSuppression": "FP",
+        "IfcAlarm": "DET",
+        "IfcSensor": "DET",
+    }
+
+    def _resolve_func(self, ifc_class: str) -> str:
+        for prefix, code in self._CLASS_TO_FUNC.items():
+            if ifc_class.startswith(prefix):
+                return code
+        return "GEN"
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        stamped = 0
+        for el in ifc.by_type("IfcElement"):
+            func = self._resolve_func(el.is_a())
+            _write_stag_prop(ifc, el, "Function", func)
+            stamped += 1
+
+        self.report({"INFO"}, f"Function stamped on {stamped} elements")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Pre-tag audit (read-only dry run)
+# ---------------------------------------------------------------------------
+
+class StingPreTagAuditOperator(bpy.types.Operator):
+    """READ-ONLY dry run — audit tag completeness without writing anything."""
+
+    bl_idname = "sting.pre_tag_audit"
+    bl_label = "Pre-Tag Audit"
+    bl_description = (
+        "Dry-run audit: count tagged / untagged / incomplete elements "
+        "and store a summary in scene['sting_pretag_audit']. No writes."
+    )
+    bl_options = {"REGISTER"}
+
+    def execute(self, context: bpy.types.Context) -> set[str]:
+        ifc = _get_ifc()
+        if ifc is None:
+            self.report({"ERROR"}, "No IFC file loaded")
+            return {"CANCELLED"}
+
+        try:
+            import ifcopenshell
+            import ifcopenshell.util.element as ifc_util
+        except ImportError as exc:
+            self.report({"ERROR"}, f"ifcopenshell unavailable: {exc}")
+            return {"CANCELLED"}
+
+        pset_name = "Pset_StingTags"
+        required = ["Discipline", "Location", "Zone", "Level", "System", "Function", "Product", "Sequence"]
+        sentinel = {"", "XX"}
+
+        total = complete = incomplete = untagged = 0
+        issues: list[dict] = []
+
+        for el in ifc.by_type("IfcElement"):
+            psets = ifc_util.get_psets(el)
+            stag = psets.get(pset_name, {})
+            total += 1
+            if not stag:
+                untagged += 1
+                continue
+            missing = [f for f in required if stag.get(f, "XX") in sentinel]
+            if not missing:
+                complete += 1
+            else:
+                incomplete += 1
+                if len(issues) < 50:
+                    issues.append({
+                        "id": el.GlobalId,
+                        "class": el.is_a(),
+                        "name": el.Name or "",
+                        "missing": missing,
+                    })
+
+        pct = round(complete / total * 100, 1) if total else 0.0
+        result = {
+            "total": total,
+            "complete": complete,
+            "incomplete": incomplete,
+            "untagged": untagged,
+            "compliance_pct": pct,
+            "sample_issues": issues,
+        }
+        context.scene["sting_pretag_audit"] = json.dumps(result)
+
+        self.report(
+            {"INFO"},
+            f"Pre-tag audit: {pct}% complete — {untagged} untagged, {incomplete} incomplete / {total} total",
+        )
+        return {"FINISHED"}
+
+
+CLASSES = (
+    StingAutoDetectLocationOperator,
+    StingAutoDetectZoneOperator,
+    StingAutoDetectFunctionOperator,
+    StingPreTagAuditOperator,
+)

--- a/stingtools-bonsai/tests/test_pset_write_arity.py
+++ b/stingtools-bonsai/tests/test_pset_write_arity.py
@@ -1,0 +1,109 @@
+"""Regression tests for the Pset-write helpers in the new operator modules.
+
+Guards the bug where spatial_ops / repair_ops / mep_ops called
+``BonsaiBridge.add_pset(ifc, element, pset_name, props)`` with four arguments
+against a three-argument signature. The resulting TypeError was swallowed by a
+bare ``except``, so every one of those ten operators reported success while
+writing nothing to the IFC.
+"""
+import importlib
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+#: The add-on directory is "stingtools-bonsai" — a hyphen, so not importable as a
+#: module name. The operator modules use package-relative imports (``..core.bonsai``),
+#: which only resolve when the add-on is loaded as a package. Bind it to this
+#: synthetic name, mirroring how Blender loads it as bl_ext.user_default.stingtools_bonsai.
+PKG = "stingtools_bonsai"
+
+
+def _stub_bpy():
+    """Minimal bpy so the operator modules import outside Blender."""
+    if "bpy" in sys.modules:
+        return
+    bpy = types.ModuleType("bpy")
+    bpy.types = types.SimpleNamespace(Operator=type("Operator", (), {}), Panel=object, Context=object)
+    _p = lambda **kw: None  # noqa: E731
+    bpy.props = types.SimpleNamespace(
+        BoolProperty=_p, StringProperty=_p, EnumProperty=_p, IntProperty=_p,
+        FloatProperty=_p, PointerProperty=_p, CollectionProperty=_p,
+        FloatVectorProperty=_p,
+    )
+    bpy.utils = types.SimpleNamespace(register_class=lambda c: None, unregister_class=lambda c: None)
+    bpy.app = types.SimpleNamespace(handlers=types.SimpleNamespace(load_post=[]))
+    bpy.data = types.SimpleNamespace(filepath="")
+    bpy.ops = types.SimpleNamespace()
+    sys.modules["bpy"] = bpy
+
+
+def _load_addon_package():
+    """Import the add-on under PKG so ``..core.bonsai`` relative imports resolve."""
+    if PKG in sys.modules:
+        return sys.modules[PKG]
+    spec = importlib.util.spec_from_file_location(
+        PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)]
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[PKG] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_stub_bpy()
+_load_addon_package()
+
+from core.bonsai import BonsaiBridge  # noqa: E402
+
+
+# (module, helper name, expected pset name)
+HELPERS = [
+    (f"{PKG}.ops.spatial_ops", "_write_stag", "Pset_StingTags"),
+    (f"{PKG}.ops.repair_ops", "_write_stag", "Pset_StingTags"),
+    (f"{PKG}.ops.mep_ops", "_write_mep_pset", "Pset_StingMEP"),
+]
+
+
+@pytest.mark.parametrize("mod_name,helper_name,pset", HELPERS)
+def test_helper_matches_add_pset_signature(mod_name, helper_name, pset, monkeypatch):
+    """The helper must call add_pset(element, pset_name, properties) — 3 args."""
+    mod = importlib.import_module(mod_name)
+    helper = getattr(mod, helper_name)
+
+    seen = {}
+
+    def fake_add_pset(element, pset_name, properties):
+        seen["element"] = element
+        seen["pset_name"] = pset_name
+        seen["properties"] = properties
+        return True
+
+    # core/__init__.py rebinds the name `core.bonsai` to the singleton instance,
+    # shadowing the submodule — reach the module through sys.modules.
+    importlib.import_module(f"{PKG}.core.bonsai")
+    bridge_mod = sys.modules[f"{PKG}.core.bonsai"]
+    monkeypatch.setattr(bridge_mod.bonsai, "add_pset", fake_add_pset)
+
+    element = MagicMock()
+    result = helper(element, {"Discipline": "M"})
+
+    assert result is True, f"{mod_name}.{helper_name} must return add_pset's result"
+    assert seen["element"] is element
+    assert seen["pset_name"] == pset
+    assert seen["properties"] == {"Discipline": "M"}
+
+
+def test_add_pset_rejects_a_model_argument():
+    """Pin the real signature the helpers must match: (element, pset_name, properties)."""
+    import inspect
+
+    params = list(inspect.signature(BonsaiBridge.add_pset).parameters)
+    assert params == ["self", "element", "pset_name", "properties"]

--- a/stingtools-bonsai/tests/test_token_lock.py
+++ b/stingtools-bonsai/tests/test_token_lock.py
@@ -42,8 +42,11 @@ class TestWriteTagSegment:
         element = MagicMock()
 
         def fake_read(el, pset, prop):
+            # TokenLock is a CSV list of locked segment names, not a boolean
+            # flag — see shared/ifc/ids/sting-tag-grammar.ids spec
+            # "TokenLock_csv_of_segments" and Pset_StingTags.xml.
             if prop == bridge._TOKEN_LOCK_PROP:
-                return "True"
+                return "ASS_DISC_TXT,ASS_LOC_TXT"
             if prop == "ASS_DISC_TXT":
                 return "M"
             return None
@@ -62,7 +65,7 @@ class TestWriteTagSegment:
 
         def fake_read(el, pset, prop):
             if prop == bridge._TOKEN_LOCK_PROP:
-                return "True"
+                return "ASS_DISC_TXT,ASS_LOC_TXT"
             if prop == "ASS_DISC_TXT":
                 return "M"
             return None
@@ -70,7 +73,7 @@ class TestWriteTagSegment:
         bridge._read_pset_property = fake_read
         bridge._write_pset_property = MagicMock(return_value=True)
 
-        # Same value — should not raise
+        # Locked, but the value is unchanged — a no-op write, not a violation
         result = bridge.write_tag_segment(element, "ASS_DISC_TXT", "M")
         assert result is True
 

--- a/stingtools-bonsai/ui/__init__.py
+++ b/stingtools-bonsai/ui/__init__.py
@@ -1,12 +1,30 @@
-"""N-panel registration. Day-1 scaffold — one root panel with About + Reload."""
+"""N-panel registration — root panel + 7 sub-panels."""
 
 from __future__ import annotations
 
 import bpy
 
-from .panel_main import StingMainPanel
+from .panel_main import (
+    StingMainPanel,
+    StingSelectPanel,
+    StingTagsPanel,
+    StingValidatePanel,
+    StingCoordPanel,
+    StingExportPanel,
+    StingSpatialPanel,
+    StingMEPPanel,
+)
 
-CLASSES = (StingMainPanel,)
+CLASSES = (
+    StingMainPanel,
+    StingSelectPanel,
+    StingTagsPanel,
+    StingValidatePanel,
+    StingCoordPanel,
+    StingExportPanel,
+    StingSpatialPanel,
+    StingMEPPanel,
+)
 
 
 def register():

--- a/stingtools-bonsai/ui/panel_main.py
+++ b/stingtools-bonsai/ui/panel_main.py
@@ -1,4 +1,4 @@
-"""STING N-panel — root + 4 sub-panels (SELECT / TAGS / VALIDATE / COORD)."""
+"""STING N-panel — root + 7 sub-panels (SELECT / TAGS / VALIDATE / COORD / EXPORT / SPATIAL / MEP CALCS)."""
 
 from __future__ import annotations
 
@@ -207,6 +207,110 @@ class StingCoordPanel(bpy.types.Panel):
 
 
 # ---------------------------------------------------------------------------
+# EXPORT sub-panel
+# ---------------------------------------------------------------------------
+
+class StingExportPanel(bpy.types.Panel):
+    bl_idname = "STING_PT_export"
+    bl_label = "EXPORT"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "STING"
+    bl_parent_id = "STING_PT_main"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: bpy.types.Context) -> None:
+        layout = self.layout
+        col = layout.column(align=True)
+        col.label(text="Data exports", icon="EXPORT")
+        col.operator("sting.export_tag_register",         icon="SPREADSHEET")
+        col.operator("sting.export_boq",                  icon="LINENUMBERS_ON")
+        col.separator()
+        col.label(text="Compliance", icon="CHECKMARK")
+        col.operator("sting.export_compliance_snapshot",  icon="RENDER_RESULT")
+        col.separator()
+        col.label(text="Audit", icon="TIME")
+        col.operator("sting.export_audit_log",            icon="FILE_TICK")
+
+
+# ---------------------------------------------------------------------------
+# SPATIAL sub-panel
+# ---------------------------------------------------------------------------
+
+class StingSpatialPanel(bpy.types.Panel):
+    bl_idname = "STING_PT_spatial"
+    bl_label = "SPATIAL"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "STING"
+    bl_parent_id = "STING_PT_main"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: bpy.types.Context) -> None:
+        layout = self.layout
+
+        col = layout.column(align=True)
+        col.label(text="Auto-detect tokens", icon="OUTLINER")
+        col.operator("sting.auto_detect_location", icon="HOME")
+        col.operator("sting.auto_detect_zone",     icon="SNAP_FACE_CENTER")
+        col.operator("sting.auto_detect_function", icon="DRIVER_TRANSFORM")
+
+        layout.separator()
+        col = layout.column(align=True)
+        col.label(text="Pre-tag audit", icon="VIEWZOOM")
+        col.operator("sting.pre_tag_audit", icon="PLAY")
+
+        # Show last audit summary if cached
+        raw = context.scene.get("sting_pretag_audit")
+        if raw:
+            try:
+                import json
+                data = json.loads(raw)
+                pct = data.get("compliance_pct", 0)
+                total = data.get("total", 0)
+                untagged = data.get("untagged", 0)
+                box = layout.box()
+                icon = "CHECKMARK" if pct >= 80 else ("ERROR" if pct < 50 else "INFO")
+                box.label(text=f"{pct}% complete  ({total} total, {untagged} untagged)", icon=icon)
+            except Exception:
+                pass
+
+        layout.separator()
+        col = layout.column(align=True)
+        col.label(text="Repair", icon="TOOL_SETTINGS")
+        col.operator("sting.repair_duplicate_seq",  icon="SORTALPHA")
+        col.operator("sting.repair_missing_pset",   icon="ADD")
+        col.operator("sting.clear_stale_tags",      icon="TRASH")
+
+
+# ---------------------------------------------------------------------------
+# MEP CALCS sub-panel
+# ---------------------------------------------------------------------------
+
+class StingMEPPanel(bpy.types.Panel):
+    bl_idname = "STING_PT_mep"
+    bl_label = "MEP CALCS"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "STING"
+    bl_parent_id = "STING_PT_main"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: bpy.types.Context) -> None:
+        layout = self.layout
+
+        col = layout.column(align=True)
+        col.label(text="Plumbing", icon="MOD_FLUID")
+        col.operator("sting.calc_pipe_flow",       icon="FORCE_WIND")
+        col.operator("sting.calc_drainage_units",  icon="TRACKING_BACKWARDS")
+
+        layout.separator()
+        col = layout.column(align=True)
+        col.label(text="Electrical", icon="LIGHT")
+        col.operator("sting.calc_conduit_fill",    icon="FULLSCREEN_ENTER")
+
+
+# ---------------------------------------------------------------------------
 # registration
 # ---------------------------------------------------------------------------
 
@@ -216,4 +320,7 @@ CLASSES = (
     StingTagsPanel,
     StingValidatePanel,
     StingCoordPanel,
+    StingExportPanel,
+    StingSpatialPanel,
+    StingMEPPanel,
 )

--- a/stingtools-core/python/stingtools_core/hosts/ifc_file.py
+++ b/stingtools-core/python/stingtools_core/hosts/ifc_file.py
@@ -25,6 +25,55 @@ _TAG_TO_PSET = {
     "product": "Product", "sequence": "Sequence",
 }
 
+#: ISO 19650 suitability/status, stored ALONGSIDE the tag segments — never
+#: inside :class:`Tag`.
+#:
+#: `Tag` is a strict 8-segment grammar: `to_full_tag`/`from_full_tag` assume
+#: exactly eight parts, so adding a ninth field would corrupt every tag string
+#: the system renders. Status is metadata *about* the element, not a segment
+#: *of* its tag, so it gets its own property in the same pset.
+#:
+#: Why it is written at all: `status` is one of the reconcile engine's
+#: TOKEN_KEYS (sync/reconcile.py), and the change feed carries it
+#: (ChangesController.cs:108). An adapter that applies a status-only remote
+#: change without persisting it re-applies that same change on EVERY subsequent
+#: pull, forever — the delta never converges because the local read-back never
+#: reflects the write.
+STATUS_PROP = "Status"
+
+#: Change-feed token key -> Tag field.
+#:
+#: The feed sends short lower-case keys (`ChangesController.cs:105-108`:
+#: `disc, loc, zone, lvl, sys, func, prod, seq, status, …`), which are also the
+#: reconcile engine's TOKEN_KEYS. The PSET uses long capitalised names
+#: (`Discipline`, `Location`, …). These are two different vocabularies for the
+#: same eight segments and they were being conflated: `apply_remote_change` fed
+#: `delta.payload` straight into `Tag.from_pset`, which looks up `"Discipline"`
+#: in a dict that only has `"disc"`. Every lookup missed, so applying a REAL feed
+#: delta wrote eight UNKNOWN sentinels — it did not just lose status, it blanked
+#: the tag. Latent only because nothing wires the pull loop yet (SB-5a).
+_FEED_TO_TAG = {
+    "disc": "discipline", "loc": "location", "zone": "zone", "lvl": "level",
+    "sys": "system", "func": "function", "prod": "product", "seq": "sequence",
+}
+
+
+def _tag_from_payload(payload: dict) -> "Tag":
+    """Build a Tag from a change-feed payload, tolerating the PSET vocabulary.
+
+    Feed keys win; PSET-cased keys are accepted so a caller hand-building a
+    payload from a pset (as some tests and the ArchiCAD route do) still works.
+    """
+    payload = payload or {}
+    if any(k in payload for k in _FEED_TO_TAG):
+        fields = {
+            field: str(payload.get(feed_key) or "")
+            for feed_key, field in _FEED_TO_TAG.items()
+            if payload.get(feed_key)
+        }
+        return Tag(**fields) if fields else Tag.from_pset(payload)
+    return Tag.from_pset(payload)
+
 
 def _ue():
     import ifcopenshell.util.element as ue  # type: ignore
@@ -107,6 +156,45 @@ class IfcFileHostAdapter(HostAdapter):
         except Exception:
             return False
 
+    def read_status(self, element: Any) -> str:
+        """ISO 19650 suitability/status for *element*, or "" when unset."""
+        try:
+            pset = _ue().get_pset(element, STING_PSET) or {}
+        except Exception:
+            return ""
+        return str(pset.get(STATUS_PROP) or "")
+
+    def write_status(self, element: Any, status: str) -> bool:
+        """Persist ISO 19650 status alongside the tag segments."""
+        try:
+            import ifcopenshell.api  # type: ignore
+        except ImportError:
+            return False
+        try:
+            pset = ifcopenshell.api.run("pset.add_pset", self.model,
+                                        product=element, name=STING_PSET)
+            ifcopenshell.api.run("pset.edit_pset", self.model,
+                                 pset=pset, properties={STATUS_PROP: str(status or "")})
+            return True
+        except Exception:
+            return False
+
+    def read_tokens(self, element: Any) -> dict:
+        """The token dict the reconcile engine compares against a remote delta.
+
+        Keys match `stingtools_core.sync.reconcile.TOKEN_KEYS` exactly — the eight
+        tag segments plus `status`. Callers building a `local_index` should use
+        this rather than assembling the dict themselves; a caller that forgets
+        `status` reintroduces the non-convergence this method exists to prevent.
+        """
+        tag = self.read_tag(element)
+        return {
+            "disc": tag.discipline, "loc": tag.location, "zone": tag.zone,
+            "lvl": tag.level, "sys": tag.system, "func": tag.function,
+            "prod": tag.product, "seq": tag.sequence,
+            "status": self.read_status(element),
+        }
+
     def apply_remote_change(self, delta: ChangeDelta) -> bool:
         """Apply a pulled change. Tags are applied here; issue/bcf/clash/transform
         deltas are recorded by the caller's sync layer (no local IFC mutation)."""
@@ -115,7 +203,18 @@ class IfcFileHostAdapter(HostAdapter):
         el = self._element_by_gid(delta.global_id)
         if el is None:
             return False
-        return self.write_tag(el, Tag.from_pset(delta.payload))
+
+        ok = self.write_tag(el, _tag_from_payload(delta.payload))
+
+        # Status travels with the tag but is not part of it. Applying the eight
+        # segments and dropping status made a status-only delta un-appliable:
+        # reconcile saw a difference, applied it, the read-back still showed the
+        # old status, and the next pull produced the identical delta. Forever.
+        payload = delta.payload or {}
+        if "status" in payload or STATUS_PROP in payload:
+            status = payload.get("status", payload.get(STATUS_PROP))
+            ok = self.write_status(el, status) and ok
+        return ok
 
     # -- helpers ---------------------------------------------------------------
     def _element_by_gid(self, gid: str) -> Optional[Any]:

--- a/stingtools-core/python/stingtools_core/hosts/inference.py
+++ b/stingtools-core/python/stingtools_core/hosts/inference.py
@@ -54,9 +54,54 @@ _SYSTEM_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
 )
 
 
+# IFC class → STING Function code. Sibling of DISCIPLINE_BY_IFC_CLASS: discipline
+# says *whose* element it is, function says *what it does*. Unmapped classes fall
+# back to GEN rather than XX — an element always has some function, we just may
+# not know a more specific one.
+FUNCTION_BY_IFC_CLASS: dict[str, str] = {
+    # Air-side supply / return
+    "IfcAirTerminal": "SUP", "IfcAirTerminalBox": "SUP", "IfcFan": "SUP",
+    "IfcDuctSegment": "SUP", "IfcDuctFitting": "SUP", "IfcDuctSilencer": "SUP",
+    "IfcUnitaryEquipment": "SUP", "IfcFilter": "RET",
+    # Public health
+    "IfcSanitaryTerminal": "SAN", "IfcSanitaryTerminalType": "SAN",
+    "IfcFlowTerminal": "SAN",
+    # Wet services
+    "IfcPipeSegment": "SUP", "IfcPipeFitting": "SUP", "IfcValve": "SUP",
+    "IfcPump": "SUP",
+    # Power
+    "IfcElectricDistributionBoard": "PWR", "IfcElectricMotor": "PWR",
+    "IfcOutlet": "PWR", "IfcCableCarrierSegment": "PWR", "IfcCableSegment": "PWR",
+    "IfcProtectiveDevice": "PWR", "IfcSwitchingDevice": "PWR",
+    # Lighting
+    "IfcLamp": "LTG", "IfcLightFixture": "LTG",
+    # Fire
+    "IfcFireSuppressionTerminal": "FP", "IfcAlarm": "FP", "IfcSensor": "FP",
+    # Thermal plant
+    "IfcBoiler": "HTG", "IfcHeatExchanger": "HTG",
+    "IfcChiller": "CLG", "IfcCoolingTower": "CLG",
+}
+
+#: Fallback when an element's class carries no known function.
+FUNCTION_FALLBACK = "GEN"
+
+
 def discipline_for_class(ifc_class: str) -> str:
     """Pure lookup: IFC class string → discipline code. ``XX`` when unknown."""
     return DISCIPLINE_BY_IFC_CLASS.get(ifc_class, SENTINEL)
+
+
+def function_for_class(ifc_class: str) -> str:
+    """Pure lookup: IFC class string → function code. ``GEN`` when unknown."""
+    return FUNCTION_BY_IFC_CLASS.get(ifc_class, FUNCTION_FALLBACK)
+
+
+def infer_function(element: Any) -> str:
+    """Function code for an ifcopenshell element via its ``is_a()`` class."""
+    try:
+        return function_for_class(element.is_a())
+    except Exception:  # pragma: no cover - defensive
+        return FUNCTION_FALLBACK
 
 
 def infer_discipline(element: Any) -> str:
@@ -153,6 +198,83 @@ def infer_product(element: Any) -> str:
         return SENTINEL
     except Exception:
         return SENTINEL
+
+
+#: Zone code assigned to an element belonging to no ``IfcZone``.
+ZONE_FALLBACK = "ZZ"
+
+#: Location code assigned when an element resolves to no ``IfcBuilding``.
+LOCATION_FALLBACK = "BLD1"
+
+#: Guard against a malformed decomposition cycle when walking up to IfcBuilding.
+_MAX_SPATIAL_DEPTH = 10
+
+
+def zone_codes_by_element(model: Any) -> dict[int, str]:
+    """Map element step-id → ``Z01``/``Z02``/… from ``IfcZone`` membership.
+
+    Zones are numbered in model order. Elements belonging to no zone are absent
+    from the result — callers apply :data:`ZONE_FALLBACK` themselves so they can
+    distinguish "no zone" from "zone 0".
+
+    Model-level rather than element-level because the code depends on the zone's
+    ordinal across the whole file, which a per-element call cannot know.
+    """
+    out: dict[int, str] = {}
+    try:
+        zone_code = {
+            zone.id(): f"Z{idx:02d}"
+            for idx, zone in enumerate(model.by_type("IfcZone"), start=1)
+        }
+        if not zone_code:
+            return out
+        for rel in model.by_type("IfcRelAssignsToGroup"):
+            group = getattr(rel, "RelatingGroup", None)
+            if group is None or not group.is_a("IfcZone"):
+                continue
+            code = zone_code.get(group.id())
+            if code is None:
+                continue
+            for obj in (rel.RelatedObjects or []):
+                if obj.is_a("IfcElement"):
+                    out[obj.id()] = code
+    except Exception:
+        return out
+    return out
+
+
+def building_codes_by_element(model: Any) -> dict[int, str]:
+    """Map element step-id → ``BLD1``/``BLD2``/… via spatial containment.
+
+    Walks ``IfcRelContainedInSpatialStructure`` then up the ``Decomposes`` chain
+    (space → storey → building). Elements that resolve to no building are absent;
+    callers apply :data:`LOCATION_FALLBACK`.
+    """
+    out: dict[int, str] = {}
+    try:
+        bld_code = {
+            bld.id(): f"BLD{idx}"
+            for idx, bld in enumerate(model.by_type("IfcBuilding"), start=1)
+        }
+        if not bld_code:
+            return out
+        for rel in model.by_type("IfcRelContainedInSpatialStructure"):
+            node = getattr(rel, "RelatingStructure", None)
+            code = None
+            for _ in range(_MAX_SPATIAL_DEPTH):
+                if node is None:
+                    break
+                if node.is_a("IfcBuilding"):
+                    code = bld_code.get(node.id())
+                    break
+                decomp = getattr(node, "Decomposes", None) or []
+                node = decomp[0].RelatingObject if decomp else None
+            if code:
+                for el in (rel.RelatedElements or []):
+                    out[el.id()] = code
+    except Exception:
+        return out
+    return out
 
 
 class SequenceAllocator:

--- a/stingtools-core/python/tests/test_hosts.py
+++ b/stingtools-core/python/tests/test_hosts.py
@@ -61,6 +61,47 @@ def test_product_for_type_name():
     assert inference.product_for_type_name(None) == "XX"
 
 
+# ── function + spatial inference (moved out of the Bonsai spatial operators) ──
+
+def test_function_for_class_known_codes():
+    assert inference.function_for_class("IfcAirTerminal") == "SUP"
+    assert inference.function_for_class("IfcFilter") == "RET"
+    assert inference.function_for_class("IfcSanitaryTerminal") == "SAN"
+    assert inference.function_for_class("IfcOutlet") == "PWR"
+    assert inference.function_for_class("IfcLightFixture") == "LTG"
+    assert inference.function_for_class("IfcAlarm") == "FP"
+    assert inference.function_for_class("IfcBoiler") == "HTG"
+    assert inference.function_for_class("IfcChiller") == "CLG"
+
+
+def test_function_for_unknown_class_falls_back_to_gen():
+    # Unlike discipline, an unmapped class gets GEN, not the XX sentinel — an
+    # element always has *some* function.
+    assert inference.function_for_class("IfcFurniture") == "GEN"
+    assert inference.function_for_class("") == "GEN"
+    assert inference.FUNCTION_FALLBACK == "GEN"
+
+
+def test_spatial_index_helpers_tolerate_a_broken_model():
+    """Both return {} rather than raising when the model cannot be queried."""
+
+    class Exploding:
+        def by_type(self, _):
+            raise RuntimeError("no such entity")
+
+    assert inference.zone_codes_by_element(Exploding()) == {}
+    assert inference.building_codes_by_element(Exploding()) == {}
+
+
+def test_spatial_index_helpers_empty_when_no_zones_or_buildings():
+    class Empty:
+        def by_type(self, _):
+            return []
+
+    assert inference.zone_codes_by_element(Empty()) == {}
+    assert inference.building_codes_by_element(Empty()) == {}
+
+
 # ── SequenceAllocator (replaces the module-global counter) ────────────────────
 
 def test_sequence_allocator_monotonic_per_group():


### PR DESCRIPTION
Long-lived branch with no PR; opening one so the work lands on main rather than sitting on a branch.

## Commits

- fix(bonsai,core): repair silent pset writes + restore adapter status API
- fix(bonsai): correct TokenLock test to CSV-of-segments semantics
- Expand Bonsai extension: 16 → 29 operators + bug fixes
- Expand Bonsai extension: 16 → 29 operators + bug fixes

## Files (14)

- `stingtools-bonsai/__init__.py`
- `stingtools-bonsai/ops/__init__.py`
- `stingtools-bonsai/ops/export_ops.py`
- `stingtools-bonsai/ops/mep_ops.py`
- `stingtools-bonsai/ops/reload_substrate.py`
- `stingtools-bonsai/ops/repair_ops.py`
- `stingtools-bonsai/ops/spatial_ops.py`
- `stingtools-bonsai/tests/test_pset_write_arity.py`
- `stingtools-bonsai/tests/test_token_lock.py`
- `stingtools-bonsai/ui/__init__.py`
- `stingtools-bonsai/ui/panel_main.py`
- `stingtools-core/python/stingtools_core/hosts/ifc_file.py`
- `stingtools-core/python/stingtools_core/hosts/inference.py`
- `stingtools-core/python/tests/test_hosts.py`

Branch tip `cb1e7bec5`. Merge status is whatever CI reports below — I did not build this locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)